### PR TITLE
MAPREDUCE-7427 Parent directory permission could be wrong while create done_intermediate directory

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/jobhistory/JobHistoryEventHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/jobhistory/JobHistoryEventHandler.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Stack;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.BlockingQueue;
@@ -212,6 +213,18 @@ public class JobHistoryEventHandler extends AbstractService
               new FsPermission(
             JobHistoryUtils.HISTORY_INTERMEDIATE_DONE_DIR_PERMISSIONS
                 .toShort()));
+        Stack<Path> dirs = new Stack<Path>();
+        Path parent = doneDirPath;
+        while (!(parent.getParent() == null) && !parent.equals(doneDirFS.getHomeDirectory())) {
+          dirs.push(parent);
+          parent = parent.getParent();
+        }
+        while (!dirs.isEmpty()) {
+          Path path = dirs.pop();
+          doneDirFS.setPermission(path,new FsPermission(
+              JobHistoryUtils.HISTORY_INTERMEDIATE_DONE_DIR_PERMISSIONS
+              .toShort()));
+        }
           // TODO Temporary toShort till new FsPermission(FsPermissions)
           // respects
         // sticky


### PR DESCRIPTION
### Description of PR
MAPREDUCE-7427 When creating "history/done_intermediate", we seem to assume that the parent directory of the folder exists and has the correct permissions. But when I run it, it doesn't work. When the umask is too strict, the permission of the parent directory will be wrong. Even under the default umask, the permission of the parent directory cannot be guaranteed to be 777. This is because the "history/done_intermediate" directory needs to be accessed by mapred, and the user when the directory was created The group information is user1 and supergroup, so mapred will access it as other user. It can be seen that at the time of creation, only the permission setting of the last-level directory is concerned (setPermission will only take effect for the last-level path), and no permission is set for the parent path. In this patch, I have given permissions to its parent path through the stack

### How was this patch tested?
Test for all parent directory permission.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

