### PR TITLE
YARN-11383. Workflow priority mappings is case sensitive

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/WorkflowPriorityMappingsManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/WorkflowPriorityMappingsManager.java
@@ -150,8 +150,8 @@ public class WorkflowPriorityMappingsManager {
     WorkflowPriorityMapping mapping;
     try {
       //Converting workflow id to lowercase as yarn converts application tags also to lowercase
-      mapping = new WorkflowPriorityMapping(StringUtils.toLowerCase(mappingArray[0]), mappingArray[1],
-          Priority.newInstance(Integer.parseInt(mappingArray[2])));
+      mapping = new WorkflowPriorityMapping(StringUtils.toLowerCase(mappingArray[0]),
+          mappingArray[1], Priority.newInstance(Integer.parseInt(mappingArray[2])));
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException(
           "Illegal workflow priority for mapping " + mappingString);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/WorkflowPriorityMappingsManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/WorkflowPriorityMappingsManager.java
@@ -56,8 +56,8 @@ public class WorkflowPriorityMappingsManager {
 
   private boolean overrideWithPriorityMappings = false;
   // Map of queue to a map of workflow ID to priority
-  private Map<String, Map<String, WorkflowPriorityMapping>> priorityMappings =
-      new HashMap<String, Map<String, WorkflowPriorityMapping>>();
+  private Map<String, Map<String, Priority>> priorityMappings =
+      new HashMap<>();
 
   public static class WorkflowPriorityMapping {
     String workflowID;
@@ -115,10 +115,9 @@ public class WorkflowPriorityMappingsManager {
    *
    * @return workflowID to priority mappings for a queue
    */
-  public Map<String, Map<String, WorkflowPriorityMapping>>
+  public Map<String, Map<String, Priority>>
       getWorkflowPriorityMappings() {
-    Map<String, Map<String, WorkflowPriorityMapping>> mappings =
-        new HashMap<String, Map<String, WorkflowPriorityMapping>>();
+    Map<String, Map<String, Priority>> mappings = new HashMap<>();
 
     Collection<String> workflowMappings = conf.getWorkflowPriorityMappings();
     for (String workflowMapping : workflowMappings) {
@@ -127,9 +126,9 @@ public class WorkflowPriorityMappingsManager {
       if (mapping != null) {
         if (!mappings.containsKey(mapping.queue)) {
           mappings.put(mapping.queue,
-              new HashMap<String, WorkflowPriorityMapping>());
+              new HashMap<String, Priority>());
         }
-        mappings.get(mapping.queue).put(mapping.workflowID, mapping);
+        mappings.get(mapping.queue).put(mapping.workflowID, mapping.priority);
       }
     }
     return mappings;
@@ -150,7 +149,8 @@ public class WorkflowPriorityMappingsManager {
     }
     WorkflowPriorityMapping mapping;
     try {
-      mapping = new WorkflowPriorityMapping(mappingArray[0], mappingArray[1],
+      //Converting workflow id to lowercase as yarn converts application tags also to lowercase
+      mapping = new WorkflowPriorityMapping(StringUtils.toLowerCase(mappingArray[0]), mappingArray[1],
           Priority.newInstance(Integer.parseInt(mappingArray[2])));
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException(
@@ -168,7 +168,7 @@ public class WorkflowPriorityMappingsManager {
     String queuePath = queue.getQueuePath();
     if (priorityMappings.containsKey(queuePath)
         && priorityMappings.get(queuePath).containsKey(workflowID)) {
-      return priorityMappings.get(queuePath).get(workflowID).priority;
+      return priorityMappings.get(queuePath).get(workflowID);
     } else {
       queue = queue.getParent();
       return getMappedPriority(workflowID, queue);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerWorkflowPriorityMapping.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerWorkflowPriorityMapping.java
@@ -98,7 +98,7 @@ public class TestCapacitySchedulerWorkflowPriorityMapping {
     CapacityScheduler cs = (CapacityScheduler) mockRM.getResourceScheduler();
     mockRM.start();
     cs.start();
-    
+
     Map<String, Object> expected = ImmutableMap.of(
         A, ImmutableMap.of("workflow3", Priority.newInstance(4)),
         B, ImmutableMap.of("workflow1", Priority.newInstance(2)),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerWorkflowPriorityMapping.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerWorkflowPriorityMapping.java
@@ -78,7 +78,7 @@ public class TestCapacitySchedulerWorkflowPriorityMapping {
     List<WorkflowPriorityMapping> mappings = Arrays.asList(
         new WorkflowPriorityMapping("workflow1", B, Priority.newInstance(2)),
         new WorkflowPriorityMapping("workflow2", A1, Priority.newInstance(3)),
-        new WorkflowPriorityMapping("workflow3", A, Priority.newInstance(4)));
+        new WorkflowPriorityMapping("Workflow3", A, Priority.newInstance(4)));
     conf.setWorkflowPriorityMappings(mappings);
   }
 
@@ -98,17 +98,11 @@ public class TestCapacitySchedulerWorkflowPriorityMapping {
     CapacityScheduler cs = (CapacityScheduler) mockRM.getResourceScheduler();
     mockRM.start();
     cs.start();
-
-    Map<String, Map<String, Object>> expected = ImmutableMap.of(
-        A, ImmutableMap.of("workflow3",
-        new WorkflowPriorityMapping(
-            "workflow3", A, Priority.newInstance(4))),
-        B, ImmutableMap.of("workflow1",
-        new WorkflowPriorityMapping(
-            "workflow1", B, Priority.newInstance(2))),
-        A1, ImmutableMap.of("workflow2",
-        new WorkflowPriorityMapping(
-            "workflow2", A1, Priority.newInstance(3))));
+    
+    Map<String, Object> expected = ImmutableMap.of(
+        A, ImmutableMap.of("workflow3", Priority.newInstance(4)),
+        B, ImmutableMap.of("workflow1", Priority.newInstance(2)),
+        A1, ImmutableMap.of("workflow2", Priority.newInstance(3)));
     assertEquals(expected, cs.getWorkflowPriorityMappingsManager()
         .getWorkflowPriorityMappings());
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Jira: [YARN-11383](https://issues.apache.org/jira/browse/YARN-11383)
Lowercasing workflowId in workflow priority mappings as yarn lowercases application tags.

### How was this patch tested?
Unit Tested

### For code changes:

- [ :white_check_mark:] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

