### PR TITLE
HDFS-16841. Enhance the function of DebugAdmin#VerifyECCommand

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDebugAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDebugAdmin.java
@@ -195,9 +195,10 @@ public class TestDebugAdmin {
     DistributedFileSystem fs = cluster.getFileSystem();
 
     assertEquals("ret: 1, verifyEC -file <file> [-blockId <blk_Id>] " +
-        "[-verifyAllFailures]  -file Verify HDFS erasure coding on all block groups of the file." +
-        "  -verifyAllFailures specify verify all failures block groups of the file," +
-        "  the default is not to verify all failures." +
+        "[-skipFailureBlocks]  -file Verify HDFS erasure coding on all block groups of the file." +
+        "  -skipFailureBlocks specify will skip any block group failures during verify," +
+        "  and continues verify all block groups of the file," +
+        "  the default is not to skip failure blocks." +
         "  -blockId specify blk_Id to verify for a specific one block group.",
         runCmd(new String[]{"verifyEC"}));
 
@@ -283,7 +284,7 @@ public class TestDebugAdmin {
     blockGroup = (LocatedStripedBlock) blocks.get(0);
     String blockName = blockGroup.getBlock().getBlockName();
     assertTrue(runCmd(new String[]{"verifyEC", "-file", "/ec/foo_new", "-blockId", blockName})
-        .contains("Checking EC block group: " + blockName + "Status: OK"));
+        .contains("ret: 0, Checking EC block group: " + blockName + "Status: OK"));
 
     // Specify -verifyAllFailures.
     indexedBlocks = StripedBlockUtil.parseStripedBlockGroup(blockGroup,
@@ -303,10 +304,11 @@ public class TestDebugAdmin {
     FileUtils.writeByteArrayToFile(blockFile, errorBytes);
     runCmd(new String[]{"computeMeta", "-block", blockFile.getAbsolutePath(),
         "-out", metaFile.getAbsolutePath()});
-    // VerifyEC and set verifyAllFailures.
+    // VerifyEC and set skipFailureBlocks.
     LocatedStripedBlock blockGroup2 = (LocatedStripedBlock) blocks.get(1);
-    assertTrue(runCmd(new String[]{"verifyEC", "-file", "/ec/foo_new", "-verifyAllFailures"})
-        .contains("Status: ERROR, message: EC compute result not match." +
+    assertTrue(runCmd(new String[]{"verifyEC", "-file", "/ec/foo_new", "-skipFailureBlocks"})
+        .contains("ret: 1, Checking EC block group: " + blockGroup.getBlock().getBlockName() +
+            "Status: ERROR, message: EC compute result not match." +
             "Checking EC block group: " + blockGroup2.getBlock().getBlockName() + "Status: OK"));
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDebugAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDebugAdmin.java
@@ -308,7 +308,7 @@ public class TestDebugAdmin {
     LocatedStripedBlock blockGroup2 = (LocatedStripedBlock) blocks.get(1);
     assertTrue(runCmd(new String[]{"verifyEC", "-file", "/ec/foo_new", "-ignoreFailures"})
         .contains("Status: ERROR, message: EC compute result not match." +
-            "Checking EC block group: " + blockGroup2.getBlock().getBlockName() + "Status: OK" ));
+            "Checking EC block group: " + blockGroup2.getBlock().getBlockName() + "Status: OK"));
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDebugAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDebugAdmin.java
@@ -194,8 +194,13 @@ public class TestDebugAdmin {
     cluster.waitActive();
     DistributedFileSystem fs = cluster.getFileSystem();
 
-    assertEquals("ret: 1, verifyEC -file <file>  Verify HDFS erasure coding on " +
-        "all block groups of the file.", runCmd(new String[]{"verifyEC"}));
+    assertEquals("ret: 1, verifyEC -file <file> [-blockId <blk_Id>] " +
+        "[-ignoreFailures]  -file Verify HDFS erasure coding on all block groups of the file." +
+        "  -ignoreFailures specify ignores any block group failures during verify," +
+        "  and continues verify all block groups of the file," +
+        "  the default is not to ignore failures." +
+        "  -blockId specify blk_Id to verify for a specific one block group.",
+        runCmd(new String[]{"verifyEC"}));
 
     assertEquals("ret: 1, File /bar does not exist.",
         runCmd(new String[]{"verifyEC", "-file", "/bar"}));
@@ -270,6 +275,40 @@ public class TestDebugAdmin {
         "-out", metaFile.getAbsolutePath()});
     assertTrue(runCmd(new String[]{"verifyEC", "-file", "/ec/foo_corrupt"})
         .contains("Status: ERROR, message: EC compute result not match."));
+
+    // Specify -blockId.
+    Path newFile = new Path(ecDir, "foo_new");
+    DFSTestUtil.createFile(fs, newFile, (int) k, 6 * m, m, repl, seed);
+    blocks = DFSTestUtil.getAllBlocks(fs, newFile);
+    assertEquals(2, blocks.size());
+    blockGroup = (LocatedStripedBlock) blocks.get(0);
+    String blockName = blockGroup.getBlock().getBlockName();
+    assertTrue(runCmd(new String[]{"verifyEC", "-file", "/ec/foo_new", "-blockId", blockName})
+        .contains("Checking EC block group: " + blockName + "Status: OK"));
+
+    // Specify -ignoreFailures.
+    indexedBlocks = StripedBlockUtil.parseStripedBlockGroup(blockGroup,
+        ecPolicy.getCellSize(), ecPolicy.getNumDataUnits(), ecPolicy.getNumParityUnits());
+    // Try corrupt block 0 in block group.
+    toCorruptLocatedBlock = indexedBlocks[0];
+    toCorruptBlock = toCorruptLocatedBlock.getBlock();
+    datanode = cluster.getDataNode(toCorruptLocatedBlock.getLocations()[0].getIpcPort());
+    blockFile = getBlockFile(datanode.getFSDataset(),
+        toCorruptBlock.getBlockPoolId(), toCorruptBlock.getLocalBlock());
+    metaFile = getMetaFile(datanode.getFSDataset(),
+        toCorruptBlock.getBlockPoolId(), toCorruptBlock.getLocalBlock());
+    metaFile.delete();
+    // Write error bytes to block file and re-generate meta checksum.
+    errorBytes = new byte[1048576];
+    new Random(0x12345678L).nextBytes(errorBytes);
+    FileUtils.writeByteArrayToFile(blockFile, errorBytes);
+    runCmd(new String[]{"computeMeta", "-block", blockFile.getAbsolutePath(),
+        "-out", metaFile.getAbsolutePath()});
+    // VerifyEC and set ignoreFailures.
+    LocatedStripedBlock blockGroup2 = (LocatedStripedBlock) blocks.get(1);
+    assertTrue(runCmd(new String[]{"verifyEC", "-file", "/ec/foo_new", "-ignoreFailures"})
+        .contains("Status: ERROR, message: EC compute result not match." +
+            "Checking EC block group: " + blockGroup2.getBlock().getBlockName() + "Status: OK" ));
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDebugAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDebugAdmin.java
@@ -195,10 +195,9 @@ public class TestDebugAdmin {
     DistributedFileSystem fs = cluster.getFileSystem();
 
     assertEquals("ret: 1, verifyEC -file <file> [-blockId <blk_Id>] " +
-        "[-ignoreFailures]  -file Verify HDFS erasure coding on all block groups of the file." +
-        "  -ignoreFailures specify ignores any block group failures during verify," +
-        "  and continues verify all block groups of the file," +
-        "  the default is not to ignore failures." +
+        "[-verifyAllFailures]  -file Verify HDFS erasure coding on all block groups of the file." +
+        "  -verifyAllFailures specify verify all failures block groups of the file," +
+        "  the default is not to verify all failures." +
         "  -blockId specify blk_Id to verify for a specific one block group.",
         runCmd(new String[]{"verifyEC"}));
 
@@ -286,7 +285,7 @@ public class TestDebugAdmin {
     assertTrue(runCmd(new String[]{"verifyEC", "-file", "/ec/foo_new", "-blockId", blockName})
         .contains("Checking EC block group: " + blockName + "Status: OK"));
 
-    // Specify -ignoreFailures.
+    // Specify -verifyAllFailures.
     indexedBlocks = StripedBlockUtil.parseStripedBlockGroup(blockGroup,
         ecPolicy.getCellSize(), ecPolicy.getNumDataUnits(), ecPolicy.getNumParityUnits());
     // Try corrupt block 0 in block group.
@@ -304,9 +303,9 @@ public class TestDebugAdmin {
     FileUtils.writeByteArrayToFile(blockFile, errorBytes);
     runCmd(new String[]{"computeMeta", "-block", blockFile.getAbsolutePath(),
         "-out", metaFile.getAbsolutePath()});
-    // VerifyEC and set ignoreFailures.
+    // VerifyEC and set verifyAllFailures.
     LocatedStripedBlock blockGroup2 = (LocatedStripedBlock) blocks.get(1);
-    assertTrue(runCmd(new String[]{"verifyEC", "-file", "/ec/foo_new", "-ignoreFailures"})
+    assertTrue(runCmd(new String[]{"verifyEC", "-file", "/ec/foo_new", "-verifyAllFailures"})
         .contains("Status: ERROR, message: EC compute result not match." +
             "Checking EC block group: " + blockGroup2.getBlock().getBlockName() + "Status: OK"));
   }


### PR DESCRIPTION

### Description of PR
[HDFS-16841](https://issues.apache.org/jira/browse/HDFS-16841)
Enhance the function of DebugAdmin#VerifyECCommand

Currently DebugAdmin#VerifyECCommand supports verify the correctness of erasure coding on file. If the first failures block group occurs during verify, the verify will end.

1.Consider add option to control whether to ignore failures block group . If set, will ignores failures block group during verify and continues verify all block groups of the file
2.add option support for specifying one block group to verify


