### PR TITLE
HDFS-16852. Skip KeyProviderCache shutdown hook registration if already shutting down

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/KeyProviderCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/KeyProviderCache.java
@@ -70,7 +70,8 @@ public class KeyProviderCache {
 
     // Register the shutdown hook when not in shutdown
     if (!ShutdownHookManager.get().isShutdownInProgress()) {
-      ShutdownHookManager.get().addShutdownHook(new KeyProviderCacheFinalizer(), SHUTDOWN_HOOK_PRIORITY);
+      ShutdownHookManager.get().addShutdownHook(
+          new KeyProviderCacheFinalizer(), SHUTDOWN_HOOK_PRIORITY);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/KeyProviderCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/KeyProviderCache.java
@@ -68,8 +68,11 @@ public class KeyProviderCache {
         })
         .build();
 
-    ShutdownHookManager.get().addShutdownHook(new KeyProviderCacheFinalizer(),
-        SHUTDOWN_HOOK_PRIORITY);
+    try {
+      ShutdownHookManager.get().addShutdownHook(new KeyProviderCacheFinalizer(), SHUTDOWN_HOOK_PRIORITY);
+    } catch (IllegalStateException e) {
+      LOG.warn("shutdownHook not added", e);
+    }
   }
 
   public KeyProvider get(final Configuration conf,

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/KeyProviderCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/KeyProviderCache.java
@@ -68,10 +68,9 @@ public class KeyProviderCache {
         })
         .build();
 
-    try {
+    // Register the shutdown hook when not in shutdown
+    if (!ShutdownHookManager.get().isShutdownInProgress()) {
       ShutdownHookManager.get().addShutdownHook(new KeyProviderCacheFinalizer(), SHUTDOWN_HOOK_PRIORITY);
-    } catch (IllegalStateException e) {
-      LOG.warn("shutdownHook not added", e);
     }
   }
 


### PR DESCRIPTION

### Description of PR

Check whether shutdown is in-progress before registering a new shutdown. Registering a shutdown hook during shutdown is not supported. For more details, please check HDFS-16852.

### How was this patch tested?
`mvn test -Dtest="TestKeyProviderCache"`

```
[INFO] Running org.apache.hadoop.hdfs.TestKeyProviderCache
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.475 s - in org.apache.hadoop.hdfs.TestKeyProviderCache
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

