### PR TITLE
HDFS-16864. Drop cache behind entire block on close

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
@@ -358,6 +358,10 @@ class BlockReceiver implements Closeable {
           streams.syncDataOut();
           datanode.metrics.addFsyncNanos(System.nanoTime() - fsyncStartNanos);
         }
+        if (dropCacheBehindWrites) {
+          streams.dropCacheBehindWrites(block.getBlockName(), 0, 0,
+              POSIX_FADV_DONTNEED);
+        }
         flushTotalNanos += flushEndNanos - flushStartNanos;
         measuredFlushTime = true;
         streams.closeDataStream();


### PR DESCRIPTION
As blocks are written posix_fadvise is called when dropCacheBehindWrites is true, but the range supplied does not include the most recent 8MB written. This change modifies BlockReceiver.close such that when dropCacheBehindWrites is true, then posix_fadvise is called on the entire block.