### PR TITLE
HDFS-16855. Remove the redundant write lock in addBlockPool. 

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -3187,17 +3187,15 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
       throws IOException {
     LOG.info("Adding block pool " + bpid);
     AddBlockPoolException volumeExceptions = new AddBlockPoolException();
-    try (AutoCloseableLock lock = lockManager.writeLock(LockLevel.BLOCK_POOl, bpid)) {
-      try {
-        volumes.addBlockPool(bpid, conf);
-      } catch (AddBlockPoolException e) {
-        volumeExceptions.mergeException(e);
-      }
-      volumeMap.initBlockPool(bpid);
-      Set<String> vols = storageMap.keySet();
-      for (String v : vols) {
-        lockManager.addLock(LockLevel.VOLUME, bpid, v);
-      }
+    try {
+      volumes.addBlockPool(bpid, conf);
+    } catch (AddBlockPoolException e) {
+      volumeExceptions.mergeException(e);
+    }
+    volumeMap.initBlockPool(bpid);
+    Set<String> vols = storageMap.keySet();
+    for (String v : vols) {
+      lockManager.addLock(LockLevel.VOLUME, bpid, v);
     }
     try {
       volumes.getAllVolumesMap(bpid, volumeMap, ramDiskReplicaTracker);


### PR DESCRIPTION
When patching the datanode's fine-grained lock, we found that the datanode couldn't start，maybe happened deadlock，when addBlockPool, so we can remove it.

org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsDatasetImpl#addBlockPool    get writeLock

org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsDatasetImpl#deepCopyReplica  need readLock

because it is not the same thread, so the write lock cannot be downgraded to a read lock