### PR TITLE
YARN-11401 Separate ApllicationMaster cleanup events and launcher events into different resource pools

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -236,7 +236,14 @@ public class YarnConfiguration extends Configuration {
   /** Number of threads used to launch/cleanup AM.*/
   public static final String RM_AMLAUNCHER_THREAD_COUNT =
       RM_PREFIX + "amlauncher.thread-count";
+
   public static final int DEFAULT_RM_AMLAUNCHER_THREAD_COUNT = 50;
+
+  /** Number of threads used to cleanup AM.*/
+  public static final String RM_AMCLEANUP_THREAD_COUNT =
+          RM_PREFIX + "amcleanup.thread-count";
+
+  public static final int DEFAULT_RM_AMCLEANUP_THREAD_COUNT = 50;
 
   /** Retry times to connect with NM.*/
   public static final String RM_NODEMANAGER_CONNECT_RETRIES =


### PR DESCRIPTION
Currently, there is only one thread pool to handle AM launch and cleanup event in ResourceManager.
We found an issue in our cluster, in some cases, too many cleanup events will block AM launcher event and make it stuck for a long time.
So in this PR, we divide the shared thread pool into two separated ones to handle AM event of different kinds in case that a flood events of cleanup events blocking launcher event for a long time and vice versa, which will badly decay throughput of ResourceManager.