### PR TITLE
HDFS-16815. Error occurred in processing CacheManagerSection for xml parsing fsimage

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageReconstructor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageReconstructor.java
@@ -1102,8 +1102,8 @@ class OfflineImageReconstructor {
         }
         actualNumPools++;
         Node pool = new Node();
-        loadNodeChildren(pool, "pool fields", "");
-        processPoolXml(node);
+        loadNodeChildren(pool, "pool fields");
+        processPoolXml(pool);
       }
       long actualNumDirectives = 0;
       while (actualNumDirectives < expectedNumDirectives) {
@@ -1115,8 +1115,8 @@ class OfflineImageReconstructor {
         }
         actualNumDirectives++;
         Node pool = new Node();
-        loadNodeChildren(pool, "directive fields", "");
-        processDirectiveXml(node);
+        loadNodeChildren(pool, "directive fields");
+        processDirectiveXml(pool);
       }
       expectTagEnd(CACHE_MANAGER_SECTION_NAME);
       recordSectionLength(SectionName.CACHE_MANAGER.name());


### PR DESCRIPTION

### Description of PR
1. We added a test method to test the CacheManagerSectionProcessor.
2. We fixed two bugs in the processor of CacheManagerSectionProcessor to make sure the xml parsing fsimage.

### How was this patch tested?
We add a test method in TestOfflineImageViewer.java. The meyhod name is testReverseXmlWithCacheManagerSection.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

