### PR TITLE
YARN-11395. RM UI, RMAttemptBlock can not render FINAL_SAVING

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/state/StateMachine.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/state/StateMachine.java
@@ -27,6 +27,7 @@ public interface StateMachine
                  <STATE extends Enum<STATE>,
                   EVENTTYPE extends Enum<EVENTTYPE>, EVENT> {
   public STATE getCurrentState();
+  public STATE getPreviousState();
   public STATE doTransition(EVENTTYPE eventType, EVENT event)
         throws InvalidStateTransitionException;
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/state/StateMachineFactory.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/state/StateMachineFactory.java
@@ -457,6 +457,7 @@ final public class StateMachineFactory
         implements StateMachine<STATE, EVENTTYPE, EVENT> {
     private final OPERAND operand;
     private STATE currentState;
+    private STATE previousState;
     private final StateTransitionListener<OPERAND, EVENT, STATE> listener;
 
     InternalStateMachine(OPERAND operand, STATE initialState) {
@@ -480,13 +481,18 @@ final public class StateMachineFactory
     }
 
     @Override
+    public synchronized STATE getPreviousState() {
+      return previousState;
+    }
+
+    @Override
     public synchronized STATE doTransition(EVENTTYPE eventType, EVENT event)
          throws InvalidStateTransitionException  {
       listener.preTransition(operand, currentState, event);
-      STATE oldState = currentState;
+      previousState = currentState;
       currentState = StateMachineFactory.this.doTransition
           (operand, currentState, eventType, event);
-      listener.postTransition(operand, oldState, currentState, event);
+      listener.postTransition(operand, previousState, currentState, event);
       return currentState;
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMServerUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMServerUtils.java
@@ -453,6 +453,17 @@ public class RMServerUtils {
     }
   }
 
+  public static YarnApplicationAttemptState convertRmAppAttemptStateToYarnApplicationAttemptState(
+      RMAppAttemptState currentState,
+      RMAppAttemptState previousState
+  ) {
+    return createApplicationAttemptState(
+        currentState == RMAppAttemptState.FINAL_SAVING
+        ? previousState
+        : currentState
+    );
+  }
+
   public static YarnApplicationAttemptState createApplicationAttemptState(
       RMAppAttemptState rmAppAttemptState) {
     switch (rmAppAttemptState) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/attempt/RMAppAttempt.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/attempt/RMAppAttempt.java
@@ -207,6 +207,14 @@ public interface RMAppAttempt extends EventHandler<RMAppAttemptEvent> {
   RMAppAttemptState getState();
 
   /**
+   * The previous state of the {@link RMAppAttempt} before the current state.
+   *
+   * @return the previous state of the {@link RMAppAttempt} before the current state
+   * for this application attempt.
+   */
+  RMAppAttemptState getPreviousState();
+
+  /**
    * Create the external user-facing state of the attempt of ApplicationMaster
    * from the current state of the {@link RMAppAttempt}.
    * 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/attempt/RMAppAttemptImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/attempt/RMAppAttemptImpl.java
@@ -2220,13 +2220,22 @@ public class RMAppAttemptImpl implements RMAppAttempt, Recoverable {
   }
 
   @Override
-  public YarnApplicationAttemptState createApplicationAttemptState() {
-    RMAppAttemptState state = getState();
-    // If AppAttempt is in FINAL_SAVING state, return its previous state.
-    if (state.equals(RMAppAttemptState.FINAL_SAVING)) {
-      state = stateBeforeFinalSaving;
+  public RMAppAttemptState getPreviousState() {
+    this.readLock.lock();
+
+    try {
+      return this.stateMachine.getPreviousState();
+    } finally {
+      this.readLock.unlock();
     }
-    return RMServerUtils.createApplicationAttemptState(state);
+  }
+
+  @Override
+  public YarnApplicationAttemptState createApplicationAttemptState() {
+    return RMServerUtils.convertRmAppAttemptStateToYarnApplicationAttemptState(
+        getState(),
+        stateBeforeFinalSaving
+    );
   }
 
   private void launchAttempt(){

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMAppAttemptBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMAppAttemptBlock.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.api.records.YarnApplicationAttemptState;
 import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.server.resourcemanager.RMServerUtils;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMApp;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.RMAppAttempt;
@@ -437,18 +438,22 @@ public class RMAppAttemptBlock extends AppAttemptBlock{
   @Override
   protected void createAttemptHeadRoomTable(Block html) {
     RMAppAttempt attempt = getRMAppAttempt();
-    if (attempt != null) {
-      if (!isApplicationInFinalState(YarnApplicationAttemptState
-          .valueOf(attempt.getAppAttemptState().toString()))) {
-        RMAppAttemptMetrics metrics = attempt.getRMAppAttemptMetrics();
-        DIV<Hamlet> pdiv = html.__(InfoBlock.class).div(_INFO_WRAP);
-        info("Application Attempt Overview").clear();
-        info("Application Attempt Metrics").__(
-          "Application Attempt Headroom : ", metrics == null ? "N/A" :
-            metrics.getApplicationAttemptHeadroom());
-        pdiv.__();
-      }
+    if (attempt != null && !isApplicationInFinalState(createApplicationAttemptState(attempt))) {
+      RMAppAttemptMetrics metrics = attempt.getRMAppAttemptMetrics();
+      DIV<Hamlet> pdiv = html.__(InfoBlock.class).div(_INFO_WRAP);
+      info("Application Attempt Overview").clear();
+      info("Application Attempt Metrics").__(
+        "Application Attempt Headroom : ", metrics == null ? "N/A" :
+          metrics.getApplicationAttemptHeadroom());
+      pdiv.__();
     }
+  }
+
+  private YarnApplicationAttemptState createApplicationAttemptState(RMAppAttempt attempt) {
+    return RMServerUtils.convertRmAppAttemptStateToYarnApplicationAttemptState(
+        attempt.getState(),
+        attempt.getPreviousState()
+    );
   }
 
   private RMAppAttempt getRMAppAttempt() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMServerUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMServerUtils.java
@@ -43,10 +43,12 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.api.records.UpdateContainerError;
 import org.apache.hadoop.yarn.api.records.UpdateContainerRequest;
+import org.apache.hadoop.yarn.api.records.YarnApplicationAttemptState;
 import org.apache.hadoop.yarn.api.records.impl.pb.UpdateContainerRequestPBImpl;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.event.Dispatcher;
 import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsManager;
+import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.RMAppAttemptState;
 import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainer;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ContainerUpdates;
@@ -408,6 +410,30 @@ public class TestRMServerUtils {
     node2Req.setRelaxLocality(false);
     Assert.assertEquals(15,
         RMServerUtils.getApplicableNodeCountForAM(rmContext, conf, reqs));
+  }
+  @Test
+  public void testConvertRmAppAttemptStateToYarnApplicationAttemptState() {
+    Assert.assertEquals(
+        YarnApplicationAttemptState.FAILED,
+        RMServerUtils.convertRmAppAttemptStateToYarnApplicationAttemptState(
+            RMAppAttemptState.FINAL_SAVING,
+            RMAppAttemptState.FAILED
+        )
+    );
+    Assert.assertEquals(
+        YarnApplicationAttemptState.SCHEDULED,
+        RMServerUtils.convertRmAppAttemptStateToYarnApplicationAttemptState(
+            RMAppAttemptState.FINAL_SAVING,
+            RMAppAttemptState.SCHEDULED
+        )
+    );
+    Assert.assertEquals(
+        YarnApplicationAttemptState.NEW,
+        RMServerUtils.convertRmAppAttemptStateToYarnApplicationAttemptState(
+            RMAppAttemptState.NEW,
+            null
+        )
+    );
   }
 
   private ResourceRequest createResourceRequest(String resource,


### PR DESCRIPTION
- In the YARN-1345 remove of FINAL_SAVING was missed from RMAttemptBlock
- Same issue was present after YARN-1345 in YARN-4411
- YARN-4411 logic was applied in this commit for FINAL_SAVING

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

