### PR TITLE
HADOOP-18581 : Handle Server KDC re-login when Server and Client run …

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -159,7 +159,7 @@ public abstract class Server {
    * Allow server to do force Kerberos re-login once after failure irrespective
    * of the last login time.
    */
-  private AtomicBoolean canTryForceLogin = new AtomicBoolean(true);
+  private final AtomicBoolean canTryForceLogin = new AtomicBoolean(true);
 
   /**
    * Logical name of the server used in metrics and monitor.
@@ -3351,8 +3351,7 @@ public abstract class Server {
       return;
     }
     LOG.warn("Initiating re-login from IPC Server");
-    if (canTryForceLogin.get()) {
-      canTryForceLogin.set(false);
+    if (canTryForceLogin.compareAndSet(true, false)) {
       if (UserGroupInformation.isLoginKeytabBased()) {
         UserGroupInformation.getLoginUser().forceReloginFromKeytab();
       } else if (UserGroupInformation.isLoginTicketBased()) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -529,11 +529,14 @@ public class UserGroupInformation {
     user.setLogin(login);
   }
 
-  /** This method is only helpful for HadoopLoginContext*/
+  /** This method checks for a successful Kerberos login
+      and returns true by default if it is not using Kerberos.
+   */
   public boolean isLoginSuccess() {
     LoginContext login = user.getLogin();
     return (login instanceof HadoopLoginContext)
-        ? ((HadoopLoginContext) login).isLoginSuccess() : true;
+        ? ((HadoopLoginContext) login).isLoginSuccess()
+        : true;
   }
 
   /**
@@ -1284,6 +1287,23 @@ public class UserGroupInformation {
   }
 
   /**
+   * Force re-Login a user in from the ticket cache irrespective of the last
+   * login time. This method assumes that login had happened already. The
+   * Subject field of this UserGroupInformation object is updated to have the
+   * new credentials.
+   *
+   * @throws IOException
+   *           raised on errors performing I/O.
+   * @throws KerberosAuthException
+   *           on a failure
+   */
+  @InterfaceAudience.Public
+  @InterfaceStability.Evolving
+  public void forceReloginFromTicketCache() throws IOException {
+    reloginFromTicketCache(true);
+  }
+
+  /**
    * Re-Login a user in from the ticket cache.  This
    * method assumes that login had happened already.
    * The Subject field of this UserGroupInformation object is updated to have
@@ -1294,14 +1314,18 @@ public class UserGroupInformation {
   @InterfaceAudience.Public
   @InterfaceStability.Evolving
   public void reloginFromTicketCache() throws IOException {
-    if (!shouldRelogin() || !isFromTicket()) {
+    reloginFromTicketCache(false);
+  }
+
+  private void reloginFromTicketCache(boolean ignoreLastLoginTime) throws IOException {
+     if (!shouldRelogin() || !isFromTicket()) {
       return;
     }
     HadoopLoginContext login = getLogin();
     if (login == null) {
       throw new KerberosAuthException(MUST_FIRST_LOGIN);
     }
-    relogin(login, false);
+    relogin(login, ignoreLastLoginTime);
   }
 
   private void relogin(HadoopLoginContext login, boolean ignoreLastLoginTime)
@@ -2090,6 +2114,7 @@ public class UserGroupInformation {
       this.conf = conf;
     }
 
+    /** Get the login status. */
     public boolean isLoginSuccess() {
       return isLoggedIn.get();
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -529,6 +529,13 @@ public class UserGroupInformation {
     user.setLogin(login);
   }
 
+  /** This method is only helpful for HadoopLoginContext*/
+  public boolean isLoginSuccess() {
+    LoginContext login = user.getLogin();
+    return (login instanceof HadoopLoginContext)
+        ? ((HadoopLoginContext) login).isLoginSuccess() : true;
+  }
+
   /**
    * Set the last login time for logged in user
    * @param loginTime the number of milliseconds since the beginning of time
@@ -2081,6 +2088,10 @@ public class UserGroupInformation {
       super(appName, subject, null, conf);
       this.appName = appName;
       this.conf = conf;
+    }
+
+    public boolean isLoginSuccess() {
+      return isLoggedIn.get();
     }
 
     String getAppName() {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -530,7 +530,9 @@ public class UserGroupInformation {
   }
 
   /** This method checks for a successful Kerberos login
-      and returns true by default if it is not using Kerberos.
+    * and returns true by default if it is not using Kerberos.
+    *
+    * @return true on successful login 
    */
   public boolean isLoginSuccess() {
     LoginContext login = user.getLogin();
@@ -1317,8 +1319,9 @@ public class UserGroupInformation {
     reloginFromTicketCache(false);
   }
 
-  private void reloginFromTicketCache(boolean ignoreLastLoginTime) throws IOException {
-     if (!shouldRelogin() || !isFromTicket()) {
+  private void reloginFromTicketCache(boolean ignoreLastLoginTime)
+      throws IOException {
+    if (!shouldRelogin() || !isFromTicket()) {
       return;
     }
     HadoopLoginContext login = getLogin();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -532,7 +532,7 @@ public class UserGroupInformation {
   /** This method checks for a successful Kerberos login
     * and returns true by default if it is not using Kerberos.
     *
-    * @return true on successful login 
+    * @return true on successful login
    */
   public boolean isLoginSuccess() {
     LoginContext login = user.getLogin();


### PR DESCRIPTION
Handle re-login in Server when client, server running in same JVM and client trying to re-login, but it fails.

For example, NameNode is server but in same JVM journal node client also running to push to edit logs. When JN client try to re-login and it fails, it will destroy server service ticket also and NameNode not able to server client request. We can see the below error logs in NameNode log file.

```
Auth failed for x.x.x.x:42199:null (GSS initiate failed) with true cause: (GSS initiate failed)
Auth failed for x.x.x.x:42199:null (GSS initiate failed) with true cause: (GSS initiate failed)
Auth failed for x.x.x.x:42199:null (GSS initiate failed) with true cause: (GSS initiate failed)
```