### PR TITLE
HDFS-16887 Log start and end of phase/step in startup progress

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/PhaseTracking.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/PhaseTracking.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.hadoop.classification.InterfaceAudience;
 
 /**
@@ -42,5 +43,16 @@ final class PhaseTracking extends AbstractTracking {
       clone.steps.put(entry.getKey(), entry.getValue().clone());
     }
     return clone;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("file", file)
+        .append("size", size)
+        .append("steps", steps)
+        .append("beginTime", beginTime)
+        .append("endTime", endTime)
+        .toString();
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/StartupProgress.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/StartupProgress.java
@@ -24,6 +24,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 
 /**
@@ -48,6 +51,9 @@ import org.apache.hadoop.classification.InterfaceAudience;
  */
 @InterfaceAudience.Private
 public class StartupProgress {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StartupProgress.class);
+
   // package-private for access by StartupProgressView
   final Map<Phase, PhaseTracking> phases =
     new ConcurrentHashMap<Phase, PhaseTracking>();
@@ -81,6 +87,7 @@ public class StartupProgress {
     if (!isComplete()) {
       phases.get(phase).beginTime = monotonicNow();
     }
+    LOG.debug("Beginning of the phase: {}", phase);
   }
 
   /**
@@ -94,6 +101,7 @@ public class StartupProgress {
     if (!isComplete(phase)) {
       lazyInitStep(phase, step).beginTime = monotonicNow();
     }
+    LOG.debug("Beginning of the step. Phase: {}, Step: {}", phase, step);
   }
 
   /**
@@ -105,6 +113,7 @@ public class StartupProgress {
     if (!isComplete()) {
       phases.get(phase).endTime = monotonicNow();
     }
+    LOG.debug("End of the phase: {}", phase);
   }
 
   /**
@@ -118,6 +127,7 @@ public class StartupProgress {
     if (!isComplete(phase)) {
       lazyInitStep(phase, step).endTime = monotonicNow();
     }
+    LOG.debug("End of the step. Phase: {}, Step: {}", phase, step);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/Step.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/Step.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.hadoop.classification.InterfaceAudience;
 
 /**
@@ -138,5 +139,15 @@ public class Step implements Comparable<Step> {
   public int hashCode() {
     return new HashCodeBuilder().append(file).append(size).append(type)
       .toHashCode();
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("file", file)
+        .append("sequenceNumber", sequenceNumber)
+        .append("size", size)
+        .append("type", type)
+        .toString();
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/StepTracking.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/StepTracking.java
@@ -18,6 +18,7 @@ package org.apache.hadoop.hdfs.server.namenode.startupprogress;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.hadoop.classification.InterfaceAudience;
 
 /**
@@ -35,5 +36,15 @@ final class StepTracking extends AbstractTracking {
     clone.count = new AtomicLong(count.get());
     clone.total = total;
     return clone;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("count", count)
+        .append("total", total)
+        .append("beginTime", beginTime)
+        .append("endTime", endTime)
+        .toString();
   }
 }


### PR DESCRIPTION
As part of Namenode startup progress, we have multiple phases and steps within phase that are instantiated. While the startup progress view can be instantiated with the current view of phase/step, having at least DEBUG logs for startup progress would be helpful to identify when a particular step for LOADING_FSIMAGE/SAVING_CHECKPOINT/LOADING_EDITS was started and ended.