### PR TITLE
HADOOP-18575: try to avoid repeatedly hitting exceptions when transformer factories do not support attributes

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/XMLUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/XMLUtils.java
@@ -179,16 +179,10 @@ public class XMLUtils {
    */
   private static void setOptionalSecureTransformerAttributes(
           TransformerFactory transformerFactory) {
-    if (CAN_SET_TRANSFORMER_ACCESS_EXTERNAL_DTD.get()) {
-      if (!bestEffortSetAttribute(transformerFactory, XMLConstants.ACCESS_EXTERNAL_DTD, "")) {
-        CAN_SET_TRANSFORMER_ACCESS_EXTERNAL_DTD.set(false);
-      }
-    }
-    if (CAN_SET_TRANSFORMER_ACCESS_EXTERNAL_STYLESHEET.get()) {
-      if (!bestEffortSetAttribute(transformerFactory, XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "")) {
-        CAN_SET_TRANSFORMER_ACCESS_EXTERNAL_STYLESHEET.set(false);
-      }
-    }
+    bestEffortSetAttribute(transformerFactory, CAN_SET_TRANSFORMER_ACCESS_EXTERNAL_DTD,
+            XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    bestEffortSetAttribute(transformerFactory, CAN_SET_TRANSFORMER_ACCESS_EXTERNAL_STYLESHEET,
+            XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
   }
 
   /**
@@ -197,18 +191,19 @@ public class XMLUtils {
    * logs the issue at debug level.
    *
    * @param transformerFactory to update
+   * @param flag that indicates whether to do the update and the flag can be set to false if an update fails
    * @param name of the attribute to set
    * @param value to set on the attribute
-   * @return whether the attribute was successfully set
    */
-  static boolean bestEffortSetAttribute(TransformerFactory transformerFactory,
-                                        String name, Object value) {
-    try {
-      transformerFactory.setAttribute(name, value);
-      return true;
-    } catch (Throwable t) {
-      LOG.debug("Issue setting TransformerFactory attribute {}: {}", name, t.toString());
+  static void bestEffortSetAttribute(TransformerFactory transformerFactory, AtomicBoolean flag,
+                                     String name, Object value) {
+    if (flag.get()) {
+      try {
+        transformerFactory.setAttribute(name, value);
+      } catch (Throwable t) {
+        flag.set(false);
+        LOG.debug("Issue setting TransformerFactory attribute {}: {}", name, t.toString());
+      }
     }
-    return false;
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/XMLUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/XMLUtils.java
@@ -191,7 +191,8 @@ public class XMLUtils {
    * logs the issue at debug level.
    *
    * @param transformerFactory to update
-   * @param flag that indicates whether to do the update and the flag can be set to false if an update fails
+   * @param flag that indicates whether to do the update and the flag can be set to
+   *             <code>false</code> if an update fails
    * @param name of the attribute to set
    * @param value to set on the attribute
    */

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestXMLUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestXMLUtils.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.util;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.SAXParser;
@@ -134,10 +135,16 @@ public class TestXMLUtils extends AbstractHadoopTestBase {
   @Test
   public void testBestEffortSetAttribute() throws Exception {
     TransformerFactory factory = TransformerFactory.newInstance();
-    Assert.assertFalse("unexpected attribute results in return of false",
-            XMLUtils.bestEffortSetAttribute(factory, "unsupportedAttribute false", "abc"));
-    Assert.assertTrue("expected attribute results in return of false",
-            XMLUtils.bestEffortSetAttribute(factory, XMLConstants.ACCESS_EXTERNAL_DTD, ""));
+    AtomicBoolean flag1 = new AtomicBoolean(true);
+    XMLUtils.bestEffortSetAttribute(factory, flag1, "unsupportedAttribute false", "abc");
+    Assert.assertFalse("unexpected attribute results in return of false?", flag1.get());
+    AtomicBoolean flag2 = new AtomicBoolean(true);
+    XMLUtils.bestEffortSetAttribute(factory, flag2, XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    Assert.assertTrue("expected attribute results in return of true?", flag2.get());
+    AtomicBoolean flag3 = new AtomicBoolean(false);
+    XMLUtils.bestEffortSetAttribute(factory, flag3, XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    Assert.assertFalse("expected attribute results in return of false if input flag is false?",
+            flag3.get());
   }
 
   private static InputStream getResourceStream(final String filename) {


### PR DESCRIPTION
### Description of PR

Concerns that the existing HADOOP-18575 solution could end up with 2 exceptions being raised, caught and ignored if Saxon is on the classpath.

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

