### PR TITLE
YARN-11367. [Federation] Fix DefaultRequestInterceptorREST Client NPE.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/AbstractRESTRequestInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/AbstractRESTRequestInterceptor.java
@@ -92,12 +92,15 @@ public abstract class AbstractRESTRequestInterceptor
     return this.nextInterceptor;
   }
 
+  /**
+   * Set User information.
+   *
+   * If the username is empty, we will use the Yarn Router user directly.
+   * Do not create a proxy user if user name matches the user name on current UGI.
+   * @param userName userName.
+   */
   private void setupUser(final String userName) {
     try {
-      /**
-       * If the username is empty, we will use the Yarn Router user directly.
-       * Do not create a proxy user if user name matches the user name on current UGI.
-       */
       if (userName == null || userName.isEmpty()) {
         user = UserGroupInformation.getCurrentUser();
       } else if (UserGroupInformation.isSecurityEnabled()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/AbstractRESTRequestInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/AbstractRESTRequestInterceptor.java
@@ -92,14 +92,15 @@ public abstract class AbstractRESTRequestInterceptor
     return this.nextInterceptor;
   }
 
-  private void setupUser(String userName) {
+  private void setupUser(final String userName) {
     try {
-      if(userName == null || userName.isEmpty()){
-        // Yarn Router user
+      /**
+       * If the username is empty, we will use the Yarn Router user directly.
+       * Do not create a proxy user if user name matches the user name on current UGI.
+       */
+      if (userName == null || userName.isEmpty()) {
         user = UserGroupInformation.getCurrentUser();
       } else if (UserGroupInformation.isSecurityEnabled()) {
-        // Do not create a proxy user if user name matches the user name on
-        // current UGI
         user = UserGroupInformation.createProxyUser(userName, UserGroupInformation.getLoginUser());
       } else if (userName.equalsIgnoreCase(UserGroupInformation.getCurrentUser().getUserName())) {
         user = UserGroupInformation.getCurrentUser();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/AbstractRESTRequestInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/AbstractRESTRequestInterceptor.java
@@ -19,6 +19,10 @@
 package org.apache.hadoop.yarn.server.router.webapp;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
+
+import java.io.IOException;
 
 /**
  * Extends the RequestInterceptor class and provides common functionality which
@@ -29,6 +33,7 @@ public abstract class AbstractRESTRequestInterceptor
 
   private Configuration conf;
   private RESTRequestInterceptor nextInterceptor;
+  private UserGroupInformation user = null;
 
   /**
    * Sets the {@link RESTRequestInterceptor} in the chain.
@@ -62,9 +67,10 @@ public abstract class AbstractRESTRequestInterceptor
    * Initializes the {@link RESTRequestInterceptor}.
    */
   @Override
-  public void init(String user) {
+  public void init(String userName) {
+    setupUser(userName);
     if (this.nextInterceptor != null) {
-      this.nextInterceptor.init(user);
+      this.nextInterceptor.init(userName);
     }
   }
 
@@ -86,4 +92,31 @@ public abstract class AbstractRESTRequestInterceptor
     return this.nextInterceptor;
   }
 
+  private void setupUser(String userName) {
+    try {
+      if(userName == null || userName.isEmpty()){
+        // Yarn Router user
+        user = UserGroupInformation.getCurrentUser();
+      } else if (UserGroupInformation.isSecurityEnabled()) {
+        // Do not create a proxy user if user name matches the user name on
+        // current UGI
+        user = UserGroupInformation.createProxyUser(userName, UserGroupInformation.getLoginUser());
+      } else if (userName.equalsIgnoreCase(UserGroupInformation.getCurrentUser().getUserName())) {
+        user = UserGroupInformation.getCurrentUser();
+      } else {
+        user = UserGroupInformation.createProxyUser(userName,
+            UserGroupInformation.getCurrentUser());
+      }
+    } catch (IOException e) {
+      String message = "Error while creating Router RMAdmin Service for user:";
+      if (user != null) {
+        message += ", user: " + user;
+      }
+      throw new YarnRuntimeException(message, e);
+    }
+  }
+
+  public UserGroupInformation getUser() {
+    return user;
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/DefaultRequestInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/DefaultRequestInterceptorREST.java
@@ -608,7 +608,7 @@ public class DefaultRequestInterceptorREST
   public Client getClient() {
     return client;
   }
-  
+
   @Override
   public NodeLabelsInfo getRMNodeLabels(HttpServletRequest hsr) {
     return RouterWebServiceUtil.genericForward(webAppAddress, hsr,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/DefaultRequestInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/DefaultRequestInterceptorREST.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Response;
 
 import com.sun.jersey.api.client.Client;
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.security.authorize.AuthorizationException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
@@ -601,5 +602,10 @@ public class DefaultRequestInterceptorREST
             RMWSConsts.RM_WEB_SERVICE_PATH + "/" + RMWSConsts.CONTAINERS + "/"
                 + containerId + "/" + RMWSConsts.SIGNAL + "/" + command, null,
             null, getConf(), client);
+  }
+
+  @VisibleForTesting
+  public Client getClient() {
+    return client;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
@@ -239,7 +239,8 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
           .isAssignableFrom(interceptorClass)) {
         interceptorInstance = (DefaultRequestInterceptorREST) ReflectionUtils
             .newInstance(interceptorClass, conf);
-
+        String userName = getUser().getUserName();
+        interceptorInstance.init(userName);
       } else {
         throw new YarnRuntimeException(
             "Class: " + interceptorClassName + " not instance of "

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
@@ -152,6 +152,9 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
 
   @Override
   public void init(String user) {
+
+    super.init(user);
+
     federationFacade = FederationStateStoreFacade.getInstance();
     rand = new Random();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
@@ -1257,4 +1257,23 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     when(mockHsr.getUserPrincipal()).thenReturn(principal);
     return mockHsr;
   }
+
+  @Test
+  public void testCheckFederationInterceptorRESTClient() {
+    SubClusterId subClusterId = SubClusterId.newInstance("SC-1");
+    String webAppSocket = "SC-1:WebAddress";
+    String webAppAddress = "http://" + webAppSocket;
+
+    Configuration configuration = new Configuration();
+    FederationInterceptorREST rest = new FederationInterceptorREST();
+    rest.setConf(configuration);
+    rest.init("router");
+
+    DefaultRequestInterceptorREST interceptorREST =
+        rest.getOrCreateInterceptorForSubCluster(subClusterId, webAppSocket);
+
+    Assert.assertNotNull(interceptorREST);
+    Assert.assertNotNull(interceptorREST.getClient());
+    Assert.assertEquals(webAppAddress, interceptorREST.getWebAppAddress());
+  }
 }


### PR DESCRIPTION
JIRA: YARN-11367. [Federation] Fix DefaultRequestInterceptorREST Client NPE.

[YARN-8529](https://issues.apache.org/jira/browse/YARN-8529). Add timeout to RouterWebServiceUtil#invokeRMWebService.

This JIRA only considers the case of Create InterceptorChain, and initializes the client in the DefaultRequestInterceptorREST#init method

```
@Override
public void init(String user) {
  webAppAddress = WebAppUtils.getRMWebAppURLWithScheme(getConf());
  client = RouterWebServiceUtil.createJerseyClient(getConf());
} 
```

However, FederationInterceptorREST#createInterceptorForSubCluster will create DefaultRequestInterceptorREST of different SubClusters. This part does not initialize the Client, resulting in NPE when calling.
```
private DefaultRequestInterceptorREST createInterceptorForSubCluster(
    SubClusterId subClusterId, String webAppAddress) {

  final Configuration conf = this.getConf();

  String interceptorClassName = conf.get(
      YarnConfiguration.ROUTER_WEBAPP_DEFAULT_INTERCEPTOR_CLASS,
      YarnConfiguration.DEFAULT_ROUTER_WEBAPP_DEFAULT_INTERCEPTOR_CLASS);
  DefaultRequestInterceptorREST interceptorInstance = null;
  try {
    Class<?> interceptorClass = conf.getClassByName(interceptorClassName);
    if (DefaultRequestInterceptorREST.class
        .isAssignableFrom(interceptorClass)) {
      interceptorInstance = (DefaultRequestInterceptorREST) ReflectionUtils
          .newInstance(interceptorClass, conf);

    } else {
      throw new YarnRuntimeException(
          "Class: " + interceptorClassName + " not instance of "
              + DefaultRequestInterceptorREST.class.getCanonicalName());
    }
  } catch (ClassNotFoundException e) {
    throw new YarnRuntimeException(
        "Could not instantiate ApplicationMasterRequestInterceptor: "
            + interceptorClassName,
        e);
  }

  String webAppAddresswithScheme =
      WebAppUtils.getHttpSchemePrefix(this.getConf()) + webAppAddress;
  interceptorInstance.setWebAppAddress(webAppAddresswithScheme);
  interceptorInstance.setSubClusterId(subClusterId);
  // Missing initialization DefaultRequestInterceptorREST#Client Code  
  interceptors.put(subClusterId, interceptorInstance);
  return interceptorInstance;
} 
```