### PR TITLE
YARN-11393. Fs2cs could be extended to set ULF to -1 upon conversion

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSConfigToCSConfigConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSConfigToCSConfigConverter.java
@@ -418,7 +418,7 @@ public class FSConfigToCSConfigConverter {
   private void emitDefaultUserLimitFactor() {
     capacitySchedulerConfig.setFloat(
             CapacitySchedulerConfiguration.
-                    PREFIX + USER_LIMIT_FACTOR,
+                    PREFIX + "root.default." + USER_LIMIT_FACTOR,
             -1.0f);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSConfigToCSConfigConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSConfigToCSConfigConverter.java
@@ -29,7 +29,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -49,7 +48,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.placemen
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.AllocationConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.AllocationConfigurationException;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.ConfigurableResource;
-import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FSLeafQueue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FSParentQueue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FSQueue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler;
@@ -293,7 +291,6 @@ public class FSConfigToCSConfigConverter {
 
   private void convertCapacitySchedulerXml(FairScheduler fs) {
     FSParentQueue rootQueue = fs.getQueueManager().getRootQueue();
-    Collection<FSLeafQueue> fsLeafQueue = fs.getQueueManager().getLeafQueues();
     emitDefaultQueueMaxParallelApplications();
     emitDefaultUserMaxParallelApplications();
     emitUserMaxParallelApplications();
@@ -313,7 +310,6 @@ public class FSConfigToCSConfigConverter {
         .withPercentages(usePercentages)
         .build();
 
-    queueConverter.emitDefaultUserLimitFactor(fsLeafQueue, capacitySchedulerConfig);
     queueConverter.convertQueueHierarchy(rootQueue);
     emitACLs(fs);
   }
@@ -416,7 +412,6 @@ public class FSConfigToCSConfigConverter {
           queueMaxAMShareDefault);
     }
   }
-
   private void emitDisablePreemptionForObserveOnlyMode() {
     if (preemptionMode == FSConfigToCSConfigConverterParams
             .PreemptionMode.OBSERVE_ONLY) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSConfigToCSConfigConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSConfigToCSConfigConverter.java
@@ -20,6 +20,7 @@ import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.C
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.MAPPING_RULE_FORMAT;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.MAPPING_RULE_JSON;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.MAPPING_RULE_FORMAT_JSON;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.USER_LIMIT_FACTOR;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter.FSQueueConverter.QUEUE_MAX_AM_SHARE_DISABLED;
 
 import java.io.ByteArrayOutputStream;
@@ -295,6 +296,7 @@ public class FSConfigToCSConfigConverter {
     emitDefaultUserMaxParallelApplications();
     emitUserMaxParallelApplications();
     emitDefaultMaxAMShare();
+    emitDefaultUserLimitFactor();
     emitDisablePreemptionForObserveOnlyMode();
 
     FSQueueConverter queueConverter = FSQueueConverterBuilder.create()
@@ -412,6 +414,14 @@ public class FSConfigToCSConfigConverter {
           queueMaxAMShareDefault);
     }
   }
+
+  private void emitDefaultUserLimitFactor() {
+    capacitySchedulerConfig.setFloat(
+            CapacitySchedulerConfiguration.
+                    PREFIX + USER_LIMIT_FACTOR,
+            -1.0f);
+  }
+
   private void emitDisablePreemptionForObserveOnlyMode() {
     if (preemptionMode == FSConfigToCSConfigConverterParams
             .PreemptionMode.OBSERVE_ONLY) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSConfigToCSConfigConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSConfigToCSConfigConverter.java
@@ -16,12 +16,10 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter;
 
-import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.DOT;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.PREFIX;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.MAPPING_RULE_FORMAT;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.MAPPING_RULE_JSON;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.MAPPING_RULE_FORMAT_JSON;
-import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.USER_LIMIT_FACTOR;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter.FSQueueConverter.QUEUE_MAX_AM_SHARE_DISABLED;
 
 import java.io.ByteArrayOutputStream;
@@ -315,7 +313,7 @@ public class FSConfigToCSConfigConverter {
         .withPercentages(usePercentages)
         .build();
 
-    emitDefaultUserLimitFactor(fsLeafQueue);
+    queueConverter.emitDefaultUserLimitFactor(fsLeafQueue, capacitySchedulerConfig);
     queueConverter.convertQueueHierarchy(rootQueue);
     emitACLs(fs);
   }
@@ -417,19 +415,6 @@ public class FSConfigToCSConfigConverter {
             MAXIMUM_APPLICATION_MASTERS_RESOURCE_PERCENT,
           queueMaxAMShareDefault);
     }
-  }
-
-  private void emitDefaultUserLimitFactor(Collection<FSLeafQueue> fsLeafQueue) {
-    fsLeafQueue
-        .forEach((leafQueue) -> {
-          if (!capacitySchedulerConfig.
-                isAutoQueueCreationV2Enabled(leafQueue.getName())) {
-            capacitySchedulerConfig.setFloat(
-                    CapacitySchedulerConfiguration.
-                            PREFIX + leafQueue.getName() + DOT + USER_LIMIT_FACTOR,
-                    -1.0f);
-          }
-        });
   }
 
   private void emitDisablePreemptionForObserveOnlyMode() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSQueueConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSQueueConverter.java
@@ -17,12 +17,16 @@
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter;
 
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.PREFIX;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.DOT;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.USER_LIMIT_FACTOR;
 
 import java.util.List;
+import java.util.Collection;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.ConfigurableResource;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FSLeafQueue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FSQueue;
@@ -213,6 +217,19 @@ public class FSQueueConverter {
       capacitySchedulerConfig.set(PREFIX + queueName + ".disable_preemption",
           "true");
     }
+  }
+
+  public void emitDefaultUserLimitFactor(Collection<FSLeafQueue> fsLeafQueue, CapacitySchedulerConfiguration config) {
+    fsLeafQueue
+          .forEach((leafQueue) -> {
+            if (!config.
+                    isAutoQueueCreationV2Enabled(leafQueue.getName())) {
+              config.setFloat(
+                      CapacitySchedulerConfiguration.
+                              PREFIX + leafQueue.getName() + DOT + USER_LIMIT_FACTOR,
+                      -1.0f);
+            }
+          });
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSQueueConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSQueueConverter.java
@@ -21,7 +21,6 @@ import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.C
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.USER_LIMIT_FACTOR;
 
 import java.util.List;
-import java.util.Collection;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.conf.Configuration;
@@ -83,6 +82,7 @@ public class FSQueueConverter {
     emitMaxParallelApps(queueName, queue);
     emitMaxAllocations(queueName, queue);
     emitPreemptionDisabled(queueName, queue);
+    emitDefaultUserLimitFactor(queueName, children);
 
     emitChildCapacity(queue);
     emitMaximumCapacity(queueName, queue);
@@ -219,17 +219,13 @@ public class FSQueueConverter {
     }
   }
 
-  public void emitDefaultUserLimitFactor(Collection<FSLeafQueue> fsLeafQueue, CapacitySchedulerConfiguration config) {
-    fsLeafQueue
-          .forEach((leafQueue) -> {
-            if (!config.
-                    isAutoQueueCreationV2Enabled(leafQueue.getName())) {
-              config.setFloat(
-                      CapacitySchedulerConfiguration.
-                              PREFIX + leafQueue.getName() + DOT + USER_LIMIT_FACTOR,
-                      -1.0f);
-            }
-          });
+  public void emitDefaultUserLimitFactor(String queueName, List<FSQueue> children) {
+    if (children.isEmpty()) {
+      capacitySchedulerConfig.setFloat(
+              CapacitySchedulerConfiguration.
+                      PREFIX + queueName + DOT + USER_LIMIT_FACTOR,
+              -1.0f);
+    }
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSConfigToCSConfigConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSConfigToCSConfigConverter.java
@@ -183,7 +183,7 @@ public class TestFSConfigToCSConfigConverter {
         conf.get(PREFIX + "root.admins.alice.maximum-am-resource-percent"));
 
     assertNull("root.users.joe maximum-am-resource-percent should be null",
-        conf.get(PREFIX + "root.users.joe maximum-am-resource-percent"));
+        conf.get(PREFIX + "root.users.joe.maximum-am-resource-percent"));
   }
 
   @Test
@@ -196,8 +196,11 @@ public class TestFSConfigToCSConfigConverter {
 
     assertEquals("Default user limit factor", "-1.0", userLimitFactor);
 
-    assertNull("root.users.joe user-limit-factor should be null",
-            conf.get(PREFIX + "root.users.joe user-limit-factor"));
+    assertEquals("root.users.joe user-limit-factor", "-1.0",
+            conf.get(PREFIX + "root.users.joe.user-limit-factor"));
+
+    assertEquals("root.admins.bob user-limit-factor", "-1.0",
+            conf.get(PREFIX + "root.admins.bob.user-limit-factor"));
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSConfigToCSConfigConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSConfigToCSConfigConverter.java
@@ -192,7 +192,7 @@ public class TestFSConfigToCSConfigConverter {
 
     Configuration conf = converter.getCapacitySchedulerConfig();
     String userLimitFactor =
-            conf.get(PREFIX + USER_LIMIT_FACTOR);
+            conf.get(PREFIX + "root.default." + USER_LIMIT_FACTOR);
 
     assertEquals("Default user limit factor", "-1.0", userLimitFactor);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSConfigToCSConfigConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSConfigToCSConfigConverter.java
@@ -191,10 +191,12 @@ public class TestFSConfigToCSConfigConverter {
     converter.convert(config);
 
     Configuration conf = converter.getCapacitySchedulerConfig();
-    String userLimitFactor =
-            conf.get(PREFIX + "root.default." + USER_LIMIT_FACTOR);
 
-    assertEquals("Default user limit factor", "-1.0", userLimitFactor);
+    assertNull("root.users user-limit-factor should be null",
+            conf.get(PREFIX + "root.users." + USER_LIMIT_FACTOR));
+
+    assertEquals("root.default user-limit-factor", "-1.0",
+            conf.get(PREFIX + "root.default.user-limit-factor"));
 
     assertEquals("root.users.joe user-limit-factor", "-1.0",
             conf.get(PREFIX + "root.users.joe.user-limit-factor"));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSConfigToCSConfigConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSConfigToCSConfigConverter.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter;
 
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.PREFIX;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.USER_LIMIT_FACTOR;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter.FSConfigToCSConfigRuleHandler.DYNAMIC_MAX_ASSIGN;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter.FSConfigToCSConfigRuleHandler.MAX_CAPACITY_PERCENTAGE;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter.FSConfigToCSConfigRuleHandler.MAX_CHILD_CAPACITY;
@@ -183,6 +184,20 @@ public class TestFSConfigToCSConfigConverter {
 
     assertNull("root.users.joe maximum-am-resource-percent should be null",
         conf.get(PREFIX + "root.users.joe maximum-am-resource-percent"));
+  }
+
+  @Test
+  public void testDefaultUserLimitFactor() throws Exception {
+    converter.convert(config);
+
+    Configuration conf = converter.getCapacitySchedulerConfig();
+    String userLimitFactor =
+            conf.get(PREFIX + USER_LIMIT_FACTOR);
+
+    assertEquals("Default user limit factor", "-1.0", userLimitFactor);
+
+    assertNull("root.users.joe user-limit-factor should be null",
+            conf.get(PREFIX + "root.users.joe user-limit-factor"));
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

