### PR TITLE
HDFS-16830. [SBN READ] dfsrouter transmit state id according to clie…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/AlignmentContext.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/AlignmentContext.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ipc;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -43,7 +44,7 @@ public interface AlignmentContext {
    *
    * @param header The RPC response header builder.
    */
-  void updateResponseState(RpcResponseHeaderProto.Builder header);
+  void updateResponseState(RpcResponseHeaderProto.Builder header, Map<String, Long> federatedState);
 
   /**
    * This is the intended client method call to implement to receive state info

--- a/hadoop-common-project/hadoop-common/src/main/proto/RpcHeader.proto
+++ b/hadoop-common-project/hadoop-common/src/main/proto/RpcHeader.proto
@@ -190,3 +190,16 @@ message RpcSaslProto {
   optional bytes token     = 3;
   repeated SaslAuth auths  = 4;
 }
+
+/////////////////////////////////////////////////
+// Alignment state for namespaces.
+/////////////////////////////////////////////////
+
+/**
+ * Clients should receive this message in RPC responses and forward it
+ * in RPC requests without interpreting it. It should be encoded
+ * as an obscure byte array when being sent to clients.
+ */
+message RouterFederatedStateProto {
+  map<string, int64> namespaceStateIds = 1; // Last seen state IDs for multiple namespaces.
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ClientGSIContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ClientGSIContext.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcRequestHeaderProto;
 import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcResponseHeaderProto;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.atomic.LongAccumulator;
 import org.apache.hadoop.thirdparty.protobuf.ByteString;
 
@@ -66,7 +67,8 @@ public class ClientGSIContext implements AlignmentContext {
    * It does not provide state alignment info therefore this does nothing.
    */
   @Override
-  public void updateResponseState(RpcResponseHeaderProto.Builder header) {
+  public void updateResponseState(RpcResponseHeaderProto.Builder header,
+      Map<String, Long> federatedState) {
     // Do nothing.
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/proto/FederationProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/proto/FederationProtocol.proto
@@ -312,16 +312,3 @@ message GetDisabledNameservicesRequestProto {
 message GetDisabledNameservicesResponseProto {
   repeated string nameServiceIds = 1;
 }
-
-/////////////////////////////////////////////////
-// Alignment state for namespaces.
-/////////////////////////////////////////////////
-
-/**
- * Clients should receive this message in RPC responses and forward it
- * in RPC requests without interpreting it. It should be encoded
- * as an obscure byte array when being sent to clients.
- */
-message RouterFederatedStateProto {
-  map<string, int64> namespaceStateIds = 1; // Last seen state IDs for multiple namespaces.
-}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.federation.router;
 
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_STATE_CONTEXT_ENABLED_KEY;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.NAMENODES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -34,6 +35,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
 import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.RouterContext;
 import org.apache.hadoop.hdfs.server.federation.RouterConfigBuilder;
@@ -42,6 +45,7 @@ import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeConte
 import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeServiceState;
 import org.apache.hadoop.hdfs.server.federation.resolver.MembershipNamenodeResolver;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
+import org.apache.hadoop.hdfs.server.namenode.ha.ObserverReadProxyProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,6 +55,7 @@ import org.junit.jupiter.api.TestInfo;
 
 public class TestObserverWithRouter {
   private static final String SKIP_BEFORE_EACH_CLUSTER_STARTUP = "SkipBeforeEachClusterStartup";
+  public static final String FEDERATION_NS = "ns-fed";
   private MiniRouterDFSCluster cluster;
   private RouterContext routerContext;
   private FileSystem fileSystem;
@@ -81,6 +86,7 @@ public class TestObserverWithRouter {
   public void startUpCluster(int numberOfObserver, Configuration confOverrides) throws Exception {
     int numberOfNamenode = 2 + numberOfObserver;
     Configuration conf = new Configuration(false);
+    conf.setBoolean(DFS_NAMENODE_STATE_CONTEXT_ENABLED_KEY, true);
     conf.setBoolean(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_DEFAULT_KEY, true);
     conf.setBoolean(DFSConfigKeys.DFS_HA_TAILEDITS_INPROGRESS_KEY, true);
     conf.set(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, "0ms");
@@ -165,6 +171,72 @@ public class TestObserverWithRouter {
         .getRPCMetrics().getObserverProxyOps();
     // getBlockLocations should be sent to observer
     assertEquals("One call should be sent to observer", 1, rpcCountForObserver);
+  }
+
+  @Test
+  @Tag(SKIP_BEFORE_EACH_CLUSTER_STARTUP)
+  public void testObserverReadMultiNameservice() throws Exception {
+    Configuration confOverrides = new Configuration(false);
+    confOverrides.setInt(RBFConfigKeys.DFS_ROUTER_OBSERVER_FEDERATED_STATE_PROPAGATION_MAXSIZE, 1);
+    startUpCluster(1, confOverrides);
+    RouterContext routerContext = cluster.getRandomRouter();
+    List<? extends FederationNamenodeContext> namenodes = routerContext
+        .getRouter().getNamenodeResolver()
+        .getNamenodesForNameserviceId(cluster.getNameservices().get(0), true);
+    assertEquals("First namenode should be observer", namenodes.get(0).getState(),
+        FederationNamenodeServiceState.OBSERVER);
+
+    // 1 Create or open file in ns0
+    Configuration clientConf = new Configuration();
+    clientConf.setBoolean("fs.hdfs.impl.disable.cache", true);
+    clientConf.set(HdfsClientConfigKeys.Failover.PROXY_PROVIDER_KEY_PREFIX + "." + FEDERATION_NS,
+        ObserverReadProxyProvider.class.getCanonicalName());
+    FileSystem fs0 = cluster.getRBFFileSystem(FEDERATION_NS, clientConf);
+    Path path0 = new Path("/ns0/testFile");
+    // Send msync, should ignore it.
+    fs0.msync();
+
+    // Send Create call to active
+    fs0.create(path0).close();
+
+    // Send read request to observer
+    fs0.open(path0).close();
+
+    // Send msync to active, only connect ns0 active
+    fs0.msync();
+
+    // 2 Create or open file in ns1
+    FileSystem fs1 = cluster.getRBFFileSystem(FEDERATION_NS, clientConf);
+    // Send msync, router should ignore it.
+    fs1.msync();
+
+    Path path1 = new Path("/ns1/testFile");
+    // Send msync, should ignore it.
+    fs1.msync();
+
+    // Send Create call to active
+    fs1.create(path1).close();
+
+    // Send read request to observer
+    fs1.open(path1).close();
+
+    // Send msync to active, only connect ns1 active
+    fs1.msync();
+
+    // Create and complete and second msync calls should be sent to active
+    long rpcCountForActive = cluster.getRouters().stream()
+        .map(s -> s.getRouter().getRpcServer().getRPCMetrics().getActiveProxyOps())
+        .reduce(0L, Long::sum);
+    assertEquals("Six calls should be sent to active", 6, rpcCountForActive);
+
+    // getBlockLocations should be sent to observer
+    long rpcCountForObserver = cluster.getRouters().stream()
+        .map(s -> s.getRouter().getRpcServer().getRPCMetrics().getObserverProxyOps())
+        .reduce(0L, Long::sum);
+    assertEquals("Two call should be sent to observer", 2, rpcCountForObserver);
+
+    fs0.close();
+    fs1.close();
   }
 
   @Test
@@ -435,8 +507,7 @@ public class TestObserverWithRouter {
     fileSystem.msync();
     rpcCountForActive = routerContext.getRouter().getRpcServer()
         .getRPCMetrics().getActiveProxyOps();
-    // 2 msync calls should be sent. One to each active namenode in the two namespaces.
-    assertEquals("Four calls should be sent to active", 4,
-        rpcCountForActive);
+    // 1 msync calls should be sent.
+    assertEquals("Four calls should be sent to active", 3, rpcCountForActive);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterFederatedState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterFederatedState.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.ipc.ClientId;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.ipc.RpcConstants;
 import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos;
-import org.apache.hadoop.hdfs.federation.protocol.proto.HdfsServerFederationProtos.RouterFederatedStateProto;
+import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RouterFederatedStateProto;
 import org.apache.hadoop.thirdparty.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.util.ProtoUtil;
 import org.junit.Test;
@@ -81,7 +81,8 @@ public class TestRouterFederatedState {
     }
 
     @Override
-    public void updateResponseState(RpcHeaderProtos.RpcResponseHeaderProto.Builder header) {}
+    public void updateResponseState(RpcHeaderProtos.RpcResponseHeaderProto.Builder header,
+        Map<String, Long> federatedState) {}
 
     @Override
     public void receiveResponseState(RpcHeaderProtos.RpcResponseHeaderProto header) {}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/GlobalStateIdContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/GlobalStateIdContext.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdfs.server.namenode;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -82,7 +83,8 @@ class GlobalStateIdContext implements AlignmentContext {
    * Server side implementation for providing state alignment info in responses.
    */
   @Override
-  public void updateResponseState(RpcResponseHeaderProto.Builder header) {
+  public void updateResponseState(RpcResponseHeaderProto.Builder header,
+      Map<String, Long> federatedState) {
     // Using getCorrectLastAppliedOrWrittenTxId will acquire the lock on
     // FSEditLog. This is needed so that ANN will return the correct state id
     // it currently has. But this may not be necessary for Observer, may want


### PR DESCRIPTION
### Description of PR

For now, dfsrouter transmit the state of all nameservice. In this PR, dfsrouter only transmit state id according to client's demand.

### How was this patch tested?

unit test. 

### For code changes:

Key code is PoolAlignmentContext::updateRequestState, here we record used namenode.
