### PR TITLE
HADOOP-18579. Warn when no region configured.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -41,6 +41,8 @@ import com.amazonaws.services.s3.model.EncryptionMaterialsProvider;
 import com.amazonaws.services.s3.model.KMSEncryptionMaterialsProvider;
 import com.amazonaws.util.AwsHostNameUtils;
 import com.amazonaws.util.RuntimeHttpUtils;
+
+import org.apache.hadoop.fs.s3a.impl.V2Migration;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.slf4j.Logger;
@@ -233,6 +235,12 @@ public class DefaultS3ClientFactory extends Configured
       final S3ClientCreationParameters parameters) {
     AmazonS3ClientBuilder b = AmazonS3Client.builder();
     configureBasicParams(b, awsConf, parameters);
+
+    String region = getConf().getTrimmed(AWS_REGION);
+
+    if (StringUtils.isBlank(region)) {
+      V2Migration.regionNotConfigured();
+    }
 
     // endpoint set up is a PITA
     AwsClientBuilder.EndpointConfiguration epr

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/V2Migration.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/V2Migration.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.fs.store.LogExactlyOnce;
 
+import static org.apache.hadoop.fs.s3a.Constants.AWS_REGION;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.SDK_V2_UPGRADE_LOG_NAME;
 
 /**
@@ -48,6 +49,9 @@ public final class V2Migration {
       new LogExactlyOnce(SDK_V2_UPGRADE_LOG);
 
   private static final LogExactlyOnce WARN_ON_GET_OBJECT_METADATA =
+      new LogExactlyOnce(SDK_V2_UPGRADE_LOG);
+
+  private static final LogExactlyOnce WARN_ON_REGION_NOT_CONFIGURED =
       new LogExactlyOnce(SDK_V2_UPGRADE_LOG);
 
   /**
@@ -93,6 +97,15 @@ public final class V2Migration {
   public static void v1GetObjectMetadataCalled() {
     WARN_ON_GET_OBJECT_METADATA.warn("getObjectMetadata() called. This operation and it's response "
         + "will be changed as part of upgrading S3A to AWS SDK V2");
+  }
+
+  /**
+   * Warns on use of getObjectMetadata.
+   */
+  public static void regionNotConfigured() {
+    WARN_ON_REGION_NOT_CONFIGURED.warn("A region has not been configured. Cross region support "
+            + "will be removed as part of upgrading S3A to AWS SDK V2. To avoid errors, set the "
+        + "bucket's region in {}.", AWS_REGION);
   }
 
 }


### PR DESCRIPTION
### Description of PR

[Jira](https://issues.apache.org/jira/browse/HADOOP-18579)

Warn when no region has been configured `fs.s3a.endpoint.region`. This is to prepare for the SDK V2 upgrade, in which requests to S3 will fail if the client is configured with an incorrect region. 

### How was this patch tested?

Did not set `fs.s3a.endpoint.region`, and checked that warning is logged when running an integration test. Set the property, and checked that warning is not logged. 

Also tested in `eu-west-1` by running `mvn -Dparallel-tests -DtestsThreadCount=16 clean verify`.


