### PR TITLE
YARN-11399 Make DelegationTokenRenwer timeout and retry feature configurable

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -818,6 +818,9 @@ public class YarnConfiguration extends Configuration {
       RM_PREFIX + "delegation-token-renewer.thread-retry-max-attempts";
   public static final int DEFAULT_RM_DT_RENEWER_THREAD_RETRY_MAX_ATTEMPTS =
       10;
+  public static final String RM_DT_RENEWER_POOL_TRACKER_ENABLED =
+          RM_PREFIX + "delegation-token-renewer.pool.tracker.enabled";
+  public static final boolean DEFAULT_RM_DT_RENEWER_POOL_TRACKER_ENABLED = true;
 
   public static final String RECOVERY_ENABLED = RM_PREFIX + "recovery.enabled";
   public static final boolean DEFAULT_RM_RECOVERY_ENABLED = false;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -1150,6 +1150,14 @@
 
   <property>
     <description>
+      Whether enable ResourceManager delegation token renew timeout and retry feature
+    </description>
+    <name>yarn.resourcemanager.delegation-token-renewer-pool.tracker.enabled</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <description>
     Thread pool size for RMApplicationHistoryWriter.
     </description>
     <name>yarn.resourcemanager.history-writer.multi-threaded-dispatcher.pool-size</name>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
@@ -165,6 +165,9 @@ public class DelegationTokenRenewer extends AbstractService {
     tokenRenewerThreadRetryMaxAttempts =
         conf.getInt(YarnConfiguration.RM_DT_RENEWER_THREAD_RETRY_MAX_ATTEMPTS,
             YarnConfiguration.DEFAULT_RM_DT_RENEWER_THREAD_RETRY_MAX_ATTEMPTS);
+    delegationTokenRenewerPoolTrackerFlag =
+        conf.getBoolean(YarnConfiguration.RM_DT_RENEWER_POOL_TRACKER_ENABLED,
+            YarnConfiguration.DEFAULT_RM_DT_RENEWER_POOL_TRACKER_ENABLED);
     setLocalSecretManagerAndServiceAddr();
     renewerService = createNewThreadPoolService(conf);
     pendingEventQueue = new LinkedBlockingQueue<DelegationTokenRenewerEvent>();


### PR DESCRIPTION
ResourceManager Delegation token renew timeout and retry mechanism is introduced in Hadoop 3.3.1, The switch of this feature is already there, but it is true and can not be disabled.
So this patch introduce a configuration to make this feature configurable.