### PR TITLE
HADOOP-18567. LogThrottlingHelper: properly trigger dependent recorders in cases of infrequent logging

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/LogThrottlingHelper.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/LogThrottlingHelper.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.log;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.apache.hadoop.util.Timer;
@@ -262,8 +263,15 @@ public class LogThrottlingHelper {
     if (primaryRecorderName.equals(recorderName) &&
         currentTimeMs - minLogPeriodMs >= lastLogTimestampMs) {
       lastLogTimestampMs = currentTimeMs;
-      for (LoggingAction log : currentLogs.values()) {
-        log.setShouldLog();
+      for (Iterator<LoggingAction> it = currentLogs.values().iterator(); it
+          .hasNext();) {
+        LoggingAction log = it.next();
+        if (log.hasLogged()) {
+          // Make sure the dependent recorders will be triggered the next time
+          it.remove();
+        } else {
+          log.setShouldLog();
+        }
       }
     }
     if (currentLog.shouldLog()) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/log/TestLogThrottlingHelper.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/log/TestLogThrottlingHelper.java
@@ -143,6 +143,18 @@ public class TestLogThrottlingHelper {
   }
 
   @Test
+  public void testInfrequentPrimaryAndDependentLoggers() {
+    helper = new LogThrottlingHelper(LOG_PERIOD, "foo", timer);
+
+    assertTrue(helper.record("foo", 0).shouldLog());
+    assertTrue(helper.record("bar", 0).shouldLog());
+
+    // Both should log once the period has elapsed
+    assertTrue(helper.record("foo", LOG_PERIOD).shouldLog());
+    assertTrue(helper.record("bar", LOG_PERIOD).shouldLog());
+  }
+
+  @Test
   public void testMultipleLoggersWithValues() {
     helper = new LogThrottlingHelper(LOG_PERIOD, "foo", timer);
 


### PR DESCRIPTION
### Description of PR
The current implementation of `LogThrottlingHelper` works well most of the time, but it missed out one case, which appears quite common in the production codes:
- if the dependent recorder was not suppressed before the primary one is triggered on the next period, then the next logging of the dependent recorder will be unexpectedly suppressed.

```
    helper = new LogThrottlingHelper(LOG_PERIOD, "foo", timer);

    assertTrue(helper.record("foo", 0).shouldLog());
    assertTrue(helper.record("bar", 0).shouldLog());

    // Both should log once the period has elapsed
    // <pos1>
    assertTrue(helper.record("foo", LOG_PERIOD).shouldLog());
    assertTrue(helper.record("bar", LOG_PERIOD).shouldLog()); <--- This assertion will now fail
```

Note if we call `helper.record("bar", LOG_PERIOD * 2)` at `<pos1>`, as the existing test cases do, it will work as expected.

### How was this patch tested?
A test case is added.
