### PR TITLE
HDFS-16856: Refactor RouterAdmin to use the AdminHelper class.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/StringUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/StringUtils.java
@@ -1135,7 +1135,25 @@ public class StringUtils {
     }
     return val;
   }
-  
+
+  /**
+   * From a list of command-line arguments, remove both an option and the
+   * next argument.
+   * @param name the name of the option
+   * @param args the list of arguments
+   * @param defaultValue the desired default value
+   * @return the value of the argument or the default value if the option wasn't
+   *         present.
+   * @throws IllegalArgumentException if the option doesn't have an argument
+   */
+  public static String popOptionWithArgument(String name,
+                                             List<String> args,
+                                             String defaultValue)
+      throws IllegalArgumentException {
+    String result = popOptionWithArgument(name, args);
+    return result == null ? defaultValue : result;
+  }
+
   /**
    * From a list of command-line arguments, remove an option.
    *
@@ -1181,6 +1199,19 @@ public class StringUtils {
       }
     }
     return null;
+  }
+  /**
+   * From a list of command-line arguments, ensure that all of the arguments
+   * have been used except a possible "--".
+   *
+   * @param args  List of arguments.
+   * @throws IllegalArgumentException if some arguments were not used
+   */
+  public static void ensureAllUsed(List<String> args) throws IllegalArgumentException {
+    if (!args.isEmpty() && !(args.size() == 1 && "--".equals(args.get(0)))) {
+      throw new IllegalArgumentException("Unknown arguments: " +
+          String.join(" ", args));
+    }
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/AdminHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/AdminHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
 
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -28,9 +28,12 @@ import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.protocol.CachePoolInfo;
 import org.apache.hadoop.tools.TableListing;
+import org.apache.hadoop.util.ToolRunner;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -88,7 +91,7 @@ public class AdminHelper {
     }
   }
 
-  static TableListing getOptionDescriptionListing() {
+  public static TableListing getOptionDescriptionListing() {
     return new TableListing.Builder()
         .addField("").addField("", true)
         .wrapWidth(MAX_LINE_WIDTH).hideHeaders().build();
@@ -123,7 +126,14 @@ public class AdminHelper {
     return limit;
   }
 
-  static Command determineCommand(String commandName, Command[] commands) {
+  /**
+   * Find the subcommand from the given list
+   * @param commandName the sub command name
+   * @param commands the list of commands
+   * @return the selected command or null if it isn't found
+   */
+  static Command determineCommand(String commandName,
+                                  Command... commands) {
     Preconditions.checkNotNull(commands);
     if (HELP_COMMAND_NAME.equals(commandName)) {
       return new HelpCommand(commands);
@@ -134,6 +144,57 @@ public class AdminHelper {
       }
     }
     return null;
+  }
+
+  /**
+   * Run a command from a list of potential commands and the cli arguments.
+   * @param toolName the name of the tool
+   * @param conf the configuration
+   * @param args the command line arguments
+   * @param commands the list of potential commands
+   * @return the return code (0 == success)
+   */
+  public static int runCommand(String toolName,
+                               Configuration conf,
+                               String[] args,
+                               Command... commands) throws IOException {
+    Command cmd = null;
+    try {
+      if (args.length == 0) {
+        throw new IllegalArgumentException("Must supply a command argument");
+      }
+      String commandName = args[0];
+      List<String> rest = new LinkedList<>(Arrays.asList(args))
+          .subList(1, args.length);
+      cmd = determineCommand(commandName, commands);
+      if (cmd == null) {
+        if (!commandName.startsWith("-")) {
+          throw new IllegalArgumentException(commandName +
+              ": Command names must start with dashes.");
+        } else {
+          throw new IllegalArgumentException("Can't understand command '" +
+              commandName + "'");
+        }
+      }
+      return cmd.run(conf, rest);
+    } catch (IllegalArgumentException iae) {
+      if (cmd == null) {
+        System.err.printf("ERROR %s: %s%n%n", toolName, iae.getLocalizedMessage());
+        printUsage(false, toolName, commands);
+      } else {
+        System.err.printf("ERROR %s %s: %s%n%n", toolName, cmd.getName(),
+            iae.getLocalizedMessage());
+        printUsage(cmd);
+      }
+      ToolRunner.printGenericCommandUsage(System.err);
+      return -1;
+    }
+  }
+
+  static void printUsage(Command command) {
+    Preconditions.checkNotNull(command);
+    System.err.printf(command.getLongUsage());
+    System.err.println();
   }
 
   static void printUsage(boolean longUsage, String toolName,
@@ -153,11 +214,69 @@ public class AdminHelper {
     System.err.println();
   }
 
-  interface Command {
+  public interface Command {
     String getName();
     String getShortUsage();
     String getLongUsage();
     int run(Configuration conf, List<String> args) throws IOException;
+  }
+
+  /**
+   * The type for the lambda of the subcommands.
+   */
+  public interface CommandFunction {
+    int apply(Configuration conf, List<String> args) throws IOException;
+  }
+
+  /**
+   * Create a Command object without defining a new class.
+   * @param name the name of the subcommand with the dash
+   * @param description the brief description of what the subcommand does
+   * @param shortUsage the short usage string (don't include the name)
+   * @param runner the lambda to execute the subcommand
+   * @param subopts a list of detailHelp for the long usage
+   * @return a new command object
+   */
+  public static Command makeCommand(String name,
+                                    String description,
+                                    String shortUsage,
+                                    CommandFunction runner,
+                                    String[]... subopts) {
+    return new Command() {
+      @Override
+      public String getName() {
+        return name;
+      }
+
+      @Override
+      public String getShortUsage() {
+        return "[" + name + " " + shortUsage + "]\n";
+      }
+
+      @Override
+      public String getLongUsage() {
+        TableListing listing = AdminHelper.getOptionDescriptionListing();
+        for(String[] opt: subopts){
+          listing.addRow(new String[]{"  " + opt[0], opt[1]});
+        }
+        return String.format("%s: %s\n  %s\n%s", name, description, shortUsage,
+            listing);
+      }
+
+      @Override
+      public int run(Configuration conf, List<String> args) throws IOException {
+        return runner.apply(conf, args);
+      }
+    };
+  }
+
+  /**
+   * A helper function to create the detailed help for makeCommand.
+   * @param values the pair of strings for the long help
+   * @return an array of the strings
+   */
+  public static String[] detailHelp(String... values) {
+    return values;
   }
 
   static class HelpCommand implements Command {
@@ -184,9 +303,8 @@ public class AdminHelper {
       listing.addRow("<command-name>", "The command for which to get " +
           "detailed help. If no command is specified, print detailed help for " +
           "all commands");
-      return getShortUsage() + "\n" +
-          "Get detailed help about a command.\n\n" +
-          listing.toString();
+      return getShortUsage() + "\n" + "Get detailed help about a command.\n\n" +
+          listing;
     }
 
     @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/CacheAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/CacheAdmin.java
@@ -63,32 +63,7 @@ public class CacheAdmin extends Configured implements Tool {
 
   @Override
   public int run(String[] args) throws IOException {
-    if (args.length == 0) {
-      AdminHelper.printUsage(false, "cacheadmin", COMMANDS);
-      ToolRunner.printGenericCommandUsage(System.err);
-      return 1;
-    }
-    AdminHelper.Command command = AdminHelper.determineCommand(args[0],
-        COMMANDS);
-    if (command == null) {
-      System.err.println("Can't understand command '" + args[0] + "'");
-      if (!args[0].startsWith("-")) {
-        System.err.println("Command names must start with dashes.");
-      }
-      AdminHelper.printUsage(false, "cacheadmin", COMMANDS);
-      ToolRunner.printGenericCommandUsage(System.err);
-      return 1;
-    }
-    List<String> argsList = new LinkedList<String>();
-    for (int j = 1; j < args.length; j++) {
-      argsList.add(args[j]);
-    }
-    try {
-      return command.run(getConf(), argsList);
-    } catch (IllegalArgumentException e) {
-      System.err.println(AdminHelper.prettifyException(e));
-      return -1;
-    }
+    return AdminHelper.runCommand("cacheadmin", getConf(), args, COMMANDS);
   }
 
   public static void main(String[] argsArray) throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/CryptoAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/CryptoAdmin.java
@@ -56,32 +56,7 @@ public class CryptoAdmin extends Configured implements Tool {
 
   @Override
   public int run(String[] args) throws IOException {
-    if (args.length == 0) {
-      AdminHelper.printUsage(false, "crypto", COMMANDS);
-      ToolRunner.printGenericCommandUsage(System.err);
-      return 1;
-    }
-    final AdminHelper.Command command = AdminHelper.determineCommand(args[0],
-        COMMANDS);
-    if (command == null) {
-      System.err.println("Can't understand command '" + args[0] + "'");
-      if (!args[0].startsWith("-")) {
-        System.err.println("Command names must start with dashes.");
-      }
-      AdminHelper.printUsage(false, "crypto", COMMANDS);
-      ToolRunner.printGenericCommandUsage(System.err);
-      return 1;
-    }
-    final List<String> argsList = new LinkedList<String>();
-    for (int j = 1; j < args.length; j++) {
-      argsList.add(args[j]);
-    }
-    try {
-      return command.run(getConf(), argsList);
-    } catch (IllegalArgumentException e) {
-      System.err.println(prettifyException(e));
-      return -1;
-    }
+    return AdminHelper.runCommand("crypto", getConf(), args, COMMANDS);
   }
 
   public static void main(String[] argsArray) throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/ECAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/ECAdmin.java
@@ -65,30 +65,7 @@ public class ECAdmin extends Configured implements Tool {
 
   @Override
   public int run(String[] args) throws Exception {
-    if (args.length == 0) {
-      AdminHelper.printUsage(false, NAME, COMMANDS);
-      ToolRunner.printGenericCommandUsage(System.err);
-      return 1;
-    }
-    final AdminHelper.Command command = AdminHelper.determineCommand(args[0],
-        COMMANDS);
-    if (command == null) {
-      System.err.println("Can't understand command '" + args[0] + "'");
-      if (!args[0].startsWith("-")) {
-        System.err.println("Command names must start with dashes.");
-      }
-      AdminHelper.printUsage(false, NAME, COMMANDS);
-      ToolRunner.printGenericCommandUsage(System.err);
-      return 1;
-    }
-    final List<String> argsList = new LinkedList<>();
-    argsList.addAll(Arrays.asList(args).subList(1, args.length));
-    try {
-      return command.run(getConf(), argsList);
-    } catch (IllegalArgumentException e) {
-      System.err.println(AdminHelper.prettifyException(e));
-      return -1;
-    }
+    return AdminHelper.runCommand(NAME, getConf(), args, COMMANDS);
   }
 
   /** Command to list the set of enabled erasure coding policies. */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/StoragePolicyAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/StoragePolicyAdmin.java
@@ -57,30 +57,7 @@ public class StoragePolicyAdmin extends Configured implements Tool {
 
   @Override
   public int run(String[] args) throws Exception {
-    if (args.length == 0) {
-      AdminHelper.printUsage(false, "storagepolicies", COMMANDS);
-      ToolRunner.printGenericCommandUsage(System.err);
-      return 1;
-    }
-    final AdminHelper.Command command = AdminHelper.determineCommand(args[0],
-        COMMANDS);
-    if (command == null) {
-      System.err.println("Can't understand command '" + args[0] + "'");
-      if (!args[0].startsWith("-")) {
-        System.err.println("Command names must start with dashes.");
-      }
-      AdminHelper.printUsage(false, "storagepolicies", COMMANDS);
-      ToolRunner.printGenericCommandUsage(System.err);
-      return 1;
-    }
-    final List<String> argsList = new LinkedList<>();
-    argsList.addAll(Arrays.asList(args).subList(1, args.length));
-    try {
-      return command.run(getConf(), argsList);
-    } catch (IllegalArgumentException e) {
-      System.err.println(AdminHelper.prettifyException(e));
-      return -1;
-    }
+    return AdminHelper.runCommand("storagepolicies", getConf(), args, COMMANDS);
   }
 
   /** Command to list all the existing storage policies */


### PR DESCRIPTION
### Description of PR

This simplifies the structure of RouterAdmin to make the various subcommands, much more consistent and have less repetition throughout the code. The user visible change is that some of the error and help messages have changed and in general are more consistent.

### How was this patch tested?

The unit test TestRouterAdminCLI was run. I'll also test the tool against our routers.