### PR TITLE
HDFS-16822. HostRestrictingAuthorizationFilter should pass through requests if they don't access WebHDFS API.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/HostRestrictingAuthorizationFilter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/HostRestrictingAuthorizationFilter.java
@@ -226,9 +226,8 @@ public class HostRestrictingAuthorizationFilter implements Filter {
     final String query = interaction.getQueryString();
     final String uri = interaction.getRequestURI();
     if (!uri.startsWith(WebHdfsFileSystem.PATH_PREFIX)) {
-      LOG.trace("Rejecting interaction; wrong URI: {}", uri);
-      interaction.sendError(HttpServletResponse.SC_NOT_FOUND,
-          "The request URI must start with " + WebHdfsFileSystem.PATH_PREFIX);
+      LOG.trace("Proceeding with interaction since the request doesn't access WebHDFS API");
+      interaction.proceed();
       return;
     }
     final String path = uri.substring(WebHdfsFileSystem.PATH_PREFIX.length());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestHostRestrictingAuthorizationFilter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestHostRestrictingAuthorizationFilter.java
@@ -244,14 +244,13 @@ public class TestHostRestrictingAuthorizationFilter {
   }
 
   /**
-   * Test acceptable behavior to malformed requests
-   * Case: the request URI does not start with "/webhdfs/v1"
+   * A request that don't access WebHDFS API should pass through.
    */
   @Test
-  public void testInvalidURI() throws Exception {
+  public void testNotWebhdfsAPIRequest() throws Exception {
     HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
     Mockito.when(request.getMethod()).thenReturn("GET");
-    Mockito.when(request.getRequestURI()).thenReturn("/InvalidURI");
+    Mockito.when(request.getRequestURI()).thenReturn("/conf");
     HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
 
     Filter filter = new HostRestrictingAuthorizationFilter();
@@ -260,11 +259,7 @@ public class TestHostRestrictingAuthorizationFilter {
     FilterConfig fc = new DummyFilterConfig(configs);
 
     filter.init(fc);
-    filter.doFilter(request, response,
-        (servletRequest, servletResponse) -> {});
-    Mockito.verify(response, Mockito.times(1))
-        .sendError(Mockito.eq(HttpServletResponse.SC_NOT_FOUND),
-                   Mockito.anyString());
+    filter.doFilter(request, response, (servletRequest, servletResponse) -> {});
     filter.destroy();
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

After HDFS-15320, HostRestrictingAuthorizationFilter returns 404 error if it receives a request that doesn't access WebHDFS API. With this change, the endpoints, such as /conf and /jmx are no longer visible. This is very inconvenient for administrators. HostRestrictingAuthorizationFilter should pass through requests if they don't access WebHDFS API.

### How was this patch tested?

- verify the unit test
- verify it in my local cluster

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
