### PR TITLE
HDFS-16883. Duplicate field name in hdfs-default.xml

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -5457,8 +5457,6 @@
 </property>
 
 <property>
-  <name>dfs.storage.policy.satisfier.enabled</name>
-  <value>false</value>
   <name>dfs.storage.policy.satisfier.mode</name>
   <value>none</value>
   <description>


### PR DESCRIPTION
### Description of PR

I found that there is duplicate field name in hdfs-default.xml.
And further investigation, `dfs.storage.policy.satisfier.enabled` is removed configuration since HDFS-13057. However, it remains in hdfs-default.xml and it shows deleted configuration through https://hadoop.apache.org/docs/r3.3.4/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml.

https://issues.apache.org/jira/browse/HDFS-16883


### How was this patch tested?

Manually


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?

