### PR TITLE
HADOOP-18505. Handled ArrayIndexOutOfBoundsException in TestCoderBase

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/DecodingState.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/DecodingState.java
@@ -39,7 +39,7 @@ class DecodingState {
                            T[] outputs) {
     if (inputs.length != decoder.getNumParityUnits() +
         decoder.getNumDataUnits()) {
-      throw new IllegalArgumentException("Invalid inputs length");
+      throw new HadoopIllegalArgumentException("Invalid inputs length");
     }
 
     if (erasedIndexes.length != outputs.length) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/DecodingState.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/DecodingState.java
@@ -39,7 +39,7 @@ class DecodingState {
                            T[] outputs) {
     if (inputs.length != decoder.getNumParityUnits() +
         decoder.getNumDataUnits()) {
-      throw new HadoopIllegalArgumentException("Invalid inputs length");
+      throw new IllegalArgumentException("Invalid inputs length");
     }
 
     if (erasedIndexes.length != outputs.length) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/TestCoderBase.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/TestCoderBase.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.io.erasurecode;
 
+import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.erasurecode.BufferAllocator.SimpleBufferAllocator;
 import org.apache.hadoop.io.erasurecode.BufferAllocator.SlicedBufferAllocator;
@@ -224,13 +225,25 @@ public abstract class TestCoderBase {
     int idx = 0;
 
     for (int i = 0; i < erasedDataIndexes.length; i++) {
-      toEraseChunks[idx ++] = dataChunks[erasedDataIndexes[i]];
-      dataChunks[erasedDataIndexes[i]] = null;
+      if (erasedDataIndexes[i] < dataChunks.length) {
+        toEraseChunks[idx ++] = dataChunks[erasedDataIndexes[i]];
+        dataChunks[erasedDataIndexes[i]] = null;
+      } else {
+        throw new HadoopIllegalArgumentException(
+            "The erased index is out of bound: erasedDataIndex="
+                + erasedDataIndexes[i]);
+      }
     }
 
     for (int i = 0; i < erasedParityIndexes.length; i++) {
-      toEraseChunks[idx ++] = parityChunks[erasedParityIndexes[i]];
-      parityChunks[erasedParityIndexes[i]] = null;
+      if (erasedParityIndexes[i] < parityChunks.length) {
+        toEraseChunks[idx ++] = parityChunks[erasedParityIndexes[i]];
+        parityChunks[erasedParityIndexes[i]] = null;
+      } else {
+        throw new HadoopIllegalArgumentException(
+            "The erased index is out of bound: erasedParityIndex="
+                + erasedParityIndexes[i]);
+      }
     }
 
     return toEraseChunks;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/TestCoderBase.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/TestCoderBase.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.io.erasurecode;
 
-import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.erasurecode.BufferAllocator.SimpleBufferAllocator;
 import org.apache.hadoop.io.erasurecode.BufferAllocator.SlicedBufferAllocator;
@@ -229,7 +228,7 @@ public abstract class TestCoderBase {
         toEraseChunks[idx ++] = dataChunks[erasedDataIndexes[i]];
         dataChunks[erasedDataIndexes[i]] = null;
       } else {
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
             "The erased index is out of bound: erasedDataIndex="
                 + erasedDataIndexes[i]);
       }
@@ -240,7 +239,7 @@ public abstract class TestCoderBase {
         toEraseChunks[idx ++] = parityChunks[erasedParityIndexes[i]];
         parityChunks[erasedParityIndexes[i]] = null;
       } else {
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
             "The erased index is out of bound: erasedParityIndex="
                 + erasedParityIndexes[i]);
       }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestDecodingValidator.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestDecodingValidator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.io.erasurecode.rawcoder;
 
+import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.io.erasurecode.ECChunk;
 import org.apache.hadoop.io.erasurecode.ErasureCodeNative;
 import org.apache.hadoop.test.GenericTestUtils;
@@ -50,6 +51,7 @@ public class TestDecodingValidator extends TestRawCoderBase {
         {RSRawErasureCoderFactory.class, 6, 3, new int[]{1}, new int[]{}},
         {RSRawErasureCoderFactory.class, 6, 3, new int[]{3}, new int[]{0}},
         {RSRawErasureCoderFactory.class, 6, 3, new int[]{2, 4}, new int[]{1}},
+        {RSRawErasureCoderFactory.class, 6, 1, new int[]{0}, new int[]{1}},
         {NativeRSRawErasureCoderFactory.class, 6, 3, new int[]{0}, new int[]{}},
         {XORRawErasureCoderFactory.class, 10, 1, new int[]{0}, new int[]{}},
         {NativeXORRawErasureCoderFactory.class, 10, 1, new int[]{0},
@@ -123,7 +125,12 @@ public class TestDecodingValidator extends TestRawCoderBase {
     }
 
     // decode
-    backupAndEraseChunks(clonedDataChunks, parityChunks);
+    try {
+      backupAndEraseChunks(clonedDataChunks, parityChunks);
+    } catch (HadoopIllegalArgumentException e) {
+      String expected = "The erased index is out of bound";
+      Assume.assumeTrue(expected, !e.toString().contains(expected));
+    }
     ECChunk[] inputChunks =
         prepareInputChunksForDecoding(clonedDataChunks, parityChunks);
     markChunks(inputChunks);
@@ -210,7 +217,12 @@ public class TestDecodingValidator extends TestRawCoderBase {
     }
 
     // decode
-    backupAndEraseChunks(clonedDataChunks, parityChunks);
+    try {
+      backupAndEraseChunks(clonedDataChunks, parityChunks);
+    } catch (HadoopIllegalArgumentException e) {
+      String expected = "The erased index is out of bound";
+      Assume.assumeTrue(expected, !e.toString().contains(expected));
+    }
     ECChunk[] inputChunks =
         prepareInputChunksForDecoding(clonedDataChunks, parityChunks);
     markChunks(inputChunks);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestDecodingValidator.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestDecodingValidator.java
@@ -127,7 +127,7 @@ public class TestDecodingValidator extends TestRawCoderBase {
     // decode
     try {
       backupAndEraseChunks(clonedDataChunks, parityChunks);
-    } catch (HadoopIllegalArgumentException e) {
+    } catch (IllegalArgumentException e) {
       String expected = "The erased index is out of bound";
       Assume.assumeTrue(expected, !e.toString().contains(expected));
     }
@@ -219,7 +219,7 @@ public class TestDecodingValidator extends TestRawCoderBase {
     // decode
     try {
       backupAndEraseChunks(clonedDataChunks, parityChunks);
-    } catch (HadoopIllegalArgumentException e) {
+    } catch (IllegalArgumentException e) {
       String expected = "The erased index is out of bound";
       Assume.assumeTrue(expected, !e.toString().contains(expected));
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestDecodingValidator.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestDecodingValidator.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.io.erasurecode.rawcoder;
 
-import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.io.erasurecode.ECChunk;
 import org.apache.hadoop.io.erasurecode.ErasureCodeNative;
 import org.apache.hadoop.test.GenericTestUtils;


### PR DESCRIPTION
### Description of PR
JIRA: [HADOOP-18505](https://issues.apache.org/jira/browse/HADOOP-18505)

### How was this patch tested?
Added a new value set and consequently modified the existing unit tests `testValidate` and `testValidateWithBadDecoding` of test class `TestDecodingValidator` to verify the code change.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

