### PR TITLE
HDFS-16873 FileStatus compareTo specify ordering by path

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileStatus.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileStatus.java
@@ -402,7 +402,8 @@ public class FileStatus implements Writable, Comparable<Object>,
   }
 
   /**
-   * Compare this FileStatus to another FileStatus
+   * Compare this FileStatus to another FileStatus based on lexicographical
+   * order of path.
    * @param   o the FileStatus to be compared.
    * @return  a negative integer, zero, or a positive integer as this object
    *   is less than, equal to, or greater than the specified object.
@@ -412,7 +413,8 @@ public class FileStatus implements Writable, Comparable<Object>,
   }
 
   /**
-   * Compare this FileStatus to another FileStatus.
+   * Compare this FileStatus to another FileStatus based on lexicographical
+   * order of path.
    * This method was added back by HADOOP-14683 to keep binary compatibility.
    *
    * @param   o the FileStatus to be compared.


### PR DESCRIPTION
### Description of PR
FileStatus implements the Comparable interface. Was looking to sort and was unable to tell what fields were used to base the sorting order on from documentation. Needed to review code to understand behavior.

Updated documentation for those looking to specify comapreTo uses lexicographical order of path. 

### How was this patch tested?
NA. Documentation update. 

Apologies for not having JIRA. Requesting access in parallel and will resubmit if this is required for such trivial changes. 