### PR TITLE
HADOOP-18526. Leak of S3AInstrumentation instances via hadoop Metrics references

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/WeakRefMetricsSource.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/WeakRefMetricsSource.java
@@ -78,6 +78,14 @@ public class WeakRefMetricsSource implements MetricsSource {
     return name;
   }
 
+  /**
+   * Get the source, will be null if the reference has been GC'd
+   * @return the source reference
+   */
+  public MetricsSource getSource() {
+    return sourceWeakReference.get();
+  }
+
   @Override
   public String toString() {
     return "WeakRefMetricsSource{" +

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/WeakRefMetricsSource.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/WeakRefMetricsSource.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.impl;
+
+import java.lang.ref.WeakReference;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsSource;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A weak referenced metrics source which avoids hanging on to large objects
+ * if somehow they don't get fully closed/cleaned up.
+ */
+@InterfaceAudience.Private
+public class WeakRefMetricsSource implements MetricsSource {
+
+  /**
+   * Name to know when unregistering.
+   */
+  private final String name;
+
+  /**
+   * Underlying metrics source.
+   */
+  private final WeakReference<MetricsSource> sourceWeakReference;
+
+  /**
+   * Constructor.
+   * @param name Name to know when unregistering.
+   * @param source metrics source
+   */
+  public WeakRefMetricsSource(final String name, final MetricsSource source) {
+    this.name = name;
+    this.sourceWeakReference = new WeakReference<>(requireNonNull(source));
+  }
+
+  /**
+   * If the weak reference is non null, update the metrics.
+   * @param collector to contain the resulting metrics snapshot
+   * @param all if true, return all metrics even if unchanged.
+   */
+  @Override
+  public void getMetrics(final MetricsCollector collector, final boolean all) {
+    MetricsSource metricsSource = sourceWeakReference.get();
+    if (metricsSource != null) {
+      metricsSource.getMetrics(collector, all);
+    }
+  }
+
+  /**
+   * Name to know when unregistering.
+   * @return the name passed in during construction.
+   */
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return "WeakRefMetricsSource{" +
+        "name='" + name + '\'' +
+        ", sourceWeakReference is " +
+        (sourceWeakReference.get() == null ? "unset" : "set") +
+        '}';
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/WeakRefMetricsSource.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/WeakRefMetricsSource.java
@@ -29,6 +29,10 @@ import static java.util.Objects.requireNonNull;
 /**
  * A weak referenced metrics source which avoids hanging on to large objects
  * if somehow they don't get fully closed/cleaned up.
+ * The JVM may clean up all objects which are only weakly referenced whenever
+ * it does a GC, <i>even if there is no memory pressure</i>.
+ * To avoid these refs being removed, always keep a strong reference around
+ * somewhere.
  */
 @InterfaceAudience.Private
 public class WeakRefMetricsSource implements MetricsSource {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -4016,6 +4016,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       LOG.debug("Statistics for {}: {}", uri,
           IOStatisticsLogging.ioStatisticsToPrettyString(getIOStatistics()));
     }
+    // and shut down the statistics, which includes deregistering the metrics
+    cleanupWithLogger(LOG, instrumentation);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -458,6 +458,12 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     AuditSpan span = null;
     try {
       LOG.debug("Initializing S3AFileSystem for {}", bucket);
+      if (LOG.isTraceEnabled()) {
+        // log a full trace for deep diagnostics of where an object is created,
+        // for tracking down memory leak issues.
+        LOG.trace("Filesystem for {} creation stack",
+            name, new RuntimeException(super.toString()));
+      }
       // clone the configuration into one with propagated bucket options
       Configuration conf = propagateBucketOptions(originalConf, bucket);
       // HADOOP-17894. remove references to s3a stores in JCEKS credentials.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -461,8 +461,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       if (LOG.isTraceEnabled()) {
         // log a full trace for deep diagnostics of where an object is created,
         // for tracking down memory leak issues.
-        LOG.trace("Filesystem for {} creation stack",
-            name, new RuntimeException(super.toString()));
+        LOG.trace("Filesystem for {} created; fs.s3a.impl.disable.cache = {}",
+            name, originalConf.getBoolean("fs.s3a.impl.disable.cache", false),
+            new RuntimeException(super.toString()));
       }
       // clone the configuration into one with propagated bucket options
       Configuration conf = propagateBucketOptions(originalConf, bucket);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -263,7 +263,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
   }
 
   /**
-   * Register this instance as a metrics source.
+   * Register this instance as a metrics source via a weak reference.
    * @param name s3a:// URI for the associated FileSystem instance
    */
   private void registerAsMetricsSource(URI name) {
@@ -277,7 +277,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     String msName = METRICS_SOURCE_BASENAME + number;
     String metricsSourceName = msName + "-" + name.getHost();
     metricsSourceReference = new WeakRefMetricsSource(metricsSourceName, this);
-    metricsSystem.register(metricsSourceName, "", this);
+    metricsSystem.register(metricsSourceName, "", metricsSourceReference);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -699,6 +699,17 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     registry.snapshot(collector.addRecord(registry.info().name()), true);
   }
 
+  /**
+   * if registered with the metrics, return the
+   * name of the source.
+   * @return the name of the metrics, or null if this instance is not bonded.
+   */
+  public String getMetricSourceName() {
+    return metricsSourceReference != null
+        ? metricsSourceReference.getName()
+        : null;
+  }
+
   public void close() {
     if (metricsSourceReference != null) {
       // get the name

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AClosedFS.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AClosedFS.java
@@ -103,4 +103,16 @@ public class ITestS3AClosedFS extends AbstractS3ATestBase {
         () ->  getFileSystem().open(path("to-open")));
   }
 
+  @Test
+  public void testClosedInstrumentation() throws Exception {
+    // no metrics
+    Assertions.assertThat(S3AInstrumentation.hasMetricSystem())
+        .describedAs("S3AInstrumentation.hasMetricSystem()")
+        .isFalse();
+
+    Assertions.assertThat(getFileSystem().getIOStatistics())
+        .describedAs("iostatistics of %s", getFileSystem())
+        .isNotNull();
+  }
+
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestInstrumentationLifecycle.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestInstrumentationLifecycle.java
@@ -22,7 +22,6 @@ import java.net.URI;
 
 import org.junit.Test;
 
-import org.apache.hadoop.fs.statistics.StoreStatisticNames;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestInstrumentationLifecycle.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestInstrumentationLifecycle.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import java.net.URI;
+
+import org.junit.Test;
+
+import org.apache.hadoop.fs.statistics.StoreStatisticNames;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static org.apache.hadoop.fs.s3a.S3AInstrumentation.getMetricsSystem;
+import static org.apache.hadoop.fs.s3a.Statistic.DIRECTORIES_CREATED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestInstrumentationLifecycle extends AbstractHadoopTestBase {
+
+  @Test
+  public void testDoubleClose() throws Throwable {
+    S3AInstrumentation instrumentation = new S3AInstrumentation(new URI("s3a://example/"));
+
+    // the metric system is created in the constructor
+    assertThat(S3AInstrumentation.hasMetricSystem())
+        .describedAs("S3AInstrumentation.hasMetricSystem()")
+        .isTrue();
+    // ask for a metric
+    String metricName = DIRECTORIES_CREATED.getSymbol();
+    assertThat(instrumentation.lookupMetric(metricName))
+        .describedAs("lookupMetric(%s) while open", metricName)
+        .isNotNull();
+
+    MetricsSystem activeMetrics = getMetricsSystem();
+
+    // this will close the metrics system
+    instrumentation.close();
+
+    // iostats is still valid
+    assertThat(instrumentation.getIOStatistics())
+        .describedAs("iostats of %s", instrumentation)
+        .isNotNull();
+
+    // no metrics
+    assertThat(S3AInstrumentation.hasMetricSystem())
+        .describedAs("S3AInstrumentation.hasMetricSystem()")
+        .isFalse();
+
+    // metric lookup still works, so any invocation of an s3a
+    // method which still updates a metric also works
+    assertThat(instrumentation.lookupMetric(metricName))
+        .describedAs("lookupMetric(%s) when closed", metricName)
+        .isNotNull();
+
+    // which we can implicitly verify by asking for it and
+    // verifying that we get given a different one back
+    // from the demand-created instance
+    MetricsSystem metrics2 = getMetricsSystem();
+    assertThat(metrics2)
+        .describedAs("metric system 2")
+        .isNotSameAs(activeMetrics);
+
+    // this is going to be a no-op
+    instrumentation.close();
+
+    // which we can verify because the metrics system doesn't
+    // get closed this time
+    assertThat(getMetricsSystem())
+        .describedAs("metric system 3")
+        .isSameAs(metrics2);
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/resources/log4j.properties
+++ b/hadoop-tools/hadoop-aws/src/test/resources/log4j.properties
@@ -53,6 +53,8 @@ log4j.logger.org.apache.hadoop.ipc.Server=WARN
 # for debugging low level S3a operations, uncomment these lines
 # Log all S3A classes
 log4j.logger.org.apache.hadoop.fs.s3a=DEBUG
+# when logging at trace, the stack of the initialize() call is logged
+#log4j.logger.org.apache.hadoop.fs.s3a.S3AFileSystem=TRACE
 #log4j.logger.org.apache.hadoop.fs.s3a.S3AUtils=INFO
 #log4j.logger.org.apache.hadoop.fs.s3a.Listing=INFO
 log4j.logger.org.apache.hadoop.fs.s3a.SDKV2Upgrade=WARN


### PR DESCRIPTION

This has triggered an OOM in a process which was churning through s3a fs instances; the increased memory footprint of IOStatistics amplified what must have been a long standing issue.

* Makes sure instrumentation is closed when fs is closed
* Uses a weak reference from metrics to instrumentation, so even if the fs wasn't closed (see HADOOP-18478), this ref would not be holding things back.


### How was this patch tested?

cloud tests. no new tests...if there are suggestions, that'd be good

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

