### PR TITLE
YARN-5607. Document TestContainerResourceUsage#waitForContainerCompletion

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockAM.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockAM.java
@@ -88,19 +88,7 @@ public class MockAM {
     this.amRMProtocol = amRMProtocol;
   }
 
-  /**
-   * Wait until an attempt has reached a specified state.
-   * The timeout is 40 seconds.
-   * @param finalState the attempt state waited
-   * @throws InterruptedException
-   *         if interrupted while waiting for the state transition
-   */
-  private void waitForState(RMAppAttemptState finalState)
-      throws InterruptedException {
-    RMApp app = context.getRMApps().get(attemptId.getApplicationId());
-    RMAppAttempt attempt = app.getRMAppAttempt(attemptId);
-    MockRM.waitForState(attempt, finalState);
-  }
+
 
   public RegisterApplicationMasterResponse registerAppAttempt()
       throws Exception {
@@ -120,7 +108,7 @@ public class MockAM {
   public RegisterApplicationMasterResponse registerAppAttempt(boolean wait)
       throws Exception {
     if (wait) {
-      waitForState(RMAppAttemptState.LAUNCHED);
+      MockRM.waitForState(RMAppAttemptState.LAUNCHED, context, attemptId);
     }
     responseId = 0;
     final RegisterApplicationMasterRequest req =
@@ -420,7 +408,7 @@ public class MockAM {
   }
 
   public void unregisterAppAttempt() throws Exception {
-    waitForState(RMAppAttemptState.RUNNING);
+    MockRM.waitForState(RMAppAttemptState.RUNNING, context, attemptId);
     unregisterAppAttempt(true);
   }
 
@@ -435,7 +423,7 @@ public class MockAM {
   public void unregisterAppAttempt(final FinishApplicationMasterRequest req,
       boolean waitForStateRunning) throws Exception {
     if (waitForStateRunning) {
-      waitForState(RMAppAttemptState.RUNNING);
+      MockRM.waitForState(RMAppAttemptState.RUNNING, context, attemptId);
     }
     if (ugi == null) {
       ugi =  UserGroupInformation.createRemoteUser(attemptId.toString());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockAM.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockAM.java
@@ -88,7 +88,19 @@ public class MockAM {
     this.amRMProtocol = amRMProtocol;
   }
 
-
+   /**
+   * Wait until an attempt has reached a specified state.
+   * The timeout is 40 seconds.
+   * @param finalState the attempt state waited
+   * @throws InterruptedException
+   *         if interrupted while waiting for the state transition
+   */
+  private void waitForState(RMAppAttemptState finalState)
+      throws InterruptedException {
+    RMApp app = context.getRMApps().get(attemptId.getApplicationId());
+    RMAppAttempt attempt = app.getRMAppAttempt(attemptId);
+    MockRM.waitForState(attempt, finalState);
+  }
 
   public RegisterApplicationMasterResponse registerAppAttempt()
       throws Exception {
@@ -108,7 +120,7 @@ public class MockAM {
   public RegisterApplicationMasterResponse registerAppAttempt(boolean wait)
       throws Exception {
     if (wait) {
-      MockRM.waitForState(RMAppAttemptState.LAUNCHED, context, attemptId);
+      waitForState(RMAppAttemptState.LAUNCHED);
     }
     responseId = 0;
     final RegisterApplicationMasterRequest req =
@@ -408,7 +420,7 @@ public class MockAM {
   }
 
   public void unregisterAppAttempt() throws Exception {
-    MockRM.waitForState(RMAppAttemptState.RUNNING, context, attemptId);
+    waitForState(RMAppAttemptState.RUNNING);
     unregisterAppAttempt(true);
   }
 
@@ -423,7 +435,7 @@ public class MockAM {
   public void unregisterAppAttempt(final FinishApplicationMasterRequest req,
       boolean waitForStateRunning) throws Exception {
     if (waitForStateRunning) {
-      MockRM.waitForState(RMAppAttemptState.RUNNING, context, attemptId);
+      waitForState(RMAppAttemptState.RUNNING);
     }
     if (ugi == null) {
       ugi =  UserGroupInformation.createRemoteUser(attemptId.toString());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockAM.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockAM.java
@@ -88,7 +88,7 @@ public class MockAM {
     this.amRMProtocol = amRMProtocol;
   }
 
-   /**
+  /**
    * Wait until an attempt has reached a specified state.
    * The timeout is 40 seconds.
    * @param finalState the attempt state waited

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockRM.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockRM.java
@@ -1013,30 +1013,16 @@ public class MockRM extends ResourceManager {
 
     public static void waitforContainerCompletion(MockRM rm, MockNM nm,
       ContainerId amContainerId, RMContainer container) throws Exception {
-    ContainerId containerId = container.getContainerId();
-    if (null != rm.scheduler.getRMContainer(containerId)) {
-      if (containerId.equals(amContainerId)) {
-        rm.waitForState(nm, containerId, RMContainerState.COMPLETED);
+      ContainerId containerId = container.getContainerId();
+      if (null != rm.scheduler.getRMContainer(containerId)) {
+        if (containerId.equals(amContainerId)) {
+          rm.waitForState(nm, containerId, RMContainerState.COMPLETED);
+        } else {
+          rm.waitForState(nm, containerId, RMContainerState.KILLED);
+        }
       } else {
-        rm.waitForState(nm, containerId, RMContainerState.KILLED);
+        rm.drainEvents();
       }
-    } else {
-      rm.drainEvents();
-    }
-  }
-
-    /**
-   * Wait until an attempt has reached a specified state.
-   * The timeout is 40 seconds.
-   * @param finalState the attempt state waited
-   * @throws InterruptedException
-   *         if interrupted while waiting for the state transition
-   */
-  public static void waitForState(RMAppAttemptState finalState, RMContext context, ApplicationAttemptId attemptId)
-      throws InterruptedException {
-    RMApp app = context.getRMApps().get(attemptId.getApplicationId());
-    RMAppAttempt attempt = app.getRMAppAttempt(attemptId);
-    MockRM.waitForState(attempt, finalState);
   }
 
   private void drainEventsImplicitly() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockRM.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockRM.java
@@ -1011,18 +1011,29 @@ public class MockRM extends ResourceManager {
     LOG.info("app is removed from scheduler, " + appId);
   }
 
-    public static void waitforContainerCompletion(MockRM rm, MockNM nm,
-      ContainerId amContainerId, RMContainer container) throws Exception {
-      ContainerId containerId = container.getContainerId();
-      if (null != rm.scheduler.getRMContainer(containerId)) {
-        if (containerId.equals(amContainerId)) {
-          rm.waitForState(nm, containerId, RMContainerState.COMPLETED);
-        } else {
-          rm.waitForState(nm, containerId, RMContainerState.KILLED);
-        }
+  /**
+   * Wait until a container has reached a completion state.
+   * The timeout is 20 seconds.
+   * @param nm A mock nodemanager
+   * @param rm A mock resourcemanager
+   * @param amContainerId The id of an am container
+   * @param container A rm container
+   * @throws Exception
+   *         if interrupted while waiting for the completion transition
+   *         or an unexpected error while MockNM is hearbeating.
+   */
+  public static void waitForContainerCompletion(MockRM rm, MockNM nm,
+    ContainerId amContainerId, RMContainer container) throws Exception {
+    ContainerId containerId = container.getContainerId();
+    if (null != rm.scheduler.getRMContainer(containerId)) {
+      if (containerId.equals(amContainerId)) {
+        rm.waitForState(nm, containerId, RMContainerState.COMPLETED);
       } else {
-        rm.drainEvents();
+        rm.waitForState(nm, containerId, RMContainerState.KILLED);
       }
+    } else {
+      rm.drainEvents();
+    }
   }
 
   private void drainEventsImplicitly() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockRM.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockRM.java
@@ -1011,6 +1011,34 @@ public class MockRM extends ResourceManager {
     LOG.info("app is removed from scheduler, " + appId);
   }
 
+    public static void waitforContainerCompletion(MockRM rm, MockNM nm,
+      ContainerId amContainerId, RMContainer container) throws Exception {
+    ContainerId containerId = container.getContainerId();
+    if (null != rm.scheduler.getRMContainer(containerId)) {
+      if (containerId.equals(amContainerId)) {
+        rm.waitForState(nm, containerId, RMContainerState.COMPLETED);
+      } else {
+        rm.waitForState(nm, containerId, RMContainerState.KILLED);
+      }
+    } else {
+      rm.drainEvents();
+    }
+  }
+
+    /**
+   * Wait until an attempt has reached a specified state.
+   * The timeout is 40 seconds.
+   * @param finalState the attempt state waited
+   * @throws InterruptedException
+   *         if interrupted while waiting for the state transition
+   */
+  public static void waitForState(RMAppAttemptState finalState, RMContext context, ApplicationAttemptId attemptId)
+      throws InterruptedException {
+    RMApp app = context.getRMApps().get(attemptId.getApplicationId());
+    RMAppAttempt attempt = app.getRMAppAttempt(attemptId);
+    MockRM.waitForState(attempt, finalState);
+  }
+
   private void drainEventsImplicitly() {
     if (!disableDrainEventsImplicitly) {
       drainEvents();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestContainerResourceUsage.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestContainerResourceUsage.java
@@ -348,7 +348,7 @@ public class TestContainerResourceUsage {
       // If keepRunningContainers is false, all live containers should now
       // be completed. Calculate the resource usage metrics for all of them.
       for (RMContainer c : rmContainers) {
-        MockRM.waitforContainerCompletion(rm, nm, amContainerId, c);
+        MockRM.waitForContainerCompletion(rm, nm, amContainerId, c);
         AggregateAppResourceUsage ru = calculateContainerResourceMetrics(c);
         memorySeconds += ru.getMemorySeconds();
         vcoreSeconds += ru.getVcoreSeconds();
@@ -400,7 +400,7 @@ public class TestContainerResourceUsage {
 
     // Calculate container usage metrics for second attempt.
     for (RMContainer c : rmContainers) {
-      MockRM.waitforContainerCompletion(rm, nm, amContainerId, c);
+      MockRM.waitForContainerCompletion(rm, nm, amContainerId, c);
       AggregateAppResourceUsage ru = calculateContainerResourceMetrics(c);
       memorySeconds += ru.getMemorySeconds();
       vcoreSeconds += ru.getVcoreSeconds();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestContainerResourceUsage.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestContainerResourceUsage.java
@@ -348,7 +348,7 @@ public class TestContainerResourceUsage {
       // If keepRunningContainers is false, all live containers should now
       // be completed. Calculate the resource usage metrics for all of them.
       for (RMContainer c : rmContainers) {
-        waitforContainerCompletion(rm, nm, amContainerId, c);
+        MockRM.waitforContainerCompletion(rm, nm, amContainerId, c);
         AggregateAppResourceUsage ru = calculateContainerResourceMetrics(c);
         memorySeconds += ru.getMemorySeconds();
         vcoreSeconds += ru.getVcoreSeconds();
@@ -400,7 +400,7 @@ public class TestContainerResourceUsage {
 
     // Calculate container usage metrics for second attempt.
     for (RMContainer c : rmContainers) {
-      waitforContainerCompletion(rm, nm, amContainerId, c);
+      MockRM.waitforContainerCompletion(rm, nm, amContainerId, c);
       AggregateAppResourceUsage ru = calculateContainerResourceMetrics(c);
       memorySeconds += ru.getMemorySeconds();
       vcoreSeconds += ru.getVcoreSeconds();
@@ -415,20 +415,6 @@ public class TestContainerResourceUsage {
 
     rm.stop();
     return;
-  }
-
-  private void waitforContainerCompletion(MockRM rm, MockNM nm,
-      ContainerId amContainerId, RMContainer container) throws Exception {
-    ContainerId containerId = container.getContainerId();
-    if (null != rm.scheduler.getRMContainer(containerId)) {
-      if (containerId.equals(amContainerId)) {
-        rm.waitForState(nm, containerId, RMContainerState.COMPLETED);
-      } else {
-        rm.waitForState(nm, containerId, RMContainerState.KILLED);
-      }
-    } else {
-      rm.drainEvents();
-    }
   }
 
   private AggregateAppResourceUsage calculateContainerResourceMetrics(


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The logic in TestContainerResourceUsage#waitForContainerCompletion (introduced in [YARN-5024](https://issues.apache.org/jira/browse/YARN-5024)) is not immediately obvious. It could use some documentation. Also, this seems like a useful helper method. Should this be moved to one of the mock classes or to a util class?

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

