### PR TITLE
HDFS-16848. RBF: Improve StateStoreZooKeeperImpl performance

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -239,6 +239,18 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
   public static final long
       FEDERATION_STORE_ROUTER_EXPIRATION_DELETION_MS_DEFAULT = -1;
 
+  // HDFS Router-based federation State Store ZK DRIVER
+  public static final String FEDERATION_STORE_ZK_DRIVER_PREFIX =
+      RBFConfigKeys.FEDERATION_STORE_PREFIX + "driver.zk.";
+  public static final String FEDERATION_STORE_ZK_PARENT_PATH =
+      FEDERATION_STORE_ZK_DRIVER_PREFIX + "parent-path";
+  public static final String FEDERATION_STORE_ZK_ASYNC_MAX_THREADS =
+      FEDERATION_STORE_ZK_DRIVER_PREFIX + "async.max.threads";
+  public static final int FEDERATION_STORE_ZK_ASYNC_MAX_THREADS_DEFAULT =
+      -1;
+  public static final String FEDERATION_STORE_ZK_PARENT_PATH_DEFAULT =
+      "/hdfs-federation";
+
   // HDFS Router safe mode
   public static final String DFS_ROUTER_SAFEMODE_ENABLE =
       FEDERATION_ROUTER_PREFIX + "safemode.enable";

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -244,12 +244,12 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
       RBFConfigKeys.FEDERATION_STORE_PREFIX + "driver.zk.";
   public static final String FEDERATION_STORE_ZK_PARENT_PATH =
       FEDERATION_STORE_ZK_DRIVER_PREFIX + "parent-path";
+  public static final String FEDERATION_STORE_ZK_PARENT_PATH_DEFAULT =
+      "/hdfs-federation";
   public static final String FEDERATION_STORE_ZK_ASYNC_MAX_THREADS =
       FEDERATION_STORE_ZK_DRIVER_PREFIX + "async.max.threads";
   public static final int FEDERATION_STORE_ZK_ASYNC_MAX_THREADS_DEFAULT =
       -1;
-  public static final String FEDERATION_STORE_ZK_PARENT_PATH_DEFAULT =
-      "/hdfs-federation";
 
   // HDFS Router safe mode
   public static final String DFS_ROUTER_SAFEMODE_ENABLE =

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/driver/impl/StateStoreZooKeeperImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/driver/impl/StateStoreZooKeeperImpl.java
@@ -260,7 +260,7 @@ public class StateStoreZooKeeperImpl extends StateStoreSerializableImpl {
     );
     try {
       if (enableConcurrent) {
-          executorService.invokeAll(callables);
+        executorService.invokeAll(callables);
       } else {
         for(Callable<Void> callable : callables) {
           callable.call();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -378,13 +378,13 @@
   </property>
 
   <property>
-    <name>dfs.federation.router.store.driver.zk.client.size</name>
+    <name>dfs.federation.router.store.driver.zk.async.max.threads</name>
     <value>-1</value>
     <description>
-      Client threads size of StateStoreZooKeeperImpl in async mode.
+      Max threads number of StateStoreZooKeeperImpl in async mode.
       The only class currently being supported:
       org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl.
-      Default value is -1, which means StateStoreZooKeeperImpl working is in sync mode.
+      Default value is -1, which means StateStoreZooKeeperImpl is working in sync mode.
       Use positive integer value to enable async mode.
     </description>
   </property>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -378,6 +378,18 @@
   </property>
 
   <property>
+    <name>dfs.federation.router.store.driver.zk.client.size</name>
+    <value></value>
+    <description>
+      Client threads size of StateStoreZooKeeperImpl in async mode.
+      The only class currently being supported:
+      org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl.
+      Default value is -1, which means StateStoreZooKeeperImpl working is in sync mode.
+      Use positive integer value to enable async mode.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.federation.router.cache.ttl</name>
     <value>1m</value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -379,7 +379,7 @@
 
   <property>
     <name>dfs.federation.router.store.driver.zk.client.size</name>
-    <value></value>
+    <value>-1</value>
     <description>
       Client threads size of StateStoreZooKeeperImpl in async mode.
       The only class currently being supported:

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -378,6 +378,14 @@
   </property>
 
   <property>
+    <name>dfs.federation.router.store.driver.zk.parent-path</name>
+    <value>/hdfs-federation</value>
+    <description>
+      The parent path of zookeeper for StateStoreZooKeeperImpl.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.federation.router.store.driver.zk.async.max.threads</name>
     <value>-1</value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreDriverBase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreDriverBase.java
@@ -119,7 +119,7 @@ public class TestStateStoreDriverBase {
   }
 
   @SuppressWarnings("unchecked")
-  private <T extends BaseRecord> T generateFakeRecord(Class<T> recordClass)
+  protected  <T extends BaseRecord> T generateFakeRecord(Class<T> recordClass)
       throws IllegalArgumentException, IllegalAccessException, IOException {
 
     if (recordClass == MembershipState.class) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateSt
 import static org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl.FEDERATION_STORE_ZK_PARENT_PATH_DEFAULT;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -76,8 +77,7 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
     // Disable auto-repair of connection
     conf.setLong(RBFConfigKeys.FEDERATION_STORE_CONNECTION_TEST_MS,
         TimeUnit.HOURS.toMillis(1));
-    conf.setBoolean(StateStoreZooKeeperImpl.FEDERATION_STORE_ZK_CLIENT_CONCURRENT,
-        true);
+    conf.setInt(StateStoreZooKeeperImpl.FEDERATION_STORE_ZK_CLIENT_THREADS_SIZE, 10);
 
     baseZNode = conf.get(FEDERATION_STORE_ZK_PARENT_PATH,
         FEDERATION_STORE_ZK_PARENT_PATH_DEFAULT);
@@ -154,6 +154,7 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
     long endAsync = Time.now();
     System.out.printf("Sync mode total running time is %d ms, and async mode total running time is %d ms",
         endSync - startSync, endAsync - startAsync);
+    assertTrue((endSync - startSync) > (endAsync - startAsync) * 5);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
@@ -152,9 +152,10 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
     long startAsync = Time.now();
     stateStoreDriver.putAll(insertList, true, false);
     long endAsync = Time.now();
-    System.out.printf("Sync mode total running time is %d ms, and async mode total running time is %d ms",
+    System.out.printf("Sync mode total running time is %d ms, "
+            + "and async mode total running time is %d ms",
         endSync - startSync, endAsync - startAsync);
-    assertTrue((endSync - startSync) > (endAsync - startAsync) * 5);
+    assertTrue((endSync - startSync) > (endAsync - startAsync) * 2);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
@@ -157,6 +157,7 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
   public void testGetNullRecord() throws Exception {
     StateStoreZooKeeperImpl stateStoreDriver = (StateStoreZooKeeperImpl) getStateStoreDriver();
     testGetNullRecord(stateStoreDriver);
+
     // test async mode
     stateStoreDriver.setEnableConcurrent(true);
     testGetNullRecord(stateStoreDriver);
@@ -178,6 +179,7 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
       IOException, SecurityException {
     StateStoreZooKeeperImpl stateStoreDriver = (StateStoreZooKeeperImpl) getStateStoreDriver();
     testPut(stateStoreDriver);
+
     // test async mode
     stateStoreDriver.setEnableConcurrent(true);
     testPut(stateStoreDriver);
@@ -188,6 +190,7 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
       throws IllegalArgumentException, IllegalAccessException, IOException {
     StateStoreZooKeeperImpl stateStoreDriver = (StateStoreZooKeeperImpl) getStateStoreDriver();
     testRemove(stateStoreDriver);
+
     // test async mode
     stateStoreDriver.setEnableConcurrent(true);
     testRemove(stateStoreDriver);
@@ -198,6 +201,7 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
       throws IllegalArgumentException, IllegalAccessException, IOException {
     StateStoreZooKeeperImpl stateStoreDriver = (StateStoreZooKeeperImpl) getStateStoreDriver();
     testFetchErrors(stateStoreDriver);
+
     // test async mode
     stateStoreDriver.setEnableConcurrent(true);
     testFetchErrors(stateStoreDriver);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
@@ -18,8 +18,6 @@
 package org.apache.hadoop.hdfs.server.federation.store.driver;
 
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.getStateStoreConfiguration;
-import static org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl.FEDERATION_STORE_ZK_PARENT_PATH;
-import static org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl.FEDERATION_STORE_ZK_PARENT_PATH_DEFAULT;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -77,10 +75,10 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
     // Disable auto-repair of connection
     conf.setLong(RBFConfigKeys.FEDERATION_STORE_CONNECTION_TEST_MS,
         TimeUnit.HOURS.toMillis(1));
-    conf.setInt(StateStoreZooKeeperImpl.FEDERATION_STORE_ZK_CLIENT_THREADS_SIZE, 10);
+    conf.setInt(RBFConfigKeys.FEDERATION_STORE_ZK_ASYNC_MAX_THREADS, 10);
 
-    baseZNode = conf.get(FEDERATION_STORE_ZK_PARENT_PATH,
-        FEDERATION_STORE_ZK_PARENT_PATH_DEFAULT);
+    baseZNode = conf.get(RBFConfigKeys.FEDERATION_STORE_ZK_PARENT_PATH,
+        RBFConfigKeys.FEDERATION_STORE_ZK_PARENT_PATH_DEFAULT);
     getStateStore(conf);
   }
 
@@ -152,16 +150,14 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
     long startAsync = Time.now();
     stateStoreDriver.putAll(insertList, true, false);
     long endAsync = Time.now();
-    System.out.printf("Sync mode total running time is %d ms, "
-            + "and async mode total running time is %d ms",
-        endSync - startSync, endAsync - startAsync);
-    assertTrue((endSync - startSync) > (endAsync - startAsync) * 2);
+    assertTrue((endSync - startSync) > (endAsync - startAsync));
   }
 
   @Test
   public void testGetNullRecord() throws Exception {
     StateStoreZooKeeperImpl stateStoreDriver = (StateStoreZooKeeperImpl) getStateStoreDriver();
     testGetNullRecord(stateStoreDriver);
+    // test async mode
     stateStoreDriver.setEnableConcurrent(true);
     testGetNullRecord(stateStoreDriver);
   }
@@ -171,6 +167,7 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
       throws IllegalArgumentException, IllegalAccessException, IOException {
     StateStoreZooKeeperImpl stateStoreDriver = (StateStoreZooKeeperImpl) getStateStoreDriver();
     testInsert(stateStoreDriver);
+    // test async mode
     stateStoreDriver.setEnableConcurrent(true);
     testInsert(stateStoreDriver);
   }
@@ -181,6 +178,7 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
       IOException, SecurityException {
     StateStoreZooKeeperImpl stateStoreDriver = (StateStoreZooKeeperImpl) getStateStoreDriver();
     testPut(stateStoreDriver);
+    // test async mode
     stateStoreDriver.setEnableConcurrent(true);
     testPut(stateStoreDriver);
   }
@@ -190,6 +188,7 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
       throws IllegalArgumentException, IllegalAccessException, IOException {
     StateStoreZooKeeperImpl stateStoreDriver = (StateStoreZooKeeperImpl) getStateStoreDriver();
     testRemove(stateStoreDriver);
+    // test async mode
     stateStoreDriver.setEnableConcurrent(true);
     testRemove(stateStoreDriver);
   }
@@ -199,6 +198,7 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
       throws IllegalArgumentException, IllegalAccessException, IOException {
     StateStoreZooKeeperImpl stateStoreDriver = (StateStoreZooKeeperImpl) getStateStoreDriver();
     testFetchErrors(stateStoreDriver);
+    // test async mode
     stateStoreDriver.setEnableConcurrent(true);
     testFetchErrors(stateStoreDriver);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
@@ -73,6 +73,8 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
     // Disable auto-repair of connection
     conf.setLong(RBFConfigKeys.FEDERATION_STORE_CONNECTION_TEST_MS,
         TimeUnit.HOURS.toMillis(1));
+    conf.setBoolean(StateStoreZooKeeperImpl.FEDERATION_STORE_ZK_CLIENT_CONCURRENT,
+        true);
 
     baseZNode = conf.get(FEDERATION_STORE_ZK_PARENT_PATH,
         FEDERATION_STORE_ZK_PARENT_PATH_DEFAULT);
@@ -91,6 +93,8 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
   @Before
   public void startup() throws IOException {
     removeAll(getStateStoreDriver());
+    StateStoreZooKeeperImpl stateStoreZooKeeper = (StateStoreZooKeeperImpl) getStateStoreDriver();
+    stateStoreZooKeeper.setEnableConcurrent(false);
   }
 
   private <T extends BaseRecord> String generateFakeZNode(
@@ -128,31 +132,46 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
 
   @Test
   public void testGetNullRecord() throws Exception {
-    testGetNullRecord(getStateStoreDriver());
+    StateStoreZooKeeperImpl stateStoreDriver = (StateStoreZooKeeperImpl) getStateStoreDriver();
+    testGetNullRecord(stateStoreDriver);
+    stateStoreDriver.setEnableConcurrent(true);
+    testGetNullRecord(stateStoreDriver);
   }
 
   @Test
   public void testInsert()
       throws IllegalArgumentException, IllegalAccessException, IOException {
-    testInsert(getStateStoreDriver());
+    StateStoreZooKeeperImpl stateStoreDriver = (StateStoreZooKeeperImpl) getStateStoreDriver();
+    testInsert(stateStoreDriver);
+    stateStoreDriver.setEnableConcurrent(true);
+    testInsert(stateStoreDriver);
   }
 
   @Test
   public void testUpdate()
       throws IllegalArgumentException, ReflectiveOperationException,
       IOException, SecurityException {
-    testPut(getStateStoreDriver());
+    StateStoreZooKeeperImpl stateStoreDriver = (StateStoreZooKeeperImpl) getStateStoreDriver();
+    testPut(stateStoreDriver);
+    stateStoreDriver.setEnableConcurrent(true);
+    testPut(stateStoreDriver);
   }
 
   @Test
   public void testDelete()
       throws IllegalArgumentException, IllegalAccessException, IOException {
-    testRemove(getStateStoreDriver());
+    StateStoreZooKeeperImpl stateStoreDriver = (StateStoreZooKeeperImpl) getStateStoreDriver();
+    testRemove(stateStoreDriver);
+    stateStoreDriver.setEnableConcurrent(true);
+    testRemove(stateStoreDriver);
   }
 
   @Test
   public void testFetchErrors()
       throws IllegalArgumentException, IllegalAccessException, IOException {
-    testFetchErrors(getStateStoreDriver());
+    StateStoreZooKeeperImpl stateStoreDriver = (StateStoreZooKeeperImpl) getStateStoreDriver();
+    testFetchErrors(stateStoreDriver);
+    stateStoreDriver.setEnableConcurrent(true);
+    testFetchErrors(stateStoreDriver);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
@@ -20,10 +20,8 @@ package org.apache.hadoop.hdfs.server.federation.store.driver;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.getStateStoreConfiguration;
 import static org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl.FEDERATION_STORE_ZK_PARENT_PATH;
 import static org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl.FEDERATION_STORE_ZK_PARENT_PATH_DEFAULT;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -43,7 +41,6 @@ import org.apache.hadoop.hdfs.server.federation.store.records.BaseRecord;
 import org.apache.hadoop.hdfs.server.federation.store.records.DisabledNameservice;
 import org.apache.hadoop.hdfs.server.federation.store.records.MembershipState;
 import org.apache.hadoop.hdfs.server.federation.store.records.MountTable;
-import org.apache.hadoop.hdfs.server.federation.store.records.QueryResult;
 import org.apache.hadoop.hdfs.server.federation.store.records.RouterState;
 import org.apache.hadoop.util.Time;
 import org.apache.zookeeper.CreateMode;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

