### PR TITLE
HDFS-16869 Fail to start NameNode when replay editlog onwing to  0 size of clientId or callId recorded in editlog

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/RetryCache.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/RetryCache.java
@@ -320,6 +320,10 @@ public class RetryCache {
   
   public void addCacheEntryWithPayload(byte[] clientId, int callId,
       Object payload) {
+    // invalid callId or clientId recorded in edit log which is meaningless and no need to be added into cache.
+    if (skipRetryCache(clientId, callId)) {
+      return;
+    }
     // since the entry is loaded from editlog, we can assume it succeeded.    
     CacheEntry newEntry = new CacheEntryWithPayload(clientId, callId, payload,
         System.nanoTime() + expirationTime, true);


### PR DESCRIPTION
We first encouter this issue in Hadoop 3.3.1 version when we are rollingUpgrade from 3.1.1 to 3.3.1, which may cause NameNode start failure but just occasionally not everytime.

The root cause for why 0 size of clientId happened here is still under investigating.
So here we add a protection judge to exclude 0 size of clientId from being added into cache.