### PR TITLE
 HDFS-16880. RBF: modify invokeSingleXXX interface in order to pass actual file src to namenode.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -484,7 +484,7 @@ public class RouterClientProtocol implements ClientProtocol {
         favoredNodes, addBlockFlags);
 
     if (previous != null) {
-      return rpcClient.invokeSingle(previous, method, LocatedBlock.class);
+      return rpcClient.invokeSingle(previous, method, LocatedBlock.class, src);
     }
 
     final List<RemoteLocation> locations =
@@ -514,7 +514,7 @@ public class RouterClientProtocol implements ClientProtocol {
         numAdditionalNodes, clientName);
 
     if (blk != null) {
-      return rpcClient.invokeSingle(blk, method, LocatedBlock.class);
+      return rpcClient.invokeSingle(blk, method, LocatedBlock.class, src);
     }
 
     final List<RemoteLocation> locations =
@@ -532,7 +532,7 @@ public class RouterClientProtocol implements ClientProtocol {
         new Class<?>[] {ExtendedBlock.class, long.class, String.class,
             String.class},
         b, fileId, new RemoteParam(), holder);
-    rpcClient.invokeSingle(b, method);
+    rpcClient.invokeSingle(b, method, src);
   }
 
   @Override
@@ -546,7 +546,7 @@ public class RouterClientProtocol implements ClientProtocol {
         new RemoteParam(), clientName, last, fileId);
 
     if (last != null) {
-      return rpcClient.invokeSingle(last, method, Boolean.class);
+      return rpcClient.invokeSingle(last, method, Boolean.class, src);
     }
 
     final List<RemoteLocation> locations =
@@ -563,7 +563,7 @@ public class RouterClientProtocol implements ClientProtocol {
     RemoteMethod method = new RemoteMethod("updateBlockForPipeline",
         new Class<?>[] {ExtendedBlock.class, String.class},
         block, clientName);
-    return rpcClient.invokeSingle(block, method, LocatedBlock.class);
+    return rpcClient.invokeSingle(block, method, LocatedBlock.class, "");
   }
 
   /**
@@ -580,7 +580,7 @@ public class RouterClientProtocol implements ClientProtocol {
         new Class<?>[] {String.class, ExtendedBlock.class, ExtendedBlock.class,
             DatanodeID[].class, String[].class},
         clientName, oldBlock, newBlock, newNodes, newStorageIDs);
-    rpcClient.invokeSingle(oldBlock, method);
+    rpcClient.invokeSingle(oldBlock, method, "");
   }
 
   @Override
@@ -805,7 +805,7 @@ public class RouterClientProtocol implements ClientProtocol {
         new Class<?>[] {String.class, List.class}, clientName, null);
     List<FederationNamespaceInfo> nss = getRenewLeaseNSs(namespaces);
     if (nss.size() == 1) {
-      rpcClient.invokeSingle(nss.get(0).getNameserviceId(), method);
+      rpcClient.invokeSingle(nss.get(0).getNameserviceId(), method, "");
     } else {
       rpcClient.invokeConcurrent(nss, method, false, false);
     }
@@ -1811,7 +1811,7 @@ public class RouterClientProtocol implements ClientProtocol {
       RemoteMethod method = new RemoteMethod("reportBadBlocks",
           new Class<?>[] {LocatedBlock[].class},
           new Object[] {bpBlocksArray});
-      rpcClient.invokeSingleBlockPool(bpId, method);
+      rpcClient.invokeSingleBlockPool(bpId, method, "");
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterNamenodeProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterNamenodeProtocol.java
@@ -81,7 +81,7 @@ public class RouterNamenodeProtocol implements NamenodeProtocol {
           NamenodeProtocol.class, "getBlocks", new Class<?>[]
           {DatanodeInfo.class, long.class, long.class, long.class},
           datanode, size, minBlockSize, hotBlockTimeInterval);
-      return rpcClient.invokeSingle(nsId, method, BlocksWithLocations.class);
+      return rpcClient.invokeSingle(nsId, method, BlocksWithLocations.class, "");
     }
     return null;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -830,13 +830,14 @@ public class RouterRpcClient {
    *
    * @param block Block used to determine appropriate nameservice.
    * @param method The remote method and parameters to invoke.
+   * @param src file path, pass "" if not have.
    * @return The result of invoking the method.
    * @throws IOException If the invoke generated an error.
    */
-  public Object invokeSingle(final ExtendedBlock block, RemoteMethod method)
+  public Object invokeSingle(final ExtendedBlock block, RemoteMethod method, String src)
       throws IOException {
     String bpId = block.getBlockPoolId();
-    return invokeSingleBlockPool(bpId, method);
+    return invokeSingleBlockPool(bpId, method, src);
   }
 
   /**
@@ -848,13 +849,14 @@ public class RouterRpcClient {
    *
    * @param bpId Block pool identifier.
    * @param method The remote method and parameters to invoke.
+   * @param src file path, pass "" if not have.
    * @return The result of invoking the method.
    * @throws IOException If the invoke generated an error.
    */
-  public Object invokeSingleBlockPool(final String bpId, RemoteMethod method)
+  public Object invokeSingleBlockPool(final String bpId, RemoteMethod method, String src)
       throws IOException {
     String nsId = getNameserviceForBlockPoolId(bpId);
-    return invokeSingle(nsId, method);
+    return invokeSingle(nsId, method, src);
   }
 
   /**
@@ -865,10 +867,11 @@ public class RouterRpcClient {
    *
    * @param nsId Target namespace for the method.
    * @param method The remote method and parameters to invoke.
+   * @param src file path, pass "" if not have.
    * @return The result of invoking the method.
    * @throws IOException If the invoke generated an error.
    */
-  public Object invokeSingle(final String nsId, RemoteMethod method)
+  public Object invokeSingle(final String nsId, RemoteMethod method, String src)
       throws IOException {
     UserGroupInformation ugi = RouterRpcServer.getRemoteUser();
     RouterRpcFairnessPolicyController controller = getRouterRpcFairnessPolicyController();
@@ -876,7 +879,12 @@ public class RouterRpcClient {
     try {
       boolean isObserverRead = isObserverReadEligible(nsId, method.getMethod());
       List<? extends FederationNamenodeContext> nns = getOrderedNamenodes(nsId, isObserverRead);
-      RemoteLocationContext loc = new RemoteLocation(nsId, "/", "/");
+      RemoteLocationContext loc;
+      if (org.apache.commons.lang3.StringUtils.isBlank(src)) {
+        loc = new RemoteLocation(nsId, "/", "/");
+      } else {
+        loc = new RemoteLocation(nsId, src, "/");
+      }
       Class<?> proto = method.getProtocol();
       Method m = method.getMethod();
       Object[] params = method.getParams(loc);
@@ -896,13 +904,14 @@ public class RouterRpcClient {
    * @param nsId Target namespace for the method.
    * @param method The remote method and parameters to invoke.
    * @param clazz Class for the return type.
+   * @param src file path, pass "" if not have.
    * @return The result of invoking the method.
    * @throws IOException If the invoke generated an error.
    */
   public <T> T invokeSingle(final String nsId, RemoteMethod method,
-      Class<T> clazz) throws IOException {
+      Class<T> clazz, String src) throws IOException {
     @SuppressWarnings("unchecked")
-    T ret = (T)invokeSingle(nsId, method);
+    T ret = (T)invokeSingle(nsId, method, src);
     return ret;
   }
 
@@ -916,14 +925,15 @@ public class RouterRpcClient {
    * @param extendedBlock Target extendedBlock for the method.
    * @param method The remote method and parameters to invoke.
    * @param clazz Class for the return type.
+   * @param src file path
    * @return The result of invoking the method.
    * @throws IOException If the invoke generated an error.
    */
   public <T> T invokeSingle(final ExtendedBlock extendedBlock,
-      RemoteMethod method, Class<T> clazz) throws IOException {
+                            RemoteMethod method, Class<T> clazz, String src) throws IOException {
     String nsId = getNameserviceForBlockPoolId(extendedBlock.getBlockPoolId());
     @SuppressWarnings("unchecked")
-    T ret = (T)invokeSingle(nsId, method);
+    T ret = (T)invokeSingle(nsId, method, src);
     return ret;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -687,7 +687,7 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
     // If default Ns is present return result from that namespace.
     if (!nsId.isEmpty()) {
       try {
-        return rpcClient.invokeSingle(nsId, method, clazz);
+        return rpcClient.invokeSingle(nsId, method, clazz, "");
       } catch (IOException ioe) {
         if (!clientProto.isUnavailableSubclusterException(ioe)) {
           LOG.debug("{} exception cannot be retried",
@@ -721,7 +721,7 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
       String nsId = fnInfo.getNameserviceId();
       LOG.debug("Invoking {} on namespace {}", method, nsId);
       try {
-        return rpcClient.invokeSingle(nsId, method, clazz);
+        return rpcClient.invokeSingle(nsId, method, clazz, "");
       } catch (IOException e) {
         LOG.debug("Failed to invoke {} on namespace {}", method, nsId, e);
         // Ignore the exception and try on other namespace, if the tried

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterRefreshFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterRefreshFairnessPolicyController.java
@@ -220,7 +220,7 @@ public class TestRouterRefreshFairnessPolicyController {
     for (int i = 0; i < nThreads; i++) {
       Thread threadAcquirePermit = new Thread(() -> {
         try {
-          client.invokeSingle(namespace, dummyMethod);
+          client.invokeSingle(namespace, dummyMethod, "");
         } catch (IOException e) {
           e.printStackTrace();
         }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
@@ -201,7 +201,7 @@ public class TestRouter {
 
     intercept(IOException.class, "Router-0",
         () -> router.getRpcServer().getRPCClient()
-            .invokeSingle("ns0", remoteMethod));
+            .invokeSingle("ns0", remoteMethod, ""));
 
     router.stop();
     router.close();


### PR DESCRIPTION
We found lots of INFO level log like below:

>2022-12-30 15:31:04,169 INFO org.apache.hadoop.hdfs.StateChange: DIR* completeFile: / is closed by DFSClient_attempt_1671783180362_213003_m_000077_0_1102875551_1
2022-12-30 15:31:04,186 INFO org.apache.hadoop.hdfs.StateChange: DIR* completeFile: / is closed by DFSClient_NONMAPREDUCE_1198313144_27480

It lost the real path of completeFile. Actually this is caused by : 

>org.apache.hadoop.hdfs.server.federation.router.RouterRpcClient#invokeSingle(java.lang.String, org.apache.hadoop.hdfs.server.federation.router.RemoteMethod)

In this method, it instantiates a RemoteLocationContext object:

>RemoteLocationContext loc = new RemoteLocation(nsId, "/", "/");

and then execute: Object[] params = method.getParams(loc);

The problem is right here, becasuse we always use new RemoteParam(), so, 

context.getDest() always return "/"; That's why we saw lots of incorrect logs.

 

After diving into invokeSingleXXX source code, I found the following RPCs classified as need actual src and not need actual src.

 

**need src path RPC:**

addBlock、abandonBlock、getAdditionalDatanode、complete

**not need src path RPC:**

updateBlockForPipeline、reportBadBlocks、getBlocks、updatePipeline、invokeAtAvailableNs（invoked by: getServerDefaults、getBlockKeys、getTransactionID、getMostRecentCheckpointTxId、versionRequest、getStoragePolicies）

 

After changes, the src can be pass to NN correctly.