### PR TITLE
HDFS-16816 RBF: auto-create user home dir for trash paths by router

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -408,4 +408,9 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
       DFS_ROUTER_FEDERATION_RENAME_PREFIX + "trash";
   public static final String DFS_ROUTER_FEDERATION_RENAME_TRASH_DEFAULT =
       "trash";
+
+  public static final String DFS_ROUTER_FEDERATION_TRASH_AUTO_CREATE_USER_HOME =
+      FEDERATION_ROUTER_PREFIX + "trash.auto-create.user.home";
+  public static final boolean
+      DFS_ROUTER_FEDERATION_TRASH_AUTO_CREATE_HOME_DIR_DEFAULT = false;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -604,7 +604,6 @@ public class RouterClientProtocol implements ClientProtocol {
         rpcServer.getLocationsForPath(src, true, false);
     final List<RemoteLocation> dstLocations =
         rpcServer.getLocationsForPath(dst, false, false);
-
     // srcLocations may be trimmed by getRenameDestinations()
     final List<RemoteLocation> locs = new LinkedList<>(srcLocations);
     RemoteParam dstParam = getRenameDestinations(locs, dstLocations);
@@ -631,7 +630,6 @@ public class RouterClientProtocol implements ClientProtocol {
         rpcServer.getLocationsForPath(src, true, false);
     final List<RemoteLocation> dstLocations =
         rpcServer.getLocationsForPath(dst, false, false);
-
     // srcLocations may be trimmed by getRenameDestinations()
     final List<RemoteLocation> locs = new LinkedList<>(srcLocations);
     RemoteParam dstParam = getRenameDestinations(locs, dstLocations);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -723,14 +723,26 @@ public class RouterClientProtocol implements ClientProtocol {
     }
   }
 
-  // Create missing user home dirs for trash paths.
-  // We assume the router is running with super-user privilege (can create
-  // user home dir in /user dir).
-  private void createUserHomeForTrashPath(List<RemoteLocation> locations) throws IOException {
+  /**
+   * Create missing user home dirs for trash paths.
+   *
+   * When there are multiple possible destination locations for a trash path,
+   * we create user home dirs at all destination locations.
+   *
+   * We assume the router is running with super-user privilege (can create
+   * user home dir in /user dir).
+   *
+   * @param src source location
+   * @param locations destination locations
+   */
+  private void createUserHomeForTrashPath(String src,
+      List<RemoteLocation> locations)
+      throws IOException {
+    List<RemoteLocation> userHomes = new ArrayList<>();
     List<RemoteLocation> missingUserHomes = new ArrayList<>();
 
-    // Identify missing trash roots
-    for(RemoteLocation loc: locations) {
+    // Get home dirs for trash paths
+    for (RemoteLocation loc : locations) {
 
       String path = loc.getDest();
       // Continue if not a trash path
@@ -738,31 +750,48 @@ public class RouterClientProtocol implements ClientProtocol {
         continue;
       }
 
-      // Check whether user home dir exists at the destination namespace
       String trashRoot = MountTableResolver.getTrashRoot();
       String userHome = new Path(trashRoot).getParent().toUri().getPath();
       RemoteLocation userHomeLoc = new RemoteLocation(loc, userHome);
-      RemoteMethod method = new RemoteMethod("getFileInfo", new Class<?>[] {String.class}, new RemoteParam());
-      HdfsFileStatus ret = rpcClient.invokeSingle(userHomeLoc, method, HdfsFileStatus.class);
+      userHomes.add(userHomeLoc);
+    }
+
+    // Use getFileInfo to identify missing user homes
+    for (RemoteLocation userHomeLoc : userHomes) {
+      RemoteMethod method =
+          new RemoteMethod("getFileInfo", new Class<?>[]{String.class},
+              new RemoteParam());
+      HdfsFileStatus ret =
+          rpcClient.invokeSingle(userHomeLoc, method, HdfsFileStatus.class);
       if (ret == null) {
         missingUserHomes.add(userHomeLoc);
       }
     }
 
-    if (!missingUserHomes.isEmpty()) {
+    // Create missing user home dirs and set owner
+    for(RemoteLocation loc: missingUserHomes) {
       // Create missing user home dirs
-      FsPermission perm = new FsPermission(FsAction.ALL, FsAction.READ_EXECUTE, FsAction.READ_EXECUTE);
-      RemoteMethod method =
-          new RemoteMethod("mkdirs", new Class<?>[]{String.class, FsPermission.class, boolean.class}, new RemoteParam(),
-              perm, true);
-      rpcClient.invokeSequentialAsRouter(missingUserHomes, method, Boolean.class, true);
+      FsPermission perm = new FsPermission(FsAction.ALL, FsAction.READ_EXECUTE,
+          FsAction.READ_EXECUTE);
+      RemoteMethod method = new RemoteMethod("mkdirs",
+          new Class<?>[]{String.class, FsPermission.class, boolean.class},
+          new RemoteParam(), perm, true);
+      boolean ret = rpcClient.invokeSingleAsRouter(loc, method,
+          Boolean.class, true);
+      if (!ret) {
+        LOG.warn("Failed to create user home dir for path={} at dest={}",
+            src, loc);
+        continue;
+      }
 
       // Set owner/group
       String username = RouterRpcServer.getRemoteUser().getShortUserName();
-      method = new RemoteMethod("setOwner", new Class<?>[]{String.class, String.class, String.class}, new RemoteParam(),
-          username, null);
+      method = new RemoteMethod("setOwner",
+          new Class<?>[]{String.class, String.class, String.class},
+          new RemoteParam(), username, null);
 
-      rpcClient.invokeSequentialAsRouter(missingUserHomes, method, Void.class, null);
+      rpcClient.invokeSingleAsRouter(loc, method, Void.class,
+          null);
     }
   }
 
@@ -780,7 +809,7 @@ public class RouterClientProtocol implements ClientProtocol {
     // Auto-create user home dir for a trash path.
     // moveToTrash() will first call fs.mkdirs() to create the parent dir, before calling rename()
     // to move the file into it. As a result, we need to create user home dir in mkdirs().
-    createUserHomeForTrashPath(locations);
+    createUserHomeForTrashPath(src, locations);
 
     // Create in all locations
     if (rpcServer.isPathAll(src)) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -789,7 +789,7 @@ public class RouterClientProtocol implements ClientProtocol {
         continue;
       }
 
-      // Set owner/group
+      // Set owner
       String username = RouterRpcServer.getRemoteUser().getShortUserName();
       method = new RemoteMethod("setOwner",
           new Class<?>[]{String.class, String.class, String.class},

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -140,6 +140,8 @@ public class RouterClientProtocol implements ClientProtocol {
   private volatile long serverDefaultsLastUpdate;
   private final long serverDefaultsValidityPeriod;
 
+  /** Whether the router should auto-create home dir for a trash path. */
+  private final boolean autoCreateUserHomeForTrash;
   /** If it requires response from all subclusters. */
   private final boolean allowPartialList;
   /** Time out when getting the mount statistics. */
@@ -166,6 +168,9 @@ public class RouterClientProtocol implements ClientProtocol {
     this.subclusterResolver = rpcServer.getSubclusterResolver();
     this.namenodeResolver = rpcServer.getNamenodeResolver();
 
+    this.autoCreateUserHomeForTrash = conf.getBoolean(
+        RBFConfigKeys.DFS_ROUTER_FEDERATION_TRASH_AUTO_CREATE_USER_HOME,
+        RBFConfigKeys.DFS_ROUTER_FEDERATION_TRASH_AUTO_CREATE_HOME_DIR_DEFAULT);
     this.allowPartialList = conf.getBoolean(
         RBFConfigKeys.DFS_ROUTER_ALLOW_PARTIAL_LIST,
         RBFConfigKeys.DFS_ROUTER_ALLOW_PARTIAL_LIST_DEFAULT);
@@ -809,7 +814,9 @@ public class RouterClientProtocol implements ClientProtocol {
     // Auto-create user home dir for a trash path.
     // moveToTrash() will first call fs.mkdirs() to create the parent dir, before calling rename()
     // to move the file into it. As a result, we need to create user home dir in mkdirs().
-    createUserHomeForTrashPath(src, locations);
+    if (autoCreateUserHomeForTrash) {
+      createUserHomeForTrashPath(src, locations);
+    }
 
     // Create in all locations
     if (rpcServer.isPathAll(src)) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -735,7 +735,7 @@ public class RouterClientProtocol implements ClientProtocol {
    * @param src source location
    * @param locations destination locations
    */
-  private void createUserHomeForTrashPath(String src,
+  void createUserHomeForTrashPath(String src,
       List<RemoteLocation> locations)
       throws IOException {
     List<RemoteLocation> userHomes = new ArrayList<>();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -946,6 +946,17 @@ public class RouterRpcClient {
     return ret;
   }
 
+  // Same as invokeSingle but uses router's login identity
+  public <T> T invokeSingleAsRouter(final RemoteLocationContext location,
+      RemoteMethod remoteMethod, Class<T> expectedResultClass,
+      Object expectedResultValue) throws IOException {
+    List<RemoteLocationContext> locations = Collections.singletonList(location);
+    @SuppressWarnings("unchecked")
+    T ret = (T)invokeSequentialAsRouter(locations, remoteMethod,
+        expectedResultClass, expectedResultValue);
+    return ret;
+  }
+
   /**
    * Invokes sequential proxy calls to different locations. Continues to invoke
    * calls until a call returns without throwing a remote exception.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -998,6 +998,18 @@ public class RouterRpcClient {
   }
 
   /**
+   * Same as the above invokeSequential, but with router ugi.
+   */
+  public <T> T invokeSequentialAsRouter(
+      final List<? extends RemoteLocationContext> locations,
+      final RemoteMethod remoteMethod, Class<T> expectedResultClass,
+      Object expectedResultValue) throws IOException {
+    UserGroupInformation routerUgi = UserGroupInformation.getLoginUser();
+    return (T) invokeSequentialInternal(remoteMethod, locations, expectedResultClass,
+        expectedResultValue, routerUgi).getResult();
+  }
+
+  /**
    * Invokes sequential proxy calls to different locations. Continues to invoke
    * calls until the success condition is met, or until all locations have been
    * attempted.
@@ -1032,9 +1044,19 @@ public class RouterRpcClient {
       final RemoteMethod remoteMethod, final List<R> locations,
       Class<T> expectedResultClass, Object expectedResultValue)
       throws IOException {
+    UserGroupInformation ugi = RouterRpcServer.getRemoteUser();
+    return invokeSequentialInternal(remoteMethod, locations, expectedResultClass,
+        expectedResultValue, ugi);
+  }
 
+  /**
+   * Call invokeSequential with a configurable ugi
+   */
+  public <R extends RemoteLocationContext, T> RemoteResult invokeSequentialInternal(
+      final RemoteMethod remoteMethod, final List<R> locations,
+      Class<T> expectedResultClass, Object expectedResultValue, UserGroupInformation ugi)
+      throws IOException {
     RouterRpcFairnessPolicyController controller = getRouterRpcFairnessPolicyController();
-    final UserGroupInformation ugi = RouterRpcServer.getRemoteUser();
     final Method m = remoteMethod.getMethod();
     List<IOException> thrownExceptions = new ArrayList<>();
     Object firstResult = null;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -952,7 +952,7 @@ public class RouterRpcClient {
    * This method is the same as invokeSingle, except that it uses router's
    * identity.
    */
-  public <T> T invokeSingleAsRouter(final RemoteLocationContext location,
+  <T> T invokeSingleAsRouter(final RemoteLocationContext location,
       RemoteMethod remoteMethod, Class<T> expectedResultClass,
       Object expectedResultValue) throws IOException {
     List<RemoteLocationContext> locations = Collections.singletonList(location);
@@ -1020,7 +1020,7 @@ public class RouterRpcClient {
    * This method is the same as invokeSequential, except that it uses
    * router's identity to make the calls.
    */
-  public <T> T invokeSequentialAsRouter(
+  <T> T invokeSequentialAsRouter(
       final List<? extends RemoteLocationContext> locations,
       final RemoteMethod remoteMethod, Class<T> expectedResultClass,
       Object expectedResultValue) throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -1016,8 +1016,10 @@ public class RouterRpcClient {
       final RemoteMethod remoteMethod, Class<T> expectedResultClass,
       Object expectedResultValue) throws IOException {
     UserGroupInformation routerUgi = UserGroupInformation.getLoginUser();
-    return (T) invokeSequentialInternal(remoteMethod, locations, expectedResultClass,
-        expectedResultValue, routerUgi).getResult();
+    @SuppressWarnings("unchecked")
+    T ret = (T) invokeSequentialInternal(remoteMethod, locations,
+      expectedResultClass, expectedResultValue, routerUgi).getResult();
+    return ret;
   }
 
   /**
@@ -1061,7 +1063,7 @@ public class RouterRpcClient {
   }
 
   /**
-   * Call invokeSequential with a configurable ugi
+   * Call invokeSequential with a configurable ugi.
    */
   public <R extends RemoteLocationContext, T> RemoteResult invokeSequentialInternal(
       final RemoteMethod remoteMethod, final List<R> locations,

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -1018,7 +1018,7 @@ public class RouterRpcClient {
     UserGroupInformation routerUgi = UserGroupInformation.getLoginUser();
     @SuppressWarnings("unchecked")
     T ret = (T) invokeSequentialInternal(remoteMethod, locations,
-      expectedResultClass, expectedResultValue, routerUgi).getResult();
+        expectedResultClass, expectedResultValue, routerUgi).getResult();
     return ret;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -946,7 +946,12 @@ public class RouterRpcClient {
     return ret;
   }
 
-  // Same as invokeSingle but uses router's login identity
+  /**
+   * Invokes a single proxy call for a single location, using router's identity.
+   *
+   * This method is the same as invokeSingle, except that it uses router's
+   * identity.
+   */
   public <T> T invokeSingleAsRouter(final RemoteLocationContext location,
       RemoteMethod remoteMethod, Class<T> expectedResultClass,
       Object expectedResultValue) throws IOException {
@@ -1009,7 +1014,11 @@ public class RouterRpcClient {
   }
 
   /**
-   * Same as the above invokeSequential, but with router ugi.
+   * Invokes sequential proxy calls to different locations, using router's
+   * identity.
+   *
+   * This method is the same as invokeSequential, except that it uses
+   * router's identity to make the calls.
    */
   public <T> T invokeSequentialAsRouter(
       final List<? extends RemoteLocationContext> locations,
@@ -1063,9 +1072,9 @@ public class RouterRpcClient {
   }
 
   /**
-   * Call invokeSequential with a configurable ugi.
+   * Actual implementation of invokeSequential with a configurable ugi.
    */
-  public <R extends RemoteLocationContext, T> RemoteResult invokeSequentialInternal(
+  private <R extends RemoteLocationContext, T> RemoteResult invokeSequentialInternal(
       final RemoteMethod remoteMethod, final List<R> locations,
       Class<T> expectedResultClass, Object expectedResultValue, UserGroupInformation ugi)
       throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -864,4 +864,12 @@
       of namespaces in use and the latency of the msync requests.
     </description>
   </property>
+  <property>
+    <name>dfs.federation.router.trash.auto-create.user.home</name>
+    <value>false</value>
+    <description>
+      Whether to enable routers to auto-create user home dir on the destination
+      namenodes for trash paths.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -869,7 +869,10 @@
     <value>false</value>
     <description>
       Whether to enable routers to auto-create user home dir on the destination
-      namenodes for trash paths.
+      namenodes for trash paths. RBF moves trash files to the trash under
+      user's home dir at the same namespace where the file is stored. However,
+      the user's home dir may not be created there. This flag enables routers
+      to auto-create these missing user home dirs using router's identity.
     </description>
   </property>
 </configuration>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
@@ -57,7 +57,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.*;
 
-
 /**
  * This is a test through the Router move data to the Trash.
  */

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
@@ -212,6 +212,9 @@ public class TestRouterTrash {
     Field autoCreateUserHomeField = RouterClientProtocol.class.getDeclaredField(
         "autoCreateUserHomeForTrash");
     autoCreateUserHomeField.setAccessible(true);
+    // Save the original value
+    boolean originalAutoCreate =
+        autoCreateUserHomeField.getBoolean(clientProcotol);
 
     // Set owner to TEST_USER for root dir
     DFSClient superUserClient = nnContext.getClient();
@@ -252,6 +255,9 @@ public class TestRouterTrash {
     assertTrue(trash.moveToTrash(filePath));
     assertFalse(nnFs.exists(filePath));
     assertTrue(nnFs.exists(new Path(trashPath)));
+
+    // Restore the autoCreateUserHome flag
+    autoCreateUserHomeField.set(clientProcotol, originalAutoCreate);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
@@ -220,8 +220,9 @@ public class TestRouterTrash {
     client.create(FILE, true);
     Path filePath = new Path(FILE);
 
-    // Set owner to TEST_USER2 for the root dir so that TEST_USER does not have permission to
-    // create his home dir under root dir. Instead, the router will create the home dir for TEST_USER.
+    // Set owner to TEST_USER2 for the root dir so that TEST_USER does not have
+    // permission to create his home dir under root dir. Instead, the router
+    // will create the home dir for TEST_USER.
     superUserClient.setOwner("/", testUser2, testUser2);
 
     // Test moveToTrash by TEST_USER


### PR DESCRIPTION
### Description of PR

In RBF, trash files are moved to trash root under user's home dir at the corresponding namespace/namenode where the files reside. This was added in [HDFS-16024](https://issues.apache.org/jira/browse/HDFS-16024). When the user home dir is not created before-hand at a namenode, we run into permission denied exceptions when trying to create the parent dir for the trash file before moving the file into it. We propose to enhance Router, to auto-create a user home's dir at the namenode for trash paths, using router's identity (which is assumed to be a super-user).

### How was this patch tested?

Add a new unit test (`testMoveToTrashAutoCreateUserHome`) to TestRouterTrash. 

mvn test -Dtest="TestRouterTrash"

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.hdfs.server.federation.router.TestRouterTrash
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.09 s - in org.apache.hadoop.hdfs.server.federation.router.TestRouterTrash
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
```

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

