### PR TITLE
HADOOP-18577 followup -javadoc fix

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/InternalConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/InternalConstants.java
@@ -37,8 +37,8 @@ public final class InternalConstants {
    * {@code "fs.capability.etags.available"}.
    * <ol>
    *   <li>{@value}: store is safe</li>
-   *   <li>!etags: store is safe</li>
-   *   <li>etags && !{@value}: store is <i>UNSAFE</i></li>
+   *   <li>no etags: store is safe</li>
+   *   <li>etags and not {@value}: store is <i>UNSAFE</i></li>
    * </ol>
    */
   public static final String CAPABILITY_SAFE_READAHEAD =


### PR DESCRIPTION
### Description of PR

use of && broke javadoc, but because of the jdk11 issues, yetus didn't notice

### How was this patch tested?

currently running a mvn javadoc 


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

