### PR TITLE
HDFS-16838. Fix NPE in testAddRplicaProcessorForAddingReplicaInMap

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
@@ -1138,7 +1138,7 @@ public class BlockPoolSlice {
   }
 
   @VisibleForTesting
-  public static void reInitializeAddReplicaThreadPool() {
+  public synchronized static void reInitializeAddReplicaThreadPool() {
     if (addReplicaThreadPool != null) {
       addReplicaThreadPool.shutdown();
       addReplicaThreadPool = null;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
@@ -1139,8 +1139,10 @@ public class BlockPoolSlice {
 
   @VisibleForTesting
   public static void reInitializeAddReplicaThreadPool() {
-    addReplicaThreadPool.shutdown();
-    addReplicaThreadPool = null;
+    if (addReplicaThreadPool != null) {
+      addReplicaThreadPool.shutdown();
+      addReplicaThreadPool = null;
+    }
   }
 
   @VisibleForTesting


### PR DESCRIPTION
### Description of PR
There is a NPE in `org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.TestFsVolumeList#testAddRplicaProcessorForAddingReplicaInMap` if we run this UT individually. And the related bug as bellow:
```
public void testAddRplicaProcessorForAddingReplicaInMap() throws Exception {
  // BUG here
  BlockPoolSlice.reInitializeAddReplicaThreadPool();
  Configuration cnf = new Configuration();
  int poolSize = 5; 
  ...
}
```