### PR TITLE
HADOOP-18560. AvroFSInput opens a stream twice and discards the second one without closing

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/AvroFSInput.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/AvroFSInput.java
@@ -60,7 +60,6 @@ public class AvroFSInput implements Closeable, SeekableInput {
             FS_OPTION_OPENFILE_READ_POLICY_SEQUENTIAL)
         .withFileStatus(status)
         .build());
-    fc.open(p);
   }
 
   @Override


### PR DESCRIPTION

### Description of PR

removes a needless line in `AvroFSInput(final FileContext fc, final Path p` which opens the path a second time and discards the result.

on input streams which immediately set up a connection with the store, this can leak connections.

Note, this is through the FileContext constructor, which is only used in production in org.apache.hadoop.fs.shell.Display, which being used from the command line, shouldn't be a long-lived process

### How was this patch tested?

going to see what yetus says.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

