### PR TITLE
YARN-6538. Inter Queue preemption is not happening when DRF is configured in extreme resource scale cases.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/resource/DefaultResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/resource/DefaultResourceCalculator.java
@@ -154,6 +154,10 @@ public class DefaultResourceCalculator extends ResourceCalculator {
   }
 
   @Override
+  public boolean isAnyRequestedResourceZeroOrNegative(Resource available, Resource resource) {
+    return resource.getMemorySize() == 0;
+  }
+  @Override
   public boolean isAnyMajorResourceAboveZero(Resource resource) {
     return resource.getMemorySize() > 0;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/resource/DominantResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/resource/DominantResourceCalculator.java
@@ -643,6 +643,22 @@ public class DominantResourceCalculator extends ResourceCalculator {
   }
 
   @Override
+  public boolean isAnyRequestedResourceZeroOrNegative(Resource available, Resource resource) {
+    int maxLength = ResourceUtils.getNumberOfCountableResourceTypes();
+    for (int i = 0; i < maxLength; i++) {
+      ResourceInformation resourceInformation = available.getResourceInformation(
+          i);
+      if (resourceInformation.getValue() != 0L) {
+        ResourceInformation ri2 = resource.getResourceInformation(i);
+        if (ri2.getValue() <= 0L) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  @Override
   public boolean isAnyMajorResourceAboveZero(Resource resource) {
     int maxLength = ResourceUtils.getNumberOfCountableResourceTypes();
     for (int i = 0; i < maxLength; i++) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/resource/ResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/resource/ResourceCalculator.java
@@ -279,6 +279,16 @@ public abstract class ResourceCalculator {
   public abstract boolean isAnyMajorResourceZeroOrNegative(Resource resource);
 
   /**
+   * Check if resource has any available (those that have non-zero available value)
+   * major resource types (which are all NodeManagers included) a zero value or negative value.
+   *
+   * @param available available resource
+   * @param resource resource
+   * @return returns true if any resource is zero.
+   */
+  public abstract boolean isAnyRequestedResourceZeroOrNegative(Resource available, Resource resource);
+
+  /**
    * Get resource <code>r</code>and normalize down using step-factor
    * <code>stepFactor</code>.
    *

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/resource/ResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/resource/ResourceCalculator.java
@@ -286,7 +286,8 @@ public abstract class ResourceCalculator {
    * @param resource resource
    * @return returns true if any resource is zero.
    */
-  public abstract boolean isAnyRequestedResourceZeroOrNegative(Resource available, Resource resource);
+  public abstract boolean isAnyRequestedResourceZeroOrNegative(
+      Resource available, Resource resource);
 
   /**
    * Get resource <code>r</code>and normalize down using step-factor

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/AbstractPreemptableResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/AbstractPreemptableResourceCalculator.java
@@ -224,7 +224,11 @@ public class AbstractPreemptableResourceCalculator {
 
       for (Iterator<TempQueuePerPartition> i = underserved.iterator(); i
           .hasNext();) {
-        if (!rc.isAnyMajorResourceAboveZero(unassigned)) {
+        // Exit the loop once any of the unassigned resources reach zero, except the optional
+        // ones which the queue has no guarantee on. This should ensure that extreme cases
+        // where one of the resources are significantly larger than the other (i.e: way below 1
+        // vcore per GB of memory)
+        if (rc.isAnyRequestedResourceZeroOrNegative(totGuarant, unassigned)) {
           break;
         }
 
@@ -265,7 +269,6 @@ public class AbstractPreemptableResourceCalculator {
       context.addPartitionToUnderServedQueues(q1.queueName, q1.partition);
     }
   }
-
 
   /**
    * This method is visible to allow sub-classes to override the initialization

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/TestProportionalCapacityPreemptionPolicyInterQueueWithDRF.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/TestProportionalCapacityPreemptionPolicyInterQueueWithDRF.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.Capacity
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.LeafQueue;
 import org.apache.hadoop.yarn.util.resource.DominantResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
-import org.mockito.Matchers;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -132,10 +131,10 @@ public class TestProportionalCapacityPreemptionPolicyInterQueueWithDRF
     policy.editSchedule();
 
     // Preemption should happen in Queue a, preempt to Queue b
-    verify(eventHandler, times(1)).handle(Matchers.argThat(
+    verify(eventHandler, times(1)).handle(argThat(
         new TestProportionalCapacityPreemptionPolicy.IsPreemptionRequestFor(
             getAppAttemptId(1))));
-    verify(eventHandler, never()).handle(Matchers.argThat(
+    verify(eventHandler, never()).handle(argThat(
         new TestProportionalCapacityPreemptionPolicy.IsPreemptionRequestFor(
             getAppAttemptId(2))));
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/TestProportionalCapacityPreemptionPolicyInterQueueWithDRF.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/TestProportionalCapacityPreemptionPolicyInterQueueWithDRF.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.Capacity
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.LeafQueue;
 import org.apache.hadoop.yarn.util.resource.DominantResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
+import org.mockito.Matchers;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -85,6 +86,56 @@ public class TestProportionalCapacityPreemptionPolicyInterQueueWithDRF
         new TestProportionalCapacityPreemptionPolicy.IsPreemptionRequestFor(
             getAppAttemptId(1))));
     verify(eventHandler, times(5)).handle(argThat(
+        new TestProportionalCapacityPreemptionPolicy.IsPreemptionRequestFor(
+            getAppAttemptId(2))));
+  }
+
+  @Test
+  public void testInterQueuePreemptionWithMultipleResourceUnbalancedCase() throws IOException {
+    /**
+     * Queue structure is:
+     *
+     * <pre>
+     *           root
+     *           /  \
+     *          a    b
+     * </pre>
+     *
+     * Scenario: Queue B : Queue A has 90/10% capacity share.
+     * Almost all the resources are allocated to Queue A, but based on memory alone
+     * containers still can be allocated elsewhere. The app on A requests a lot more.
+     * The app on Queue B needs a little memory (still fits in the remaining  resources),
+     * but needs a lot of vcores. Enough resources must be preempted from the app on A
+     * to allow the app on B launch.
+     */
+    String labelsConfig = "=65536:50,true;"; // default partition
+    String nodesConfig = // only one node
+        "n1=";
+
+    String queuesConfig =
+        //    guaranteed, max,  used,   pending
+        "root(=[65536:50 65536:50 61440:45 132096:525]);" + // root
+            "-a(=[2048:5 65536:50 61440:45 131072:500]);" + // a
+            "-b(=[63488:45 65536:50 0:0 1024:25]);"; // b
+
+
+    String appsConfig =
+        //queueName\t(priority,resource,host,expression,#repeat,reserved)
+        "a\t(1,61440:45,n1,,20,false);" + // app1 in a
+            "b\t(1,1024:25,n1,,30,false)"; // app2 in b
+
+    buildEnv(labelsConfig, nodesConfig, queuesConfig, appsConfig, true);
+    Resource ul = Resource.newInstance(65536, 50);
+    when(((LeafQueue)(cs.getQueue("root.a")))
+        .getResourceLimitForAllUsers(any(), any(), any(), any())
+    ).thenReturn(ul);
+    policy.editSchedule();
+
+    // Preemption should happen in Queue a, preempt to Queue b
+    verify(eventHandler, times(1)).handle(Matchers.argThat(
+        new TestProportionalCapacityPreemptionPolicy.IsPreemptionRequestFor(
+            getAppAttemptId(1))));
+    verify(eventHandler, never()).handle(Matchers.argThat(
         new TestProportionalCapacityPreemptionPolicy.IsPreemptionRequestFor(
             getAppAttemptId(2))));
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### How was this patch tested?

Extended the UTs and run the existing ones.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

