### PR TITLE
HDFS-16861. RBF. Truncate API always fails when dirs use AllResolver oder on Router  

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -702,8 +702,9 @@ public class RouterClientProtocol implements ClientProtocol {
     RemoteMethod method = new RemoteMethod("truncate",
         new Class<?>[] {String.class, long.class, String.class},
         new RemoteParam(), newLength, clientName);
+    // Truncate can return true/false, so don't expect a result
     return rpcClient.invokeSequential(locations, method, Boolean.class,
-        Boolean.TRUE);
+        null);
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -411,9 +411,8 @@ public class RouterClientProtocol implements ClientProtocol {
     RemoteMethod method = new RemoteMethod("setReplication",
         new Class<?>[] {String.class, short.class}, new RemoteParam(),
         replication);
-    if (rpcServer.isInvokeConcurrent(src)) {
-      return !rpcClient.invokeConcurrent(locations, method, Boolean.class)
-          .containsValue(false);
+    if (rpcServer.isPathAll(src)) {
+      return rpcClient.invokeAll(locations, method);
     } else {
       return rpcClient.invokeSequential(locations, method, Boolean.class,
           Boolean.TRUE);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -411,8 +411,9 @@ public class RouterClientProtocol implements ClientProtocol {
     RemoteMethod method = new RemoteMethod("setReplication",
         new Class<?>[] {String.class, short.class}, new RemoteParam(),
         replication);
-    if (rpcServer.isPathAll(src)) {
-      return rpcClient.invokeAll(locations, method);
+    if (rpcServer.isInvokeConcurrent(src)) {
+      return !rpcClient.invokeConcurrent(locations, method, Boolean.class)
+          .containsValue(false);
     } else {
       return rpcClient.invokeSequential(locations, method, Boolean.class,
           Boolean.TRUE);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAllResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAllResolver.java
@@ -200,13 +200,10 @@ public class TestRouterAllResolver {
     routerFs.truncate(testTruncateFilePath, 10);
     TestFileTruncate.checkBlockRecovery(testTruncateFilePath,
         (DistributedFileSystem) routerFs);
-    assertEquals("Truncate file  fails", 10,
+    assertEquals("Truncate file fails", 10,
         routerFs.getFileStatus(testTruncateFilePath).getLen());
-
-    // Test setReplication
-    assertTrue(routerFs.setReplication(testTruncateFilePath, (short)2));
-    assertEquals("SetReplication file fails", 2,
-        routerFs.getFileStatus(testTruncateFilePath).getReplication());
+    assertDirsEverywhere(path, 9);
+    assertFilesDistributed(path, 16);
 
     // Removing a directory should remove it from every subcluster
     routerFs.delete(new Path(path + "/dir2/dir22/dir220"), true);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAllResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAllResolver.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.server.federation.RouterConfigBuilder;
 import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.NamenodeContext;
 import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.RouterContext;
@@ -46,6 +47,7 @@ import org.apache.hadoop.hdfs.server.federation.store.protocol.AddMountTableEntr
 import org.apache.hadoop.hdfs.server.federation.store.protocol.GetMountTableEntriesRequest;
 import org.apache.hadoop.hdfs.server.federation.store.protocol.GetMountTableEntriesResponse;
 import org.apache.hadoop.hdfs.server.federation.store.records.MountTable;
+import org.apache.hadoop.hdfs.server.namenode.TestFileTruncate;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -190,6 +192,16 @@ public class TestRouterAllResolver {
         routerFs.getFileStatus(testFilePath).getLen() > 110);
     assertDirsEverywhere(path, 9);
     assertFilesDistributed(path, 15);
+
+    // Test truncate
+    String testTruncateFile = path + "/dir2/dir22/dir220/file-truncate.txt";
+    createTestFile(routerFs, testTruncateFile);
+    Path testTruncateFilePath = new Path(testTruncateFile);
+    routerFs.truncate(testTruncateFilePath, 10);
+    TestFileTruncate.checkBlockRecovery(testTruncateFilePath,
+        (DistributedFileSystem) routerFs);
+    assertEquals("Truncate file  fails", 10,
+        routerFs.getFileStatus(testTruncateFilePath).getLen());
 
     // Removing a directory should remove it from every subcluster
     routerFs.delete(new Path(path + "/dir2/dir22/dir220"), true);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAllResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAllResolver.java
@@ -203,6 +203,11 @@ public class TestRouterAllResolver {
     assertEquals("Truncate file  fails", 10,
       routerFs.getFileStatus(testTruncateFilePath).getLen());
 
+    // Test setReplication
+    assertTrue(routerFs.setReplication(testTruncateFilePath,(short) 2));
+    assertEquals("SetReplication file fails", 2,
+      routerFs.getFileStatus(testTruncateFilePath).getReplication());
+
     // Removing a directory should remove it from every subcluster
     routerFs.delete(new Path(path + "/dir2/dir22/dir220"), true);
     assertDirsEverywhere(path, 8);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAllResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAllResolver.java
@@ -199,14 +199,14 @@ public class TestRouterAllResolver {
     Path testTruncateFilePath = new Path(testTruncateFile);
     routerFs.truncate(testTruncateFilePath, 10);
     TestFileTruncate.checkBlockRecovery(testTruncateFilePath,
-      (DistributedFileSystem) routerFs);
+        (DistributedFileSystem) routerFs);
     assertEquals("Truncate file  fails", 10,
-      routerFs.getFileStatus(testTruncateFilePath).getLen());
+        routerFs.getFileStatus(testTruncateFilePath).getLen());
 
     // Test setReplication
-    assertTrue(routerFs.setReplication(testTruncateFilePath,(short) 2));
+    assertTrue(routerFs.setReplication(testTruncateFilePath,(short)2));
     assertEquals("SetReplication file fails", 2,
-      routerFs.getFileStatus(testTruncateFilePath).getReplication());
+        routerFs.getFileStatus(testTruncateFilePath).getReplication());
 
     // Removing a directory should remove it from every subcluster
     routerFs.delete(new Path(path + "/dir2/dir22/dir220"), true);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAllResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAllResolver.java
@@ -199,9 +199,9 @@ public class TestRouterAllResolver {
     Path testTruncateFilePath = new Path(testTruncateFile);
     routerFs.truncate(testTruncateFilePath, 10);
     TestFileTruncate.checkBlockRecovery(testTruncateFilePath,
-        (DistributedFileSystem) routerFs);
+      (DistributedFileSystem) routerFs);
     assertEquals("Truncate file  fails", 10,
-        routerFs.getFileStatus(testTruncateFilePath).getLen());
+      routerFs.getFileStatus(testTruncateFilePath).getLen());
 
     // Removing a directory should remove it from every subcluster
     routerFs.delete(new Path(path + "/dir2/dir22/dir220"), true);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAllResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAllResolver.java
@@ -204,7 +204,7 @@ public class TestRouterAllResolver {
         routerFs.getFileStatus(testTruncateFilePath).getLen());
 
     // Test setReplication
-    assertTrue(routerFs.setReplication(testTruncateFilePath,(short)2));
+    assertTrue(routerFs.setReplication(testTruncateFilePath, (short)2));
     assertEquals("SetReplication file fails", 2,
         routerFs.getFileStatus(testTruncateFilePath).getReplication());
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/HDFS-16861

### How was this patch tested?
add truncate api test in TestRouterAllResolver

### For code changes:
in RouterClientProtocol
```
  @Override
  public boolean truncate(String src, long newLength, String clientName)
      throws IOException {
...
    // Truncate can return true/false, so don't expect a result
    return rpcClient.invokeSequential(locations, method, Boolean.class,
        null);
  }
```

