### PR TITLE
HDFS-16853. BugFix HADOOP-18324 caused UT TestLeaseRecovery2#testHardLeaseRecoveryAfterNameNodeRestart failed

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -1251,7 +1251,10 @@ public class Client implements AutoCloseable {
     
     private synchronized void markClosed(IOException e) {
       if (shouldCloseConnection.compareAndSet(false, true)) {
-        while (rpcRequestQueue.poll() != null);
+        Pair<Call, ResponseBuffer> request;
+        while ((request = rpcRequestQueue.poll()) != null) {
+          LOG.debug("Clean {} from RpcRequestQueue.", request.getLeft());
+        }
         closeException = e;
         notifyAll();
       }


### PR DESCRIPTION
### Description of PR
Jira: [HDFS-16853](https://issues.apache.org/jira/browse/HDFS-16853)

The UT `TestLeaseRecovery2#testHardLeaseRecoveryAfterNameNodeRestart` failed with error message: `Waiting for cluster to become active`. And the blocking jstack as bellows:
```
"BP-1618793397-192.168.3.4-1669198559828 heartbeating to localhost/127.0.0.1:54673" #260 daemon prio=5 os_prio=31 tid=0x
00007fc1108fa000 nid=0x19303 waiting on condition [0x0000700017884000]
   java.lang.Thread.State: WAITING (parking)
        at sun.misc.Unsafe.park(Native Method)
        - parking to wait for  <0x00000007430a9ec0> (a java.util.concurrent.SynchronousQueue$TransferQueue)
        at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
        at java.util.concurrent.SynchronousQueue$TransferQueue.awaitFulfill(SynchronousQueue.java:762)
        at java.util.concurrent.SynchronousQueue$TransferQueue.transfer(SynchronousQueue.java:695)
        at java.util.concurrent.SynchronousQueue.put(SynchronousQueue.java:877)
        at org.apache.hadoop.ipc.Client$Connection.sendRpcRequest(Client.java:1186)
        at org.apache.hadoop.ipc.Client.call(Client.java:1482)
        at org.apache.hadoop.ipc.Client.call(Client.java:1429)
        at org.apache.hadoop.ipc.ProtobufRpcEngine2$Invoker.invoke(ProtobufRpcEngine2.java:258)
        at org.apache.hadoop.ipc.ProtobufRpcEngine2$Invoker.invoke(ProtobufRpcEngine2.java:139)
        at com.sun.proxy.$Proxy23.sendHeartbeat(Unknown Source)
        at org.apache.hadoop.hdfs.protocolPB.DatanodeProtocolClientSideTranslatorPB.sendHeartbeat(DatanodeProtocolClient
SideTranslatorPB.java:168)
        at org.apache.hadoop.hdfs.server.datanode.BPServiceActor.sendHeartBeat(BPServiceActor.java:570)
        at org.apache.hadoop.hdfs.server.datanode.BPServiceActor.offerService(BPServiceActor.java:714)
        at org.apache.hadoop.hdfs.server.datanode.BPServiceActor.run(BPServiceActor.java:915)
        at java.lang.Thread.run(Thread.java:748) 
```

After looking into the code and found that this bug is imported by HADOOP-18324. Because `RpcRequestSender` exited without cleaning up the `rpcRequestQueue`, then caused `BPServiceActor` was blocked in sending request.

### How was this patch tested?

The failed UT:
```
org.apache.hadoop.hdfs.TestLeaseRecovery2#testHardLeaseRecoveryAfterNameNodeRestart
org.apache.hadoop.hdfs.TestLeaseRecovery2#testHardLeaseRecoveryAfterNameNodeRestart2
org.apache.hadoop.hdfs.TestLeaseRecovery2#testHardLeaseRecoveryWithRenameAfterNameNodeRestart
```
