### PR TITLE
HADOOP-18590. Publish SBOM artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <spotbugs-maven-plugin.version>4.2.0</spotbugs-maven-plugin.version>
     <jsonschema2pojo-maven-plugin.version>1.1.1</jsonschema2pojo-maven-plugin.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+    <cyclonedx.version>2.7.3</cyclonedx.version>
 
     <shell-executable>bash</shell-executable>
 
@@ -484,6 +485,19 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
         </plugin>
+        <plugin>
+          <groupId>org.cyclonedx</groupId>
+          <artifactId>cyclonedx-maven-plugin</artifactId>
+          <version>${cyclonedx.version}</version>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>makeBom</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -591,6 +605,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
### Description of PR

This PR aims to publish SBOM artifacts.

- https://cwiki.apache.org/confluence/display/COMDEV/SBOM

Here is an article to give some context.
- https://www.activestate.com/blog/why-the-us-government-is-mandating-software-bill-of-materials-sbom/

Software Bill of Materials (SBOM) are additional artifacts containing the aggregate of all direct and transitive dependencies of a project. The US Government (based on NIST recommendations) currently accepts only the three most popular SBOM standards as valid, namely: [CycloneDX](https://cyclonedx.org/), [Software Identification (SWID) tag](https://csrc.nist.gov/projects/Software-Identification-SWID), [Software Package Data Exchange® (SPDX)](https://spdx.dev/).

This PR uses [CycloneDX maven plugin](https://github.com/CycloneDX/cyclonedx-maven-plugin), a lightweight software bill of materials (SBOM) standard designed for use in application security contexts and supply chain component analysis.

### How was this patch tested?

Manually. For example, `hadoop-auth-3.4.0-SNAPSHOT.jar` will have `hadoop-auth-3.4.0-SNAPSHOT-cyclonedx.xml` and `hadoop-auth-3.4.0-SNAPSHOT-cyclonedx.json` SBOM files additionally.

```
$ mvn install -DskipTests
...

$ ls -l ~/.m2/repository/org/apache/hadoop/hadoop-auth/3.4.0-SNAPSHOT
total 960
-rw-r--r--  1 dongjoon  staff     373 Jan  6 12:47 _remote.repositories
-rw-r--r--  1 dongjoon  staff   84913 Jan  6 12:47 hadoop-auth-3.4.0-SNAPSHOT-cyclonedx.json
-rw-r--r--  1 dongjoon  staff   73722 Jan  6 12:47 hadoop-auth-3.4.0-SNAPSHOT-cyclonedx.xml
-rw-r--r--  1 dongjoon  staff   84457 Jan  6 12:47 hadoop-auth-3.4.0-SNAPSHOT-sources.jar
-rw-r--r--  1 dongjoon  staff  114087 Jan  6 12:47 hadoop-auth-3.4.0-SNAPSHOT-tests.jar
-rw-r--r--  1 dongjoon  staff  106678 Jan  6 12:47 hadoop-auth-3.4.0-SNAPSHOT.jar
-rw-r--r--  1 dongjoon  staff    8707 Jun  7  2022 hadoop-auth-3.4.0-SNAPSHOT.pom
-rw-r--r--  1 dongjoon  staff    1537 Jan  6 12:47 maven-metadata-local.xml
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

