### PR TITLE
YARN-6412 aux-services classpath not documented

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -2468,11 +2468,11 @@
   </property>
 
   <property>
-    <description>Normally, we do not need to set this configuration. The class would be loaded from customized classpath
-      if it does not belongs to system-classes. For example, by default, the package org.apache.hadoop is in the
-      system-classes, if your class CustomAuxService is in the package org.apache.hadoop, it would not be loaded
-      from customized classpath. To solve this, either we could change the package for CustomAuxService, or configure
-      our own system-classes which exclude org.apache.hadoop.</description>
+    <description>Normally this configuration shouldn't be manually set. The class would be loaded from customized
+      classpath if it does not belong to system-classes. By default, the package org.apache.hadoop is part of the
+      system-classes. If for example the class CustomAuxService is in the package org.apache.hadoop, it will not be
+      loaded from the customized classpath. To solve this, either the package of CustomAuxService could be changed,
+      or a separate system-classes could be configured which excludes the package org.apache.hadoop.</description>
     <name>yarn.nodemanager.aux-services.%s.system-classes</name>
     <value></value>
   </property>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -2460,6 +2460,24 @@
   </property>
 
   <property>
+    <description>Provide local directory which includes the related jar file as well as all the dependencies’
+      jar file. We could specify the single jar file or use ${local_dir_to_jar}/* to load all
+      jars under the dep directory.</description>
+    <name>yarn.nodemanager.aux-services.%s.classpath</name>
+    <value>NONE</value>
+  </property>
+
+  <property>
+    <description>Normally, we do not need to set this configuration. The class would be loaded from customized classpath
+      if it does not belongs to system-classes. For example, by default, the package org.apache.hadoop is in the
+      system-classes, if your class CustomAuxService is in the package org.apache.hadoop, it would not be loaded
+      from customized classpath. To solve this, either we could change the package for CustomAuxService, or configure
+      our own system-classes which exclude org.apache.hadoop.</description>
+    <name>yarn.nodemanager.aux-services.%s.system-classes</name>
+    <value></value>
+  </property>
+
+  <property>
     <description>No. of ms to wait between sending a SIGTERM and SIGKILL to a container</description>
     <name>yarn.nodemanager.sleep-delay-before-sigkill.ms</name>
     <value>250</value>


### PR DESCRIPTION
[YARN-6412](https://issues.apache.org/jira/browse/YARN-6412)
[YARN-4577](https://issues.apache.org/jira/browse/YARN-4577) introduced two new configuration entries yarn.nodemanager.aux-services.%s.classpath and yarn.nodemanager.aux-services.%s.system-classes. These are not documented in hadoop-yarn-common/.../yarn-default.xml
