### PR TITLE
YARN-11408. Add a check of autoQueueCreation is disabled for emitDefaultUserLimitFactor method

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSQueueConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSQueueConverter.java
@@ -16,13 +16,15 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter;
 
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.AUTO_CREATE_CHILD_QUEUE_ENABLED;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.AUTO_QUEUE_CREATION_V2_ENABLED;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.DEFAULT_AUTO_CREATE_CHILD_QUEUE_ENABLED;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.DEFAULT_AUTO_QUEUE_CREATION_ENABLED;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.PREFIX;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.DOT;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.USER_LIMIT_FACTOR;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.conf.Configuration;
@@ -222,7 +224,8 @@ public class FSQueueConverter {
   }
 
   public void emitDefaultUserLimitFactor(String queueName, List<FSQueue> children) {
-    if (children.isEmpty() && checkAutoQueueCreationV2Disabled(queueName)) {
+    if (children.isEmpty() && checkAutoQueueCreationV2Disabled(queueName) &&
+        checkAutoCreateChildQueueDisabled(queueName)) {
       capacitySchedulerConfig.setFloat(
               CapacitySchedulerConfiguration.
                       PREFIX + queueName + DOT + USER_LIMIT_FACTOR,
@@ -312,8 +315,15 @@ public class FSQueueConverter {
   }
 
   private boolean checkAutoQueueCreationV2Disabled(String queueName) {
-    return !Objects.equals(capacitySchedulerConfig.get(
-        PREFIX + queueName + DOT + AUTO_QUEUE_CREATION_V2_ENABLED), "true");
+    return !capacitySchedulerConfig.getBoolean(
+        PREFIX + queueName + DOT + AUTO_QUEUE_CREATION_V2_ENABLED,
+        DEFAULT_AUTO_QUEUE_CREATION_ENABLED);
+  }
+
+  private boolean checkAutoCreateChildQueueDisabled(String queueName) {
+    return !capacitySchedulerConfig.getBoolean(
+        PREFIX + queueName + DOT + AUTO_CREATE_CHILD_QUEUE_ENABLED,
+        DEFAULT_AUTO_CREATE_CHILD_QUEUE_ENABLED);
   }
 
   private String getQueueShortName(String queueName) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSQueueConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSQueueConverter.java
@@ -16,9 +16,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter;
 
-import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.AUTO_CREATE_CHILD_QUEUE_ENABLED;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.AUTO_QUEUE_CREATION_V2_ENABLED;
-import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.DEFAULT_AUTO_CREATE_CHILD_QUEUE_ENABLED;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.DEFAULT_AUTO_QUEUE_CREATION_ENABLED;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.PREFIX;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.DOT;
@@ -224,8 +222,7 @@ public class FSQueueConverter {
   }
 
   public void emitDefaultUserLimitFactor(String queueName, List<FSQueue> children) {
-    if (children.isEmpty() && checkAutoQueueCreationV2Disabled(queueName) &&
-        checkAutoCreateChildQueueDisabled(queueName)) {
+    if (children.isEmpty() && checkAutoQueueCreationV2Disabled(queueName)) {
       capacitySchedulerConfig.setFloat(
               CapacitySchedulerConfiguration.
                       PREFIX + queueName + DOT + USER_LIMIT_FACTOR,
@@ -318,12 +315,6 @@ public class FSQueueConverter {
     return !capacitySchedulerConfig.getBoolean(
         PREFIX + queueName + DOT + AUTO_QUEUE_CREATION_V2_ENABLED,
         DEFAULT_AUTO_QUEUE_CREATION_ENABLED);
-  }
-
-  private boolean checkAutoCreateChildQueueDisabled(String queueName) {
-    return !capacitySchedulerConfig.getBoolean(
-        PREFIX + queueName + DOT + AUTO_CREATE_CHILD_QUEUE_ENABLED,
-        DEFAULT_AUTO_CREATE_CHILD_QUEUE_ENABLED);
   }
 
   private String getQueueShortName(String queueName) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSConfigToCSConfigConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSConfigToCSConfigConverter.java
@@ -16,11 +16,6 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter;
 
-import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.AUTO_CREATE_CHILD_QUEUE_ENABLED;
-import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.AUTO_QUEUE_CREATION_V2_ENABLED;
-import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.DEFAULT_AUTO_CREATE_CHILD_QUEUE_ENABLED;
-import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.DEFAULT_AUTO_QUEUE_CREATION_ENABLED;
-import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.DOT;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.PREFIX;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.USER_LIMIT_FACTOR;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter.FSConfigToCSConfigRuleHandler.DYNAMIC_MAX_ASSIGN;
@@ -201,8 +196,6 @@ public class TestFSConfigToCSConfigConverter {
             conf.get(PREFIX + "root.users." + USER_LIMIT_FACTOR));
     assertEquals("root.users auto-queue-creation-v2.enabled", "true",
             conf.get(PREFIX + "root.users.auto-queue-creation-v2.enabled"));
-    assertNull( "root.users auto-create-child-queue.enabled should be null",
-            conf.get(PREFIX + "root.users.auto-create-child-queue.enabled"));
 
     assertEquals("root.default user-limit-factor", "-1.0",
             conf.get(PREFIX + "root.default.user-limit-factor"));
@@ -214,8 +207,6 @@ public class TestFSConfigToCSConfigConverter {
             conf.get(PREFIX + "root.admins.bob.user-limit-factor"));
     assertNull("root.admin.bob auto-queue-creation-v2.enabled should be null",
             conf.get(PREFIX + "root.admin.bob.auto-queue-creation-v2.enabled"));
-    assertNull( "root.admin.bob auto-create-child-queue.enabled should be null",
-            conf.get(PREFIX + "root.admin.bob.auto-create-child-queue.enabled"));
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSConfigToCSConfigConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSConfigToCSConfigConverter.java
@@ -16,6 +16,11 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter;
 
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.AUTO_CREATE_CHILD_QUEUE_ENABLED;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.AUTO_QUEUE_CREATION_V2_ENABLED;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.DEFAULT_AUTO_CREATE_CHILD_QUEUE_ENABLED;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.DEFAULT_AUTO_QUEUE_CREATION_ENABLED;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.DOT;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.PREFIX;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.USER_LIMIT_FACTOR;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter.FSConfigToCSConfigRuleHandler.DYNAMIC_MAX_ASSIGN;
@@ -194,6 +199,10 @@ public class TestFSConfigToCSConfigConverter {
 
     assertNull("root.users user-limit-factor should be null",
             conf.get(PREFIX + "root.users." + USER_LIMIT_FACTOR));
+    assertEquals("root.users auto-queue-creation-v2.enabled", "true",
+            conf.get(PREFIX + "root.users.auto-queue-creation-v2.enabled"));
+    assertNull( "root.users auto-create-child-queue.enabled should be null",
+            conf.get(PREFIX + "root.users.auto-create-child-queue.enabled"));
 
     assertEquals("root.default user-limit-factor", "-1.0",
             conf.get(PREFIX + "root.default.user-limit-factor"));
@@ -203,6 +212,10 @@ public class TestFSConfigToCSConfigConverter {
 
     assertEquals("root.admins.bob user-limit-factor", "-1.0",
             conf.get(PREFIX + "root.admins.bob.user-limit-factor"));
+    assertNull("root.admin.bob auto-queue-creation-v2.enabled should be null",
+            conf.get(PREFIX + "root.admin.bob.auto-queue-creation-v2.enabled"));
+    assertNull( "root.admin.bob auto-create-child-queue.enabled should be null",
+            conf.get(PREFIX + "root.admin.bob.auto-create-child-queue.enabled"));
   }
 
   @Test


### PR DESCRIPTION
Change-Id: If1e36c5969d270c1b81a4bbd2e883fa819c81f20

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

