### PR TITLE
YARN-11409. Fix Typo of ResourceManager#webapp module.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/DeSelectFields.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/DeSelectFields.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.yarn.webapp.BadRequestException;
 
 /**
  * DeSelectFields make the <code>/apps</code> api more flexible.
- * It can be used to strip off more fields if there's such use case in future.
+ * It can be used to strip off more fields if there's such use case in the future.
  * You can simply extend it via two steps:
  * <br> 1. add a <code>DeSelectType</code> enum with a string literals
  * <br> 2. write your logical based on
@@ -60,10 +60,10 @@ public class DeSelectFields {
             if (type == null) {
               LOG.warn("Invalid deSelects string " + literals.trim());
               DeSelectType[] typeArray = DeSelectType.values();
-              String allSuppportLiterals = Arrays.toString(typeArray);
+              String allSupportLiterals = Arrays.toString(typeArray);
               throw new BadRequestException("Invalid deSelects string "
                   + literals.trim() + " specified. It should be one of "
-                  + allSuppportLiterals);
+                  + allSupportLiterals);
             } else {
               this.types.add(type);
             }
@@ -74,7 +74,7 @@ public class DeSelectFields {
   }
 
   /**
-   * Determine the deselect type should be handled or not.
+   * Determine to deselect type should be handled or not.
    * @param type deselected type
    * @return true if the deselect type should be handled
    */
@@ -83,7 +83,7 @@ public class DeSelectFields {
   }
 
   /**
-   * Deselect field type, can be boost in future.
+   * Deselect field type, can be boosted in the future.
    */
   public enum DeSelectType {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServiceProtocol.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServiceProtocol.java
@@ -215,7 +215,7 @@ public interface RMWebServiceProtocol {
       String groupBy);
 
   /**
-   * This method retrieve the last n activities inside scheduler and it is
+   * This method retrieve the last n activities inside scheduler, and it is
    * reachable by using {@link RMWSConsts#SCHEDULER_BULK_ACTIVITIES}.
    *
    * @param hsr the servlet request
@@ -633,7 +633,7 @@ public interface RMWebServiceProtocol {
    * @throws IOException when a {@link ReservationDeleteRequest} cannot be
    *           created from the {@link ReservationDeleteRequestInfo}. This
    *           exception is also thrown on
-   *           {@code ClientRMService.deleteReservation} invokation failure.
+   *           {@code ClientRMService.deleteReservation} invocation failure.
    * @throws InterruptedException if doAs action throws an InterruptedException.
    */
   Response deleteReservation(ReservationDeleteRequestInfo resContext,
@@ -719,7 +719,7 @@ public interface RMWebServiceProtocol {
   AppAttemptsInfo getAppAttempts(HttpServletRequest hsr, String appId);
 
   /**
-   * This method verifies if an user has access to a specified queue.
+   * This method verifies if a user has access to a specified queue.
    *
    * @return Response containing the status code.
    *

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
@@ -323,7 +323,7 @@ public class RMWebServices extends WebServices implements RMWebServiceProtocol {
    * @param doAdminACLsCheck
    *          boolean flag to indicate whether ACLs check is needed
    * @throws AuthorizationException
-   *           in case of no access to perfom this op.
+   *           in case of no access to perform this op.
    */
   private void initForWritableEndpoints(UserGroupInformation callerUGI,
       boolean doAdminACLsCheck) throws AuthorizationException {
@@ -768,7 +768,7 @@ public class RMWebServices extends WebServices implements RMWebServiceProtocol {
       return activitiesManager.getActivitiesInfo(nodeId, activitiesGroupBy);
     }
 
-    // Return a activities info with error message
+    // Return an activities info with error message
     return new ActivitiesInfo(errMessage, nodeId);
   }
 
@@ -965,10 +965,10 @@ public class RMWebServices extends WebServices implements RMWebServiceProtocol {
       for (String action : actions) {
         if (!EnumUtils.isValidEnum(RMWSConsts.AppActivitiesRequiredAction.class,
             action.toUpperCase())) {
-          String errMesasge =
+          String errMessage =
               "Got invalid action: " + action + ", valid actions: " + Arrays
                   .asList(RMWSConsts.AppActivitiesRequiredAction.values());
-          throw new IllegalArgumentException(errMesasge);
+          throw new IllegalArgumentException(errMessage);
         }
         requiredActions.add(RMWSConsts.AppActivitiesRequiredAction
             .valueOf(action.toUpperCase()));
@@ -981,10 +981,10 @@ public class RMWebServices extends WebServices implements RMWebServiceProtocol {
     if (groupBy != null) {
       if (!EnumUtils.isValidEnum(RMWSConsts.ActivitiesGroupBy.class,
           groupBy.toUpperCase())) {
-        String errMesasge =
+        String errMessage =
             "Got invalid groupBy: " + groupBy + ", valid groupBy types: "
                 + Arrays.asList(RMWSConsts.ActivitiesGroupBy.values());
-        throw new IllegalArgumentException(errMesasge);
+        throw new IllegalArgumentException(errMessage);
       }
       return RMWSConsts.ActivitiesGroupBy.valueOf(groupBy.toUpperCase());
     }
@@ -2328,7 +2328,7 @@ public class RMWebServices extends WebServices implements RMWebServiceProtocol {
     }
     if (resContext.getReservationId() == null) {
       throw new BadRequestException(
-          "Update operations must specify an existing ReservaitonId");
+          "Update operations must specify an existing ReservationId");
     }
 
     ReservationRequestInterpreter[] values =
@@ -2700,7 +2700,7 @@ public class RMWebServices extends WebServices implements RMWebServiceProtocol {
         return Response.status(Status.OK).entity("Configuration under " +
             "store successfully formatted.").build();
       } catch (Exception e) {
-        LOG.error("Exception thrown when formating configuration", e);
+        LOG.error("Exception thrown when formatting configuration", e);
         return Response.status(Status.BAD_REQUEST).entity(e.getMessage())
             .build();
       }
@@ -2906,7 +2906,7 @@ public class RMWebServices extends WebServices implements RMWebServiceProtocol {
     initForReadableEndpoints();
 
     // For the user who invokes this REST call, he/she should have admin access
-    // to the queue. Otherwise we will reject the call.
+    // to the queue. Otherwise, we will reject the call.
     UserGroupInformation callerUGI = getCallerUserGroupInformation(hsr, true);
     if (callerUGI != null && !this.rm.getResourceScheduler().checkAccess(
         callerUGI, QueueACL.ADMINISTER_QUEUE, queue)) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RmController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RmController.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.yarn.webapp.YarnWebParams;
 import com.google.inject.Inject;
 
 // Do NOT rename/refactor this to RMView as it will wreak havoc
-// on Mac OS HFS as its case-insensitive!
+// on macOS HFS as its case-insensitive!
 public class RmController extends Controller {
 
   @Inject

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RmView.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RmView.java
@@ -27,7 +27,7 @@ import static org.apache.hadoop.yarn.webapp.YarnWebParams.APP_STATE;
 import static org.apache.hadoop.yarn.webapp.view.JQueryUI.*;
 
 // Do NOT rename/refactor this to RMView as it will wreak havoc
-// on Mac OS HFS
+// on macOS HFS
 public class RmView extends TwoColumnLayout {
   static final int MAX_DISPLAY_ROWS = 100;  // direct table rendering
   static final int MAX_FAST_ROWS = 1000;    // inline js array

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/CapacitySchedulerLeafQueueInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/CapacitySchedulerLeafQueueInfo.java
@@ -61,7 +61,7 @@ public class CapacitySchedulerLeafQueueInfo extends CapacitySchedulerQueueInfo {
   protected String orderingPolicyDisplayName;
 
   CapacitySchedulerLeafQueueInfo() {
-  };
+  }
 
   CapacitySchedulerLeafQueueInfo(CapacityScheduler cs, AbstractLeafQueue q) {
     super(cs, q);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/CapacitySchedulerQueueInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/CapacitySchedulerQueueInfo.java
@@ -96,7 +96,7 @@ public class CapacitySchedulerQueueInfo {
       new AutoQueueTemplatePropertiesInfo();
 
   CapacitySchedulerQueueInfo() {
-  };
+  }
 
   CapacitySchedulerQueueInfo(CapacityScheduler cs, CSQueue q) {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/PartitionInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/PartitionInfo.java
@@ -49,7 +49,7 @@ public class PartitionInfo {
 
   /**
    * This method will generate a new PartitionInfo object based on two PartitionInfo objects.
-   * The combination process is mainly based on the Resources.add method.
+   * The combination process is mainly based on the Resources. Add method.
    *
    * @param left left PartitionInfo Object.
    * @param right right PartitionInfo Object.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ReservationDeleteResponseInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ReservationDeleteResponseInfo.java
@@ -23,7 +23,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
- * Simple class that represent a reponse to a delete operation.
+ * Simple class that represent a response to a delete operation.
  */
 @XmlRootElement(name = "reservation-delete-response")
 @XmlAccessorType(XmlAccessType.FIELD)


### PR DESCRIPTION
JIRA: YARN-11409. Fix Typo of ResourceManager#webapp moudle.

When finishing [YARN-11218](https://issues.apache.org/jira/browse/YARN-11218), I found some typo problems in RM's RMWebServices. I checked the java class of the webapp moudle and fixed the typo problems.