### PR TITLE
HDFS-16846. EC: Only EC blocks should be effected by max-streams-hard-limit configuration

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -1829,9 +1829,9 @@ public class DatanodeManager {
     int totalECBlocks = nodeinfo.getNumberOfBlocksToBeErasureCoded();
     int totalBlocks = totalReplicateBlocks + totalECBlocks;
     if (totalBlocks > 0) {
-      int maxECTransfers;
       int maxReplicationTransfers = blockManager.getMaxReplicationStreams()
-              - xmitsInProgress;;
+              - xmitsInProgress;
+      int maxECTransfers;
       if (nodeinfo.isDecommissionInProgress()) {
         maxECTransfers = blockManager.getReplicationStreamsHardLimit()
             - xmitsInProgress;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -1829,18 +1829,20 @@ public class DatanodeManager {
     int totalECBlocks = nodeinfo.getNumberOfBlocksToBeErasureCoded();
     int totalBlocks = totalReplicateBlocks + totalECBlocks;
     if (totalBlocks > 0) {
-      int maxTransfers;
+      int maxECTransfers;
+      int maxReplicationTransfers = blockManager.getMaxReplicationStreams()
+              - xmitsInProgress;;
       if (nodeinfo.isDecommissionInProgress()) {
-        maxTransfers = blockManager.getReplicationStreamsHardLimit()
+        maxECTransfers = blockManager.getReplicationStreamsHardLimit()
             - xmitsInProgress;
       } else {
-        maxTransfers = blockManager.getMaxReplicationStreams()
+        maxECTransfers = blockManager.getMaxReplicationStreams()
             - xmitsInProgress;
       }
       int numReplicationTasks = (int) Math.ceil(
-          (double) (totalReplicateBlocks * maxTransfers) / totalBlocks);
+          (double) (totalReplicateBlocks * maxReplicationTransfers) / totalBlocks);
       int numECTasks = (int) Math.ceil(
-          (double) (totalECBlocks * maxTransfers) / totalBlocks);
+          (double) (totalECBlocks * maxECTransfers) / totalBlocks);
       LOG.debug("Pending replication tasks: {} erasure-coded tasks: {}.",
           numReplicationTasks, numECTasks);
       // check pending replication tasks

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -1826,32 +1826,25 @@ public class DatanodeManager {
     // NN chooses pending tasks based on the ratio between the lengths of
     // replication and erasure-coded block queues.
     int replicationBlocks = nodeinfo.getNumberOfReplicateBlocks();
-    int ecReplicatedBlocks = nodeinfo.getNumberOfECReplicatedBlocks();
-    int ecReconstructedBlocks = nodeinfo.getNumberOfBlocksToBeErasureCoded();
-    int totalBlocks = replicationBlocks + ecReplicatedBlocks + ecReconstructedBlocks;
+    int ecBlocksToBeReplicated = nodeinfo.getNumberOfECBlocksToBeReplicated();
+    int ecBlocksToBeErasureCoded = nodeinfo.getNumberOfBlocksToBeErasureCoded();
+    int totalBlocks = replicationBlocks + ecBlocksToBeReplicated + ecBlocksToBeErasureCoded;
     if (totalBlocks > 0) {
-      int maxReplicationTransfers = blockManager.getMaxReplicationStreams()
-              - xmitsInProgress;
+      int maxTransfers = blockManager.getMaxReplicationStreams() - xmitsInProgress;
       int maxECReplicatedTransfers;
-      int maxECReconstructedTransfers;
       if (nodeinfo.isDecommissionInProgress()) {
         maxECReplicatedTransfers = blockManager.getReplicationStreamsHardLimit()
             - xmitsInProgress;
-        maxECReconstructedTransfers = blockManager.getReplicationStreamsHardLimit()
-                - xmitsInProgress;
       } else {
-        maxECReplicatedTransfers = blockManager.getMaxReplicationStreams()
-            - xmitsInProgress;
-        maxECReconstructedTransfers = blockManager.getMaxReplicationStreams()
-                - xmitsInProgress;
+        maxECReplicatedTransfers = maxTransfers;
       }
       int numReplicationTasks = (int) Math.ceil(
-          (double) (replicationBlocks * maxReplicationTransfers) / totalBlocks);
+          (double) (replicationBlocks * maxTransfers) / totalBlocks);
       int numEcReplicatedTasks = (int) Math.ceil(
-              (double) (ecReplicatedBlocks * maxECReplicatedTransfers) / totalBlocks);
+              (double) (ecBlocksToBeReplicated * maxECReplicatedTransfers) / totalBlocks);
       int numECReconstructedTasks = (int) Math.ceil(
-          (double) (ecReconstructedBlocks * maxECReconstructedTransfers) / totalBlocks);
-      LOG.debug("Pending replication tasks: {} ec replicated tasks: {} " +
+          (double) (ecBlocksToBeErasureCoded * maxTransfers) / totalBlocks);
+      LOG.debug("Pending replication tasks: {} ec to be replicated tasks: {} " +
                       "ec reconstruction tasks: {}.",
           numReplicationTasks, numEcReplicatedTasks, numECReconstructedTasks);
       // check pending replication tasks

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/ErasureCodingWork.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/ErasureCodingWork.java
@@ -164,7 +164,7 @@ class ErasureCodingWork extends BlockReconstructionWork {
         stripedBlk.getDataBlockNum(), blockIndex);
     final Block targetBlk = new Block(stripedBlk.getBlockId() + blockIndex,
         internBlkLen, stripedBlk.getGenerationStamp());
-    source.addBlockToBeReplicated(targetBlk,
+    source.addECBlockToBeReplicated(targetBlk,
         new DatanodeStorageInfo[] {target});
     LOG.debug("Add replication task from source {} to "
         + "target {} for EC block {}", source, target, targetBlk);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithStriped.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithStriped.java
@@ -759,7 +759,7 @@ public class TestDecommissionWithStriped {
     DatanodeInfo extraDn = getDatanodeOutOfTheBlock(blk);
     DatanodeDescriptor target = bm.getDatanodeManager()
         .getDatanode(extraDn.getDatanodeUuid());
-    dn0.addBlockToBeReplicated(targetBlk,
+    dn0.addECBlockToBeReplicated(targetBlk,
         new DatanodeStorageInfo[] {target.getStorageInfos()[0]});
 
     // dn0 replicates in success
@@ -883,7 +883,7 @@ public class TestDecommissionWithStriped {
         .getDatanode(extraDn.getDatanodeUuid());
     DatanodeDescriptor dnStartIndexDecommission = bm.getDatanodeManager()
         .getDatanode(dnLocs[decommNodeIndex].getDatanodeUuid());
-    dnStartIndexDecommission.addBlockToBeReplicated(targetBlk,
+    dnStartIndexDecommission.addECBlockToBeReplicated(targetBlk,
         new DatanodeStorageInfo[] {target.getStorageInfos()[0]});
 
     // Wait for replication success.
@@ -972,7 +972,7 @@ public class TestDecommissionWithStriped {
     DatanodeInfo extraDn = getDatanodeOutOfTheBlock(blk);
     DatanodeDescriptor target = bm.getDatanodeManager()
         .getDatanode(extraDn.getDatanodeUuid());
-    dn0.addBlockToBeReplicated(targetBlk,
+    dn0.addECBlockToBeReplicated(targetBlk,
         new DatanodeStorageInfo[] {target.getStorageInfos()[0]});
 
     // dn0 replicates in success

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
@@ -967,20 +967,22 @@ public class TestDatanodeManager {
    * Verify the correctness of pending recovery process.
    *
    * @param numReplicationBlocks the number of replication blocks in the queue.
-   * @param numECBlocks number of EC blocks in the queue.
+   * @param numEcBlocksToBeReplicated the number of EC blocks to be replicated in the queue.
+   * @param numBlocksToBeErasureCoded number of EC blocks to be erasure coded in the queue.
    * @param maxTransfers the maxTransfer value.
    * @param maxTransfersHardLimit the maxTransfer hard limit value.
-   * @param numReplicationTasks the number of replication tasks polled from
-   *                            the queue.
-   * @param numECTasks the number of EC tasks polled from the queue.
+   * @param numReplicationTasks the number of replication tasks polled from the queue.
+   * @param numECTasksToBeReplicated the number of EC tasks to be replicated polled from the queue.
+   * @param numECTasksToBeErasureCoded the number of EC tasks to be erasure coded polled from
+   *                                   the queue.
    * @param isDecommissioning if the node is in the decommissioning process.
    *
    * @throws IOException
    */
   private void verifyPendingRecoveryTasks(
-      int numReplicationBlocks, int numEcReplicatedBlocks, int numECBlocks,
+      int numReplicationBlocks, int numEcBlocksToBeReplicated, int numBlocksToBeErasureCoded,
       int maxTransfers, int maxTransfersHardLimit, int numReplicationTasks,
-      int numECReplicatedTasks, int numECTasks, boolean isDecommissioning)
+      int numECTasksToBeReplicated, int numECTasksToBeErasureCoded, boolean isDecommissioning)
       throws IOException {
     FSNamesystem fsn = Mockito.mock(FSNamesystem.class);
     Mockito.when(fsn.hasWriteLock()).thenReturn(true);
@@ -1009,25 +1011,25 @@ public class TestDatanodeManager {
           .thenReturn(tasks);
     }
 
-    if (numEcReplicatedBlocks > 0) {
-      Mockito.when(nodeInfo.getNumberOfECReplicatedBlocks())
-              .thenReturn(numEcReplicatedBlocks);
+    if (numEcBlocksToBeReplicated > 0) {
+      Mockito.when(nodeInfo.getNumberOfECBlocksToBeReplicated())
+              .thenReturn(numEcBlocksToBeReplicated);
 
       List<BlockTargetPair> ecReplicatedTasks =
               Collections.nCopies(
-                      Math.min(numECReplicatedTasks, numEcReplicatedBlocks),
+                      Math.min(numECTasksToBeReplicated, numEcBlocksToBeReplicated),
                       new BlockTargetPair(null, null));
-      Mockito.when(nodeInfo.getReplicationCommand(numECReplicatedTasks))
+      Mockito.when(nodeInfo.getReplicationCommand(numECTasksToBeReplicated))
               .thenReturn(ecReplicatedTasks);
     }
 
-    if (numECBlocks > 0) {
+    if (numBlocksToBeErasureCoded > 0) {
       Mockito.when(nodeInfo.getNumberOfBlocksToBeErasureCoded())
-          .thenReturn(numECBlocks);
+          .thenReturn(numBlocksToBeErasureCoded);
 
       List<BlockECReconstructionInfo> tasks =
-          Collections.nCopies(numECTasks, null);
-      Mockito.when(nodeInfo.getErasureCodeCommand(numECTasks))
+          Collections.nCopies(numECTasksToBeErasureCoded, null);
+      Mockito.when(nodeInfo.getErasureCodeCommand(numECTasksToBeErasureCoded))
           .thenReturn(tasks);
     }
 
@@ -1038,7 +1040,7 @@ public class TestDatanodeManager {
         SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT);
 
     long expectedNumCmds = Arrays.stream(
-        new int[]{numReplicationTasks, numECTasks})
+        new int[]{numReplicationTasks, numECTasksToBeErasureCoded})
         .filter(x -> x > 0)
         .count();
     assertEquals(expectedNumCmds, cmds.length);
@@ -1052,15 +1054,15 @@ public class TestDatanodeManager {
       idx++;
     }
 
-    if (numECTasks > 0) {
+    if (numECTasksToBeErasureCoded > 0) {
       assertTrue(cmds[idx] instanceof BlockECReconstructionCommand);
       BlockECReconstructionCommand cmd =
           (BlockECReconstructionCommand) cmds[idx];
-      assertEquals(numECTasks, cmd.getECTasks().size());
+      assertEquals(numECTasksToBeErasureCoded, cmd.getECTasks().size());
     }
 
     Mockito.verify(nodeInfo).getReplicationCommand(numReplicationTasks);
-    Mockito.verify(nodeInfo).getErasureCodeCommand(numECTasks);
+    Mockito.verify(nodeInfo).getErasureCodeCommand(numECTasksToBeErasureCoded);
   }
 
   @Test
@@ -1073,7 +1075,7 @@ public class TestDatanodeManager {
     verifyPendingRecoveryTasks(400, 0, 1, 20, 30, 20, 0, 1, false);
 
     // Tasks use dfs.namenode.replication.max-streams-hard-limit for decommissioning node
-    verifyPendingRecoveryTasks(20, 10, 10, 20, 40, 10, 10, 10, true);
+    verifyPendingRecoveryTasks(20, 10, 10, 20, 40, 10, 10, 5, true);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
@@ -1061,7 +1061,7 @@ public class TestDatanodeManager {
     verifyPendingRecoveryTasks(400, 1, 20, 30, 20, 1, false);
 
     // Tasks use dfs.namenode.replication.max-streams-hard-limit for decommissioning node
-    verifyPendingRecoveryTasks(30, 30, 20, 30, 15, 15, true);
+    verifyPendingRecoveryTasks(30, 30, 20, 30, 10, 15, true);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
@@ -1019,7 +1019,7 @@ public class TestDatanodeManager {
               Collections.nCopies(
                       Math.min(numECTasksToBeReplicated, numEcBlocksToBeReplicated),
                       new BlockTargetPair(null, null));
-      Mockito.when(nodeInfo.getReplicationCommand(numECTasksToBeReplicated))
+      Mockito.when(nodeInfo.getECReplicatedCommand(numECTasksToBeReplicated))
               .thenReturn(ecReplicatedTasks);
     }
 
@@ -1040,17 +1040,17 @@ public class TestDatanodeManager {
         SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT);
 
     long expectedNumCmds = Arrays.stream(
-        new int[]{numReplicationTasks, numECTasksToBeErasureCoded})
+        new int[]{numReplicationTasks + numECTasksToBeReplicated, numECTasksToBeErasureCoded})
         .filter(x -> x > 0)
         .count();
     assertEquals(expectedNumCmds, cmds.length);
 
     int idx = 0;
-    if (numReplicationTasks > 0) {
+    if (numReplicationTasks > 0 || numECTasksToBeReplicated > 0) {
       assertTrue(cmds[idx] instanceof BlockCommand);
       BlockCommand cmd = (BlockCommand) cmds[0];
-      assertEquals(numReplicationTasks, cmd.getBlocks().length);
-      assertEquals(numReplicationTasks, cmd.getTargets().length);
+      assertEquals(numReplicationTasks + numECTasksToBeReplicated, cmd.getBlocks().length);
+      assertEquals(numReplicationTasks + numECTasksToBeReplicated, cmd.getTargets().length);
       idx++;
     }
 
@@ -1062,6 +1062,7 @@ public class TestDatanodeManager {
     }
 
     Mockito.verify(nodeInfo).getReplicationCommand(numReplicationTasks);
+    Mockito.verify(nodeInfo).getECReplicatedCommand(numECTasksToBeReplicated);
     Mockito.verify(nodeInfo).getErasureCodeCommand(numECTasksToBeErasureCoded);
   }
 


### PR DESCRIPTION
In [HDFS-16613](https://issues.apache.org/jira/browse/HDFS-16613), the dfs.namenode.replication.max-streams-hard-limit configuration will only affect decommissioning DataNode, but will not distinguish between replication blocks and EC blocks. Even if DataNodes have only replication files, they will always generate high network traffic. So this configuration should only effect EC blocks.