### PR TITLE
 HDFS-16879. EC: Fsck -blockId shows number of redundant internal block replicas for EC Blocks

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NamenodeFsck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NamenodeFsck.java
@@ -320,6 +320,10 @@ public class NamenodeFsck implements DataEncryptionKeyFactory {
       }
       out.println("No. of corrupted Replica: " +
           numberReplicas.corruptReplicas());
+      // for striped blocks only and number of redundant internal block replicas.
+      if (blockInfo.isStriped()) {
+        out.println("No. of redundant Replica: " + numberReplicas.redundantInternalBlocks());
+      }
       //record datanodes that have corrupted block replica
       Collection<DatanodeDescriptor> corruptionRecord = null;
       if (blockManager.getCorruptReplicas(block) != null) {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
[HDFS-16879](https://issues.apache.org/jira/browse/HDFS-16879)
For the block of the ec file run hdfs fsck -blockId xxx can add shows number of redundant internal block replicas.

### For code changes:
for example: the current blockgroup has 10 live replicas, and it will show there are 9 live replicas.
actually, there is a live replica that should be in the redundant state, can add shows "No. of redundant Replica: 1"

```
hdfs fsck -blockId blk_-xxx

Block Id: blk_-xxx
Block belongs to: /ec/file1
No. of Expected Replica: 9
No. of live Replica: 9
No. of excess Replica: 0
No. of stale Replica: 0
No. of decommissioned Replica: 0
No. of decommissioning Replica: 0
No. of corrupted Replica: 0
Block replica on datanode/rack: ip-xxx1 is HEALTHY
Block replica on datanode/rack: ip-xxx2 is HEALTHY
Block replica on datanode/rack: ip-xxx3 is HEALTHY
Block replica on datanode/rack: ip-xxx4 is HEALTHY
Block replica on datanode/rack: ip-xxx5 is HEALTHY
Block replica on datanode/rack: ip-xxx6 is HEALTHY
Block replica on datanode/rack: ip-xxx7 is HEALTHY
Block replica on datanode/rack: ip-xxx8 is HEALTHY
Block replica on datanode/rack: ip-xxx9 is HEALTHY
Block replica on datanode/rack: ip-xxx10 is HEALTHY
```

