### PR TITLE
YARN-10946. Moved QueueInfo creation to separate class

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractCSQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractCSQueue.java
@@ -198,26 +198,14 @@ public abstract class AbstractCSQueue implements CSQueue {
     return queueCapacities.getCapacity();
   }
 
-  public float getCapacityByNodeLabel(String nodeLabel) {
-    return queueCapacities.getCapacity(nodeLabel);
-  }
-
   @Override
   public float getAbsoluteCapacity() {
     return queueCapacities.getAbsoluteCapacity();
   }
 
-  public float getAbsoluteCapacityByNodeLabel(String nodeLabel) {
-    return queueCapacities.getAbsoluteCapacity(nodeLabel);
-  }
-
   @Override
   public float getAbsoluteMaximumCapacity() {
     return queueCapacities.getAbsoluteMaximumCapacity();
-  }
-
-  public float getAbsoluteMaximumCapacityByNodeLabel(String nodeLabel) {
-    return queueCapacities.getAbsoluteMaximumCapacity(nodeLabel);
   }
 
   @Override
@@ -230,21 +218,9 @@ public abstract class AbstractCSQueue implements CSQueue {
     return queueCapacities.getMaximumCapacity();
   }
 
-  public float getMaximumCapacityByNodeLabel(String nodeLabel) {
-    return queueCapacities.getMaximumCapacity(nodeLabel);
-  }
-
-  public float getMaxAMResourcePercentageByNodeLabel(String nodeLabel) {
-    return queueCapacities.getMaxAMResourcePercentage(nodeLabel);
-  }
-
   @Override
   public float getUsedCapacity() {
     return queueCapacities.getUsedCapacity();
-  }
-
-  public float getWeight() {
-    return queueCapacities.getWeight();
   }
 
   @Override
@@ -602,6 +578,10 @@ public abstract class AbstractCSQueue implements CSQueue {
   }
 
   protected QueueInfo getQueueInfo() {
+    // Deliberately doesn't use lock here, because this method will be invoked
+    // from schedulerApplicationAttempt, to avoid deadlock, sacrifice
+    // consistency here.
+    // TODO, improve this
     return CSQueueInfoProvider.getQueueInfo(this);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CSQueueInfoProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CSQueueInfoProvider.java
@@ -1,0 +1,106 @@
+package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
+
+import org.apache.hadoop.yarn.api.records.QueueConfigurations;
+import org.apache.hadoop.yarn.api.records.QueueInfo;
+import org.apache.hadoop.yarn.api.records.QueueStatistics;
+import org.apache.hadoop.yarn.factories.RecordFactory;
+import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.QueueResourceQuotas;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public final class CSQueueInfoProvider {
+
+  private static final RecordFactory recordFactory =
+          RecordFactoryProvider.getRecordFactory(null);
+
+  public CSQueueInfoProvider() {
+  }
+
+  public static QueueInfo getQueueInfo(AbstractCSQueue csQueue) {
+    // Deliberately doesn't use lock here, because this method will be invoked
+    // from schedulerApplicationAttempt, to avoid deadlock, sacrifice
+    // consistency here.
+    // TODO, improve this
+    QueueInfo queueInfo = recordFactory.newRecordInstance(QueueInfo.class);
+    queueInfo.setQueueName(csQueue.getQueuePathObject().getLeafName());
+    queueInfo.setQueuePath(csQueue.getQueuePathObject().getFullPath());
+    queueInfo.setAccessibleNodeLabels(csQueue.getAccessibleNodeLabels());
+    queueInfo.setCapacity(csQueue.getCapacity());
+    queueInfo.setMaximumCapacity(csQueue.getMaximumCapacity());
+    queueInfo.setQueueState(csQueue.getState());
+    queueInfo.setDefaultNodeLabelExpression(csQueue.getDefaultNodeLabelExpression());
+    queueInfo.setCurrentCapacity(csQueue.getUsedCapacity());
+    queueInfo.setQueueStatistics(getQueueStatistics(csQueue));
+    queueInfo.setPreemptionDisabled(csQueue.getPreemptionDisabled());
+    queueInfo.setIntraQueuePreemptionDisabled(
+            csQueue.getIntraQueuePreemptionDisabled());
+    queueInfo.setQueueConfigurations(getQueueConfigurations(csQueue));
+    queueInfo.setWeight(csQueue.getWeight());
+    queueInfo.setMaxParallelApps(csQueue.getMaxParallelApps());
+    return queueInfo;
+  }
+
+  private static QueueStatistics getQueueStatistics(AbstractCSQueue csQueue) {
+    // Deliberately doesn't use lock here, because this method will be invoked
+    // from schedulerApplicationAttempt, to avoid deadlock, sacrifice
+    // consistency here.
+    // TODO, improve this
+    QueueStatistics stats = recordFactory.newRecordInstance(
+            QueueStatistics.class);
+    CSQueueMetrics queueMetrics = csQueue.getMetrics();
+    stats.setNumAppsSubmitted(queueMetrics.getAppsSubmitted());
+    stats.setNumAppsRunning(queueMetrics.getAppsRunning());
+    stats.setNumAppsPending(queueMetrics.getAppsPending());
+    stats.setNumAppsCompleted(queueMetrics.getAppsCompleted());
+    stats.setNumAppsKilled(queueMetrics.getAppsKilled());
+    stats.setNumAppsFailed(queueMetrics.getAppsFailed());
+    stats.setNumActiveUsers(queueMetrics.getActiveUsers());
+    stats.setAvailableMemoryMB(queueMetrics.getAvailableMB());
+    stats.setAllocatedMemoryMB(queueMetrics.getAllocatedMB());
+    stats.setPendingMemoryMB(queueMetrics.getPendingMB());
+    stats.setReservedMemoryMB(queueMetrics.getReservedMB());
+    stats.setAvailableVCores(queueMetrics.getAvailableVirtualCores());
+    stats.setAllocatedVCores(queueMetrics.getAllocatedVirtualCores());
+    stats.setPendingVCores(queueMetrics.getPendingVirtualCores());
+    stats.setReservedVCores(queueMetrics.getReservedVirtualCores());
+    stats.setPendingContainers(queueMetrics.getPendingContainers());
+    stats.setAllocatedContainers(queueMetrics.getAllocatedContainers());
+    stats.setReservedContainers(queueMetrics.getReservedContainers());
+    return stats;
+  }
+
+  private static Map<String, QueueConfigurations> getQueueConfigurations(AbstractCSQueue csQueue) {
+    Map<String, QueueConfigurations> queueConfigurations = new HashMap<>();
+    Set<String> nodeLabels = csQueue.getNodeLabelsForQueue();
+    QueueResourceQuotas queueResourceQuotas = csQueue.getQueueResourceQuotas();
+    for (String nodeLabel : nodeLabels) {
+      QueueConfigurations queueConfiguration =
+              recordFactory.newRecordInstance(QueueConfigurations.class);
+      float capacity = csQueue.getCapacityByNodeLabel(nodeLabel);
+      float absoluteCapacity = csQueue.getAbsoluteCapacityByNodeLabel(nodeLabel);
+      float maxCapacity = csQueue.getMaximumCapacityByNodeLabel(nodeLabel);
+      float absMaxCapacity =
+              csQueue.getAbsoluteMaximumCapacityByNodeLabel(nodeLabel);
+      float maxAMPercentage =
+              csQueue.getMaxAMResourcePercentageByNodeLabel(nodeLabel);
+      queueConfiguration.setCapacity(capacity);
+      queueConfiguration.setAbsoluteCapacity(absoluteCapacity);
+      queueConfiguration.setMaxCapacity(maxCapacity);
+      queueConfiguration.setAbsoluteMaxCapacity(absMaxCapacity);
+      queueConfiguration.setMaxAMPercentage(maxAMPercentage);
+      queueConfiguration.setConfiguredMinCapacity(
+              queueResourceQuotas.getConfiguredMinResource(nodeLabel));
+      queueConfiguration.setConfiguredMaxCapacity(
+              queueResourceQuotas.getConfiguredMaxResource(nodeLabel));
+      queueConfiguration.setEffectiveMinCapacity(
+              queueResourceQuotas.getEffectiveMinResource(nodeLabel));
+      queueConfiguration.setEffectiveMaxCapacity(
+              queueResourceQuotas.getEffectiveMaxResource(nodeLabel));
+      queueConfigurations.put(nodeLabel, queueConfiguration);
+    }
+    return queueConfigurations;
+  }
+}


### PR DESCRIPTION
Change-Id: If4da3cd24e9b2a94689ef8e1ea5b69dc1b84288b

### Description of PR
AbstractCSQueue: Create separate class for constructing Queue API objects

Relevant methods are: 
- org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.AbstractCSQueue#getQueueConfigurations
- org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.AbstractCSQueue#getQueueInfo
- org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.AbstractCSQueue#getQueueStatistics

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

