### PR TITLE
HDFS-16871 DiskBalancer process may throw IllegalArgumentException when the target DataNode has capital letter in hostname

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/diskbalancer/datamodel/DiskBalancerCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/diskbalancer/datamodel/DiskBalancerCluster.java
@@ -389,6 +389,6 @@ public class DiskBalancerCluster {
    * @return DiskBalancerDataNode.
    */
   public DiskBalancerDataNode getNodeByName(String hostName) {
-    return hostNames.get(hostName);
+    return hostNames.get(hostName.toLowerCase(Locale.US));
   }
 }


### PR DESCRIPTION
For a Datanode with lowercase letter in hostname, everyting is ok,
but for a Datanode with uppercase hostname, when Balancer process try ro migrate on it, there will be a IllegalArgumentException thrown.

For more details, Pls refer to jira HDFS-16871
