### PR TITLE
HADOOP-18561. Update commons-net to 3.9.0

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -251,7 +251,7 @@ commons-collections:commons-collections:3.2.2
 commons-daemon:commons-daemon:1.0.13
 commons-io:commons-io:2.8.0
 commons-logging:commons-logging:1.1.3
-commons-net:commons-net:3.8.0
+commons-net:commons-net:3.9.0
 de.ruedigermoeller:fst:2.50
 io.grpc:grpc-api:1.26.0
 io.grpc:grpc-context:1.26.0

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -123,7 +123,7 @@
     <commons-logging.version>1.1.3</commons-logging.version>
     <commons-logging-api.version>1.1</commons-logging-api.version>
     <commons-math3.version>3.6.1</commons-math3.version>
-    <commons-net.version>3.8.0</commons-net.version>
+    <commons-net.version>3.9.0</commons-net.version>
     <commons-text.version>1.10.0</commons-text.version>
 
     <kerby.version>2.0.2</kerby.version>


### PR DESCRIPTION
Addresses CVE-2021-37533, which *only* relates to ftp.

Applications not using the ftp:// filesystem, which, as anyone who has used it will know is very minimal and so rarely used, is not a critical part of the project.

This is a due diligence PR rather than an emergency fix.


### How was this patch tested?

waiting for yetus

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

