### PR TITLE
YARN-11382 ClientRMService forget to record some audit logs after checkAccess.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClientRMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClientRMService.java
@@ -420,6 +420,8 @@ public class ClientRMService extends AbstractService implements
     GetApplicationReportResponse response = recordFactory
         .newRecordInstance(GetApplicationReportResponse.class);
     response.setApplicationReport(report);
+    RMAuditLogger.logSuccess(callerUGI.getUserName(),
+        AuditConstants.GET_APP_REPORT, "ClientRMService", applicationId);
     return response;
   }
 
@@ -449,7 +451,14 @@ public class ClientRMService extends AbstractService implements
       ApplicationAttemptReport attemptReport = appAttempt
           .createApplicationAttemptReport();
       response = GetApplicationAttemptReportResponse.newInstance(attemptReport);
+      RMAuditLogger.logSuccess(callerUGI.getUserName(),
+          AuditConstants.GET_APP_ATTEMPT_REPORT, "ClientRMService",
+          applicationId, appAttemptId);
     }else{
+      RMAuditLogger.logFailure(callerUGI.getShortUserName(),
+          AuditConstants.GET_APP_ATTEMPT_REPORT, "User does not have privilege to "
+          + ApplicationAccessType.VIEW_APP.toString(), "ClientRMService",
+          AuditConstants.UNAUTHORIZED_USER, applicationId, appAttemptId);
       throw new YarnException("User " + callerUGI.getShortUserName()
           + " does not have privilege to see this attempt " + appAttemptId);
     }
@@ -480,7 +489,13 @@ public class ClientRMService extends AbstractService implements
             .createApplicationAttemptReport());
       }
       response = GetApplicationAttemptsResponse.newInstance(listAttempts);
+      RMAuditLogger.logSuccess(callerUGI.getUserName(),
+          AuditConstants.GET_APP_ATTEMPTS, "ClientRMService", appId);
     } else {
+      RMAuditLogger.logFailure(callerUGI.getShortUserName(),
+          AuditConstants.GET_APP_ATTEMPTS, "User does not have privilege to "
+          + ApplicationAccessType.VIEW_APP.toString(), "ClientRMService",
+          AuditConstants.UNAUTHORIZED_USER, appId);
       throw new YarnException("User " + callerUGI.getShortUserName()
           + " does not have privilege to see this application " + appId);
     }
@@ -525,7 +540,13 @@ public class ClientRMService extends AbstractService implements
       }
       response = GetContainerReportResponse.newInstance(rmContainer
           .createContainerReport());
+      RMAuditLogger.logSuccess(callerUGI.getUserName(),
+          AuditConstants.GET_CONTAINER_REPORT, "ClientRMService", appId);
     } else {
+      RMAuditLogger.logFailure(callerUGI.getShortUserName(),
+          AuditConstants.GET_CONTAINER_REPORT, "User does not have privilege to "
+          + ApplicationAccessType.VIEW_APP.toString(), "ClientRMService",
+          AuditConstants.UNAUTHORIZED_USER, appId);
       throw new YarnException("User " + callerUGI.getShortUserName()
           + " does not have privilege to see this application " + appId);
     }
@@ -568,7 +589,13 @@ public class ClientRMService extends AbstractService implements
         listContainers.add(rmContainer.createContainerReport());
       }
       response = GetContainersResponse.newInstance(listContainers);
+      RMAuditLogger.logSuccess(callerUGI.getUserName(),
+          AuditConstants.GET_CONTAINERS, "ClientRMService", appId);
     } else {
+      RMAuditLogger.logFailure(callerUGI.getShortUserName(),
+          AuditConstants.GET_CONTAINERS, "User doesn't have permissions to "
+          + ApplicationAccessType.VIEW_APP.toString(), "ClientRMService",
+          AuditConstants.UNAUTHORIZED_USER, appId);
       throw new YarnException("User " + callerUGI.getShortUserName()
           + " does not have privilege to see this application " + appId);
     }
@@ -1475,7 +1502,7 @@ public class ClientRMService extends AbstractService implements
             requestInfo.getReservationId());
     }
 
-    checkReservationACLs(requestInfo.getQueue(),
+    String user = checkReservationACLs(requestInfo.getQueue(),
             AuditConstants.LIST_RESERVATION_REQUEST, reservationId);
 
     long startTime = Math.max(requestInfo.getStartTime(), 0);
@@ -1492,6 +1519,8 @@ public class ClientRMService extends AbstractService implements
                     reservations, includeResourceAllocations);
 
     response.setReservationAllocationState(info);
+    RMAuditLogger.logSuccess(user, AuditConstants.LIST_RESERVATION_REQUEST,
+        "ClientRMService: " + reservationId);
     return response;
   }
 


### PR DESCRIPTION
YARN-11382 ClientRMService forget to record some audit logs after checkAccess and just throw an YarnException("User does not have privilege to do something……").
Here is an example in method "getContainers":
```java
@Override public GetContainersResponse getContainers(GetContainersRequest request)           
    throws YarnException, IOException { 
    ...... 
    boolean allowAccess = checkAccess(callerUGI, application.getUser(),  ApplicationAccessType.VIEW_APP, application); 
    GetContainersResponse response = null; 
    if (allowAccess) { 
        ...... 
        // a logSuccess should be called here. 
    } else { 
        // a logFailure should be called here. 
        throw new YarnException("User " + callerUGI.getShortUserName() + " does not have privilege to see this application " + appId); 
    } 
    return response; 
}
```
And other methods(e.g. signalToContainer) in this class logSuccess or logFailure after accessCheck.
I think the requests from users are very critical for auditing and audit logs should  be recorded here.

Also, I found some AuditConstants in RMAuditLogger for these request (except getApplicationReport), so I guess write audit log for them is in the developer's planning but maybe forgotten.
```java
public class RMAuditLogger {
  ......
    public static class AuditConstants {
    ......
    public static final String GET_APP_ATTEMPTS = "Get Application Attempts";
    public static final String GET_APP_ATTEMPT_REPORT
        = "Get Application Attempt Report";
    public static final String GET_CONTAINERS = "Get Containers";
    public static final String GET_CONTAINER_REPORT = "Get Container Report";
    ......
```

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

