### PR TITLE
YARN-11402 Plenty of useless logs printed during ResourceManager startup and recover containers of unknown application

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
@@ -506,6 +506,7 @@ public abstract class AbstractYarnScheduler
   private void killOrphanContainerOnNode(RMNode node,
       NMContainerStatus container) {
     if (!container.getContainerState().equals(ContainerState.COMPLETE)) {
+      LOG.warn("Killing container " + container + " for unknown application");
       this.rmContext.getDispatcher().getEventHandler().handle(
         new RMNodeCleanContainerEvent(node.getNodeID(),
           container.getContainerId()));
@@ -528,17 +529,12 @@ public abstract class AbstractYarnScheduler
                 .getApplicationId();
         RMApp rmApp = rmContext.getRMApps().get(appId);
         if (rmApp == null) {
-          LOG.error("Skip recovering container " + container
-              + " for unknown application.");
           killOrphanContainerOnNode(nm, container);
           continue;
         }
 
         SchedulerApplication<T> schedulerApp = applications.get(appId);
         if (schedulerApp == null) {
-          LOG.info("Skip recovering container  " + container
-              + " for unknown SchedulerApplication. "
-              + "Application current state is " + rmApp.getState());
           killOrphanContainerOnNode(nm, container);
           continue;
         }


### PR DESCRIPTION
Tens of thousands of meaningless logs are frequently printed during ResourceManager startup and recover container.
As we know, ResourceManager will always keep 10k application information by default. In our very big scale cluster, it is very usual that resourcemanager try to recover the containers which already finished and does not exist in ResourceManager but still reported by nodemanager.
Under this case, below logs will be frequently printed, more importantly, this log is meaningless, in real production setups, the maintainers actually more care about which containers are properly recovered or killed not the ones are skipped.
The related code are as follows,
![image](https://user-images.githubusercontent.com/78128883/208641490-28abaf03-d4c5-4735-93a3-aae9aca21227.png)

So we move the log into function killOrphanContainerOnNode().
![image](https://user-images.githubusercontent.com/78128883/208641574-9bf36787-d3b3-4b0d-9ee9-aa14e4151da1.png)

Only the containers to be killed need to be loged which is vital for trouble shooting to distinguish whether the containers are kill by hadoop inner mechanism or by users themselves.

