### PR TITLE
MAPREDUCE-7026. Shuffle Fetcher does not log the actual error message thrown by ShuffleHandler

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/Fetcher.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/Fetcher.java
@@ -36,6 +36,7 @@ import javax.crypto.SecretKey;
 import javax.net.ssl.HttpsURLConnection;
 
 import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.Counters;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.Reporter;
@@ -71,6 +72,7 @@ public class Fetcher<K, V> extends Thread {
   private static final long FETCH_RETRY_DELAY_DEFAULT = 1000L;
   static final int TOO_MANY_REQ_STATUS_CODE = 429;
   private static final String FETCH_RETRY_AFTER_HEADER = "Retry-After";
+  private static final int MAX_ERROR_LENGTH = 10000;
 
   protected final Reporter reporter;
   @VisibleForTesting
@@ -508,6 +510,18 @@ public class Fetcher<K, V> extends Thread {
         decompressedLength = header.uncompressedLength;
         forReduce = header.forReduce;
       } catch (IllegalArgumentException e) {
+        byte[] bytes = new byte[MAX_ERROR_LENGTH];
+        int len = 0;
+        int c = input.read();
+        while (c != -1 || len < MAX_ERROR_LENGTH) {
+          bytes[len] = (byte) c;
+          len++;
+          c = input.read();
+        }
+        String errorMessage = Text.decode(bytes, 0, len);
+        if (errorMessage.length() > 0) {
+          LOG.warn("Error message from Shuffle Handler: " + errorMessage);
+        }
         badIdErrs.increment(1);
         LOG.warn("Invalid map id ", e);
         //Don't know which one was bad, so consider all of them as bad


### PR DESCRIPTION
### Description of PR

Shuffle Fetcher does not log the actual error message thrown by ShuffleHandler

JIRA - MAPREDUCE-7026

### How was this patch tested?

Verified by looking at changed logs.


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

