### PR TITLE
MAPREDUCE-7422/MAPREDUCE-7428

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/pom.xml
@@ -124,26 +124,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/pom.xml
@@ -70,40 +70,40 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdfs</artifactId>
-      <scope>test</scope>
-      <type>test-jar</type>
-      <exclusions>
-        <exclusion>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm-commons</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-yarn-server-tests</artifactId>
-      <scope>test</scope>
-      <type>test-jar</type>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-mapreduce-client-app</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-mapreduce-client-app</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
+       <groupId>org.apache.hadoop</groupId>
+       <artifactId>hadoop-hdfs</artifactId>
+       <scope>test</scope>
+       <type>test-jar</type>
+        <exclusions>
+            <exclusion>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-commons</artifactId>
+            </exclusion>
+        </exclusions>
+     </dependency>
+     <dependency>
+       <groupId>org.apache.hadoop</groupId>
+       <artifactId>hadoop-yarn-server-tests</artifactId>
+       <scope>test</scope>
+       <type>test-jar</type>
+     </dependency>
+     <dependency>
+       <groupId>org.apache.hadoop</groupId>
+       <artifactId>hadoop-mapreduce-client-app</artifactId>
+       <scope>provided</scope>
+     </dependency>
+     <dependency>
+       <groupId>org.apache.hadoop</groupId>
+       <artifactId>hadoop-mapreduce-client-app</artifactId>
+       <type>test-jar</type>
+       <scope>test</scope>
+     </dependency>
     <dependency>
       <groupId>com.sun.jersey.jersey-test-framework</groupId>
       <artifactId>jersey-test-framework-grizzly2</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
+     <dependency>
        <groupId>org.apache.hadoop</groupId>
        <artifactId>hadoop-mapreduce-client-hs</artifactId>
        <scope>test</scope>
@@ -118,7 +118,7 @@
       <groupId>org.apache.hadoop.thirdparty</groupId>
       <artifactId>hadoop-shaded-guava</artifactId>
       <scope>provided</scope>
-    </dependency>
+     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -126,21 +126,6 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/TestAggregateWordCount.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/TestAggregateWordCount.java
@@ -21,9 +21,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.After;
+import org.junit.Test;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -34,19 +33,14 @@ import org.apache.hadoop.mapred.HadoopTestCase;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.ExitUtil.ExitException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TestAggregateWordCount extends HadoopTestCase {
   public TestAggregateWordCount() throws IOException {
     super(LOCAL_MR, LOCAL_FS, 1, 1);
   }
 
-  @BeforeEach
-  public void setUp() throws Exception {
-    super.setUp();
-  }
-
-  @AfterEach
+  @After
   public void tearDown() throws Exception {
     FileSystem fs = getFileSystem();
     if (fs != null) {
@@ -64,7 +58,7 @@ public class TestAggregateWordCount extends HadoopTestCase {
   private static final Path OUTPUT_PATH = new Path(TEST_DIR, "outPath");
 
   @Test
-  void testAggregateTestCount()
+  public void testAggregateTestCount()
       throws IOException, ClassNotFoundException, InterruptedException {
 
     ExitUtil.disableSystemExit();
@@ -76,7 +70,7 @@ public class TestAggregateWordCount extends HadoopTestCase {
     FileUtil.write(fs, file2, "Hello Hadoop");
 
     String[] args =
-        new String[]{INPUT_PATH.toString(), OUTPUT_PATH.toString(), "1",
+        new String[] {INPUT_PATH.toString(), OUTPUT_PATH.toString(), "1",
             "textinputformat"};
 
     // Run AggregateWordCount Job.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/TestBaileyBorweinPlouffe.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/TestBaileyBorweinPlouffe.java
@@ -18,36 +18,35 @@
 package org.apache.hadoop.examples;
 
 import java.math.BigInteger;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.Test;
+import org.junit.Assert;
 
 /** Tests for BaileyBorweinPlouffe */
 public class TestBaileyBorweinPlouffe {
 
   @Test
-  void testMod() {
+  public void testMod() {
     final BigInteger TWO = BigInteger.ONE.add(BigInteger.ONE);
-    for (long n = 3; n < 100; n++) {
+    for(long n = 3; n < 100; n++) {
       for (long e = 1; e < 100; e++) {
         final long r = TWO.modPow(
             BigInteger.valueOf(e), BigInteger.valueOf(n)).longValue();
-        assertEquals(r, BaileyBorweinPlouffe
-            .mod(e, n), "e=" + e + ", n=" + n);
+        Assert.assertEquals("e=" + e + ", n=" + n, r, BaileyBorweinPlouffe
+            .mod(e, n));
       }
     }
   }
 
   @Test
-  void testHexDigit() {
+  public void testHexDigit() {
     final long[] answers = {0x43F6, 0xA308, 0x29B7, 0x49F1, 0x8AC8, 0x35EA};
     long d = 1;
-    for (int i = 0; i < answers.length; i++) {
-      assertEquals(answers[i], BaileyBorweinPlouffe
-          .hexDigits(d), "d=" + d);
+    for(int i = 0; i < answers.length; i++) {
+      Assert.assertEquals("d=" + d, answers[i], BaileyBorweinPlouffe
+          .hexDigits(d));
       d *= 10;
     }
 
-    assertEquals(0x243FL, BaileyBorweinPlouffe.hexDigits(0));
-  }
+    Assert.assertEquals(0x243FL, BaileyBorweinPlouffe.hexDigits(0));
+ }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/TestWordStats.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/TestWordStats.java
@@ -17,6 +17,8 @@
 */
 package org.apache.hadoop.examples;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -29,11 +31,9 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
 
 public class TestWordStats {
 
@@ -241,14 +241,13 @@ public class TestWordStats {
     return dir.delete();
   }
 
-  @BeforeEach public void setup() throws Exception {
+  @Before public void setup() throws Exception {
     deleteDir(new File(MEAN_OUTPUT));
     deleteDir(new File(MEDIAN_OUTPUT));
     deleteDir(new File(STDDEV_OUTPUT));
   }
 
-  @Test
-  void testGetTheMean() throws Exception {
+  @Test public void testGetTheMean() throws Exception {
     String args[] = new String[2];
     args[0] = INPUT;
     args[1] = MEAN_OUTPUT;
@@ -262,8 +261,7 @@ public class TestWordStats {
     assertEquals(mean, wr.read(INPUT), 0.0);
   }
 
-  @Test
-  void testGetTheMedian() throws Exception {
+  @Test public void testGetTheMedian() throws Exception {
     String args[] = new String[2];
     args[0] = INPUT;
     args[1] = MEDIAN_OUTPUT;
@@ -277,8 +275,7 @@ public class TestWordStats {
     assertEquals(median, wr.read(INPUT), 0.0);
   }
 
-  @Test
-  void testGetTheStandardDeviation() throws Exception {
+  @Test public void testGetTheStandardDeviation() throws Exception {
     String args[] = new String[2];
     args[0] = INPUT;
     args[1] = STDDEV_OUTPUT;
@@ -292,7 +289,7 @@ public class TestWordStats {
     assertEquals(stddev, wr.read(INPUT), 0.0);
   }
 
-  @AfterAll public static void cleanup() throws Exception {
+  @AfterClass public static void cleanup() throws Exception {
     deleteDir(new File(MEAN_OUTPUT));
     deleteDir(new File(MEDIAN_OUTPUT));
     deleteDir(new File(STDDEV_OUTPUT));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/pi/math/TestLongLong.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/pi/math/TestLongLong.java
@@ -19,9 +19,8 @@ package org.apache.hadoop.examples.pi.math;
 
 import java.math.BigInteger;
 import java.util.Random;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.Test;
+import org.junit.Assert;
 
 public class TestLongLong {
 
@@ -40,12 +39,12 @@ public class TestLongLong {
         "\na = %x\nb = %x\nll= " + ll + "\nbi= " + bi.toString(16) + "\n", a,
         b);
     //System.out.println(s);
-    assertEquals(bi, ll.toBigInteger(), s);
+    Assert.assertEquals(s, bi, ll.toBigInteger());
   }
 
   @Test
-  void testMultiplication() {
-    for (int i = 0; i < 100; i++) {
+  public void testMultiplication() {
+    for(int i = 0; i < 100; i++) {
       final long a = nextPositiveLong();
       final long b = nextPositiveLong();
       verifyMultiplication(a, b);
@@ -55,8 +54,8 @@ public class TestLongLong {
   }
 
   @Test
-  void testRightShift() {
-    for (int i = 0; i < 1000; i++) {
+  public void testRightShift() {
+    for(int i = 0; i < 1000; i++) {
       final long a = nextPositiveLong();
       final long b = nextPositiveLong();
       verifyRightShift(a, b);
@@ -70,12 +69,12 @@ public class TestLongLong {
     final String s = String.format(
         "\na = %x\nb = %x\nll= " + ll + "\nbi= " + bi.toString(16) + "\n", a,
         b);
-    assertEquals(bi, ll.toBigInteger(), s);
+    Assert.assertEquals(s, bi, ll.toBigInteger());
 
     for (int i = 0; i < LongLong.SIZE >> 1; i++) {
       final long result = ll.shiftRight(i) & MASK;
       final long expected = bi.shiftRight(i).longValue() & MASK;
-      assertEquals(expected, result, s);
+      Assert.assertEquals(s, expected, result);
     }
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/pi/math/TestModular.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/pi/math/TestModular.java
@@ -21,9 +21,8 @@ import java.math.BigInteger;
 import java.util.Random;
 
 import org.apache.hadoop.examples.pi.Util.Timer;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class TestModular{
   private static final Random RANDOM = new Random();
@@ -53,13 +52,13 @@ public class TestModular{
   }
 
   @Test
-  void testDiv() {
-    for (long n = 2; n < 100; n++)
-      for (long r = 1; r < n; r++) {
+  public void testDiv() {
+    for(long n = 2; n < 100; n++)
+      for(long r = 1; r < n; r++) {
         final long a = div(0, r, n);
-        final long b = (long) ((r * 1.0 / n) * (1L << DIV_VALID_BIT));
+        final long b = (long)((r*1.0/n) * (1L << DIV_VALID_BIT));
         final String s = String.format("r=%d, n=%d, a=%X, b=%X", r, n, a, b);
-        assertEquals(b, a, s);
+        Assert.assertEquals(s, b, a);
       }
   }
 
@@ -152,8 +151,9 @@ public class TestModular{
         final long answer = rn[i][j][1];
         final long s = square_slow(r, n);
         if (s != answer) {
-          assertEquals(
-              answer, s, "r=" + r + ", n=" + n + ", answer=" + answer + " but s=" + s);
+          Assert.assertEquals(
+              "r=" + r + ", n=" + n + ", answer=" + answer + " but s=" + s,
+              answer, s);
         }
       }
     }
@@ -168,8 +168,9 @@ public class TestModular{
         final long answer = rn[i][j][1];
         final long s = square(r, n, r2p64);
         if (s != answer) {
-          assertEquals(
-              answer, s, "r=" + r + ", n=" + n + ", answer=" + answer + " but s=" + s);
+          Assert.assertEquals(
+              "r=" + r + ", n=" + n + ", answer=" + answer + " but s=" + s,
+              answer, s);
         }
       }
     }
@@ -184,8 +185,9 @@ public class TestModular{
         final BigInteger R = BigInteger.valueOf(r);
         final long s = R.multiply(R).mod(N).longValue();
         if (s != answer) {
-          assertEquals(
-              answer, s, "r=" + r + ", n=" + n + ", answer=" + answer + " but s=" + s);
+          Assert.assertEquals(
+              "r=" + r + ", n=" + n + ", answer=" + answer + " but s=" + s,
+              answer, s);
         }
       }
     }
@@ -200,8 +202,9 @@ public class TestModular{
         final BigInteger R = BigInteger.valueOf(r);
         final long s = R.modPow(TWO, N).longValue();
         if (s != answer) {
-          assertEquals(
-              answer, s, "r=" + r + ", n=" + n + ", answer=" + answer + " but s=" + s);
+          Assert.assertEquals(
+              "r=" + r + ", n=" + n + ", answer=" + answer + " but s=" + s,
+              answer, s);
         }
       }
     }
@@ -296,8 +299,9 @@ public class TestModular{
         final long answer = en[i][j][1];
         final long s = Modular.mod(e, n);
         if (s != answer) {
-          assertEquals(
-              answer, s, "e=" + e + ", n=" + n + ", answer=" + answer + " but s=" + s);
+          Assert.assertEquals(
+              "e=" + e + ", n=" + n + ", answer=" + answer + " but s=" + s,
+              answer, s);
         }
       }
     }
@@ -312,8 +316,9 @@ public class TestModular{
         final long answer = en[i][j][1];
         final long s = m2.mod(e);
         if (s != answer) {
-          assertEquals(
-              answer, s, "e=" + e + ", n=" + n + ", answer=" + answer + " but s=" + s);
+          Assert.assertEquals(
+              "e=" + e + ", n=" + n + ", answer=" + answer + " but s=" + s,
+              answer, s);
         }
       }
     }
@@ -327,8 +332,9 @@ public class TestModular{
         final long answer = en[i][j][1];
         final long s = m2.mod2(e);
         if (s != answer) {
-          assertEquals(
-              answer, s, "e=" + e + ", n=" + n + ", answer=" + answer + " but s=" + s);
+          Assert.assertEquals(
+              "e=" + e + ", n=" + n + ", answer=" + answer + " but s=" + s,
+              answer, s);
         }
       }
     }
@@ -342,8 +348,9 @@ public class TestModular{
         final long answer = en[i][j][1];
         final long s = TWO.modPow(BigInteger.valueOf(e), N).longValue();
         if (s != answer) {
-          assertEquals(
-              answer, s, "e=" + e + ", n=" + n + ", answer=" + answer + " but s=" + s);
+          Assert.assertEquals(
+              "e=" + e + ", n=" + n + ", answer=" + answer + " but s=" + s,
+              answer, s);
         }
       }
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/pi/math/TestSummation.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/pi/math/TestSummation.java
@@ -28,9 +28,8 @@ import org.apache.hadoop.examples.pi.Container;
 import org.apache.hadoop.examples.pi.Util;
 import org.apache.hadoop.examples.pi.Util.Timer;
 import org.apache.hadoop.examples.pi.math.TestModular.Montgomery2;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.Test;
+import org.junit.Assert;
 
 public class TestSummation {
   static final Random RANDOM = new Random();
@@ -59,12 +58,12 @@ public class TestSummation {
 
     final List<Summation> combined = Util.combine(a);
 //    Util.out.println("combined=" + combined);
-    assertEquals(1, combined.size());
-    assertEquals(sigma, combined.get(0));
+    Assert.assertEquals(1, combined.size());
+    Assert.assertEquals(sigma, combined.get(0));
   }
 
   @Test
-  void testSubtract() {
+  public void testSubtract() {
     final Summation sigma = newSummation(3, 10000, 20);
     final int size = 10;
     final List<Summation> parts = Arrays.asList(sigma.partition(size));
@@ -73,10 +72,10 @@ public class TestSummation {
     runTestSubtract(sigma, new ArrayList<Summation>());
     runTestSubtract(sigma, parts);
 
-    for (int n = 1; n < size; n++) {
-      for (int j = 0; j < 10; j++) {
+    for(int n = 1; n < size; n++) {
+      for(int j = 0; j < 10; j++) {
         final List<Summation> diff = new ArrayList<Summation>(parts);
-        for (int i = 0; i < n; i++)
+        for(int i = 0; i < n; i++)
           diff.remove(RANDOM.nextInt(diff.size()));
 ///        Collections.sort(diff);
         runTestSubtract(sigma, diff);
@@ -133,16 +132,16 @@ public class TestSummation {
     t.tick("sigma=" + sigma);
     final double value = sigma.compute();
     t.tick("compute=" + value);
-    assertEquals(value, sigma.compute_modular(), DOUBLE_DELTA);
+    Assert.assertEquals(value, sigma.compute_modular(), DOUBLE_DELTA);
     t.tick("compute_modular");
-    assertEquals(value, sigma.compute_montgomery(), DOUBLE_DELTA);
+    Assert.assertEquals(value, sigma.compute_montgomery(), DOUBLE_DELTA);
     t.tick("compute_montgomery");
-    assertEquals(value, sigma.compute_montgomery2(), DOUBLE_DELTA);
+    Assert.assertEquals(value, sigma.compute_montgomery2(), DOUBLE_DELTA);
     t.tick("compute_montgomery2");
 
-    assertEquals(value, sigma.compute_modBigInteger(), DOUBLE_DELTA);
+    Assert.assertEquals(value, sigma.compute_modBigInteger(), DOUBLE_DELTA);
     t.tick("compute_modBigInteger");
-    assertEquals(value, sigma.compute_modPow(), DOUBLE_DELTA);
+    Assert.assertEquals(value, sigma.compute_modPow(), DOUBLE_DELTA);
     t.tick("compute_modPow");
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/terasort/TestTeraSort.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/terasort/TestTeraSort.java
@@ -25,15 +25,14 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileAlreadyExistsException;
 import org.apache.hadoop.mapred.HadoopTestCase;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.After;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class TestTeraSort extends HadoopTestCase {
   private static final Logger LOG = LoggerFactory.getLogger(TestTeraSort.class);
@@ -43,12 +42,7 @@ public class TestTeraSort extends HadoopTestCase {
     super(LOCAL_MR, LOCAL_FS, 1, 1);
   }
 
-  @BeforeEach
-  public void setUp() throws Exception {
-    super.setUp();
-  }
-
-  @AfterEach
+  @After
   public void tearDown() throws Exception {
     getFileSystem().delete(TEST_DIR, true);
     super.tearDown();
@@ -91,7 +85,7 @@ public class TestTeraSort extends HadoopTestCase {
   }
 
   @Test
-  void testTeraSort() throws Exception {
+  public void testTeraSort() throws Exception {
     // Run TeraGen to generate input for 'terasort'
     runTeraGen(createJobConf(), SORT_INPUT_PATH);
 
@@ -116,11 +110,11 @@ public class TestTeraSort extends HadoopTestCase {
 
     // Run tera-validator to check if sort worked correctly
     runTeraValidator(createJobConf(), SORT_OUTPUT_PATH,
-        TERA_OUTPUT_PATH);
+      TERA_OUTPUT_PATH);
   }
 
   @Test
-  void testTeraSortWithLessThanTwoArgs() throws Exception {
+  public void testTeraSortWithLessThanTwoArgs() throws Exception {
     String[] args = new String[1];
     assertThat(new TeraSort().run(args)).isEqualTo(2);
   }


### PR DESCRIPTION


Rollback of the changes trying to move mr to junit5 as tests were failing/being skipped.

*   MAPREDUCE-7422 Upgrade Junit 4 to 5 in hadoop-mapreduce-examples (#5029)
*  MAPREDUCE-7428. Fix failures related to Junit 4 to Junit 5 upgrade in org.apache.hadoop.mapreduce.v2.app.webapp (#5209)

if yetus is happy with test coverage will apply locally (so patches can go in independently)
