### PR TITLE
HDFS-16870 HDFS client ip should also be logged when NameNode is processing reportBadBlocks

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -5884,6 +5884,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
    */
   void reportBadBlocks(LocatedBlock[] blocks) throws IOException {
     checkOperation(OperationCategory.WRITE);
+    InetAddress remoteIp = Server.getRemoteIp();
     writeLock();
     try {
       checkOperation(OperationCategory.WRITE);
@@ -5893,7 +5894,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
         String[] storageIDs = blocks[i].getStorageIDs();
         for (int j = 0; j < nodes.length; j++) {
           NameNode.stateChangeLog.info("*DIR* reportBadBlocks for block: {} on"
-              + " datanode: {}", blk, nodes[j].getXferAddr());
+              + " datanode: {}" + " client: {}", blk, nodes[j].getXferAddr(), remoteIp);
           blockManager.findAndMarkBlockAsCorrupt(blk, nodes[j],
               storageIDs == null ? null: storageIDs[j],
               "client machine reported it");


### PR DESCRIPTION
There are two scenarios involded for reportBadBlocks
1-HDFS client will report bad block to NameNode once the block size or data is not consistent with meta;
2-DataNode will report bad block to NameNode via heartbeat if Replica stored on Datanode is corrupted or be modified.

As for now, when namenode process reportBadBlock rpc request, only DataNode address is logged.
Client Ip should also be logged to distinguish where the report comes from, which is very useful for trouble shooting.