### PR TITLE
HDFS-16886: Fixes error in documentation for StateStoreRecordsOperations.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/driver/StateStoreRecordOperations.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/driver/StateStoreRecordOperations.java
@@ -56,7 +56,7 @@ public interface StateStoreRecordOperations {
    * @param clazz Class of record to fetch.
    * @param query Query to filter results.
    * @return A single record matching the query. Null if there are no matching
-   *         records or more than one matching record in the store.
+   *         records.
    * @throws IOException If multiple records match or if the data store cannot
    *           be queried.
    */


### PR DESCRIPTION
HDFS-16886: Fixes error in documentation for StateStoreRecordsOperations.

### Description of PR

For StateStoreRecordOperations#get(Class ..., Query ...), when multiple records match, the documentation says a null value should be returned and an IOException should be thrown. Both can't happen.

I believe the intended behavior is that an IOException is thrown. This is the implementation in StateStoreBaseImpl.

### How was this patch tested?

No test. Just a simple documentation change.

### For code changes: