### PR TITLE
HADOOP-18521. Draft change - ABFS Prefetch corruption

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
@@ -94,6 +94,7 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
   private long fCursorAfterLastRead = -1;
   private int bCursor = 0;   // cursor of read within buffer - offset of next byte to be returned from buffer
   private int limit = 0;     // offset of next byte to be read into buffer from service (i.e., upper marker+1
+
   //                                                      of valid bytes in buffer)
   private boolean closed = false;
   private TracingContext tracingContext;
@@ -744,6 +745,8 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
   byte[] getBuffer() {
     return buffer;
   }
+
+  public boolean isClosed() { return closed; }
 
   @VisibleForTesting
   public boolean isReadAheadEnabled() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ReadBufferManager.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ReadBufferManager.java
@@ -247,7 +247,7 @@ final class ReadBufferManager {
 
     // first, try buffers where all bytes have been consumed (approximated as first and last bytes consumed)
     for (ReadBuffer buf : completedReadList) {
-      if (buf.isFirstByteConsumed() && buf.isLastByteConsumed()) {
+      if (buf.getStream().isClosed() || (buf.isFirstByteConsumed() && buf.isLastByteConsumed())) {
         nodeToEvict = buf;
         break;
       }
@@ -544,7 +544,6 @@ final class ReadBufferManager {
     LOGGER.debug("Purging stale buffers for AbfsInputStream {} ", stream);
     readAheadQueue.removeIf(readBuffer -> readBuffer.getStream() == stream);
     purgeList(stream, completedReadList);
-    purgeList(stream, inProgressList);
   }
 
   /**


### PR DESCRIPTION
A ReadBuffer with a valid Buffer assigned to it can be in certain states when stream is closed, and with the above change, I am trying to address it as below :
1. Is in QueueReadAheadList - No change, the earlier purge takes care of it
2. Is in CompletedList - No change again, the earlier purge takes care of it
3. Is InProgressList but yet to make the network call - If stream is closed, stop network call and move the ReadBuffer as a failure into completed list
4. Is InProgressList , just finished the network call - If stream is closed, network call was successful or not, move the ReadBuffer as a failure into completed list

Now, when in state 3 or 4, the purge method might not pick it as it might have executed first. In that case, to prioritize these ReadBuffers for eviction, have added the check for stream is closed in the eviction code as well. 