### PR TITLE
HDFS-16844: Adds resilancy when StateStore gets exceptions.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
@@ -128,9 +128,13 @@ public class MembershipNamenodeResolver
     // Our cache depends on the store, update it first
     try {
       MembershipStore membership = getMembershipStore();
-      membership.loadCache(force);
+      if (!membership.loadCache(force)) {
+        return false;
+      }
       DisabledNameserviceStore disabled = getDisabledNameserviceStore();
-      disabled.loadCache(force);
+      if (!disabled.loadCache(force)) {
+        return false;
+      }
     } catch (IOException e) {
       LOG.error("Cannot update membership from the State Store", e);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
@@ -398,7 +398,9 @@ public class MountTableResolver
     try {
       // Our cache depends on the store, update it first
       MountTableStore mountTable = this.getMountTableStore();
-      mountTable.loadCache(force);
+      if (!mountTable.loadCache(force)) {
+        return false;
+      }
 
       GetMountTableEntriesRequest request =
           GetMountTableEntriesRequest.newInstance("/");

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/CachedRecordStore.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/CachedRecordStore.java
@@ -100,7 +100,7 @@ public abstract class CachedRecordStore<R extends BaseRecord>
    * @throws StateStoreUnavailableException If the cache is not initialized.
    */
   private void checkCacheAvailable() throws StateStoreUnavailableException {
-    if (!this.initialized) {
+    if (!getDriver().isDriverReady() || !this.initialized) {
       throw new StateStoreUnavailableException(
           "Cached State Store not initialized, " +
           getRecordClass().getSimpleName() + " records not valid");
@@ -125,7 +125,6 @@ public abstract class CachedRecordStore<R extends BaseRecord>
       } catch (IOException e) {
         LOG.error("Cannot get \"{}\" records from the State Store",
             getRecordClass().getSimpleName());
-        this.initialized = false;
         return false;
       }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/impl/MembershipStoreImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/impl/MembershipStoreImpl.java
@@ -185,7 +185,9 @@ public class MembershipStoreImpl
 
   @Override
   public boolean loadCache(boolean force) throws IOException {
-    super.loadCache(force);
+    if (!super.loadCache(force)) {
+      return false;
+    }
 
     // Update local cache atomically
     cacheWriteLock.lock();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/MockStateStoreDriver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/MockStateStoreDriver.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreBase
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -32,9 +33,9 @@ import java.util.Map;
  * upon demand.
  */
 public class MockStateStoreDriver extends StateStoreBaseImpl {
-  boolean giveErrors = false;
-  boolean initialized = false;
-  Map<String, Map<String, BaseRecord>> valueMap = new HashMap<>();
+  private boolean giveErrors = false;
+  private boolean initialized = false;
+  private final Map<String, Map<String, BaseRecord>> valueMap = new HashMap<>();
 
   @Override
   public boolean initDriver() {
@@ -59,6 +60,18 @@ public class MockStateStoreDriver extends StateStoreBaseImpl {
     initialized = false;
   }
 
+  /**
+   * Should this object throw an IOException on each following call?
+   * @param value should we throw errors?
+   */
+  public void setGiveErrors(boolean value) {
+    giveErrors = value;
+  }
+
+  /**
+   * Check to see if this StateStore should throw IOException on each call.
+   * @throws IOException thrown if giveErrors has been set
+   */
   private void checkErrors() throws IOException {
     if (giveErrors) {
       throw new IOException("Induced errors");
@@ -66,11 +79,11 @@ public class MockStateStoreDriver extends StateStoreBaseImpl {
   }
 
   @Override
-  @SuppressWarnings({"rawtypes"})
-  public <T extends BaseRecord> QueryResult get(Class<T> clazz) throws IOException {
+  @SuppressWarnings("unchecked")
+  public <T extends BaseRecord> QueryResult<T> get(Class<T> clazz) throws IOException {
     checkErrors();
     Map<String, BaseRecord> map = valueMap.get(StateStoreUtils.getRecordName(clazz));
-    List<BaseRecord> results = map != null ? new ArrayList<>(map.values()) : new ArrayList<>();
+    List<T> results = map != null ? new ArrayList<>((Collection<T>) map.values()) : new ArrayList<>();
     return new QueryResult<>(results, System.currentTimeMillis());
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/MockStateStoreDriver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/MockStateStoreDriver.java
@@ -83,7 +83,8 @@ public class MockStateStoreDriver extends StateStoreBaseImpl {
   public <T extends BaseRecord> QueryResult<T> get(Class<T> clazz) throws IOException {
     checkErrors();
     Map<String, BaseRecord> map = valueMap.get(StateStoreUtils.getRecordName(clazz));
-    List<T> results = map != null ? new ArrayList<>((Collection<T>) map.values()) : new ArrayList<>();
+    List<T> results =
+        map != null ? new ArrayList<>((Collection<T>) map.values()) : new ArrayList<>();
     return new QueryResult<>(results, System.currentTimeMillis());
   }
 
@@ -125,7 +126,7 @@ public class MockStateStoreDriver extends StateStoreBaseImpl {
     Map<String, BaseRecord> map =
         valueMap.get(StateStoreUtils.getRecordName(clazz));
     if (map != null) {
-      for (Iterator<BaseRecord> itr = map.values().iterator(); itr.hasNext(); ) {
+      for (Iterator<BaseRecord> itr = map.values().iterator(); itr.hasNext();) {
         BaseRecord record = itr.next();
         if (query.matches((T) record)) {
           itr.remove();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/MockStateStoreDriver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/MockStateStoreDriver.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.store.records;
+
+import org.apache.hadoop.hdfs.server.federation.store.StateStoreUtils;
+import org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreBaseImpl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A mock StateStoreDriver that runs in memory that can force IOExceptions
+ * upon demand.
+ */
+public class MockStateStoreDriver extends StateStoreBaseImpl {
+  boolean giveErrors = false;
+  boolean initialized = false;
+  Map<String, Map<String, BaseRecord>> valueMap = new HashMap<>();
+
+  @Override
+  public boolean initDriver() {
+    initialized = true;
+    return true;
+  }
+
+  @Override
+  public <T extends BaseRecord> boolean initRecordStorage(String className,
+                                                          Class<T> clazz) {
+    return true;
+  }
+
+  @Override
+  public boolean isDriverReady() {
+    return initialized;
+  }
+
+  @Override
+  public void close() throws Exception {
+    valueMap.clear();
+    initialized = false;
+  }
+
+  private void checkErrors() throws IOException {
+    if (giveErrors) {
+      throw new IOException("Induced errors");
+    }
+  }
+
+  @Override
+  @SuppressWarnings({"rawtypes"})
+  public <T extends BaseRecord> QueryResult get(Class<T> clazz) throws IOException {
+    checkErrors();
+    Map<String, BaseRecord> map = valueMap.get(StateStoreUtils.getRecordName(clazz));
+    List<BaseRecord> results = map != null ? new ArrayList<>(map.values()) : new ArrayList<>();
+    return new QueryResult<>(results, System.currentTimeMillis());
+  }
+
+  @Override
+  public <T extends BaseRecord> boolean putAll(List<T> records,
+                                               boolean allowUpdate,
+                                               boolean errorIfExists)
+      throws IOException {
+    checkErrors();
+    for (T record : records) {
+      Map<String, BaseRecord> map =
+          valueMap.computeIfAbsent(StateStoreUtils.getRecordName(record.getClass()),
+              k -> new HashMap<>());
+      String key = record.getPrimaryKey();
+      BaseRecord oldRecord = map.get(key);
+      if (oldRecord == null || allowUpdate) {
+        map.put(key, record);
+      } else if (errorIfExists) {
+        throw new IOException("Record already exists for " + record.getClass()
+            + ": " + key);
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public <T extends BaseRecord> boolean removeAll(Class<T> clazz) throws IOException {
+    checkErrors();
+    return valueMap.remove(StateStoreUtils.getRecordName(clazz)) != null;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T extends BaseRecord> int remove(Class<T> clazz,
+                                           Query<T> query)
+      throws IOException {
+    checkErrors();
+    int result = 0;
+    Map<String, BaseRecord> map =
+        valueMap.get(StateStoreUtils.getRecordName(clazz));
+    if (map != null) {
+      for (Iterator<BaseRecord> itr = map.values().iterator(); itr.hasNext(); ) {
+        BaseRecord record = itr.next();
+        if (query.matches((T) record)) {
+          itr.remove();
+          result += 1;
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/TestRouterState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/TestRouterState.java
@@ -121,8 +121,10 @@ public class TestRouterState {
     assertEquals(2, result.size());
 
     // cause io errors and then reload the cache
-    driver.giveErrors = true;
+    driver.setGiveErrors(true);
+    long previousUpdate = service.getCacheUpdateTime();
     service.refreshCaches(true);
+    assertEquals(previousUpdate, service.getCacheUpdateTime());
 
     // make sure the old cache is still there
     result = resolver.getNamenodesForBlockPoolId("block1");

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/TestRouterState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/TestRouterState.java
@@ -20,11 +20,7 @@ package org.apache.hadoop.hdfs.server.federation.store.records;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeContext;
@@ -33,10 +29,8 @@ import org.apache.hadoop.hdfs.server.federation.resolver.MembershipNamenodeResol
 import org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys;
 import org.apache.hadoop.hdfs.server.federation.router.RouterServiceState;
 import org.apache.hadoop.hdfs.server.federation.store.StateStoreService;
-import org.apache.hadoop.hdfs.server.federation.store.StateStoreUtils;
 import org.apache.hadoop.hdfs.server.federation.store.driver.StateStoreDriver;
 import org.apache.hadoop.hdfs.server.federation.store.driver.StateStoreSerializer;
-import org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreBaseImpl;
 import org.junit.Test;
 
 /**
@@ -95,104 +89,6 @@ public class TestRouterState {
         serializer.deserialize(serializedString, RouterState.class);
 
     validateRecord(newRecord);
-  }
-
-  /**
-   * A mock StateStoreDriver that runs in memory and can cause errors.
-   */
-  public static class MockStateStoreDriver extends StateStoreBaseImpl {
-    boolean giveErrors = false;
-    boolean initialized = false;
-    Map<String, Map<String, BaseRecord>> valueMap = new HashMap<>();
-
-    @Override
-    public boolean initDriver() {
-      initialized = true;
-      return true;
-    }
-
-    @Override
-    public <T extends BaseRecord> boolean initRecordStorage(String className,
-                                                            Class<T> clazz) {
-      return true;
-    }
-
-    @Override
-    public boolean isDriverReady() {
-      return initialized;
-    }
-
-    @Override
-    public void close() throws Exception {
-      valueMap.clear();
-      initialized = false;
-    }
-
-    private void checkErrors() throws IOException {
-      if (giveErrors) {
-        throw new IOException("Induced errors");
-      }
-    }
-
-    @Override
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    public <T extends BaseRecord> QueryResult get(Class<T> clazz) throws IOException {
-      checkErrors();
-      Map<String, BaseRecord> map = valueMap.get(StateStoreUtils.getRecordName(clazz));
-      List<BaseRecord> results = map != null
-          ? new ArrayList<>(map.values()) : new ArrayList<>();
-      return new QueryResult<>(results, System.currentTimeMillis());
-    }
-
-    @Override
-    public <T extends BaseRecord> boolean putAll(List<T> records,
-                                                 boolean allowUpdate,
-                                                 boolean errorIfExists)
-        throws IOException {
-      checkErrors();
-      for (T record: records) {
-        Map<String, BaseRecord> map =
-            valueMap.computeIfAbsent(StateStoreUtils.getRecordName(record.getClass()),
-                k -> new HashMap<>());
-        String key = record.getPrimaryKey();
-        BaseRecord oldRecord = map.get(key);
-        if (oldRecord == null || allowUpdate) {
-          map.put(key, record);
-        } else if (errorIfExists) {
-          throw new IOException("Record already exists for " + record.getClass()
-              + ": " + key);
-        }
-      }
-      return true;
-    }
-
-    @Override
-    public <T extends BaseRecord> boolean removeAll(Class<T> clazz) throws IOException {
-      checkErrors();
-      valueMap.remove(StateStoreUtils.getRecordName(clazz));
-      return true;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <T extends BaseRecord> int remove(Class<T> clazz,
-                                             Query<T> query)
-        throws IOException {
-      checkErrors();
-      int result = 0;
-      Map<String, BaseRecord> map =
-          valueMap.get(StateStoreUtils.getRecordName(clazz));
-      if (map != null) {
-        for (Iterator<BaseRecord> itr = map.values().iterator(); itr.hasNext(); ) {
-          BaseRecord record = itr.next();
-          if (query.matches((T) record)) {
-            itr.remove();
-            result += 1;
-          }
-        }
-      }
-      return result;
-    }
   }
 
   @Test


### PR DESCRIPTION
Addresses 'Cannot locate a registered namenode for XXX' errors.

It was tested in our RBF cluster and dramatically improved stability when using the HDFS state store.