### PR TITLE
HDFS-16859. RBF: Move LOG.debug into if condition acquirePermit

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/AbstractRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/AbstractRouterRpcFairnessPolicyController.java
@@ -63,10 +63,14 @@ public class AbstractRouterRpcFairnessPolicyController
   @Override
   public boolean acquirePermit(String nsId) {
     try {
-      LOG.debug("Taking lock for nameservice {}", nsId);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Taking lock for nameservice {}", nsId);
+      }
       return this.permits.get(nsId).tryAcquire(acquireTimeoutMs, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      LOG.debug("Cannot get a permit for nameservice {}", nsId);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Cannot get a permit for nameservice {}", nsId);
+      }
     }
     return false;
   }
@@ -78,7 +82,9 @@ public class AbstractRouterRpcFairnessPolicyController
 
   @Override
   public void shutdown() {
-    LOG.debug("Shutting down router fairness policy controller");
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Shutting down router fairness policy controller");
+    }
     // drain all semaphores
     for (Semaphore sema: this.permits.values()) {
       sema.drainPermits();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The invoke frequency of method AbstractRouterRpcFairnessPolicyController#acquirePermit is high.  before getting the permit of a nameservice, there is always a LOG.debug statement.

It is better to move the statement into if condition statement. 

### How was this patch tested?

no need to test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

