### PR TITLE
HADOOP-18539. Upgrade ojalgo to 51.4.1

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -489,7 +489,7 @@ org.checkerframework:checker-qual:3.8.0
 org.codehaus.mojo:animal-sniffer-annotations:1.21
 org.jruby.jcodings:jcodings:1.0.13
 org.jruby.joni:joni:2.1.2
-org.ojalgo:ojalgo:43.0
+org.ojalgo:ojalgo:51.4.1
 org.slf4j:jul-to-slf4j:1.7.36
 org.slf4j:slf4j-api:1.7.36
 org.slf4j:slf4j-reload4j:1.7.36

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -940,7 +940,7 @@
       <dependency>
           <groupId>org.ojalgo</groupId>
           <artifactId>ojalgo</artifactId>
-          <version>43.0</version>
+          <version>51.4.1</version>
       </dependency>
       <dependency>
         <groupId>com.sun.jersey</groupId>


### PR DESCRIPTION


### Description of PR
Upgrade ojalgo to 51.4.1

### How was this patch tested?
Compilation sucessful, hadoop-resourceestimator test cases ran successfully 

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

