### PR TITLE
HDFS-16813. Remove parameter validation logic such as dfs.namenode.decommission.blocks.per.interval in DatanodeAdminManager#activate

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
@@ -114,12 +114,10 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
           DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_BLOCKS_PER_INTERVAL_DEFAULT;
     }
 
-    final String deprecatedKey =
-        "dfs.namenode.decommission.nodes.per.interval";
+    final String deprecatedKey = "dfs.namenode.decommission.nodes.per.interval";
     final String strNodes = conf.get(deprecatedKey);
     if (strNodes != null) {
-      LOG.warn("Deprecated configuration key {} will be ignored.",
-          deprecatedKey);
+      LOG.warn("Deprecated configuration key {} will be ignored.", deprecatedKey);
       LOG.warn("Please update your configuration to use {} instead.",
           DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_BLOCKS_PER_INTERVAL_KEY);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
@@ -113,6 +113,17 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
       numBlocksPerCheck =
           DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_BLOCKS_PER_INTERVAL_DEFAULT;
     }
+
+    final String deprecatedKey =
+        "dfs.namenode.decommission.nodes.per.interval";
+    final String strNodes = conf.get(deprecatedKey);
+    if (strNodes != null) {
+      LOG.warn("Deprecated configuration key {} will be ignored.",
+          deprecatedKey);
+      LOG.warn("Please update your configuration to use {} instead.",
+          DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_BLOCKS_PER_INTERVAL_KEY);
+    }
+
     LOG.info("Initialized the Default Decommission and Maintenance monitor");
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminManager.java
@@ -108,32 +108,6 @@ public class DatanodeAdminManager {
     Preconditions.checkArgument(intervalSecs >= 0, "Cannot set a negative " +
         "value for " + DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_INTERVAL_KEY);
 
-    int blocksPerInterval = conf.getInt(
-        DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_BLOCKS_PER_INTERVAL_KEY,
-        DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_BLOCKS_PER_INTERVAL_DEFAULT);
-
-    final String deprecatedKey =
-        "dfs.namenode.decommission.nodes.per.interval";
-    final String strNodes = conf.get(deprecatedKey);
-    if (strNodes != null) {
-      LOG.warn("Deprecated configuration key {} will be ignored.",
-          deprecatedKey);
-      LOG.warn("Please update your configuration to use {} instead.",
-          DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_BLOCKS_PER_INTERVAL_KEY);
-    }
-
-    Preconditions.checkArgument(blocksPerInterval > 0,
-        "Must set a positive value for "
-        + DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_BLOCKS_PER_INTERVAL_KEY);
-
-    final int maxConcurrentTrackedNodes = conf.getInt(
-        DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_MAX_CONCURRENT_TRACKED_NODES,
-        DFSConfigKeys
-            .DFS_NAMENODE_DECOMMISSION_MAX_CONCURRENT_TRACKED_NODES_DEFAULT);
-    Preconditions.checkArgument(maxConcurrentTrackedNodes >= 0,
-        "Cannot set a negative value for "
-        + DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_MAX_CONCURRENT_TRACKED_NODES);
-
     Class cls = null;
     try {
       cls = conf.getClass(
@@ -153,10 +127,7 @@ public class DatanodeAdminManager {
         TimeUnit.SECONDS);
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Activating DatanodeAdminManager with interval {} seconds, " +
-              "{} max blocks per interval, " +
-              "{} max concurrently tracked nodes.", intervalSecs,
-          blocksPerInterval, maxConcurrentTrackedNodes);
+      LOG.debug("Activating DatanodeAdminManager with interval {} seconds.", intervalSecs);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminManager.java
@@ -126,9 +126,7 @@ public class DatanodeAdminManager {
     executor.scheduleWithFixedDelay(monitor, intervalSecs, intervalSecs,
         TimeUnit.SECONDS);
 
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Activating DatanodeAdminManager with interval {} seconds.", intervalSecs);
-    }
+    LOG.debug("Activating DatanodeAdminManager with interval {} seconds.", intervalSecs);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminMonitorBase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminMonitorBase.java
@@ -124,10 +124,8 @@ public abstract class DatanodeAdminMonitorBase
               .DFS_NAMENODE_DECOMMISSION_MAX_CONCURRENT_TRACKED_NODES_DEFAULT;
     }
 
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Activating DatanodeAdminMonitor with {} max concurrently tracked nodes.",
-          maxConcurrentTrackedNodes);
-    }
+    LOG.debug("Activating DatanodeAdminMonitor with {} max concurrently tracked nodes.",
+        maxConcurrentTrackedNodes);
 
     processConf();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminMonitorBase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminMonitorBase.java
@@ -123,6 +123,12 @@ public abstract class DatanodeAdminMonitorBase
           DFSConfigKeys
               .DFS_NAMENODE_DECOMMISSION_MAX_CONCURRENT_TRACKED_NODES_DEFAULT;
     }
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Activating DatanodeAdminMonitor with {} max concurrently tracked nodes.",
+          maxConcurrentTrackedNodes);
+    }
+
     processConf();
   }
 


### PR DESCRIPTION
### Description of PR
In DatanodeAdminManager#activate

```
int blocksPerInterval = conf.getInt(
    DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_BLOCKS_PER_INTERVAL_KEY,
    DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_BLOCKS_PER_INTERVAL_DEFAULT);

final String deprecatedKey =
    "dfs.namenode.decommission.nodes.per.interval";
final String strNodes = conf.get(deprecatedKey);
if (strNodes != null) {
  LOG.warn("Deprecated configuration key {} will be ignored.",
      deprecatedKey);
  LOG.warn("Please update your configuration to use {} instead.",
      DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_BLOCKS_PER_INTERVAL_KEY);
}

checkArgument(blocksPerInterval > 0,
    "Must set a positive value for "
    + DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_BLOCKS_PER_INTERVAL_KEY);

final int maxConcurrentTrackedNodes = conf.getInt(
    DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_MAX_CONCURRENT_TRACKED_NODES,
    DFSConfigKeys
        .DFS_NAMENODE_DECOMMISSION_MAX_CONCURRENT_TRACKED_NODES_DEFAULT);
checkArgument(maxConcurrentTrackedNodes >= 0, "Cannot set a negative " +
    "value for "
    + DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_MAX_CONCURRENT_TRACKED_NODES);
```
there is no need for parameters
dfs.namenode.decommission.blocks.per.interval and
dfs.namenode.decommission.max.concurrent.tracked.nodes to verify.
Because the parameters are processed in DatanodeAdminMonitorBase and DatanodeAdminDefaultMonitor.

### For code changes:

-In [HDFS-16813](https://issues.apache.org/jira/browse/HDFS-16813) parameter validation logic such as dfs.namenode.decommission.blocks.per.interval in DatanodeAdminManager#activate

