### PR TITLE
YARN-11386. Fix issue with classpath resolution

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
@@ -246,7 +246,7 @@ public class ContainerLaunch implements Callable<Integer> {
       launchContext.setCommands(newCmds);
 
       // The actual expansion of environment variables happens after calling
-      // sanitizeEnv.  This allows variables specified in NM_ADMIN_USER_ENV
+      // addConfigsToEnv.  This allows variables specified in NM_ADMIN_USER_ENV
       // to reference user or container-defined variables.
       Map<String, String> environment = launchContext.getEnvironment();
       // /////////////////////////// End of variable expansion
@@ -340,12 +340,14 @@ public class ContainerLaunch implements Callable<Integer> {
       try (DataOutputStream containerScriptOutStream =
                lfs.create(nmPrivateContainerScriptPath,
                    EnumSet.of(CREATE, OVERWRITE))) {
+        addConfigsToEnv(environment);
+
+        expandAllEnvironmentVars(environment, containerLogDir);
+
         // Sanitize the container's environment
         sanitizeEnv(environment, containerWorkDir, appDirs, userLocalDirs,
             containerLogDirs, localResources, nmPrivateClasspathJarDir,
             nmEnvVars);
-
-        expandAllEnvironmentVars(environment, containerLogDir);
 
         // Add these if needed after expanding so we don't expand key values.
         if (keystore != null) {
@@ -1641,13 +1643,35 @@ public class ContainerLaunch implements Callable<Integer> {
       addToEnvMap(environment, nmVars, "JVM_PID", "$$");
     }
 
+    // TODO: Remove Windows check and use this approach on all platforms after
+    // additional testing.  See YARN-358.
+    if (Shell.WINDOWS) {
+      sanitizeWindowsEnv(environment, pwd,
+          resources, nmPrivateClasspathJarDir);
+    }
+
+    // put AuxiliaryService data to environment
+    for (Map.Entry<String, ByteBuffer> meta : containerManager
+        .getAuxServiceMetaData().entrySet()) {
+      AuxiliaryServiceHelper.setServiceDataIntoEnv(
+          meta.getKey(), meta.getValue(), environment);
+      nmVars.add(AuxiliaryServiceHelper.getPrefixServiceName(meta.getKey()));
+    }
+  }
+
+  /**
+   * There are some configurations (such as {@link YarnConfiguration.NM_ADMIN_USER_ENV}) whose
+   * values need to be added to the environment variables.
+   *
+   * @param environment The environment variables map to add the configuration values to.
+   */
+  private void addConfigsToEnv(Map<String, String> environment) {
     // variables here will be forced in, even if the container has
     // specified them.  Note: we do not track these in nmVars, to
     // allow them to be ordered properly if they reference variables
     // defined by the user.
     String defEnvStr = conf.get(YarnConfiguration.DEFAULT_NM_ADMIN_USER_ENV);
-    Apps.setEnvFromInputProperty(environment,
-        YarnConfiguration.NM_ADMIN_USER_ENV, defEnvStr, conf,
+    Apps.setEnvFromInputProperty(environment, YarnConfiguration.NM_ADMIN_USER_ENV, defEnvStr, conf,
         File.pathSeparator);
 
     if (!Shell.WINDOWS) {
@@ -1658,39 +1682,21 @@ public class ContainerLaunch implements Callable<Integer> {
         String userPath = environment.get(Environment.PATH.name());
         environment.remove(Environment.PATH.name());
         if (userPath == null || userPath.isEmpty()) {
-          Apps.addToEnvironment(environment, Environment.PATH.name(),
-              forcePath, File.pathSeparator);
-          Apps.addToEnvironment(environment, Environment.PATH.name(),
-              "$PATH", File.pathSeparator);
+          Apps.addToEnvironment(environment, Environment.PATH.name(), forcePath,
+              File.pathSeparator);
+          Apps.addToEnvironment(environment, Environment.PATH.name(), "$PATH", File.pathSeparator);
         } else {
-          Apps.addToEnvironment(environment, Environment.PATH.name(),
-              forcePath, File.pathSeparator);
-          Apps.addToEnvironment(environment, Environment.PATH.name(),
-              userPath, File.pathSeparator);
+          Apps.addToEnvironment(environment, Environment.PATH.name(), forcePath,
+              File.pathSeparator);
+          Apps.addToEnvironment(environment, Environment.PATH.name(), userPath, File.pathSeparator);
         }
       }
-    }
-
-    // TODO: Remove Windows check and use this approach on all platforms after
-    // additional testing.  See YARN-358.
-    if (Shell.WINDOWS) {
-
-      sanitizeWindowsEnv(environment, pwd,
-          resources, nmPrivateClasspathJarDir);
-    }
-    // put AuxiliaryService data to environment
-    for (Map.Entry<String, ByteBuffer> meta : containerManager
-        .getAuxServiceMetaData().entrySet()) {
-      AuxiliaryServiceHelper.setServiceDataIntoEnv(
-          meta.getKey(), meta.getValue(), environment);
-      nmVars.add(AuxiliaryServiceHelper.getPrefixServiceName(meta.getKey()));
     }
   }
 
   private void sanitizeWindowsEnv(Map<String, String> environment, Path pwd,
       Map<Path, List<String>> resources, Path nmPrivateClasspathJarDir)
       throws IOException {
-
     String inputClassPath = environment.get(Environment.CLASSPATH.name());
 
     if (inputClassPath != null && !inputClassPath.isEmpty()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
@@ -1665,7 +1665,7 @@ public class ContainerLaunch implements Callable<Integer> {
    *
    * @param environment The environment variables map to add the configuration values to.
    */
-  private void addConfigsToEnv(Map<String, String> environment) {
+  public void addConfigsToEnv(Map<String, String> environment) {
     // variables here will be forced in, even if the container has
     // specified them.  Note: we do not track these in nmVars, to
     // allow them to be ordered properly if they reference variables

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
@@ -1660,7 +1660,7 @@ public class ContainerLaunch implements Callable<Integer> {
   }
 
   /**
-   * There are some configurations (such as {@link YarnConfiguration.NM_ADMIN_USER_ENV}) whose
+   * There are some configurations (such as {@value YarnConfiguration#NM_ADMIN_USER_ENV}) whose
    * values need to be added to the environment variables.
    *
    * @param environment The environment variables map to add the configuration values to.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
@@ -808,6 +808,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     resources.put(userjar, lpaths);
     Path nmp = new Path(testDir);
 
+    launch.addConfigsToEnv(userSetEnv);
     launch.sanitizeEnv(userSetEnv, pwd, appDirs, userLocalDirs, containerLogs,
         resources, nmp, nmEnvTrack);
     Assert.assertTrue(userSetEnv.containsKey("MALLOC_ARENA_MAX"));
@@ -864,6 +865,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
 
     ContainerLaunch launch = new ContainerLaunch(distContext, conf,
         dispatcher, exec, null, container, dirsHandler, containerManager);
+    launch.addConfigsToEnv(userSetEnv);
     launch.sanitizeEnv(userSetEnv, pwd, appDirs, userLocalDirs, containerLogs,
         resources, nmp, nmEnvTrack);
 
@@ -876,6 +878,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     containerLaunchContext.setEnvironment(userSetEnv);
     when(container.getLaunchContext()).thenReturn(containerLaunchContext);
 
+    launch.addConfigsToEnv(userSetEnv);
     launch.sanitizeEnv(userSetEnv, pwd, appDirs, userLocalDirs, containerLogs,
         resources, nmp, nmEnvTrack);
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
While launching the AM, the client puts the classpath into environment HashMap of the ContainerLaunchContext. To support cross-platform compatibility, some special notations must be used by the client. For example, `<CPS>` must be used as the classpath separator instead of ";" (Windows) or ":" (Linux). The NM would resolve all the `<CPS>` using the appropriate path separator according to the OS platform, prior to launching the container. In addition to this, the NM is also expected to expand and resolve all of the wildcard ( * ) occurrences in the classpath before launching the container, since the JVM doesn't understand the wildcard charater.

The issue we see here is, neither `<CPS>` resolution nor wildcard expansion is happening.

I tested this from Spark. To run a Spark application on YARN, one needs to set the spark.yarn.jars config to point to the location where Spark jars are present. NM would then add these jars to the classpath before launching the Spark AM container. The resolution didn't happen -

```
Manifest-Version:
1.0
Class-Path:
file:/D:/tmp/hadoop-Gautham/nm-local-dir/usercache/Gautham/appcache/application_1670138957874_0001/container_1670138957874_0001_01_000001/%7B%7BPWD%7D%7D%3CCPS%3E%7B%7BPWD%7D%7D/__spark_conf__%3CCPS%3E%7B%7BPWD%7D%7D/__spark_libs__/*%3CCPS%3E/D:/projects/github/apache/spark/jars/*%3CCPS%3E%7B%7BPWD%7D%7D/__spark_conf__/__hadoop_conf__
file:/D:/tmp/hadoop-Gautham/nm-local-dir/usercache/Gautham/appcache/application_1670138957874_0001/container_1670138957874_0001_01_000001/__spark_conf__/
file:/D:/tmp/hadoop-Gautham/nm-local-dir/usercache/Gautham/appcache/application_1670138957874_0001/container_1670138957874_0001_01_000001/__app__.jar
```

Note that `%3CCPS%3E` in the above code block should've been replaced by ";" or ":" as part of classpath resolution. Since this didn't happen, NM failed to launch the Spark AM container -

```
Could not find or load main class org.apache.spark.deploy.yarn.ApplicationMaster
```

### How was this patch tested?
I tested locally by submitting a Spark job and ensured that it ran successfully.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

