### PR TITLE
YARN-11400 The residual data stored in leveldb for finished containers should be cleared in the NodeManager heartbeat response…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeStatusUpdaterImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeStatusUpdaterImpl.java
@@ -717,6 +717,8 @@ public class NodeStatusUpdaterImpl extends AbstractService implements
         org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerState.DONE)) {
         context.getContainers().remove(containerId);
         removedContainers.add(containerId);
+        // For the finished containers, the residual data stored in leveldb should also be cleared
+        addCompletedContainer(containerId);
         iter.remove();
       }
       pendingCompletedContainers.remove(containerId);


### PR DESCRIPTION
The residual data stored in leveldb for finished containers should be cleared in the NodeManager heartbeat response