### PR TITLE
HDFS-16827. [RBF SBN] RouterStateIdContext shouldn't update the ResponseState if client doesn't use ObserverReadProxyProvider

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -119,6 +119,7 @@ import org.apache.hadoop.security.authorize.ServiceAuthorizationManager;
 import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.SecretManager.InvalidToken;
 import org.apache.hadoop.security.token.TokenIdentifier;
+import org.apache.hadoop.thirdparty.protobuf.AbstractMessageLite;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.ProtoUtil;
 import org.apache.hadoop.util.StringUtils;
@@ -153,6 +154,7 @@ public abstract class Server {
   private ExceptionsHandler exceptionsHandler = new ExceptionsHandler();
   private Tracer tracer;
   private AlignmentContext alignmentContext;
+  private static final ByteString EMPTY_BYTE_STRING = ByteString.newOutput().toByteString();
   /**
    * Logical name of the server used in metrics and monitor.
    */
@@ -939,7 +941,7 @@ public abstract class Server {
     private boolean isCallCoordinated;
     // Serialized RouterFederatedStateProto message to
     // store last seen states for multiple namespaces.
-    private ByteString federatedNamespaceState;
+    private ByteString federatedNamespaceState = null;
 
     Call() {
       this(RpcConstants.INVALID_CALL_ID, RpcConstants.INVALID_RETRY_COUNT,
@@ -2881,6 +2883,9 @@ public abstract class Server {
             call.setClientStateId(stateId);
             if (header.hasRouterFederatedState()) {
               call.setFederatedNamespaceState(header.getRouterFederatedState());
+            } else if (header.hasStateId()) {
+              // Only used to determine whether to return federatedNamespaceState.
+              call.setFederatedNamespaceState(EMPTY_BYTE_STRING);
             }
           }
         } catch (IOException ioe) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -119,7 +119,6 @@ import org.apache.hadoop.security.authorize.ServiceAuthorizationManager;
 import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.SecretManager.InvalidToken;
 import org.apache.hadoop.security.token.TokenIdentifier;
-import org.apache.hadoop.thirdparty.protobuf.AbstractMessageLite;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.ProtoUtil;
 import org.apache.hadoop.util.StringUtils;
@@ -2885,7 +2884,7 @@ public abstract class Server {
           if (header.hasRouterFederatedState()) {
             call.setFederatedNamespaceState(header.getRouterFederatedState());
           } else if (header.hasStateId()) {
-            // Only used to determine whether to return federatedNamespaceState.
+            // Set one empty FederatedNamespaceState to identify the client want to get stateId.
             call.setFederatedNamespaceState(EMPTY_BYTE_STRING);
           }
         } catch (IOException ioe) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -2884,7 +2884,7 @@ public abstract class Server {
           if (header.hasRouterFederatedState()) {
             call.setFederatedNamespaceState(header.getRouterFederatedState());
           } else if (header.hasStateId()) {
-            // Set one empty FederatedNamespaceState to identify the client want to get stateId.
+            // Set one empty FederatedNamespaceState to identify the client wants to get stateId.
             call.setFederatedNamespaceState(EMPTY_BYTE_STRING);
           }
         } catch (IOException ioe) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -2881,12 +2881,12 @@ public abstract class Server {
             stateId = alignmentContext.receiveRequestState(
                 header, getMaxIdleTime());
             call.setClientStateId(stateId);
-            if (header.hasRouterFederatedState()) {
-              call.setFederatedNamespaceState(header.getRouterFederatedState());
-            } else if (header.hasStateId()) {
-              // Only used to determine whether to return federatedNamespaceState.
-              call.setFederatedNamespaceState(EMPTY_BYTE_STRING);
-            }
+          }
+          if (header.hasRouterFederatedState()) {
+            call.setFederatedNamespaceState(header.getRouterFederatedState());
+          } else if (header.hasStateId()) {
+            // Only used to determine whether to return federatedNamespaceState.
+            call.setFederatedNamespaceState(EMPTY_BYTE_STRING);
           }
         } catch (IOException ioe) {
           throw new RpcServerException("Processing RPC request caught ", ioe);

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ClientGSIContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ClientGSIContext.java
@@ -88,10 +88,9 @@ public class ClientGSIContext implements AlignmentContext {
    */
   @Override
   public synchronized void updateRequestState(RpcRequestHeaderProto.Builder header) {
-    if (lastSeenStateId.get() != Long.MIN_VALUE) {
+    if (routerFederatedState == null) {
       header.setStateId(lastSeenStateId.get());
-    }
-    if (routerFederatedState != null) {
+    } else {
       header.setRouterFederatedState(routerFederatedState);
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterStateIdContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterStateIdContext.java
@@ -127,9 +127,18 @@ class RouterStateIdContext implements AlignmentContext {
     return clientStateID;
   }
 
+  /**
+   * @return true if the federatedNamespaceState of current request is not null, else false.
+   */
+  private boolean shouldUpdateResponseState() {
+    Server.Call call = Server.getCurCall().get();
+    return call != null && call.getFederatedNamespaceState() != null;
+  }
+
   @Override
   public void updateResponseState(RpcResponseHeaderProto.Builder header) {
-    if (namespaceIdMap.size() <= maxSizeOfFederatedStateToPropagate) {
+    if (namespaceIdMap.size() <= maxSizeOfFederatedStateToPropagate
+        && shouldUpdateResponseState()) {
       setResponseHeaderState(header);
     }
   }


### PR DESCRIPTION
### Description of PR

[HDFS-16827](https://issues.apache.org/jira/browse/HDFS-16827)

RouterStateIdContext shouldn't update the ResponseState if client doesn't use ObserverReadProxyProvider. 

