### PR TITLE
HDFS-16884. Fix TestFsDatasetImpl#testConcurrentWriteAndDeleteBlock failed

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -664,7 +664,7 @@ public class TestFsDatasetImpl {
     }
     // Wait for the async deletion task finish.
     GenericTestUtils.waitFor(() -> dataset.asyncDiskService.countPendingDeletions() == 0,
-        100, 1000);
+        100, 10000);
     for (String bpid : dataset.volumeMap.getBlockPoolList()) {
       assertEquals(numBlocks / 2, dataset.volumeMap.size(bpid));
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -662,6 +662,9 @@ public class TestFsDatasetImpl {
     for (Future<?> f : futureList) {
       f.get();
     }
+    // Wait for the async deletion task finish.
+    GenericTestUtils.waitFor(() -> dataset.asyncDiskService.countPendingDeletions() == 0,
+        100, 1000);
     for (String bpid : dataset.volumeMap.getBlockPoolList()) {
       assertEquals(numBlocks / 2, dataset.volumeMap.size(bpid));
     }


### PR DESCRIPTION
### Description of PR
[HDFS-16884](https://issues.apache.org/jira/browse/HDFS-16884)

Since the default is async delete replica on the datanode, the replica may not be deleted during the execution of UT#testConcurrentWriteAndDeleteBlock, resulting in a mismatch between the number of replicas in each dataset obtained at the end and the expectation
