### PR TITLE
HDFS-16885. Fix TestHdfsConfigFields#testCompareConfigurationClassAgainstXml failed

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -1241,6 +1241,15 @@
 </property>
 
 <property>
+  <name>dfs.namenode.access-control-enforcer-reporting-threshold-ms</name>
+  <value>1000</value>
+  <description>
+    If an external AccessControlEnforcer runs for a long time to check permission with the FSnamesystem lock,
+    this will be logged as the lock is released. This sets how long the lock must be held for logging to occur.
+  </description>
+</property>
+
+<property>
   <name>dfs.datanode.plugins</name>
   <value></value>
   <description>Comma-separated list of datanode plug-ins to be activated.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -1241,15 +1241,6 @@
 </property>
 
 <property>
-  <name>dfs.namenode.access-control-enforcer-reporting-threshold-ms</name>
-  <value>1000</value>
-  <description>
-    If an external AccessControlEnforcer runs for a long time to check permission with the FSnamesystem lock,
-    we will print a WARN message when it happens. This sets how long must be run for logging to occur.
-  </description>
-</property>
-
-<property>
   <name>dfs.datanode.plugins</name>
   <value></value>
   <description>Comma-separated list of datanode plug-ins to be activated.
@@ -3439,6 +3430,15 @@
   <description>When a read lock is held on the namenode for a long time,
     this will be logged as the lock is released. This sets how long the
     lock must be held for logging to occur.
+  </description>
+</property>
+
+<property>
+  <name>dfs.namenode.access-control-enforcer-reporting-threshold-ms</name>
+  <value>1000</value>
+  <description>
+    If an external AccessControlEnforcer runs for a long time to check permission with the FSnamesystem lock,
+    print a WARN log message. This sets how long must be run for logging to occur.
   </description>
 </property>
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -1245,7 +1245,7 @@
   <value>1000</value>
   <description>
     If an external AccessControlEnforcer runs for a long time to check permission with the FSnamesystem lock,
-    this will be logged as the lock is released. This sets how long the lock must be held for logging to occur.
+    we will print a WARN message when it happens. This sets how long must be run for logging to occur.
   </description>
 </property>
 


### PR DESCRIPTION
### Description of PR
[HDFS-16885](https://issues.apache.org/jira/browse/HDFS-16885)

A new parameter "dfs.namenode.access-control-enforcer-reporting-threshold-ms" was introduced in [HDFS-16881](https://issues.apache.org/jira/browse/HDFS-16881).
However, this parameter was not added to hdfs-default.xml, cause run TestHdfsConfigFields#testCompareConfigurationClassAgainstXml failed.