### PR TITLE
HDFS-16834: Removes request stateID consistency constraint between clients in different connection pools.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/PoolAlignmentContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/PoolAlignmentContext.java
@@ -71,8 +71,7 @@ public class PoolAlignmentContext implements AlignmentContext {
    */
   @Override
   public void updateRequestState(RpcHeaderProtos.RpcRequestHeaderProto.Builder header) {
-    long maxStateId = Long.max(poolLocalStateId.get(), sharedGlobalStateId.get());
-    header.setStateId(maxStateId);
+    header.setStateId(poolLocalStateId.get());
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestPoolAlignmentContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestPoolAlignmentContext.java
@@ -32,7 +32,6 @@ public class TestPoolAlignmentContext {
     PoolAlignmentContext poolContext1 = new PoolAlignmentContext(routerStateIdContext, namespaceId);
     PoolAlignmentContext poolContext2 = new PoolAlignmentContext(routerStateIdContext, namespaceId);
 
-    routerStateIdContext.getNamespaceStateId(namespaceId).accumulate(20L);
     assertRequestHeaderStateId(poolContext1, Long.MIN_VALUE);
     assertRequestHeaderStateId(poolContext2, Long.MIN_VALUE);
     Assertions.assertEquals(20L, poolContext1.getLastSeenStateId());

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestPoolAlignmentContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestPoolAlignmentContext.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcRequestHeaderProto;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+public class TestPoolAlignmentContext {
+  @Test
+  public void testNamenodeRequestsOnlyUsePoolLocalStateID() {
+    RouterStateIdContext routerStateIdContext = new RouterStateIdContext(new Configuration());
+    String namespaceId = "namespace1";
+    routerStateIdContext.getNamespaceStateId(namespaceId).accumulate(20L);
+    PoolAlignmentContext poolContext1 = new PoolAlignmentContext(routerStateIdContext, namespaceId);
+    PoolAlignmentContext poolContext2 = new PoolAlignmentContext(routerStateIdContext, namespaceId);
+
+    routerStateIdContext.getNamespaceStateId(namespaceId).accumulate(20L);
+    assertRequestHeaderStateId(poolContext1, Long.MIN_VALUE);
+    assertRequestHeaderStateId(poolContext2, Long.MIN_VALUE);
+    Assertions.assertEquals(20L, poolContext1.getLastSeenStateId());
+    Assertions.assertEquals(20L, poolContext2.getLastSeenStateId());
+
+    poolContext1.advanceClientStateId(30L);
+    assertRequestHeaderStateId(poolContext1, 30L);
+    assertRequestHeaderStateId(poolContext2, Long.MIN_VALUE);
+    Assertions.assertEquals(20L, poolContext1.getLastSeenStateId());
+    Assertions.assertEquals(20L, poolContext2.getLastSeenStateId());
+  }
+
+  private void assertRequestHeaderStateId(PoolAlignmentContext poolAlignmentContext,
+      Long expectedValue) {
+    RpcRequestHeaderProto.Builder builder = RpcRequestHeaderProto.newBuilder();
+    poolAlignmentContext.updateRequestState(builder);
+    Assertions.assertEquals(expectedValue, builder.getStateId());
+  }
+}


### PR DESCRIPTION
HDFS-16834: Removes request stateID consistency constraint between clients in different connection pools.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

When sending requests to the namenode, we should only use the poolLocalStateId. Maxing it with the sharedGlobalStateId makes reads consistent across all clients using a router, which is not necessary and will lead to more waiting on the observer.

### How was this patch tested?
Tests in TestObserverWithRouter still pass.

### For code changes:

- [x ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?

