### PR TITLE
HDFS-16833. NameNode should log internal EC blocks instead of the EC block group when it receives block reports.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -3616,7 +3616,7 @@ public class BlockManager implements BlockStatsMXBean {
     if (storedBlock == null || storedBlock.isDeleted()) {
       // If this block does not belong to anyfile, then we are done.
       blockLog.debug("BLOCK* addStoredBlock: {} on {} size {} but it does not belong to any file",
-          block, node, block.getNumBytes());
+          reportedBlock, node, reportedBlock.getNumBytes());
       // we could add this block to invalidate set of this datanode.
       // it will happen in next block report otherwise.
       return block;
@@ -3631,12 +3631,12 @@ public class BlockManager implements BlockStatsMXBean {
           (node.isDecommissioned() || node.isDecommissionInProgress()) ? 0 : 1;
       if (logEveryBlock) {
         blockLog.info("BLOCK* addStoredBlock: {} is added to {} (size={})",
-            node, storedBlock, storedBlock.getNumBytes());
+            node, reportedBlock, reportedBlock.getNumBytes());
       }
     } else if (result == AddBlockResult.REPLACED) {
       curReplicaDelta = 0;
       blockLog.warn("BLOCK* addStoredBlock: block {} moved to storageType " +
-          "{} on node {}", storedBlock, storageInfo.getStorageType(), node);
+          "{} on node {}", reportedBlock, storageInfo.getStorageType(), node);
     } else {
       // if the same block is added again and the replica was corrupt
       // previously because of a wrong gen stamp, remove it from the
@@ -3646,8 +3646,8 @@ public class BlockManager implements BlockStatsMXBean {
       curReplicaDelta = 0;
       if (blockLog.isDebugEnabled()) {
         blockLog.debug("BLOCK* addStoredBlock: Redundant addStoredBlock request"
-                + " received for {} on node {} size {}", storedBlock, node,
-            storedBlock.getNumBytes());
+                + " received for {} on node {} size {}", reportedBlock, node,
+            reportedBlock.getNumBytes());
       }
     }
 


### PR DESCRIPTION
### Description of PR
JIRA: HDFS-16833
NameNode should log internal EC blocks instead of the EC block group when it receives block reports.

Before this PR
```
// replica file
2022-11-04 10:38:20,124 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11007 is added to blk_1073741825_1001 (size=1024)
2022-11-04 10:38:20,126 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11004 is added to blk_1073741825_1001 (size=1024)
2022-11-04 10:38:20,126 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11001 is added to blk_1073741825_1001 (size=1024)

// ec file
2022-11-04 10:39:02,376 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11008 is added to blk_-9223372036854775792_1002 (size=0)
2022-11-04 10:39:02,381 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11000 is added to blk_-9223372036854775792_1002 (size=0)
2022-11-04 10:39:02,383 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11001 is added to blk_-9223372036854775792_1002 (size=0)
2022-11-04 10:39:02,385 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11007 is added to blk_-9223372036854775792_1002 (size=0)
2022-11-04 10:39:02,387 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11009 is added to blk_-9223372036854775792_1002 (size=0)
2022-11-04 10:39:02,389 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11004 is added to blk_-9223372036854775792_1002 (size=0)
2022-11-04 10:39:02,390 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11006 is added to blk_-9223372036854775792_1002 (size=0)
2022-11-04 10:39:02,393 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11002 is added to blk_-9223372036854775792_1002 (size=0)
2022-11-04 10:39:02,395 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11003 is added to blk_-9223372036854775792_1002 (size=0)
```

After this PR
```
// replica file
2022-11-04 10:46:23,321 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11008 is added to blk_1073741825_1001 (size=1024)
2022-11-04 10:46:23,324 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11002 is added to blk_1073741825_1001 (size=1024)
2022-11-04 10:46:23,325 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11003 is added to blk_1073741825_1001 (size=1024)

// ec file
2022-11-04 10:47:53,469 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11009 is added to blk_-9223372036854775792_1002 (size=4194304)
2022-11-04 10:47:53,473 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11002 is added to blk_-9223372036854775791_1002 (size=4194304)
2022-11-04 10:47:53,474 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11006 is added to blk_-9223372036854775790_1002 (size=4194304)
2022-11-04 10:47:53,483 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11008 is added to blk_-9223372036854775789_1002 (size=4194304)
2022-11-04 10:47:53,485 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11003 is added to blk_-9223372036854775788_1002 (size=4194304)
2022-11-04 10:47:53,486 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11004 is added to blk_-9223372036854775787_1002 (size=4194304)
2022-11-04 10:47:53,488 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11001 is added to blk_-9223372036854775786_1002 (size=4194304)
2022-11-04 10:47:53,490 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11007 is added to blk_-9223372036854775785_1002 (size=4194304)
2022-11-04 10:47:53,491 [Block report processor] INFO  BlockStateChange (BlockManager.java:addStoredBlock(3633)) - BLOCK* addStoredBlock: 127.0.0.1:11000 is added to blk_-9223372036854775784_1002 (size=4194304)
```

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?

