### PR TITLE
HADOOP-18583. Native code to load OpenSSL 3.x symbols

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/crypto/OpensslCipher.c
+++ b/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/crypto/OpensslCipher.c
@@ -24,6 +24,57 @@
  
 #include "org_apache_hadoop_crypto_OpensslCipher.h"
 
+/*
+   # OpenSSL ABI Symbols
+
+   Available on all OpenSSL versions:
+
+   | Function                       | 1.0 | 1.1 | 3.0 |
+   |--------------------------------|-----|-----|-----|
+   | EVP_CIPHER_CTX_new             | YES | YES | YES |
+   | EVP_CIPHER_CTX_free            | YES | YES | YES |
+   | EVP_CIPHER_CTX_set_padding     | YES | YES | YES |
+   | EVP_CIPHER_CTX_test_flags      | YES | YES | YES |
+   | EVP_CipherInit_ex              | YES | YES | YES |
+   | EVP_CipherUpdate               | YES | YES | YES |
+   | EVP_CipherFinal_ex             | YES | YES | YES |
+   | ENGINE_by_id                   | YES | YES | YES |
+   | ENGINE_free                    | YES | YES | YES |
+   | EVP_aes_256_ctr                | YES | YES | YES |
+   | EVP_aes_128_ctr                | YES | YES | YES |
+
+   Available on old versions:
+
+   | Function                       | 1.0 | 1.1 | 3.0 |
+   |--------------------------------|-----|-----|-----|
+   | EVP_CIPHER_CTX_cleanup         | YES | --- | --- |
+   | EVP_CIPHER_CTX_init            | YES | --- | --- |
+   | EVP_CIPHER_CTX_block_size      | YES | YES | --- |
+   | EVP_CIPHER_CTX_encrypting      | --- | YES | --- |
+
+   Available on new versions:
+
+   | Function                       | 1.0 | 1.1 | 3.0 |
+   |--------------------------------|-----|-----|-----|
+   | OPENSSL_init_crypto            | --- | YES | YES |
+   | EVP_CIPHER_CTX_reset           | --- | YES | YES |
+   | EVP_CIPHER_CTX_get_block_size  | --- | --- | YES |
+   | EVP_CIPHER_CTX_is_encrypting   | --- | --- | YES |
+
+   Optionally available on new versions:
+
+   | Function                       | 1.0 | 1.1 | 3.0 |
+   |--------------------------------|-----|-----|-----|
+   | EVP_sm4_ctr                    | --- | opt | opt |
+
+   Name changes:
+
+   | < 3.0 name                 | >= 3.0 name                    |
+   |----------------------------|--------------------------------|
+   | EVP_CIPHER_CTX_block_size  | EVP_CIPHER_CTX_get_block_size  |
+   | EVP_CIPHER_CTX_encrypting  | EVP_CIPHER_CTX_is_encrypting   |
+ */
+
 #ifdef UNIX
 static EVP_CIPHER_CTX * (*dlsym_EVP_CIPHER_CTX_new)(void);
 static void (*dlsym_EVP_CIPHER_CTX_free)(EVP_CIPHER_CTX *);
@@ -106,6 +157,15 @@ static __dlsym_ENGINE_free dlsym_ENGINE_free;
 static HMODULE openssl;
 #endif
 
+// names changed in OpenSSL 3 ABI - see History section in EVP_EncryptInit(3)
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#define CIPHER_CTX_BLOCK_SIZE "EVP_CIPHER_CTX_get_block_size"
+#define CIPHER_CTX_ENCRYPTING "EVP_CIPHER_CTX_is_encrypting"
+#else
+#define CIPHER_CTX_BLOCK_SIZE "EVP_CIPHER_CTX_block_size"
+#define CIPHER_CTX_ENCRYPTING "EVP_CIPHER_CTX_encrypting"
+#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+
 static void loadAesCtr(JNIEnv *env)
 {
 #ifdef UNIX
@@ -170,10 +230,10 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_crypto_OpensslCipher_initIDs
   LOAD_DYNAMIC_SYMBOL(dlsym_EVP_CIPHER_CTX_test_flags, env, openssl,  \
                       "EVP_CIPHER_CTX_test_flags");
   LOAD_DYNAMIC_SYMBOL(dlsym_EVP_CIPHER_CTX_block_size, env, openssl,  \
-                      "EVP_CIPHER_CTX_block_size");
+                      CIPHER_CTX_BLOCK_SIZE);
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
   LOAD_DYNAMIC_SYMBOL(dlsym_EVP_CIPHER_CTX_encrypting, env, openssl,  \
-                      "EVP_CIPHER_CTX_encrypting");
+                      CIPHER_CTX_ENCRYPTING);
 #endif
   LOAD_DYNAMIC_SYMBOL(dlsym_EVP_CipherInit_ex, env, openssl,  \
                       "EVP_CipherInit_ex");
@@ -209,11 +269,11 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_crypto_OpensslCipher_initIDs
                       openssl, "EVP_CIPHER_CTX_test_flags");
   LOAD_DYNAMIC_SYMBOL(__dlsym_EVP_CIPHER_CTX_block_size,  \
                       dlsym_EVP_CIPHER_CTX_block_size, env,  \
-                      openssl, "EVP_CIPHER_CTX_block_size");
+                      openssl, CIPHER_CTX_BLOCK_SIZE);
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
   LOAD_DYNAMIC_SYMBOL(__dlsym_EVP_CIPHER_CTX_encrypting,  \
                       dlsym_EVP_CIPHER_CTX_encrypting, env,  \
-                      openssl, "EVP_CIPHER_CTX_encrypting");
+                      openssl, CIPHER_CTX_ENCRYPTING);
 #endif
   LOAD_DYNAMIC_SYMBOL(__dlsym_EVP_CipherInit_ex, dlsym_EVP_CipherInit_ex,  \
                       env, openssl, "EVP_CipherInit_ex");


### PR DESCRIPTION
### Description of PR

Fix for HADOOP-18583. OpenSSL 3.x broke existing ABI - the symbols for

* `EVP_CIPHER_CTX_block_size` and
* `EVP_CIPHER_CTX_encrypting`

are now called

* `EVP_CIPHER_CTX_get_block_size` and
* `EVP_CIPHER_CTX_is_encrypting` respectively (c.f. commit [ed576acdf591d4164905ab98e89ca5a3b99d90ab](https://github.com/openssl/openssl/commit/ed576acdf591d4164905ab98e89ca5a3b99d90ab) that landed in [openssl-3.0.0-beta1](https://github.com/openssl/openssl/releases/tag/openssl-3.0.0-beta1))

The PR changes the hadoop-common native code such that when compiled against OpenSSL 3.x, it can successfully load the OpenSSL 3.x symbols at runtime.


### How was this patch tested?

A patched version of Hadoop 3.3.4 was compiled on an x86-64 Ubuntu 22.04 machine and `hadoop checknative` was invoked.

```
$ openssl version
OpenSSL 3.0.2 15 Mar 2022 (Library: OpenSSL 3.0.2 15 Mar 2022)
$ hadoop checknative
2022-12-24 11:54:31,538 INFO bzip2.Bzip2Factory: Successfully loaded & initialized native-bzip2 library system-native
2022-12-24 11:54:31,539 INFO zlib.ZlibFactory: Successfully loaded & initialized native-zlib library
2022-12-24 11:54:31,558 INFO nativeio.NativeIO: The native code was built without PMDK support.
Native library checking:
hadoop:  true /hadoop/lib/native/libhadoop.so.1.0.0
zlib:    true /lib/x86_64-linux-gnu/libz.so.1
zstd  :  true /lib/x86_64-linux-gnu/libzstd.so.1
bzip2:   true /lib/x86_64-linux-gnu/libbz2.so.1
openssl: true /lib/x86_64-linux-gnu/libcrypto.so
ISA-L:   true /lib/x86_64-linux-gnu/libisal.so.2
PMDK:    false The native code was built without PMDK support.
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

