### PR TITLE
YARN-8900. [Follow Up] Fix FederationInterceptorREST#invokeConcurrent Inaccurate Order of Subclusters.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
@@ -45,7 +45,6 @@ import javax.ws.rs.core.Response.Status;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -2533,8 +2532,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
     // If there is a sub-cluster access error,
     // we should choose whether to throw exception information according to user configuration.
     // Send the requests in parallel.
-    CompletionService<SubClusterResult<R>> compSvc =
-        new ExecutorCompletionService<>(threadpool);
+    CompletionService<SubClusterResult<R>> compSvc = new ExecutorCompletionService<>(threadpool);
 
     // This part of the code should be able to expose the accessed Exception information.
     // We use Pair to store related information. The left value of the Pair is the response,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
@@ -2334,15 +2334,15 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
         }
 
         Exception exception = triple.getRight();
+
         // If allowPartialResult=false, it means that if an exception occurs in a subCluster,
         // an exception will be thrown directly.
         if (!allowPartialResult && exception != null) {
           throw exception;
         }
-
       } catch (Throwable e) {
-        String msg = String.format("SubCluster %s failed to %s report.",
-            subClusterInfo.getSubClusterId(), request.getMethodName());
+        String msg = String.format("SubCluster %s failed to %s report.", subClusterInfo,
+            request.getMethodName());
         LOG.error(msg, e);
         throw new YarnRuntimeException(e.getCause().getMessage(), e);
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
@@ -2622,7 +2622,6 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
   @VisibleForTesting
   public Map<SubClusterInfo, NodesInfo> invokeConcurrentGetNodeLabel()
       throws IOException, YarnException {
-    NodesInfo nodes = new NodesInfo();
     Map<SubClusterId, SubClusterInfo> subClustersActive = getActiveSubclusters();
     Class[] argsClasses = new Class[]{String.class};
     Object[] args = new Object[]{null};

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/dao/SubClusterResult.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/dao/SubClusterResult.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.yarn.server.router.webapp.dao;
+
+import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;
+
+public class SubClusterResult<R> {
+  private SubClusterInfo subClusterInfo;
+  private R response;
+  private Exception exception;
+
+  public SubClusterResult() {
+  }
+
+  public SubClusterResult(SubClusterInfo subCluster, R res, Exception ex) {
+    this.subClusterInfo = subCluster;
+    this.response = res;
+    this.exception = ex;
+  }
+
+  public SubClusterInfo getSubClusterInfo() {
+    return subClusterInfo;
+  }
+
+  public void setSubClusterInfo(SubClusterInfo subClusterInfo) {
+    this.subClusterInfo = subClusterInfo;
+  }
+
+  public Exception getException() {
+    return exception;
+  }
+
+  public void setException(Exception exception) {
+    this.exception = exception;
+  }
+
+  public R getResponse() {
+    return response;
+  }
+
+  public void setResponse(R response) {
+    this.response = response;
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
@@ -1553,7 +1553,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
       Assert.assertEquals(expectNodeId, nodeId);
     });
   }
-  
+
   @Test
   public void testPostDelegationTokenErrorHsr() throws Exception {
     // Prepare delegationToken data

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
@@ -1561,7 +1561,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
       Assert.assertEquals(expectNodeId, nodeId);
     });
   }
-  
+
   @Test
   public void testGetSchedulerInfo() {
     // In this test case, we will get the return results of 4 sub-clusters.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
@@ -1485,4 +1485,32 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     Assert.assertNotNull(interceptorREST.getClient());
     Assert.assertEquals(webAppAddress, interceptorREST.getWebAppAddress());
   }
+
+  @Test
+  public void testInvokeConcurrent() throws IOException, YarnException {
+
+    // We design such a test case, we call the interceptor's getNodes interface,
+    // this interface will generate the following test data
+    // subCluster0 Node 0
+    // subCluster1 Node 1
+    // subCluster2 Node 2
+    // subCluster3 Node 3
+    // We use the returned data to verify whether the subClusterId
+    // of the multi-thread call can match the node data
+    Map<SubClusterInfo, NodesInfo> subClusterInfoNodesInfoMap =
+        interceptor.invokeConcurrentGetNodeLabel();
+    Assert.assertNotNull(subClusterInfoNodesInfoMap);
+    Assert.assertEquals(4, subClusterInfoNodesInfoMap.size());
+
+    subClusterInfoNodesInfoMap.forEach((subClusterInfo, nodesInfo) -> {
+      String subClusterId = subClusterInfo.getSubClusterId().getId();
+      List<NodeInfo> nodeInfos = nodesInfo.getNodes();
+      Assert.assertNotNull(nodeInfos);
+      Assert.assertEquals(1, nodeInfos.size());
+
+      String expectNodeId = "Node " + subClusterId;
+      String nodeId = nodeInfos.get(0).getNodeId();
+      Assert.assertEquals(expectNodeId, nodeId);
+    });
+  }
 }


### PR DESCRIPTION
JIRA: YARN-8900. [Router] Federation: routing getContainers REST invocations transparently to multiple RMs.

### BackGround

In `FederationInterceptorREST#invokeConcurrent`, we define the `invokeConcurrent` method, which is used to call multiple sub-clusters concurrently to improve performance. `ExecutorCompletionService` can help us execute Tasks concurrently, but it cannot guarantee the return order of results, and the return order of results may be inconsistent.

Examples are as follows:
We have 4 `subClusters`, using `invokeConcurrent` to call concurrently, our call sequence is
`subCluster1`, `subCluster2`, `subCluster3`, `subCluster4`. But because the `execution time` of interfaces of subclusters is different, we can get the following order. `subCluster2`, `subCluster1`, `subCluster4`, `subCluster3`.

This part of the code may get inaccurate results and sub-cluster mapping.

```
clusterIds.stream().forEach(clusterId -> {
      try {
        Future<Pair<R, Exception>> future = compSvc.take();
        Pair<R, Exception> pair = future.get();
        R response = pair.getKey();
        if (response != null) {
          results.put(clusterId, response);
        }
       .....
      } catch (Throwable e) {
        String msg = String.format("SubCluster %s failed to %s report.",
            clusterId.getSubClusterId(), request.getMethodName());
        LOG.error(msg, e);
        throw new YarnRuntimeException(e.getCause().getMessage(), e);
      }
    });
```

### Influences

This problem will not affect the accuracy of the overall returned results of the interface, because we will integrate the returned results for the interfaces involved in `FederationInterceptorREST`. The known impact is that when a certain sub-cluster is abnormal, it may cause the printed error log is inaccurate.

Examples are as follows:

When we use the results, we ignore the subcluster information.
```
public NodesInfo getNodes(String states) {
    NodesInfo nodes = new NodesInfo();
    try {
      Map<SubClusterId, SubClusterInfo> subClustersActive = getActiveSubclusters();
      Class[] argsClasses = new Class[]{String.class};
      Object[] args = new Object[]{states};
      ClientMethod remoteMethod = new ClientMethod("getNodes", argsClasses, args);
      Map<SubClusterInfo, NodesInfo> nodesMap =
          invokeConcurrent(subClustersActive.values(), remoteMethod, NodesInfo.class);
      nodesMap.values().stream().forEach(nodesInfo -> {
        nodes.addAll(nodesInfo.getNodes());
      });
    } catch (NotFoundException e) {
      LOG.error("get all active sub cluster(s) error.", e);
      throw e;
    } catch (YarnException e) {
      LOG.error("getNodes by states = {} error.", states, e);
      throw new YarnRuntimeException(e);
    } catch (IOException e) {
      LOG.error("getNodes by states = {} error with io error.", states, e);
      throw new YarnRuntimeException(e);
    }

    // Delete duplicate from all the node reports got from all the available
    // YARN RMs. Nodes can be moved from one subclusters to another. In this
    // operation they result LOST/RUNNING in the previous SubCluster and
    // NEW/RUNNING in the new one.
    return RouterWebServiceUtil.deleteDuplicateNodesInfo(nodes.getNodes());
  }
```

`FederationClientInterceptor#invokeConcurrent` And `FederationRMAdminInterceptor#invokeConcurrent` will not have this problem, because the result contains subClusterId.

Examples are as follows:
```
Map<SubClusterId, R> results = new TreeMap<>();
    try {
      futures.addAll(executorService.invokeAll(callables));
      futures.stream().forEach(future -> {
        SubClusterId subClusterId = null;
        try {
          Pair<SubClusterId, Object> pair = future.get();
          subClusterId = pair.getKey();
          Object result = pair.getValue();
          results.put(subClusterId, clazz.cast(result));
        } catch (InterruptedException | ExecutionException e) {
          Throwable cause = e.getCause();
          LOG.error("Cannot execute {} on {}: {}", request.getMethodName(),
              subClusterId.getId(), cause.getMessage());
          exceptions.put(subClusterId, e);
        }
      });
    } catch (InterruptedException e) {
      throw new YarnException("invokeConcurrent Failed.", e);
    }
```