### PR TITLE
HADOOP-18591. Fix a typo in Trash

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Trash.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Trash.java
@@ -69,7 +69,7 @@ public class Trash extends Configured {
    * Hence we get the file system of the fully-qualified resolved-path and
    * then move the path p to the trashbin in that volume,
    * @param fs - the filesystem of path p
-   * @param p - the  path being deleted - to be moved to trasg
+   * @param p - the path being deleted - to be moved to trash
    * @param conf - configuration
    * @return false if the item is already in the trash or trash is disabled
    * @throws IOException on error


### PR DESCRIPTION
### Description of PR
[HADOOP-18591](https://issues.apache.org/jira/browse/HADOOP-18591) Fix a typo in Trash, change 'trasg' to 'trash'

### How was this patch tested?
no need test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id ('HADOOP-18591')?

