### PR TITLE
HADOOP-18521. ABFS ReadBufferManager must not reuse in-progress buffers

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
@@ -422,6 +422,36 @@ public final class StreamStatisticNames {
       = "stream_read_prefetch_operations";
 
   /**
+   * Count of prefetch blocks used.
+   */
+  public static final String STREAM_READ_PREFETCH_BLOCKS_USED
+      = "stream_read_prefetch_blocks_used";
+  /**
+   * Count of prefetch bytes used.
+   */
+  public static final String STREAM_READ_PREFETCH_BYTES_USED
+      = "stream_read_prefetch_bytes_used";
+
+  /**
+   * Count of prefetch blocks discarded unused: {@value}.
+   */
+  public static final String STREAM_READ_PREFETCH_BLOCKS_DISCARDED
+      = "stream_read_prefetch_blocks_discarded";
+
+  /**
+   * Count of prefetch bytes discarded from unused blocks: {@value}.
+   * May or may not include bytes from blocks which were partially accessed.
+   */
+  public static final String STREAM_READ_PREFETCH_BYTES_DISCARDED
+      = "stream_read_prefetch_bytes_discarded";
+
+  /**
+   * Count of prefetch blocks evicted, used or unused: {@value}.
+   */
+  public static final String STREAM_READ_PREFETCH_BLOCKS_EVICTED
+      = "stream_read_prefetch_blocks_evicted";
+
+  /**
    * Total number of block in disk cache.
    */
   public static final String STREAM_READ_BLOCKS_IN_FILE_CACHE

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -31,7 +31,6 @@ import java.time.Duration;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.Optional;
@@ -46,6 +45,7 @@ import java.util.concurrent.Future;
 import javax.annotation.Nullable;
 
 import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
 import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -291,7 +291,7 @@ public class AzureBlobFileSystem extends FileSystem
     LOG.debug("AzureBlobFileSystem.openFileWithOptions path: {}", path);
     AbstractFSBuilderImpl.rejectUnknownMandatoryKeys(
         parameters.getMandatoryKeys(),
-        Collections.emptySet(),
+        ConfigurationKeys.KNOWN_OPENFILE_KEYS,
         "for " + path);
     return LambdaUtils.eval(
         new CompletableFuture<>(), () ->
@@ -1628,6 +1628,7 @@ public class AzureBlobFileSystem extends FileSystem
     case CommonPathCapabilities.FS_PERMISSIONS:
     case CommonPathCapabilities.FS_APPEND:
     case CommonPathCapabilities.ETAGS_AVAILABLE:
+    case ConfigurationKeys.FS_AZURE_CAPABILITY_PREFETCH_SAFE: // safe from buffer sharing:
       return true;
 
     case CommonPathCapabilities.ETAGS_PRESERVED_IN_RENAME:

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -18,9 +18,16 @@
 
 package org.apache.hadoop.fs.azurebfs.constants;
 
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.FileSystem;
+
+import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_STANDARD_OPTIONS;
 
 /**
  * Responsible to keep all the Azure Blob File System configurations keys in Hadoop configuration file.
@@ -259,5 +266,27 @@ public final class ConfigurationKeys {
    * @see FileSystem#openFile(org.apache.hadoop.fs.Path)
    */
   public static final String FS_AZURE_BUFFERED_PREAD_DISABLE = "fs.azure.buffered.pread.disable";
+
+  /**
+   * Has the ReadBufferManager fix of HADOOP-18521 been applied?
+   * This can be queried on {@code hasCapability()} and
+   * on the filesystem {@code hasPathCapability()} probes.
+   */
+  public static final String FS_AZURE_CAPABILITY_PREFETCH_SAFE = "fs.azure.capability.prefetch.safe";
+
+  /**
+   * Known keys for openFile(), including the standard ones.
+   */
+  public static final Set<String> KNOWN_OPENFILE_KEYS;
+
+  static {
+    Set<String> collect = Stream.of(
+            FS_AZURE_CAPABILITY_PREFETCH_SAFE,
+            FS_AZURE_BUFFERED_PREAD_DISABLE)
+        .collect(Collectors.toSet());
+    collect.addAll(FS_OPTION_OPENFILE_STANDARD_OPTIONS);
+    KNOWN_OPENFILE_KEYS = Collections.unmodifiableSet(collect);
+  }
+
   private ConfigurationKeys() {}
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatistics.java
@@ -19,8 +19,8 @@
 package org.apache.hadoop.fs.azurebfs.services;
 
 import org.apache.hadoop.classification.InterfaceStability;
-import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 
 /**
  * Interface for statistics for the AbfsInputStream.
@@ -99,7 +99,7 @@ public interface AbfsInputStreamStatistics extends IOStatisticsSource {
    * Get the IOStatisticsStore instance from AbfsInputStreamStatistics.
    * @return instance of IOStatisticsStore which extends IOStatistics.
    */
-  IOStatistics getIOStatistics();
+  IOStatisticsStore getIOStatistics();
 
   /**
    * Makes the string of all the AbfsInputStream statistics.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatisticsImpl.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatisticsImpl.java
@@ -20,13 +20,20 @@ package org.apache.hadoop.fs.azurebfs.services;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 import org.apache.hadoop.classification.VisibleForTesting;
 
+import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsToPrettyString;
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.ACTION_HTTP_GET_REQUEST;
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.SUFFIX_MEAN;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_ACTIVE_PREFETCH_OPERATIONS;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PREFETCH_BLOCKS_DISCARDED;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PREFETCH_BLOCKS_EVICTED;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PREFETCH_BLOCKS_USED;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PREFETCH_BYTES_DISCARDED;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PREFETCH_BYTES_USED;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PREFETCH_OPERATIONS;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.iostatisticsStore;
 
 /**
@@ -48,9 +55,15 @@ public class AbfsInputStreamStatisticsImpl
           StreamStatisticNames.BYTES_READ_BUFFER,
           StreamStatisticNames.REMOTE_READ_OP,
           StreamStatisticNames.READ_AHEAD_BYTES_READ,
-          StreamStatisticNames.REMOTE_BYTES_READ
-          )
-      .withDurationTracking(ACTION_HTTP_GET_REQUEST)
+          StreamStatisticNames.REMOTE_BYTES_READ,
+          STREAM_READ_PREFETCH_BLOCKS_USED,
+          STREAM_READ_PREFETCH_BYTES_USED,
+          STREAM_READ_PREFETCH_BLOCKS_DISCARDED,
+          STREAM_READ_PREFETCH_BYTES_DISCARDED,
+          STREAM_READ_PREFETCH_BLOCKS_EVICTED)
+      .withGauges(STREAM_READ_ACTIVE_PREFETCH_OPERATIONS)
+      .withDurationTracking(ACTION_HTTP_GET_REQUEST,
+          STREAM_READ_PREFETCH_OPERATIONS)
       .build();
 
   /* Reference to the atomic counter for frequently updated counters to avoid
@@ -183,7 +196,7 @@ public class AbfsInputStreamStatisticsImpl
    * @return IOStatisticsStore instance which extends IOStatistics.
    */
   @Override
-  public IOStatistics getIOStatistics() {
+  public IOStatisticsStore getIOStatistics() {
     return ioStatisticsStore;
   }
 
@@ -270,7 +283,7 @@ public class AbfsInputStreamStatisticsImpl
   public String toString() {
     final StringBuilder sb = new StringBuilder(
         "StreamStatistics{");
-    sb.append(ioStatisticsStore.toString());
+    sb.append(ioStatisticsToPrettyString(ioStatisticsStore));
     sb.append('}');
     return sb.toString();
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ReadBufferStreamOperations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ReadBufferStreamOperations.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
+import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
+
+/**
+ * Interface which is required for read buffer stream
+ * calls.
+ * Extracted from {@code AbfsInputStream} to make testing
+ * easier and to isolate what operations the read buffer
+ * makes of the streams using it.
+ */
+interface ReadBufferStreamOperations {
+
+  /**
+   * Read a block from the store.
+   * @param position position in file
+   * @param b destination buffer.
+   * @param offset offset in buffer
+   * @param length length of read
+   * @param tracingContext trace context
+   * @return count of bytes read.
+   * @throws IOException failure.
+   */
+  int readRemote(long position,
+      byte[] b,
+      int offset,
+      int length,
+      TracingContext tracingContext) throws IOException;
+
+  /**
+   * Is the stream closed?
+   * This must be thread safe as prefetch operations in
+   * different threads probe this before closure.
+   * @return true if the stream has been closed.
+   */
+  boolean isClosed();
+
+  String getStreamID();
+
+  IOStatisticsStore getIOStatistics();
+
+  /**
+   * Get the stream path as a string.
+   * @return path string.
+   */
+  String getPath();
+
+
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ReadBufferWorker.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ReadBufferWorker.java
@@ -21,13 +21,25 @@ package org.apache.hadoop.fs.azurebfs.services;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.azurebfs.contracts.services.ReadBufferStatus;
+import org.apache.hadoop.fs.statistics.DurationTracker;
+
+import static org.apache.hadoop.util.Preconditions.checkState;
 
 class ReadBufferWorker implements Runnable {
 
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ReadBufferWorker.class);
+
   protected static final CountDownLatch UNLEASH_WORKERS = new CountDownLatch(1);
   private int id;
+
+  private boolean doneReadingInvoked;
 
   ReadBufferWorker(final int id) {
     this.id = id;
@@ -61,27 +73,93 @@ class ReadBufferWorker implements Runnable {
         return;
       }
       if (buffer != null) {
-        try {
-          // do the actual read, from the file.
-          int bytesRead = buffer.getStream().readRemote(
-              buffer.getOffset(),
-              buffer.getBuffer(),
-              0,
-              // If AbfsInputStream was created with bigger buffer size than
-              // read-ahead buffer size, make sure a valid length is passed
-              // for remote read
-              Math.min(buffer.getRequestedLength(), buffer.getBuffer().length),
-                  buffer.getTracingContext());
-
-          bufferManager.doneReading(buffer, ReadBufferStatus.AVAILABLE, bytesRead);  // post result back to ReadBufferManager
-        } catch (IOException ex) {
-          buffer.setErrException(ex);
-          bufferManager.doneReading(buffer, ReadBufferStatus.READ_FAILED, 0);
-        } catch (Exception ex) {
-          buffer.setErrException(new PathIOException(buffer.getStream().getPath(), ex));
-          bufferManager.doneReading(buffer, ReadBufferStatus.READ_FAILED, 0);
-        }
+        fetchBuffer(bufferManager, buffer);
       }
     }
+  }
+
+  /**
+   * Fetch the data for the buffer.
+   * @param bufferManager buffer manager.
+   * @param buffer the buffer to read in.
+   */
+  @VisibleForTesting
+  void fetchBuffer(final ReadBufferManager bufferManager, final ReadBuffer buffer) {
+    LOGGER.trace("Reading {}", buffer);
+    doneReadingInvoked = false;
+    // Stop network call if stream is closed
+    if (postFailureWhenStreamClosed(bufferManager, buffer)) {
+      // stream closed before the HTTP request was initiated.
+      // Immediately move to the next request in the queue.
+      return;
+    }
+    checkState(buffer.hasIndexedBuffer(),
+        "ReadBuffer buffer has no allocated buffer to read into: %s",
+        buffer);
+    // input stream is updated with count/duration of prefetching
+    DurationTracker tracker = buffer.trackPrefetchOperation();
+    try {
+      // do the actual read, from the file.
+      int bytesRead = buffer.getStream().readRemote(
+          buffer.getOffset(),
+          buffer.getBuffer(),
+          0,
+          // If AbfsInputStream was created with bigger buffer size than
+          // read-ahead buffer size, make sure a valid length is passed
+          // for remote read
+          Math.min(buffer.getRequestedLength(), buffer.getBuffer().length),
+          buffer.getTracingContext());
+      LOGGER.trace("Read {} bytes", bytesRead);
+
+      // Update failure to completed list if stream is closed
+      if (!postFailureWhenStreamClosed(bufferManager, buffer)) {
+        // post result back to ReadBufferManager
+        doneReading(bufferManager, buffer, ReadBufferStatus.AVAILABLE, bytesRead);
+      }
+      tracker.close();
+    } catch (Exception ex) {
+      tracker.failed();
+      IOException ioe = ex instanceof IOException
+          ? (IOException) ex
+          : new PathIOException(buffer.getStream().getPath(), ex);
+      buffer.setErrException(ioe);
+      LOGGER.debug("prefetch failure for {}", buffer, ex);
+
+      // if doneReading hasn't already been called for this iteration, call it.
+      // the check ensures that any exception raised in doneReading() doesn't trigger
+      // a second attempt.
+      if (!doneReadingInvoked) {
+        doneReading(bufferManager, buffer, ReadBufferStatus.READ_FAILED, 0);
+      }
+    }
+  }
+
+  /**
+   * Check for the owning stream being closed; if so it
+   * reports it to the buffer manager and then returns "true".
+   * @param bufferManager buffer manager
+   * @param buffer buffer to review
+   * @return true if the stream is closed
+   */
+  private boolean postFailureWhenStreamClosed(
+      ReadBufferManager bufferManager,
+      ReadBuffer buffer) {
+
+    // When stream is closed report failure to be picked by eviction
+    if (buffer.isStreamClosed()) {
+      LOGGER.debug("Stream closed; failing read");
+      // Fail read
+      doneReading(bufferManager, buffer, ReadBufferStatus.READ_FAILED, 0);
+      return true;
+    }
+    return false;
+  }
+
+  private void doneReading(final ReadBufferManager bufferManager,
+      final ReadBuffer buffer,
+      final ReadBufferStatus result,
+      final int bytesActuallyRead) {
+    doneReadingInvoked = true;
+    bufferManager.doneReading(buffer, result, bytesActuallyRead);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsInputStream.java
@@ -21,25 +21,40 @@ package org.apache.hadoop.fs.azurebfs.services;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
+import java.util.concurrent.ExecutionException;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FutureDataInputStreamBuilder;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
 import org.apache.hadoop.fs.azurebfs.AbstractAbfsIntegrationTest;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
-import org.junit.Test;
+import org.apache.hadoop.fs.impl.OpenFileParameters;
 
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_READ_AHEAD_QUEUE_DEPTH;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.ONE_MB;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class ITestAbfsInputStream extends AbstractAbfsIntegrationTest {
 
@@ -255,4 +270,120 @@ public class ITestAbfsInputStream extends AbstractAbfsIntegrationTest {
     assertEquals(0, abfsInputStream.getLimit());
     assertEquals(0, abfsInputStream.getBCursor());
   }
+
+  private void writeBufferToNewFile(Path testFile, byte[] buffer) throws IOException {
+    AzureBlobFileSystem fs = getFileSystem();
+    fs.create(testFile);
+    FSDataOutputStream out = fs.append(testFile);
+    out.write(buffer);
+    out.close();
+  }
+
+  private void verifyOpenWithProvidedStatus(Path path, FileStatus fileStatus,
+      byte[] buf, AbfsRestOperationType source)
+      throws IOException, ExecutionException, InterruptedException {
+    byte[] readBuf = new byte[buf.length];
+    AzureBlobFileSystem fs = getFileSystem();
+    FutureDataInputStreamBuilder builder = fs.openFile(path);
+    builder.withFileStatus(fileStatus);
+    FSDataInputStream in = builder.build().get();
+    assertEquals(String.format(
+        "Open with fileStatus [from %s result]: Incorrect number of bytes read",
+        source), buf.length, in.read(readBuf));
+    assertArrayEquals(String
+        .format("Open with fileStatus [from %s result]: Incorrect read data",
+            source), readBuf, buf);
+  }
+
+  private void checkGetPathStatusCalls(Path testFile, FileStatus fileStatus,
+      AzureBlobFileSystemStore abfsStore, AbfsClient mockClient,
+      AbfsRestOperationType source, TracingContext tracingContext)
+      throws IOException {
+
+    // verify GetPathStatus not invoked when FileStatus is provided
+    abfsStore.openFileForRead(testFile, Optional
+        .ofNullable(new OpenFileParameters().withStatus(fileStatus)), null, tracingContext);
+    verify(mockClient, times(0).description((String.format(
+        "FileStatus [from %s result] provided, GetFileStatus should not be invoked",
+        source)))).getPathStatus(anyString(), anyBoolean(), any(TracingContext.class));
+
+    // verify GetPathStatus invoked when FileStatus not provided
+    abfsStore.openFileForRead(testFile,
+        Optional.empty(), null,
+        tracingContext);
+    verify(mockClient, times(1).description(
+        "GetPathStatus should be invoked when FileStatus not provided"))
+        .getPathStatus(anyString(), anyBoolean(), any(TracingContext.class));
+
+    Mockito.reset(mockClient); //clears invocation count for next test case
+  }
+
+  @Test
+  public void testOpenFileWithOptions() throws Exception {
+    AzureBlobFileSystem fs = getFileSystem();
+    String testFolder = "/testFolder";
+    Path smallTestFile = new Path(testFolder + "/testFile0");
+    Path largeTestFile = new Path(testFolder + "/testFile1");
+    fs.mkdirs(new Path(testFolder));
+    int readBufferSize = getConfiguration().getReadBufferSize();
+    byte[] smallBuffer = new byte[5];
+    byte[] largeBuffer = new byte[readBufferSize + 5];
+    new Random().nextBytes(smallBuffer);
+    new Random().nextBytes(largeBuffer);
+    writeBufferToNewFile(smallTestFile, smallBuffer);
+    writeBufferToNewFile(largeTestFile, largeBuffer);
+
+    FileStatus[] getFileStatusResults = {fs.getFileStatus(smallTestFile),
+        fs.getFileStatus(largeTestFile)};
+    FileStatus[] listStatusResults = fs.listStatus(new Path(testFolder));
+
+    // open with fileStatus from GetPathStatus
+    verifyOpenWithProvidedStatus(smallTestFile, getFileStatusResults[0],
+        smallBuffer, AbfsRestOperationType.GetPathStatus);
+    verifyOpenWithProvidedStatus(largeTestFile, getFileStatusResults[1],
+        largeBuffer, AbfsRestOperationType.GetPathStatus);
+
+    // open with fileStatus from ListStatus
+    verifyOpenWithProvidedStatus(smallTestFile, listStatusResults[0], smallBuffer,
+        AbfsRestOperationType.ListPaths);
+    verifyOpenWithProvidedStatus(largeTestFile, listStatusResults[1], largeBuffer,
+        AbfsRestOperationType.ListPaths);
+
+    // verify number of GetPathStatus invocations
+    AzureBlobFileSystemStore abfsStore = getAbfsStore(fs);
+    AbfsClient mockClient = spy(getAbfsClient(abfsStore));
+    setAbfsClient(abfsStore, mockClient);
+    TracingContext tracingContext = getTestTracingContext(fs, false);
+    checkGetPathStatusCalls(smallTestFile, getFileStatusResults[0],
+        abfsStore, mockClient, AbfsRestOperationType.GetPathStatus, tracingContext);
+    checkGetPathStatusCalls(largeTestFile, getFileStatusResults[1],
+        abfsStore, mockClient, AbfsRestOperationType.GetPathStatus, tracingContext);
+    checkGetPathStatusCalls(smallTestFile, listStatusResults[0],
+        abfsStore, mockClient, AbfsRestOperationType.ListPaths, tracingContext);
+    checkGetPathStatusCalls(largeTestFile, listStatusResults[1],
+        abfsStore, mockClient, AbfsRestOperationType.ListPaths, tracingContext);
+
+    // Verify with incorrect filestatus
+    getFileStatusResults[0].setPath(new Path("wrongPath"));
+    intercept(ExecutionException.class,
+        () -> verifyOpenWithProvidedStatus(smallTestFile,
+            getFileStatusResults[0], smallBuffer,
+            AbfsRestOperationType.GetPathStatus));
+  }
+
+  @Test
+  public void testDefaultReadaheadQueueDepth() throws Exception {
+    Configuration config = getRawConfiguration();
+    config.unset(FS_AZURE_READ_AHEAD_QUEUE_DEPTH);
+    AzureBlobFileSystem fs = getFileSystem(config);
+    Path testFile = path("/testFile");
+    fs.create(testFile).close();
+    FSDataInputStream in = fs.open(testFile);
+    Assertions.assertThat(
+            ((AbfsInputStream) in.getWrappedStream()).getReadAheadQueueDepth())
+        .describedAs("readahead queue depth should be set to default value 2")
+        .isEqualTo(2);
+    in.close();
+  }
+
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestReadBufferManager.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestReadBufferManager.java
@@ -1,0 +1,576 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import java.io.EOFException;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.assertj.core.api.AbstractLongAssert;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.fs.azurebfs.contracts.services.ReadBufferStatus;
+import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
+import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+import org.apache.hadoop.util.functional.FunctionRaisingIOE;
+
+import static org.apache.hadoop.fs.azurebfs.services.ReadBufferManager.NUM_BUFFERS;
+import static org.apache.hadoop.fs.azurebfs.services.ReadBufferManager.getBufferManager;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertThatStatisticCounter;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_ACTIVE_PREFETCH_OPERATIONS;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PREFETCH_BLOCKS_DISCARDED;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PREFETCH_BLOCKS_EVICTED;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PREFETCH_BLOCKS_USED;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PREFETCH_BYTES_DISCARDED;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PREFETCH_BYTES_USED;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PREFETCH_OPERATIONS;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.iostatisticsStore;
+import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+
+/**
+ * Unit tests for ReadBufferManager; uses stub ReadBufferStreamOperations
+ * to simulate failures, count statistics etc.
+ */
+public class TestReadBufferManager extends AbstractHadoopTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestReadBufferManager.class);
+
+  private ReadBufferManager bufferManager;
+
+  @Before
+  public void setup() throws Exception {
+    bufferManager = getBufferManager();
+  }
+
+  /**
+   * doneReading of a not in-progress ReadBuffer is an error.
+   */
+  @Test
+  public void testBufferNotInProgressList() throws Throwable {
+    ReadBuffer buffer = readBuffer(new StubReadBufferOperations());
+    intercept(IllegalStateException.class, () ->
+        bufferManager.doneReading(buffer, ReadBufferStatus.READ_FAILED, 0));
+  }
+
+  /**
+   * Create a read buffer.
+   * @param operations callbacks to use
+   * @return a buffer bonded to the operations, and with a countdown latch.
+   */
+  private static ReadBuffer readBuffer(final ReadBufferStreamOperations operations) {
+    final ReadBuffer buffer = new ReadBuffer();
+    buffer.setStream(operations);
+    buffer.setLatch(new CountDownLatch(1));
+    return buffer;
+  }
+
+  /**
+   * zero byte results are not considered successes, but not failures either.
+   */
+  @Test
+  public void testZeroByteRead() throws Throwable {
+    final StubReadBufferOperations operations = new StubReadBufferOperations();
+    operations.setBytesToRead(0);
+
+    ReadBuffer buffer = prefetch(operations, 0);
+
+    // buffer has its indexed buffer released and fields updated.
+    Assertions.assertThat(buffer)
+        .matches(b -> b.getStatus() == ReadBufferStatus.AVAILABLE, "buffer is available")
+        .matches(b -> !b.hasIndexedBuffer(), "no indexed buffer")
+        .matches(b -> b.getLength() == 0, "buffer is empty");
+
+    // even though it succeeded, it didn't return any data, so
+    // not placed on the completed list.
+    assertNotInCompletedList(buffer);
+  }
+
+  /**
+   * Returning a negative number is the same as a zero byte response.
+   */
+  @Test
+  public void testNegativeByteRead() throws Throwable {
+    final StubReadBufferOperations operations = new StubReadBufferOperations();
+    operations.setBytesToRead(-1);
+    ReadBuffer buffer = prefetch(operations, 0);
+
+    // buffer has its indexed buffer released and fields updated.
+    Assertions.assertThat(buffer)
+        .matches(b -> b.getStatus() == ReadBufferStatus.AVAILABLE, "buffer is available")
+        .matches(b -> !b.hasIndexedBuffer(), "no indexed buffer")
+        .matches(b -> b.getLength() == 0, "buffer is empty");
+
+    // even though it succeeded, it didn't return any data, so
+    // not placed on the completed list.
+    assertNotInCompletedList(buffer);
+  }
+
+  /**
+   * Queue a prefetch against the passed in stream operations, then block
+   * awaiting its actual execution.
+   * @param operations operations to use
+   * @param offset offset of the read.
+   * @return the completed buffer.
+   * @throws InterruptedException await was interrupted
+   */
+  private ReadBuffer prefetch(final ReadBufferStreamOperations operations, final int offset)
+      throws InterruptedException {
+    return awaitDone(bufferManager.queueReadAhead(operations, offset, 1, null));
+  }
+
+  /**
+   * read raises an IOE; must be caught, saved without wrapping to the ReadBuffer,
+   * which is declared {@code READ_FAILED}.
+   * The buffer is freed but it is still placed in the completed list.
+   * Evictions don't find it (no buffer to return) but will silently
+   * evict() it when it is out of date.
+   */
+  @Test
+  public void testIOEInRead() throws Throwable {
+
+    final StubReadBufferOperations operations = new StubReadBufferOperations();
+    final EOFException ioe = new EOFException("eof");
+    operations.exceptionToRaise = ioe;
+    ReadBuffer buffer = prefetch(operations, 0);
+
+    // buffer has its indexed buffer released and fields updated.
+    Assertions.assertThat(buffer)
+        .matches(b -> b.getStatus() == ReadBufferStatus.READ_FAILED, "buffer is failed")
+        .matches(b -> !b.hasIndexedBuffer(), "no indexed buffer")
+        .extracting(ReadBuffer::getErrException)
+        .isEqualTo(ioe);
+
+    // it is on the completed list for followup reads
+    assertInCompletedList(buffer);
+
+    // evict doesn't find it, as there is no useful buffer
+    Assertions.assertThat(bufferManager.callTryEvict())
+        .describedAs("evict() should not find failed buffer")
+        .isFalse();
+    assertInCompletedList(buffer);
+
+    // set the timestamp to be some time ago
+    buffer.setTimeStamp(1000);
+
+    // evict still doesn't find it
+    Assertions.assertThat(bufferManager.callTryEvict())
+        .describedAs("evict() should not find failed buffer")
+        .isFalse();
+
+    // but now it was evicted due to its age
+    assertNotInCompletedList(buffer);
+    operations.assertCounter(STREAM_READ_PREFETCH_BLOCKS_EVICTED)
+        .isEqualTo(1);
+  }
+
+  /**
+   * Stream is closed before the read; this should trigger failure before
+   * {@code readRemote()} is invoked.
+   * The stream state change does not invoke
+   * {@link ReadBufferManager#purgeBuffersForStream(ReadBufferStreamOperations)};
+   * success relies on ReadBufferWorker.
+   */
+  @Test
+  public void testClosedBeforeRead() throws Throwable {
+
+    final StubReadBufferOperations operations = new StubReadBufferOperations();
+    operations.setClosed(true);
+    // this exception won't get raised because the read was cancelled first
+    operations.exceptionToRaise = new EOFException("eof");
+
+    ReadBuffer buffer = prefetch(operations, 0);
+
+    // buffer has its indexed buffer released and fields updated.
+    Assertions.assertThat(buffer)
+        .matches(b -> b.getStatus() == ReadBufferStatus.READ_FAILED, "buffer is failed")
+        .matches(b -> !b.hasIndexedBuffer(), "no indexed buffer")
+        .extracting(ReadBuffer::getErrException)
+        .isNull();
+
+    // its on the completed list for followup reads
+    assertNotInCompletedList(buffer);
+  }
+
+  /**
+   * Stream is closed during the read; this should trigger failure.
+   * The stream state change does not invoke
+   * {@link ReadBufferManager#purgeBuffersForStream(ReadBufferStreamOperations)};
+   * success relies on ReadBufferWorker.
+   */
+  @Test
+  public void testClosedDuringRead() throws Throwable {
+
+    //  have a different handler for the read call.
+    final StubReadBufferOperations operations =
+        new StubReadBufferOperations((self) -> {
+          self.setClosed(true);
+          return 1;
+        });
+
+    ReadBuffer buffer = prefetch(operations, 0);
+
+    // buffer has its indexed buffer released and fields updated.
+    Assertions.assertThat(buffer)
+        .matches(b -> b.getStatus() == ReadBufferStatus.READ_FAILED, "buffer is failed")
+        .matches(b -> !b.hasIndexedBuffer(), "no indexed buffer")
+        .extracting(ReadBuffer::getErrException)
+        .isNull();
+
+    // its on the completed list for followup reads
+    assertNotInCompletedList(buffer);
+    operations.assertCounter(STREAM_READ_PREFETCH_BLOCKS_DISCARDED)
+        .isEqualTo(1);
+  }
+
+  /**
+   * When a stream is closed, all entries in the completed list are closed.
+   */
+  @Test
+  public void testStreamCloseEvictsCompleted() throws Throwable {
+    final StubReadBufferOperations operations = new StubReadBufferOperations();
+    operations.bytesToRead = 1;
+    // two successes
+    ReadBuffer buffer1 = prefetch(operations, 0);
+    ReadBuffer buffer2 = prefetch(operations, 1000);
+
+    // final read is a failure
+    operations.exceptionToRaise = new FileNotFoundException("/fnfe");
+    ReadBuffer failed = prefetch(operations, 2000);
+
+    List<ReadBuffer> buffers = Arrays.asList(buffer1, buffer2, failed);
+
+    // all buffers must be in the completed list
+    buffers.forEach(TestReadBufferManager::assertInCompletedList);
+
+    // xor for an exclusivity assertion.
+    // the read failed xor it succeeded with an indexed buffer.
+    Assertions.assertThat(buffers)
+        .allMatch(b ->
+            b.getStatus() == ReadBufferStatus.READ_FAILED
+            ^ b.hasIndexedBuffer(),
+            "either was failure or it has an indexed buffer but not both");
+
+    // now state that buffer 1 was read
+    buffer1.dataConsumedByStream(0, 1);
+    Assertions.assertThat(buffer1)
+        .matches(ReadBuffer::isAnyByteConsumed, "any byte consumed")
+        .matches(ReadBuffer::isFirstByteConsumed, "first byte consumed")
+        .matches(ReadBuffer::isLastByteConsumed, "last byte consumed");
+    operations.assertCounter(STREAM_READ_PREFETCH_BLOCKS_USED)
+        .isEqualTo(1);
+
+    operations.assertCounter(STREAM_READ_PREFETCH_BYTES_USED)
+        .isEqualTo(1);
+
+    // now tell buffer manager of the stream closure
+    operations.setClosed(true);
+    bufferManager.purgeBuffersForStream(operations);
+
+    // now the buffers are out the list
+    buffers.forEach(TestReadBufferManager::assertNotInCompletedList);
+    Assertions.assertThat(buffers)
+        .allMatch(b -> !b.hasIndexedBuffer(), "no indexed buffer");
+
+    // all blocks declared evicted
+    operations.assertCounter(STREAM_READ_PREFETCH_BLOCKS_EVICTED)
+        .isEqualTo(3);
+    // only one buffer was evicted unused; the error buffer
+    // doesn't get included, while the first buffer was
+    // used.
+    operations.assertCounter(STREAM_READ_PREFETCH_BLOCKS_DISCARDED)
+        .isEqualTo(1);
+  }
+
+  /**
+   * Even if (somehow) the closed stream makes it to the completed list,
+   * if it succeeded it will be found and returned.
+   */
+  @Test
+  public void testEvictFindsClosedStreams() throws Throwable {
+    final StubReadBufferOperations operations = new StubReadBufferOperations();
+    operations.bytesToRead = 1;
+    // two successes
+    ReadBuffer buffer1 = prefetch(operations, 0);
+
+    // final read is a failure
+    operations.exceptionToRaise = new FileNotFoundException("/fnfe");
+    ReadBuffer failed = prefetch(operations, 2000);
+
+    List<ReadBuffer> buffers = Arrays.asList(buffer1, failed);
+
+    // all buffers must be in the completed list
+    buffers.forEach(TestReadBufferManager::assertInCompletedList);
+
+    // xor for an exclusivity assertion.
+    // the read failed xor it succeeded with an indexed buffer.
+    Assertions.assertThat(buffers)
+        .allMatch(b ->
+            b.getStatus() == ReadBufferStatus.READ_FAILED
+            ^ b.hasIndexedBuffer(),
+            "either was failure or it has an indexed buffer but not both");
+
+    // now state that buffer 1 was read
+    buffer1.dataConsumedByStream(0, 1);
+
+    // now close the stream without telling the buffer manager
+    operations.setClosed(true);
+
+    // evict finds the buffer with data
+    Assertions.assertThat(bufferManager.callTryEvict())
+        .describedAs("evict() should return closed buffer with data")
+        .isTrue();
+
+    // but now it was evicted due to its age
+    assertNotInCompletedList(buffer1);
+    assertInCompletedList(failed);
+
+    // second still doesn't find the failed buffer, as it has no data
+    Assertions.assertThat(bufferManager.callTryEvict())
+        .describedAs("evict() should not find failed buffer")
+        .isFalse();
+
+    // but it was quietly evicted due to its state
+    assertNotInCompletedList(failed);
+
+  }
+
+  /**
+   * HADOOP-18521: if we remove ownership of a buffer during the remote read,
+   * things blow up.
+   */
+  @Test
+  public void testOwnershipChangedDuringRead() throws Throwable {
+
+    final Object blockUntilReadStarted = new Object();
+    // this stores the reference and is the object waited on to
+    // block read operation until buffer index is patched.
+
+    final AtomicReference<ReadBuffer> bufferRef = new AtomicReference<>();
+
+    //  handler blocks for buffer reference update.
+    final StubReadBufferOperations operations =
+        new StubReadBufferOperations((self) -> {
+          synchronized (blockUntilReadStarted) {
+            blockUntilReadStarted.notify();
+          }
+          synchronized (bufferRef) {
+            if (bufferRef.get() == null) {
+              try {
+                bufferRef.wait();
+              } catch (InterruptedException e) {
+                throw new InterruptedIOException("interrupted");
+              }
+            }
+          }
+          return 1;
+        });
+
+    // queue the operation
+    ReadBuffer buffer = bufferManager.queueReadAhead(operations, 0, 1, null);
+
+    synchronized (blockUntilReadStarted) {
+      blockUntilReadStarted.wait();
+    }
+
+    // set the buffer index to a different value
+    final int index = buffer.getBufferindex();
+    final int newIndex = (index + 1) % NUM_BUFFERS;
+    LOG.info("changing buffer index from {} to {}", index, newIndex);
+    buffer.setBufferindex(newIndex);
+
+    // notify waiting buffer
+    synchronized (bufferRef) {
+      bufferRef.set(buffer);
+      bufferRef.notifyAll();
+    }
+
+    awaitDone(buffer);
+
+    // buffer has its indexed buffer released and fields updated.
+    Assertions.assertThat(buffer)
+        .matches(b -> b.getStatus() == ReadBufferStatus.READ_FAILED, "buffer is failed")
+        .extracting(ReadBuffer::getErrException)
+        .isNotNull();
+
+    assertExceptionContains("not owned", buffer.getErrException());
+
+    // its on the completed list for followup reads
+    assertNotInCompletedList(buffer);
+
+    bufferManager.testResetReadBufferManager();
+  }
+
+  /**
+   * Assert that a buffer is not in the completed list.
+   * @param buffer buffer to validate.
+   */
+  private static void assertNotInCompletedList(final ReadBuffer buffer) {
+    Assertions.assertThat(getBufferManager().getCompletedReadListCopy())
+        .describedAs("completed read list")
+        .doesNotContain(buffer);
+  }
+
+  /**
+   * Assert that a buffer is in the completed list.
+   * @param buffer buffer to validate.
+   */
+  private static void assertInCompletedList(final ReadBuffer buffer) {
+    Assertions.assertThat(getBufferManager().getCompletedReadListCopy())
+        .describedAs("completed read list")
+        .contains(buffer);
+  }
+
+  /**
+   * Awaits for a buffer to be read; times out eventually and then raises an
+   * assertion.
+   * @param buffer buffer to block on.
+   * @return
+   * @throws InterruptedException interrupted.
+   */
+  private static ReadBuffer awaitDone(final ReadBuffer buffer) throws InterruptedException {
+    LOG.info("awaiting latch of {}", buffer);
+    Assertions.assertThat(buffer.getLatch().await(1, TimeUnit.MINUTES))
+        .describedAs("awaiting release of latch on %s", buffer)
+        .isTrue();
+    LOG.info("Prefetch completed of {}", buffer);
+    return buffer;
+  }
+
+  /**
+   * Stub implementation of {@link ReadBufferStreamOperations}.
+   * IOStats are collected and a lambda-function can be provided
+   * which is evaluated on a readRemote call. The default one is
+   * {@link #raiseOrReturn(StubReadBufferOperations)}.
+   */
+  private static final class StubReadBufferOperations
+      implements ReadBufferStreamOperations {
+
+    private final IOStatisticsStore iostats = iostatisticsStore()
+        .withCounters(
+            STREAM_READ_ACTIVE_PREFETCH_OPERATIONS,
+            STREAM_READ_PREFETCH_BLOCKS_DISCARDED,
+            STREAM_READ_PREFETCH_BLOCKS_USED,
+            STREAM_READ_PREFETCH_BYTES_DISCARDED,
+            STREAM_READ_PREFETCH_BLOCKS_EVICTED,
+            STREAM_READ_PREFETCH_BYTES_USED,
+            STREAM_READ_PREFETCH_OPERATIONS)
+        .build();
+
+    private boolean closed;
+
+    private int bytesToRead;
+
+    private IOException exceptionToRaise;
+
+    /**
+     * Function which takes a ref to this object and
+     * returns the number of bytes read.
+     * Invoked in the {@link #readRemote(long, byte[], int, int, TracingContext)}
+     * call.
+     */
+    private final FunctionRaisingIOE<StubReadBufferOperations, Integer> action;
+
+    /**
+     * Simple constructor.
+     */
+    private StubReadBufferOperations() {
+      // trivia, you can't use a this(this::raiseOrReturn) call here.
+      this.action = this::raiseOrReturn;
+    }
+
+    /**
+     * constructor.
+     * @param action lambda expression to call in readRemote()
+     */
+    private StubReadBufferOperations(
+        FunctionRaisingIOE<StubReadBufferOperations, Integer> action) {
+      this.action = action;
+    }
+
+    @Override
+    public int readRemote(
+        final long position,
+        final byte[] b,
+        final int offset,
+        final int length,
+        final TracingContext tracingContext) throws IOException {
+      return action.apply(this);
+    }
+
+    private int raiseOrReturn(StubReadBufferOperations self) throws IOException {
+      if (exceptionToRaise != null) {
+        throw exceptionToRaise;
+      }
+      return bytesToRead;
+    }
+
+    @Override
+    public boolean isClosed() {
+      return closed;
+    }
+
+    private void setClosed(final boolean closed) {
+      this.closed = closed;
+    }
+
+    private int getBytesToRead() {
+      return bytesToRead;
+    }
+
+    private void setBytesToRead(final int bytesToRead) {
+      this.bytesToRead = bytesToRead;
+    }
+
+    @Override
+    public String getStreamID() {
+      return "streamid";
+    }
+
+    @Override
+    public IOStatisticsStore getIOStatistics() {
+      return iostats;
+    }
+
+    @Override
+    public String getPath() {
+      return "/path";
+    }
+
+    /**
+     * start asserting about a counter.
+     * @param key key
+     * @return assert builder
+     */
+    AbstractLongAssert<?> assertCounter(String key) {
+      return assertThatStatisticCounter(iostats, key);
+    }
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/resources/log4j.properties
+++ b/hadoop-tools/hadoop-azure/src/test/resources/log4j.properties
@@ -26,6 +26,8 @@ log4j.logger.org.apache.hadoop.fs.azure.AzureFileSystemThreadPoolExecutor=DEBUG
 log4j.logger.org.apache.hadoop.fs.azure.BlockBlobAppendStream=DEBUG
 log4j.logger.org.apache.hadoop.fs.azurebfs.contracts.services.TracingService=TRACE
 log4j.logger.org.apache.hadoop.fs.azurebfs.services.AbfsClient=DEBUG
+log4j.logger.org.apache.hadoop.fs.azurebfs.services.ReadBufferManager=TRACE
+log4j.logger.org.apache.hadoop.fs.azurebfs.services.ReadBufferWorker=TRACE
 
 # after here: turn off log messages from other parts of the system
 # which only clutter test reports.


### PR DESCRIPTION
Addresses the issue by not trying to cancel in-progress reads when a stream
is closed()...they are allowed to continue and then their data discarded.
To enable discarding, AbfsInputStreams export their `closed` state in
which is now AtomicBool internally so reader threads can probe it.

The shared buffers now have owner tracking, which will reject
* attempts to acquire an owned buffer
* attempts to return a buffer not owned
Plus
* Lots of other invariants added to validate the state
* useful to string values

Also adds path and stream capability probe for the fix;
cloudstore "pathcapability" probe can report this.
Hadoop 3.3.2 added the path capability
"fs.capability.paths.acls", so two probes can
determine if abfs is exposed: 

not vulnerable
```
  !hasPathCability("fs.capability.paths.acls")
  || hasPathCability("fs.azure.capability.prefetch.safe")
```

vulnerable
```
  hasPathCability("fs.capability.paths.acls")
  && !hasPathCability("fs.azure.capability.prefetch.safe")
```

It can also be demanded in an openFile() call.
That block the code ever working on a version without
the race condition. Possibly a bit excessive.

### How was this patch tested?

needs more tests with multi GB csv files to validate the patch.
Unable to come up with good tests to recreate the failure condition.


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

