### PR TITLE
HADOOP-18510. Support confidential client in Azure refresh token gran…

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -839,8 +839,10 @@ public class AbfsConfiguration{
               getMandatoryPasswordString(FS_AZURE_ACCOUNT_OAUTH_REFRESH_TOKEN);
           String clientId =
               getMandatoryPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID);
+          String clientSecret =
+                  getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_SECRET);
           tokenProvider = new RefreshTokenBasedTokenProvider(authEndpoint,
-              clientId, refreshToken);
+              clientId, clientSecret, refreshToken);
           LOG.trace("RefreshTokenBasedTokenProvider initialized");
         } else {
           throw new IllegalArgumentException("Failed to initialize " + tokenProviderClass);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/AzureADAuthenticator.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/AzureADAuthenticator.java
@@ -162,6 +162,7 @@ public final class AzureADAuthenticator {
    *                     with the user's directory (obtain from
    *                     Active Directory configuration)
    * @param clientId the client ID (GUID) of the client web app obtained from Azure Active Directory configuration
+   * @param clientSecret the client secret of the client web app obtained from Azure Active Directory configuration
    * @param refreshToken the refresh token
    * @return {@link AzureADToken} obtained using the refresh token
    * @throws IOException throws IOException if there is a failure in connecting to Azure AD
@@ -172,8 +173,9 @@ public final class AzureADAuthenticator {
     QueryParams qp = new QueryParams();
     qp.add("grant_type", "refresh_token");
     qp.add("refresh_token", refreshToken);
-    qp.add("client_id", clientId);
-
+    if (clientId != null) {
+      qp.add("client_id", clientId);
+    }
     if (clientSecret != null) {
       qp.add("client_secret", clientSecret);
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/AzureADAuthenticator.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/AzureADAuthenticator.java
@@ -168,12 +168,14 @@ public final class AzureADAuthenticator {
    */
   public static AzureADToken getTokenUsingRefreshToken(
       final String authEndpoint, final String clientId,
-      final String refreshToken) throws IOException {
+      final String clientSecret, final String refreshToken) throws IOException {
     QueryParams qp = new QueryParams();
     qp.add("grant_type", "refresh_token");
     qp.add("refresh_token", refreshToken);
-    if (clientId != null) {
-      qp.add("client_id", clientId);
+    qp.add("client_id", clientId);
+
+    if (clientSecret != null) {
+      qp.add("client_secret", clientSecret);
     }
     LOG.debug("AADToken: starting to fetch token using refresh token for client ID " + clientId);
     return getTokenCall(authEndpoint, qp.serialize(), null, null);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/RefreshTokenBasedTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/RefreshTokenBasedTokenProvider.java
@@ -35,21 +35,25 @@ public class RefreshTokenBasedTokenProvider extends AccessTokenProvider {
 
   private final String clientId;
 
+  private final String clientSecret;
+
   private final String refreshToken;
 
   /**
    * Constructs a token provider based on the refresh token provided.
    *
-   * @param clientId the client ID (GUID) of the client web app obtained from Azure Active Directory configuration
+   * @param clientId the client ID (GUID) of the client obtained from Azure Active Directory configuration
+   * @param clientSecret the client secret of the client obtained from Azure Active Directory configuration
    * @param refreshToken the refresh token
    */
   public RefreshTokenBasedTokenProvider(final String authEndpoint,
-      String clientId, String refreshToken) {
+      String clientId, String clientSecret, String refreshToken) {
     Preconditions.checkNotNull(authEndpoint, "authEndpoint");
     Preconditions.checkNotNull(clientId, "clientId");
     Preconditions.checkNotNull(refreshToken, "refreshToken");
     this.authEndpoint = authEndpoint;
     this.clientId = clientId;
+    this.clientSecret = clientSecret;
     this.refreshToken = refreshToken;
   }
 
@@ -58,6 +62,6 @@ public class RefreshTokenBasedTokenProvider extends AccessTokenProvider {
   protected AzureADToken refreshToken() throws IOException {
     LOG.debug("AADToken: refreshing refresh-token based token");
     return AzureADAuthenticator
-        .getTokenUsingRefreshToken(authEndpoint, clientId, refreshToken);
+        .getTokenUsingRefreshToken(authEndpoint, clientId, clientSecret, refreshToken);
   }
 }


### PR DESCRIPTION
### Description of PR

Enforcing public client is a bad idea. We should not weaker our software just so the hadoop connector is able to refresh the token.
Therefore the idea would be to support both public and confidential OAuth2 client.

The fix is pretty straight forward, it consist of transiting the client secret to the azure refresh token grant flow and inject it into the request if present.

### How was this patch tested?

Not yet, will see how I can test it quickly on our side with a patch.

### For code changes:

- [ x ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?


