### PR TITLE
YARN-11404. Add junit5 dependency to hadoop-mapreduce-client-app to fix few unit test failure

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/pom.xml
@@ -101,6 +101,39 @@
       <scope>test</scope>
    </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>4.11.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-core</artifactId>
+      <version>1.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-jupiter</artifactId>
+      <version>1.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestLocalContainerLauncher.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestLocalContainerLauncher.java
@@ -100,7 +100,7 @@ public class TestLocalContainerLauncher {
   @SuppressWarnings("rawtypes")
   @Test
   @Timeout(10000)
-  void testKillJob() throws Exception {
+  public void testKillJob() throws Exception {
     JobConf conf = new JobConf();
     AppContext context = mock(AppContext.class);
     // a simple event handler solely to detect the container cleaned event
@@ -188,7 +188,7 @@ public class TestLocalContainerLauncher {
 
 
   @Test
-  void testRenameMapOutputForReduce() throws Exception {
+  public void testRenameMapOutputForReduce() throws Exception {
     final JobConf conf = new JobConf();
 
     final MROutputFiles mrOutputFiles = new MROutputFiles();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestLocalContainerLauncher.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestLocalContainerLauncher.java
@@ -53,10 +53,11 @@ import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.event.EventHandler;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
@@ -75,7 +76,7 @@ public class TestLocalContainerLauncher {
     fs.delete(p, true);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupTestDirs() throws IOException {
     testWorkDir = new File("target",
         TestLocalContainerLauncher.class.getCanonicalName());
@@ -89,7 +90,7 @@ public class TestLocalContainerLauncher {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanupTestDirs() throws IOException {
     if (testWorkDir != null) {
       delete(testWorkDir);
@@ -97,8 +98,9 @@ public class TestLocalContainerLauncher {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test(timeout=10000)
-  public void testKillJob() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testKillJob() throws Exception {
     JobConf conf = new JobConf();
     AppContext context = mock(AppContext.class);
     // a simple event handler solely to detect the container cleaned event
@@ -186,7 +188,7 @@ public class TestLocalContainerLauncher {
 
 
   @Test
-  public void testRenameMapOutputForReduce() throws Exception {
+  void testRenameMapOutputForReduce() throws Exception {
     final JobConf conf = new JobConf();
 
     final MROutputFiles mrOutputFiles = new MROutputFiles();
@@ -198,8 +200,8 @@ public class TestLocalContainerLauncher {
     final Path mapOut = mrOutputFiles.getOutputFileForWrite(1);
     conf.set(MRConfig.LOCAL_DIR, localDirs[1].toString());
     final Path mapOutIdx = mrOutputFiles.getOutputIndexFileForWrite(1);
-    Assert.assertNotEquals("Paths must be different!",
-        mapOut.getParent(), mapOutIdx.getParent());
+    Assertions.assertNotEquals(mapOut.getParent(), mapOutIdx.getParent(),
+        "Paths must be different!");
 
     // make both dirs part of LOCAL_DIR
     conf.setStrings(MRConfig.LOCAL_DIR, localDirs);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptFinishingMonitor.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptFinishingMonitor.java
@@ -37,15 +37,15 @@ import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.util.SystemClock;
 
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TestTaskAttemptFinishingMonitor {
 
   @Test
-  public void testFinshingAttemptTimeout()
+  void testFinshingAttemptTimeout()
       throws IOException, InterruptedException {
     SystemClock clock = SystemClock.getInstance();
     Configuration conf = new Configuration();
@@ -87,7 +87,7 @@ public class TestTaskAttemptFinishingMonitor {
     }
     taskAttemptFinishingMonitor.stop();
 
-    assertTrue("Finishing attempt didn't time out.", eventHandler.timedOut);
+    assertTrue(eventHandler.timedOut, "Finishing attempt didn't time out.");
 
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptFinishingMonitor.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptFinishingMonitor.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
 public class TestTaskAttemptFinishingMonitor {
 
   @Test
-  void testFinshingAttemptTimeout()
+  public void testFinshingAttemptTimeout()
       throws IOException, InterruptedException {
     SystemClock clock = SystemClock.getInstance();
     Configuration conf = new Configuration();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptListenerImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptListenerImpl.java
@@ -19,19 +19,18 @@ package org.apache.hadoop.mapred;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -67,14 +66,15 @@ import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.util.ControlledClock;
 import org.apache.hadoop.yarn.util.SystemClock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -87,7 +87,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests the behavior of TaskAttemptListenerImpl.
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TestTaskAttemptListenerImpl {
   private static final String ATTEMPT1_ID =
       "attempt_123456789012_0001_m_000001_0";
@@ -172,7 +172,7 @@ public class TestTaskAttemptListenerImpl {
     }
   }
 
-  @After
+  @AfterEach
   public void after() throws IOException {
     if (listener != null) {
       listener.close();
@@ -180,8 +180,9 @@ public class TestTaskAttemptListenerImpl {
     }
   }
 
-  @Test  (timeout=5000)
-  public void testGetTask() throws IOException {
+  @Test
+  @Timeout(5000)
+  void testGetTask() throws IOException {
     configureMocks();
     startListener(false);
 
@@ -189,12 +190,12 @@ public class TestTaskAttemptListenerImpl {
     //The JVM ID has not been registered yet so we should kill it.
     JvmContext context = new JvmContext();
 
-    context.jvmId = id; 
+    context.jvmId = id;
     JvmTask result = listener.getTask(context);
     assertNotNull(result);
     assertTrue(result.shouldDie);
 
-    // Verify ask after registration but before launch. 
+    // Verify ask after registration but before launch.
     // Don't kill, should be null.
     //Now put a task with the ID
     listener.registerPendingTask(task, wid);
@@ -238,8 +239,9 @@ public class TestTaskAttemptListenerImpl {
 
   }
 
-  @Test (timeout=5000)
-  public void testJVMId() {
+  @Test
+  @Timeout(5000)
+  void testJVMId() {
 
     JVMId jvmid = new JVMId("test", 1, true, 2);
     JVMId jvmid1 = JVMId.forName("jvm_test_0001_m_000002");
@@ -247,8 +249,9 @@ public class TestTaskAttemptListenerImpl {
     assertEquals(0, jvmid.compareTo(jvmid1));
   }
 
-  @Test (timeout=10000)
-  public void testGetMapCompletionEvents() throws IOException {
+  @Test
+  @Timeout(10000)
+  void testGetMapCompletionEvents() throws IOException {
     TaskAttemptCompletionEvent[] empty = {};
     TaskAttemptCompletionEvent[] taskEvents = {
         createTce(0, true, TaskAttemptCompletionEventStatus.OBSOLETE),
@@ -257,12 +260,6 @@ public class TestTaskAttemptListenerImpl {
         createTce(3, false, TaskAttemptCompletionEventStatus.FAILED) };
     TaskAttemptCompletionEvent[] mapEvents = { taskEvents[0], taskEvents[2] };
     Job mockJob = mock(Job.class);
-    when(mockJob.getTaskAttemptCompletionEvents(0, 100))
-      .thenReturn(taskEvents);
-    when(mockJob.getTaskAttemptCompletionEvents(0, 2))
-      .thenReturn(Arrays.copyOfRange(taskEvents, 0, 2));
-    when(mockJob.getTaskAttemptCompletionEvents(2, 100))
-      .thenReturn(Arrays.copyOfRange(taskEvents, 2, 4));
     when(mockJob.getMapAttemptCompletionEvents(0, 100)).thenReturn(
         TypeConverter.fromYarn(mapEvents));
     when(mockJob.getMapAttemptCompletionEvents(0, 2)).thenReturn(
@@ -312,8 +309,9 @@ public class TestTaskAttemptListenerImpl {
     return tce;
   }
 
-  @Test (timeout=10000)
-  public void testCommitWindow() throws IOException {
+  @Test
+  @Timeout(10000)
+  void testCommitWindow() throws IOException {
     SystemClock clock = SystemClock.getInstance();
 
     configureMocks();
@@ -353,7 +351,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  public void testCheckpointIDTracking()
+  void testCheckpointIDTracking()
     throws IOException, InterruptedException{
     configureMocks();
     listener = new MockTaskAttemptListenerImpl(
@@ -409,7 +407,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  public void testStatusUpdateProgress()
+  void testStatusUpdateProgress()
       throws IOException, InterruptedException {
     configureMocks();
     startListener(true);
@@ -430,7 +428,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  public void testPingUpdateProgress() throws IOException, InterruptedException {
+  void testPingUpdateProgress() throws IOException, InterruptedException {
     configureMocks();
     Configuration conf = new Configuration();
     conf.setBoolean(MRJobConfig.MR_TASK_ENABLE_PING_FOR_LIVELINESS_CHECK, true);
@@ -447,7 +445,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  public void testSingleStatusUpdate()
+  void testSingleStatusUpdate()
       throws IOException, InterruptedException {
     configureMocks();
     startListener(true);
@@ -465,7 +463,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  public void testStatusUpdateEventCoalescing()
+  void testStatusUpdateEventCoalescing()
       throws IOException, InterruptedException {
     configureMocks();
     startListener(true);
@@ -486,7 +484,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  public void testCoalescedStatusUpdatesCleared()
+  void testCoalescedStatusUpdatesCleared()
       throws IOException, InterruptedException {
     // First two events are coalesced, the third is not
     configureMocks();
@@ -510,7 +508,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  public void testStatusUpdateFromUnregisteredTask() throws Exception {
+  void testStatusUpdateFromUnregisteredTask() throws Exception {
     configureMocks();
     ControlledClock clock = new ControlledClock();
     clock.setTime(0);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptListenerImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptListenerImpl.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.mapred;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -78,6 +79,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -182,7 +184,7 @@ public class TestTaskAttemptListenerImpl {
 
   @Test
   @Timeout(5000)
-  void testGetTask() throws IOException {
+  public void testGetTask() throws IOException {
     configureMocks();
     startListener(false);
 
@@ -241,7 +243,7 @@ public class TestTaskAttemptListenerImpl {
 
   @Test
   @Timeout(5000)
-  void testJVMId() {
+  public void testJVMId() {
 
     JVMId jvmid = new JVMId("test", 1, true, 2);
     JVMId jvmid1 = JVMId.forName("jvm_test_0001_m_000002");
@@ -251,7 +253,7 @@ public class TestTaskAttemptListenerImpl {
 
   @Test
   @Timeout(10000)
-  void testGetMapCompletionEvents() throws IOException {
+  public void testGetMapCompletionEvents() throws IOException {
     TaskAttemptCompletionEvent[] empty = {};
     TaskAttemptCompletionEvent[] taskEvents = {
         createTce(0, true, TaskAttemptCompletionEventStatus.OBSOLETE),
@@ -260,6 +262,12 @@ public class TestTaskAttemptListenerImpl {
         createTce(3, false, TaskAttemptCompletionEventStatus.FAILED) };
     TaskAttemptCompletionEvent[] mapEvents = { taskEvents[0], taskEvents[2] };
     Job mockJob = mock(Job.class);
+    lenient().when(mockJob.getTaskAttemptCompletionEvents(0, 100))
+        .thenReturn(taskEvents);
+    lenient().when(mockJob.getTaskAttemptCompletionEvents(0, 2))
+        .thenReturn(Arrays.copyOfRange(taskEvents, 0, 2));
+    lenient().when(mockJob.getTaskAttemptCompletionEvents(2, 100))
+        .thenReturn(Arrays.copyOfRange(taskEvents, 2, 4));
     when(mockJob.getMapAttemptCompletionEvents(0, 100)).thenReturn(
         TypeConverter.fromYarn(mapEvents));
     when(mockJob.getMapAttemptCompletionEvents(0, 2)).thenReturn(
@@ -311,7 +319,7 @@ public class TestTaskAttemptListenerImpl {
 
   @Test
   @Timeout(10000)
-  void testCommitWindow() throws IOException {
+  public void testCommitWindow() throws IOException {
     SystemClock clock = SystemClock.getInstance();
 
     configureMocks();
@@ -351,7 +359,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  void testCheckpointIDTracking()
+  public void testCheckpointIDTracking()
     throws IOException, InterruptedException{
     configureMocks();
     listener = new MockTaskAttemptListenerImpl(
@@ -407,7 +415,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  void testStatusUpdateProgress()
+  public void testStatusUpdateProgress()
       throws IOException, InterruptedException {
     configureMocks();
     startListener(true);
@@ -428,7 +436,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  void testPingUpdateProgress() throws IOException, InterruptedException {
+  public void testPingUpdateProgress() throws IOException, InterruptedException {
     configureMocks();
     Configuration conf = new Configuration();
     conf.setBoolean(MRJobConfig.MR_TASK_ENABLE_PING_FOR_LIVELINESS_CHECK, true);
@@ -445,7 +453,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  void testSingleStatusUpdate()
+  public void testSingleStatusUpdate()
       throws IOException, InterruptedException {
     configureMocks();
     startListener(true);
@@ -463,7 +471,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  void testStatusUpdateEventCoalescing()
+  public void testStatusUpdateEventCoalescing()
       throws IOException, InterruptedException {
     configureMocks();
     startListener(true);
@@ -484,7 +492,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  void testCoalescedStatusUpdatesCleared()
+  public void testCoalescedStatusUpdatesCleared()
       throws IOException, InterruptedException {
     // First two events are coalesced, the third is not
     configureMocks();
@@ -508,7 +516,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  void testStatusUpdateFromUnregisteredTask() throws Exception {
+  public void testStatusUpdateFromUnregisteredTask() throws Exception {
     configureMocks();
     ControlledClock clock = new ControlledClock();
     clock.setTime(0);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptListenerImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptListenerImpl.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.mapred;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -79,7 +78,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -262,12 +260,6 @@ public class TestTaskAttemptListenerImpl {
         createTce(3, false, TaskAttemptCompletionEventStatus.FAILED) };
     TaskAttemptCompletionEvent[] mapEvents = { taskEvents[0], taskEvents[2] };
     Job mockJob = mock(Job.class);
-    lenient().when(mockJob.getTaskAttemptCompletionEvents(0, 100))
-        .thenReturn(taskEvents);
-    lenient().when(mockJob.getTaskAttemptCompletionEvents(0, 2))
-        .thenReturn(Arrays.copyOfRange(taskEvents, 0, 2));
-    lenient().when(mockJob.getTaskAttemptCompletionEvents(2, 100))
-        .thenReturn(Arrays.copyOfRange(taskEvents, 2, 4));
     when(mockJob.getMapAttemptCompletionEvents(0, 100)).thenReturn(
         TypeConverter.fromYarn(mapEvents));
     when(mockJob.getMapAttemptCompletionEvents(0, 2)).thenReturn(

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestYarnChild.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestYarnChild.java
@@ -45,7 +45,7 @@ public class TestYarnChild {
   }
 
   @Test
-  void testReportErrorWhenCapacityExceptionNotHappenByDefault()
+  public void testReportErrorWhenCapacityExceptionNotHappenByDefault()
       throws IOException {
     Exception exception = new RuntimeException(new IOException());
 
@@ -53,7 +53,7 @@ public class TestYarnChild {
   }
 
   @Test
-  void testReportErrorWhenCapacityExceptionNotHappenAndFastFailDisabled()
+  public void testReportErrorWhenCapacityExceptionNotHappenAndFastFailDisabled()
       throws IOException {
     Exception exception = new RuntimeException(new IOException());
     conf.setBoolean(KILL_LIMIT_EXCEED_CONF_NAME, false);
@@ -62,7 +62,7 @@ public class TestYarnChild {
   }
 
   @Test
-  void testReportErrorWhenCapacityExceptionNotHappenAndFastFailEnabled()
+  public void testReportErrorWhenCapacityExceptionNotHappenAndFastFailEnabled()
       throws IOException {
     Exception exception = new RuntimeException(new IOException());
     conf.setBoolean(KILL_LIMIT_EXCEED_CONF_NAME, true);
@@ -71,7 +71,7 @@ public class TestYarnChild {
   }
 
   @Test
-  void testReportErrorWhenCapacityExceptionHappenByDefault()
+  public void testReportErrorWhenCapacityExceptionHappenByDefault()
       throws IOException {
     Exception exception =
         new RuntimeException(new ClusterStorageCapacityExceededException());
@@ -80,7 +80,7 @@ public class TestYarnChild {
   }
 
   @Test
-  void testReportErrorWhenCapacityExceptionHappenAndFastFailDisabled()
+  public void testReportErrorWhenCapacityExceptionHappenAndFastFailDisabled()
       throws IOException {
     Exception exception =
         new RuntimeException(new ClusterStorageCapacityExceededException());
@@ -90,7 +90,7 @@ public class TestYarnChild {
   }
 
   @Test
-  void testReportErrorWhenCapacityExceptionHappenAndFastFailEnabled()
+  public void testReportErrorWhenCapacityExceptionHappenAndFastFailEnabled()
       throws IOException {
     Exception exception =
         new RuntimeException(new ClusterStorageCapacityExceededException());
@@ -100,7 +100,7 @@ public class TestYarnChild {
   }
 
   @Test
-  void testReportErrorWhenCapacityExceptionHappenInThirdOfExceptionChain()
+  public void testReportErrorWhenCapacityExceptionHappenInThirdOfExceptionChain()
       throws IOException {
     Exception exception = new RuntimeException(new IllegalStateException(
         new ClusterStorageCapacityExceededException()));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestYarnChild.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestYarnChild.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ClusterStorageCapacityExceededException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.*;
 
@@ -36,7 +36,7 @@ public class TestYarnChild {
   final static private String KILL_LIMIT_EXCEED_CONF_NAME =
       "mapreduce.job.dfs.storage.capacity.kill-limit-exceed";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     task = mock(Task.class);
     umbilical = mock(TaskUmbilicalProtocol.class);
@@ -45,7 +45,7 @@ public class TestYarnChild {
   }
 
   @Test
-  public void testReportErrorWhenCapacityExceptionNotHappenByDefault()
+  void testReportErrorWhenCapacityExceptionNotHappenByDefault()
       throws IOException {
     Exception exception = new RuntimeException(new IOException());
 
@@ -53,7 +53,7 @@ public class TestYarnChild {
   }
 
   @Test
-  public void testReportErrorWhenCapacityExceptionNotHappenAndFastFailDisabled()
+  void testReportErrorWhenCapacityExceptionNotHappenAndFastFailDisabled()
       throws IOException {
     Exception exception = new RuntimeException(new IOException());
     conf.setBoolean(KILL_LIMIT_EXCEED_CONF_NAME, false);
@@ -62,7 +62,7 @@ public class TestYarnChild {
   }
 
   @Test
-  public void testReportErrorWhenCapacityExceptionNotHappenAndFastFailEnabled()
+  void testReportErrorWhenCapacityExceptionNotHappenAndFastFailEnabled()
       throws IOException {
     Exception exception = new RuntimeException(new IOException());
     conf.setBoolean(KILL_LIMIT_EXCEED_CONF_NAME, true);
@@ -71,7 +71,7 @@ public class TestYarnChild {
   }
 
   @Test
-  public void testReportErrorWhenCapacityExceptionHappenByDefault()
+  void testReportErrorWhenCapacityExceptionHappenByDefault()
       throws IOException {
     Exception exception =
         new RuntimeException(new ClusterStorageCapacityExceededException());
@@ -80,7 +80,7 @@ public class TestYarnChild {
   }
 
   @Test
-  public void testReportErrorWhenCapacityExceptionHappenAndFastFailDisabled()
+  void testReportErrorWhenCapacityExceptionHappenAndFastFailDisabled()
       throws IOException {
     Exception exception =
         new RuntimeException(new ClusterStorageCapacityExceededException());
@@ -90,7 +90,7 @@ public class TestYarnChild {
   }
 
   @Test
-  public void testReportErrorWhenCapacityExceptionHappenAndFastFailEnabled()
+  void testReportErrorWhenCapacityExceptionHappenAndFastFailEnabled()
       throws IOException {
     Exception exception =
         new RuntimeException(new ClusterStorageCapacityExceededException());
@@ -100,7 +100,7 @@ public class TestYarnChild {
   }
 
   @Test
-  public void testReportErrorWhenCapacityExceptionHappenInThirdOfExceptionChain()
+  void testReportErrorWhenCapacityExceptionHappenInThirdOfExceptionChain()
       throws IOException {
     Exception exception = new RuntimeException(new IllegalStateException(
         new ClusterStorageCapacityExceededException()));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestEvents.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestEvents.java
@@ -53,7 +53,7 @@ public class TestEvents {
    */
   @Test
   @Timeout(10000)
-  void testTaskAttemptFinishedEvent() throws Exception {
+  public void testTaskAttemptFinishedEvent() throws Exception {
     JobID jid = new JobID("001", 1);
     TaskID tid = new TaskID(jid, TaskType.REDUCE, 2);
     TaskAttemptID taskAttemptId = new TaskAttemptID(tid, 3);
@@ -82,7 +82,7 @@ public class TestEvents {
 
   @Test
   @Timeout(10000)
-  void testJobPriorityChange() throws Exception {
+  public void testJobPriorityChange() throws Exception {
     org.apache.hadoop.mapreduce.JobID jid = new JobID("001", 1);
     JobPriorityChangeEvent test = new JobPriorityChangeEvent(jid,
         JobPriority.LOW);
@@ -92,7 +92,7 @@ public class TestEvents {
 
   @Test
   @Timeout(10000)
-  void testJobQueueChange() throws Exception {
+  public void testJobQueueChange() throws Exception {
     org.apache.hadoop.mapreduce.JobID jid = new JobID("001", 1);
     JobQueueChangeEvent test = new JobQueueChangeEvent(jid,
         "newqueue");
@@ -107,7 +107,7 @@ public class TestEvents {
    */
   @Test
   @Timeout(10000)
-  void testTaskUpdated() throws Exception {
+  public void testTaskUpdated() throws Exception {
     JobID jid = new JobID("001", 1);
     TaskID tid = new TaskID(jid, TaskType.REDUCE, 2);
     TaskUpdatedEvent test = new TaskUpdatedEvent(tid, 1234L);
@@ -122,7 +122,7 @@ public class TestEvents {
    */
   @Test
   @Timeout(10000)
-  void testEvents() throws Exception {
+  public void testEvents() throws Exception {
     EventReader reader = new EventReader(new DataInputStream(
         new ByteArrayInputStream(getEvents())));
     HistoryEvent e = reader.getNextEvent();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestEvents.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestEvents.java
@@ -19,8 +19,8 @@
 package org.apache.hadoop.mapreduce.jobhistory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -40,7 +40,8 @@ import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.mapreduce.v2.app.job.impl.JobImpl;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineEvent;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineMetric;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestEvents {
 
@@ -50,9 +51,9 @@ public class TestEvents {
    * 
    * @throws Exception
    */
-  @Test(timeout = 10000)
-  public void testTaskAttemptFinishedEvent() throws Exception {
-
+  @Test
+  @Timeout(10000)
+  void testTaskAttemptFinishedEvent() throws Exception {
     JobID jid = new JobID("001", 1);
     TaskID tid = new TaskID(jid, TaskType.REDUCE, 2);
     TaskAttemptID taskAttemptId = new TaskAttemptID(tid, 3);
@@ -79,18 +80,19 @@ public class TestEvents {
    * @throws Exception
    */
 
-  @Test(timeout = 10000)
-  public void testJobPriorityChange() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testJobPriorityChange() throws Exception {
     org.apache.hadoop.mapreduce.JobID jid = new JobID("001", 1);
     JobPriorityChangeEvent test = new JobPriorityChangeEvent(jid,
         JobPriority.LOW);
     assertThat(test.getJobId().toString()).isEqualTo(jid.toString());
     assertThat(test.getPriority()).isEqualTo(JobPriority.LOW);
-
   }
-  
-  @Test(timeout = 10000)
-  public void testJobQueueChange() throws Exception {
+
+  @Test
+  @Timeout(10000)
+  void testJobQueueChange() throws Exception {
     org.apache.hadoop.mapreduce.JobID jid = new JobID("001", 1);
     JobQueueChangeEvent test = new JobQueueChangeEvent(jid,
         "newqueue");
@@ -103,14 +105,14 @@ public class TestEvents {
    * 
    * @throws Exception
    */
-  @Test(timeout = 10000)
-  public void testTaskUpdated() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testTaskUpdated() throws Exception {
     JobID jid = new JobID("001", 1);
     TaskID tid = new TaskID(jid, TaskType.REDUCE, 2);
     TaskUpdatedEvent test = new TaskUpdatedEvent(tid, 1234L);
     assertThat(test.getTaskId().toString()).isEqualTo(tid.toString());
     assertThat(test.getFinishTime()).isEqualTo(1234L);
-
   }
 
   /*
@@ -118,9 +120,9 @@ public class TestEvents {
    * instance of HistoryEvent Different HistoryEvent should have a different
    * datum.
    */
-  @Test(timeout = 10000)
-  public void testEvents() throws Exception {
-
+  @Test
+  @Timeout(10000)
+  void testEvents() throws Exception {
     EventReader reader = new EventReader(new DataInputStream(
         new ByteArrayInputStream(getEvents())));
     HistoryEvent e = reader.getNextEvent();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestJobHistoryEventHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestJobHistoryEventHandler.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.mapreduce.jobhistory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -81,11 +81,12 @@ import org.apache.hadoop.yarn.event.DrainDispatcher;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.server.MiniYARNCluster;
 import org.apache.hadoop.yarn.server.timeline.TimelineStore;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -101,7 +102,7 @@ public class TestJobHistoryEventHandler {
   private static MiniDFSCluster dfsCluster = null;
   private static String coreSitePath;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass() throws Exception {
     coreSitePath = "." + File.separator + "target" + File.separator +
             "test-classes" + File.separator + "core-site.xml";
@@ -109,17 +110,18 @@ public class TestJobHistoryEventHandler {
     dfsCluster = new MiniDFSCluster.Builder(conf).build();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUpClass() throws Exception {
     dfsCluster.shutdown();
   }
 
-  @After
+  @AfterEach
   public void cleanTest() throws Exception {
     new File(coreSitePath).delete();
   }
 
-  @Test (timeout=50000)
+  @Test
+  @Timeout(50000)
   public void testFirstFlushOnCompletionEvent() throws Exception {
     TestParams t = new TestParams();
     Configuration conf = new Configuration();
@@ -162,8 +164,9 @@ public class TestJobHistoryEventHandler {
     }
   }
 
-  @Test (timeout=50000)
-  public void testMaxUnflushedCompletionEvents() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testMaxUnflushedCompletionEvents() throws Exception {
     TestParams t = new TestParams();
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, t.workDir);
@@ -207,8 +210,9 @@ public class TestJobHistoryEventHandler {
     }
   }
 
-  @Test (timeout=50000)
-  public void testUnflushedTimer() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testUnflushedTimer() throws Exception {
     TestParams t = new TestParams();
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, t.workDir);
@@ -232,26 +236,27 @@ public class TestJobHistoryEventHandler {
       mockWriter = jheh.getEventWriter();
       verify(mockWriter).write(any(HistoryEvent.class));
 
-      for (int i = 0 ; i < 100 ; i++) {
+      for (int i = 0; i < 100; i++) {
         queueEvent(jheh, new JobHistoryEvent(t.jobId, new TaskFinishedEvent(
             t.taskID, t.taskAttemptID, 0, TaskType.MAP, "", null, 0)));
       }
 
       handleNextNEvents(jheh, 9);
-      Assert.assertTrue(jheh.getFlushTimerStatus());
+      Assertions.assertTrue(jheh.getFlushTimerStatus());
       verify(mockWriter, times(0)).flush();
 
       Thread.sleep(2 * 4 * 1000l); // 4 seconds should be enough. Just be safe.
       verify(mockWriter).flush();
-      Assert.assertFalse(jheh.getFlushTimerStatus());
+      Assertions.assertFalse(jheh.getFlushTimerStatus());
     } finally {
       jheh.stop();
       verify(mockWriter).close();
     }
   }
 
-  @Test (timeout=50000)
-  public void testBatchedFlushJobEndMultiplier() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testBatchedFlushJobEndMultiplier() throws Exception {
     TestParams t = new TestParams();
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, t.workDir);
@@ -295,8 +300,9 @@ public class TestJobHistoryEventHandler {
   }
 
   // In case of all types of events, process Done files if it's last AM retry
-  @Test (timeout=50000)
-  public void testProcessDoneFilesOnLastAMRetry() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testProcessDoneFilesOnLastAMRetry() throws Exception {
     TestParams t = new TestParams(true);
     Configuration conf = new Configuration();
 
@@ -309,12 +315,12 @@ public class TestJobHistoryEventHandler {
     try {
       jheh.start();
       handleEvent(jheh, new JobHistoryEvent(t.jobId, new AMStartedEvent(
-        t.appAttemptId, 200, t.containerId, "nmhost", 3000, 4000, -1)));
+          t.appAttemptId, 200, t.containerId, "nmhost", 3000, 4000, -1)));
       verify(jheh, times(0)).processDoneFiles(any(JobId.class));
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-        new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
-          0, 0, 0, 0, 0, 0, JobStateInternal.ERROR.toString())));
+          new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
+              0, 0, 0, 0, 0, 0, JobStateInternal.ERROR.toString())));
       verify(jheh, times(1)).processDoneFiles(any(JobId.class));
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId, new JobFinishedEvent(
@@ -323,13 +329,13 @@ public class TestJobHistoryEventHandler {
       verify(jheh, times(2)).processDoneFiles(any(JobId.class));
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-        new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
-          0, 0, 0, 0, 0, 0, JobStateInternal.FAILED.toString())));
+          new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
+              0, 0, 0, 0, 0, 0, JobStateInternal.FAILED.toString())));
       verify(jheh, times(3)).processDoneFiles(any(JobId.class));
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-        new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
-          0, 0, 0, 0, 0, 0, JobStateInternal.KILLED.toString())));
+          new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
+              0, 0, 0, 0, 0, 0, JobStateInternal.KILLED.toString())));
       verify(jheh, times(4)).processDoneFiles(any(JobId.class));
 
       mockWriter = jheh.getEventWriter();
@@ -341,8 +347,9 @@ public class TestJobHistoryEventHandler {
   }
 
   // Skip processing Done files in case of ERROR, if it's not last AM retry
-  @Test (timeout=50000)
-  public void testProcessDoneFilesNotLastAMRetry() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testProcessDoneFilesNotLastAMRetry() throws Exception {
     TestParams t = new TestParams(false);
     Configuration conf = new Configuration();
     JHEvenHandlerForTest realJheh =
@@ -354,13 +361,13 @@ public class TestJobHistoryEventHandler {
     try {
       jheh.start();
       handleEvent(jheh, new JobHistoryEvent(t.jobId, new AMStartedEvent(
-        t.appAttemptId, 200, t.containerId, "nmhost", 3000, 4000, -1)));
+          t.appAttemptId, 200, t.containerId, "nmhost", 3000, 4000, -1)));
       verify(jheh, times(0)).processDoneFiles(t.jobId);
 
       // skip processing done files
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-        new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
-          0, 0, 0, 0, 0, 0, JobStateInternal.ERROR.toString())));
+          new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
+              0, 0, 0, 0, 0, 0, JobStateInternal.ERROR.toString())));
       verify(jheh, times(0)).processDoneFiles(t.jobId);
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId, new JobFinishedEvent(
@@ -369,13 +376,13 @@ public class TestJobHistoryEventHandler {
       verify(jheh, times(1)).processDoneFiles(t.jobId);
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-        new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
-          0, 0, 0, 0, 0, 0, JobStateInternal.FAILED.toString())));
+          new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
+              0, 0, 0, 0, 0, 0, JobStateInternal.FAILED.toString())));
       verify(jheh, times(2)).processDoneFiles(t.jobId);
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-        new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
-          0, 0, 0, 0, 0, 0, JobStateInternal.KILLED.toString())));
+          new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
+              0, 0, 0, 0, 0, 0, JobStateInternal.KILLED.toString())));
       verify(jheh, times(3)).processDoneFiles(t.jobId);
 
       mockWriter = jheh.getEventWriter();
@@ -387,7 +394,7 @@ public class TestJobHistoryEventHandler {
   }
 
   @Test
-  public void testPropertyRedactionForJHS() throws Exception {
+  void testPropertyRedactionForJHS() throws Exception {
     final Configuration conf = new Configuration();
 
     String sensitivePropertyName = "aws.fake.credentials.name";
@@ -421,16 +428,15 @@ public class TestJobHistoryEventHandler {
 
       // load the job_conf.xml in JHS directory and verify property redaction.
       Path jhsJobConfFile = getJobConfInIntermediateDoneDir(conf, params.jobId);
-      Assert.assertTrue("The job_conf.xml file is not in the JHS directory",
-          FileContext.getFileContext(conf).util().exists(jhsJobConfFile));
+      Assertions.assertTrue(FileContext.getFileContext(conf).util().exists(jhsJobConfFile),
+          "The job_conf.xml file is not in the JHS directory");
       Configuration jhsJobConf = new Configuration();
 
       try (InputStream input = FileSystem.get(conf).open(jhsJobConfFile)) {
         jhsJobConf.addResource(input);
-        Assert.assertEquals(
-            sensitivePropertyName + " is not redacted in HDFS.",
-            MRJobConfUtil.REDACTION_REPLACEMENT_VAL,
-            jhsJobConf.get(sensitivePropertyName));
+        Assertions.assertEquals(MRJobConfUtil.REDACTION_REPLACEMENT_VAL,
+            jhsJobConf.get(sensitivePropertyName),
+            sensitivePropertyName + " is not redacted in HDFS.");
       }
     } finally {
       jheh.stop();
@@ -456,19 +462,20 @@ public class TestJobHistoryEventHandler {
     fs.delete(new Path(intermDoneDirPrefix), true);
   }
 
-  @Test (timeout=50000)
-  public void testDefaultFsIsUsedForHistory() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testDefaultFsIsUsedForHistory() throws Exception {
     // Create default configuration pointing to the minicluster
     Configuration conf = new Configuration();
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY,
-            dfsCluster.getURI().toString());
+        dfsCluster.getURI().toString());
     FileOutputStream os = new FileOutputStream(coreSitePath);
     conf.writeXml(os);
     os.close();
 
     // simulate execution under a non-default namenode
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY,
-            "file:///");
+        "file:///");
 
     TestParams t = new TestParams();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, t.dfsWorkDir);
@@ -490,11 +497,11 @@ public class TestJobHistoryEventHandler {
       // If we got here then event handler worked but we don't know with which
       // file system. Now we check that history stuff was written to minicluster
       FileSystem dfsFileSystem = dfsCluster.getFileSystem();
-      assertTrue("Minicluster contains some history files",
-          dfsFileSystem.globStatus(new Path(t.dfsWorkDir + "/*")).length != 0);
+      assertTrue(dfsFileSystem.globStatus(new Path(t.dfsWorkDir + "/*")).length != 0,
+          "Minicluster contains some history files");
       FileSystem localFileSystem = LocalFileSystem.get(conf);
-      assertFalse("No history directory on non-default file system",
-          localFileSystem.exists(new Path(t.dfsWorkDir)));
+      assertFalse(localFileSystem.exists(new Path(t.dfsWorkDir)),
+          "No history directory on non-default file system");
     } finally {
       jheh.stop();
       purgeHdfsHistoryIntermediateDoneDirectory(conf);
@@ -502,14 +509,14 @@ public class TestJobHistoryEventHandler {
   }
 
   @Test
-  public void testGetHistoryIntermediateDoneDirForUser() throws IOException {
+  void testGetHistoryIntermediateDoneDirForUser() throws IOException {
     // Test relative path
     Configuration conf = new Configuration();
     conf.set(JHAdminConfig.MR_HISTORY_INTERMEDIATE_DONE_DIR,
         "/mapred/history/done_intermediate");
     conf.set(MRJobConfig.USER_NAME, System.getProperty("user.name"));
     String pathStr = JobHistoryUtils.getHistoryIntermediateDoneDirForUser(conf);
-    Assert.assertEquals("/mapred/history/done_intermediate/" +
+    Assertions.assertEquals("/mapred/history/done_intermediate/" +
         System.getProperty("user.name"), pathStr);
 
     // Test fully qualified path
@@ -523,14 +530,15 @@ public class TestJobHistoryEventHandler {
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY,
             "file:///");
     pathStr = JobHistoryUtils.getHistoryIntermediateDoneDirForUser(conf);
-    Assert.assertEquals(dfsCluster.getURI().toString() +
+    Assertions.assertEquals(dfsCluster.getURI().toString() +
         "/mapred/history/done_intermediate/" + System.getProperty("user.name"),
         pathStr);
   }
 
   // test AMStartedEvent for submitTime and startTime
-  @Test (timeout=50000)
-  public void testAMStartedEvent() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testAMStartedEvent() throws Exception {
     TestParams t = new TestParams();
     Configuration conf = new Configuration();
 
@@ -571,8 +579,9 @@ public class TestJobHistoryEventHandler {
 
   // Have JobHistoryEventHandler handle some events and make sure they get
   // stored to the Timeline store
-  @Test (timeout=50000)
-  public void testTimelineEventHandling() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testTimelineEventHandling() throws Exception {
     TestParams t = new TestParams(RunningAppContext.class, false);
     Configuration conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.TIMELINE_SERVICE_ENABLED, true);
@@ -598,13 +607,13 @@ public class TestJobHistoryEventHandler {
       jheh.getDispatcher().await();
       TimelineEntities entities = ts.getEntities("MAPREDUCE_JOB", null, null,
               null, null, null, null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+      Assertions.assertEquals(1, entities.getEntities().size());
       TimelineEntity tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(t.jobId.toString(), tEntity.getEntityId());
-      Assert.assertEquals(1, tEntity.getEvents().size());
-      Assert.assertEquals(EventType.AM_STARTED.toString(),
+      Assertions.assertEquals(t.jobId.toString(), tEntity.getEntityId());
+      Assertions.assertEquals(1, tEntity.getEvents().size());
+      Assertions.assertEquals(EventType.AM_STARTED.toString(),
               tEntity.getEvents().get(0).getEventType());
-      Assert.assertEquals(currentTime - 10,
+      Assertions.assertEquals(currentTime - 10,
               tEntity.getEvents().get(0).getTimestamp());
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
@@ -615,17 +624,17 @@ public class TestJobHistoryEventHandler {
       jheh.getDispatcher().await();
       entities = ts.getEntities("MAPREDUCE_JOB", null, null, null,
               null, null, null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+      Assertions.assertEquals(1, entities.getEntities().size());
       tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(t.jobId.toString(), tEntity.getEntityId());
-      Assert.assertEquals(2, tEntity.getEvents().size());
-      Assert.assertEquals(EventType.JOB_SUBMITTED.toString(),
+      Assertions.assertEquals(t.jobId.toString(), tEntity.getEntityId());
+      Assertions.assertEquals(2, tEntity.getEvents().size());
+      Assertions.assertEquals(EventType.JOB_SUBMITTED.toString(),
               tEntity.getEvents().get(0).getEventType());
-      Assert.assertEquals(EventType.AM_STARTED.toString(),
+      Assertions.assertEquals(EventType.AM_STARTED.toString(),
               tEntity.getEvents().get(1).getEventType());
-      Assert.assertEquals(currentTime + 10,
+      Assertions.assertEquals(currentTime + 10,
               tEntity.getEvents().get(0).getTimestamp());
-      Assert.assertEquals(currentTime - 10,
+      Assertions.assertEquals(currentTime - 10,
               tEntity.getEvents().get(1).getTimestamp());
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
@@ -634,80 +643,80 @@ public class TestJobHistoryEventHandler {
       jheh.getDispatcher().await();
       entities = ts.getEntities("MAPREDUCE_JOB", null, null, null,
               null, null, null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+      Assertions.assertEquals(1, entities.getEntities().size());
       tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(t.jobId.toString(), tEntity.getEntityId());
-      Assert.assertEquals(3, tEntity.getEvents().size());
-      Assert.assertEquals(EventType.JOB_SUBMITTED.toString(),
+      Assertions.assertEquals(t.jobId.toString(), tEntity.getEntityId());
+      Assertions.assertEquals(3, tEntity.getEvents().size());
+      Assertions.assertEquals(EventType.JOB_SUBMITTED.toString(),
               tEntity.getEvents().get(0).getEventType());
-      Assert.assertEquals(EventType.AM_STARTED.toString(),
+      Assertions.assertEquals(EventType.AM_STARTED.toString(),
               tEntity.getEvents().get(1).getEventType());
-      Assert.assertEquals(EventType.JOB_QUEUE_CHANGED.toString(),
+      Assertions.assertEquals(EventType.JOB_QUEUE_CHANGED.toString(),
               tEntity.getEvents().get(2).getEventType());
-      Assert.assertEquals(currentTime + 10,
+      Assertions.assertEquals(currentTime + 10,
               tEntity.getEvents().get(0).getTimestamp());
-      Assert.assertEquals(currentTime - 10,
+      Assertions.assertEquals(currentTime - 10,
               tEntity.getEvents().get(1).getTimestamp());
-      Assert.assertEquals(currentTime - 20,
+      Assertions.assertEquals(currentTime - 20,
               tEntity.getEvents().get(2).getTimestamp());
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-              new JobFinishedEvent(TypeConverter.fromYarn(t.jobId), 0, 0, 0, 0,
+          new JobFinishedEvent(TypeConverter.fromYarn(t.jobId), 0, 0, 0, 0,
               0, 0, 0, new Counters(), new Counters(), new Counters()), currentTime));
       jheh.getDispatcher().await();
       entities = ts.getEntities("MAPREDUCE_JOB", null, null, null,
-              null, null, null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+          null, null, null, null, null, null);
+      Assertions.assertEquals(1, entities.getEntities().size());
       tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(t.jobId.toString(), tEntity.getEntityId());
-      Assert.assertEquals(4, tEntity.getEvents().size());
-      Assert.assertEquals(EventType.JOB_SUBMITTED.toString(),
+      Assertions.assertEquals(t.jobId.toString(), tEntity.getEntityId());
+      Assertions.assertEquals(4, tEntity.getEvents().size());
+      Assertions.assertEquals(EventType.JOB_SUBMITTED.toString(),
               tEntity.getEvents().get(0).getEventType());
-      Assert.assertEquals(EventType.JOB_FINISHED.toString(),
+      Assertions.assertEquals(EventType.JOB_FINISHED.toString(),
               tEntity.getEvents().get(1).getEventType());
-      Assert.assertEquals(EventType.AM_STARTED.toString(),
+      Assertions.assertEquals(EventType.AM_STARTED.toString(),
               tEntity.getEvents().get(2).getEventType());
-      Assert.assertEquals(EventType.JOB_QUEUE_CHANGED.toString(),
+      Assertions.assertEquals(EventType.JOB_QUEUE_CHANGED.toString(),
               tEntity.getEvents().get(3).getEventType());
-      Assert.assertEquals(currentTime + 10,
+      Assertions.assertEquals(currentTime + 10,
               tEntity.getEvents().get(0).getTimestamp());
-      Assert.assertEquals(currentTime,
+      Assertions.assertEquals(currentTime,
               tEntity.getEvents().get(1).getTimestamp());
-      Assert.assertEquals(currentTime - 10,
+      Assertions.assertEquals(currentTime - 10,
               tEntity.getEvents().get(2).getTimestamp());
-      Assert.assertEquals(currentTime - 20,
+      Assertions.assertEquals(currentTime - 20,
               tEntity.getEvents().get(3).getTimestamp());
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
             new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId),
             0, 0, 0, 0, 0, 0, 0, JobStateInternal.KILLED.toString()),
-            currentTime + 20));
+          currentTime + 20));
       jheh.getDispatcher().await();
       entities = ts.getEntities("MAPREDUCE_JOB", null, null, null,
               null, null, null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+      Assertions.assertEquals(1, entities.getEntities().size());
       tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(t.jobId.toString(), tEntity.getEntityId());
-      Assert.assertEquals(5, tEntity.getEvents().size());
-      Assert.assertEquals(EventType.JOB_KILLED.toString(),
+      Assertions.assertEquals(t.jobId.toString(), tEntity.getEntityId());
+      Assertions.assertEquals(5, tEntity.getEvents().size());
+      Assertions.assertEquals(EventType.JOB_KILLED.toString(),
               tEntity.getEvents().get(0).getEventType());
-      Assert.assertEquals(EventType.JOB_SUBMITTED.toString(),
+      Assertions.assertEquals(EventType.JOB_SUBMITTED.toString(),
               tEntity.getEvents().get(1).getEventType());
-      Assert.assertEquals(EventType.JOB_FINISHED.toString(),
+      Assertions.assertEquals(EventType.JOB_FINISHED.toString(),
               tEntity.getEvents().get(2).getEventType());
-      Assert.assertEquals(EventType.AM_STARTED.toString(),
+      Assertions.assertEquals(EventType.AM_STARTED.toString(),
               tEntity.getEvents().get(3).getEventType());
-      Assert.assertEquals(EventType.JOB_QUEUE_CHANGED.toString(),
+      Assertions.assertEquals(EventType.JOB_QUEUE_CHANGED.toString(),
               tEntity.getEvents().get(4).getEventType());
-      Assert.assertEquals(currentTime + 20,
+      Assertions.assertEquals(currentTime + 20,
               tEntity.getEvents().get(0).getTimestamp());
-      Assert.assertEquals(currentTime + 10,
+      Assertions.assertEquals(currentTime + 10,
               tEntity.getEvents().get(1).getTimestamp());
-      Assert.assertEquals(currentTime,
+      Assertions.assertEquals(currentTime,
               tEntity.getEvents().get(2).getTimestamp());
-      Assert.assertEquals(currentTime - 10,
+      Assertions.assertEquals(currentTime - 10,
               tEntity.getEvents().get(3).getTimestamp());
-      Assert.assertEquals(currentTime - 20,
+      Assertions.assertEquals(currentTime - 20,
               tEntity.getEvents().get(4).getTimestamp());
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
@@ -715,13 +724,13 @@ public class TestJobHistoryEventHandler {
       jheh.getDispatcher().await();
       entities = ts.getEntities("MAPREDUCE_TASK", null, null, null,
               null, null, null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+      Assertions.assertEquals(1, entities.getEntities().size());
       tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(t.taskID.toString(), tEntity.getEntityId());
-      Assert.assertEquals(1, tEntity.getEvents().size());
-      Assert.assertEquals(EventType.TASK_STARTED.toString(),
+      Assertions.assertEquals(t.taskID.toString(), tEntity.getEntityId());
+      Assertions.assertEquals(1, tEntity.getEvents().size());
+      Assertions.assertEquals(EventType.TASK_STARTED.toString(),
               tEntity.getEvents().get(0).getEventType());
-      Assert.assertEquals(TaskType.MAP.toString(),
+      Assertions.assertEquals(TaskType.MAP.toString(),
               tEntity.getEvents().get(0).getEventInfo().get("TASK_TYPE"));
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
@@ -729,30 +738,31 @@ public class TestJobHistoryEventHandler {
       jheh.getDispatcher().await();
       entities = ts.getEntities("MAPREDUCE_TASK", null, null, null,
               null, null, null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+      Assertions.assertEquals(1, entities.getEntities().size());
       tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(t.taskID.toString(), tEntity.getEntityId());
-      Assert.assertEquals(2, tEntity.getEvents().size());
-      Assert.assertEquals(EventType.TASK_STARTED.toString(),
+      Assertions.assertEquals(t.taskID.toString(), tEntity.getEntityId());
+      Assertions.assertEquals(2, tEntity.getEvents().size());
+      Assertions.assertEquals(EventType.TASK_STARTED.toString(),
               tEntity.getEvents().get(1).getEventType());
-      Assert.assertEquals(TaskType.REDUCE.toString(),
+      Assertions.assertEquals(TaskType.REDUCE.toString(),
               tEntity.getEvents().get(0).getEventInfo().get("TASK_TYPE"));
-      Assert.assertEquals(TaskType.MAP.toString(),
+      Assertions.assertEquals(TaskType.MAP.toString(),
               tEntity.getEvents().get(1).getEventInfo().get("TASK_TYPE"));
     }
   }
 
-  @Test (timeout=50000)
-  public void testCountersToJSON() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testCountersToJSON() throws Exception {
     JobHistoryEventHandler jheh = new JobHistoryEventHandler(null, 0);
     Counters counters = new Counters();
     CounterGroup group1 = counters.addGroup("DOCTORS",
-            "Incarnations of the Doctor");
+        "Incarnations of the Doctor");
     group1.addCounter("PETER_CAPALDI", "Peter Capaldi", 12);
     group1.addCounter("MATT_SMITH", "Matt Smith", 11);
     group1.addCounter("DAVID_TENNANT", "David Tennant", 10);
     CounterGroup group2 = counters.addGroup("COMPANIONS",
-            "Companions of the Doctor");
+        "Companions of the Doctor");
     group2.addCounter("CLARA_OSWALD", "Clara Oswald", 6);
     group2.addCounter("RORY_WILLIAMS", "Rory Williams", 5);
     group2.addCounter("AMY_POND", "Amy Pond", 4);
@@ -775,30 +785,31 @@ public class TestJobHistoryEventHandler {
         + "{\"NAME\":\"MATT_SMITH\",\"DISPLAY_NAME\":\"Matt Smith\",\"VALUE\":"
         + "11},{\"NAME\":\"PETER_CAPALDI\",\"DISPLAY_NAME\":\"Peter Capaldi\","
         + "\"VALUE\":12}]}]";
-    Assert.assertEquals(expected, jsonStr);
+    Assertions.assertEquals(expected, jsonStr);
   }
 
-  @Test (timeout=50000)
-  public void testCountersToJSONEmpty() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testCountersToJSONEmpty() throws Exception {
     JobHistoryEventHandler jheh = new JobHistoryEventHandler(null, 0);
     Counters counters = null;
     JsonNode jsonNode = JobHistoryEventUtils.countersToJSON(counters);
     String jsonStr = new ObjectMapper().writeValueAsString(jsonNode);
     String expected = "[]";
-    Assert.assertEquals(expected, jsonStr);
+    Assertions.assertEquals(expected, jsonStr);
 
     counters = new Counters();
     jsonNode = JobHistoryEventUtils.countersToJSON(counters);
     jsonStr = new ObjectMapper().writeValueAsString(jsonNode);
     expected = "[]";
-    Assert.assertEquals(expected, jsonStr);
+    Assertions.assertEquals(expected, jsonStr);
 
     counters.addGroup("DOCTORS", "Incarnations of the Doctor");
     jsonNode = JobHistoryEventUtils.countersToJSON(counters);
     jsonStr = new ObjectMapper().writeValueAsString(jsonNode);
     expected = "[{\"NAME\":\"DOCTORS\",\"DISPLAY_NAME\":\"Incarnations of the "
         + "Doctor\",\"COUNTERS\":[]}]";
-    Assert.assertEquals(expected, jsonStr);
+    Assertions.assertEquals(expected, jsonStr);
   }
 
   private void queueEvent(JHEvenHandlerForTest jheh, JobHistoryEvent event) {
@@ -895,7 +906,7 @@ public class TestJobHistoryEventHandler {
    * a JobUnsuccessfulEvent for jobs which were still running (so that they may
    * show up in the JobHistoryServer)
    */
-  public void testSigTermedFunctionality() throws IOException {
+  void testSigTermedFunctionality() throws IOException {
     AppContext mockedContext = Mockito.mock(AppContext.class);
     JHEventHandlerForSigtermTest jheh =
       new JHEventHandlerForSigtermTest(mockedContext, 0);
@@ -912,8 +923,9 @@ public class TestJobHistoryEventHandler {
     }
     jheh.stop();
     //Make sure events were handled
-    assertTrue("handleEvent should've been called only 4 times but was "
-      + jheh.eventsHandled, jheh.eventsHandled == 4);
+    assertTrue(jheh.eventsHandled == 4,
+        "handleEvent should've been called only 4 times but was "
+        + jheh.eventsHandled);
 
     //Create a new jheh because the last stop closed the eventWriter etc.
     jheh = new JHEventHandlerForSigtermTest(mockedContext, 0);
@@ -934,15 +946,16 @@ public class TestJobHistoryEventHandler {
     }
     jheh.stop();
     //Make sure events were handled, 4 + 1 finish event
-    assertTrue("handleEvent should've been called only 5 times but was "
-        + jheh.eventsHandled, jheh.eventsHandled == 5);
-    assertTrue("Last event handled wasn't JobUnsuccessfulCompletionEvent",
-        jheh.lastEventHandled.getHistoryEvent()
-        instanceof JobUnsuccessfulCompletionEvent);
+    assertTrue(jheh.eventsHandled == 5, "handleEvent should've been called only 5 times but was "
+        + jheh.eventsHandled);
+    assertTrue(jheh.lastEventHandled.getHistoryEvent()
+        instanceof JobUnsuccessfulCompletionEvent,
+        "Last event handled wasn't JobUnsuccessfulCompletionEvent");
   }
 
-  @Test (timeout=50000)
-  public void testSetTrackingURLAfterHistoryIsWritten() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testSetTrackingURLAfterHistoryIsWritten() throws Exception {
     TestParams t = new TestParams(true);
     Configuration conf = new Configuration();
 
@@ -972,8 +985,9 @@ public class TestJobHistoryEventHandler {
     }
   }
 
-  @Test (timeout=50000)
-  public void testDontSetTrackingURLIfHistoryWriteFailed() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testDontSetTrackingURLIfHistoryWriteFailed() throws Exception {
     TestParams t = new TestParams(true);
     Configuration conf = new Configuration();
 
@@ -1003,8 +1017,9 @@ public class TestJobHistoryEventHandler {
       jheh.stop();
     }
   }
-  @Test (timeout=50000)
-  public void testDontSetTrackingURLIfHistoryWriteThrows() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testDontSetTrackingURLIfHistoryWriteThrows() throws Exception {
     TestParams t = new TestParams(true);
     Configuration conf = new Configuration();
 
@@ -1039,8 +1054,9 @@ public class TestJobHistoryEventHandler {
     }
   }
 
-  @Test(timeout = 50000)
-  public void testJobHistoryFilePermissions() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testJobHistoryFilePermissions() throws Exception {
     TestParams t = new TestParams(true);
     Configuration conf = new Configuration();
     String setFilePermission = "777";

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestJobHistoryEventHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestJobHistoryEventHandler.java
@@ -166,7 +166,7 @@ public class TestJobHistoryEventHandler {
 
   @Test
   @Timeout(50000)
-  void testMaxUnflushedCompletionEvents() throws Exception {
+  public void testMaxUnflushedCompletionEvents() throws Exception {
     TestParams t = new TestParams();
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, t.workDir);
@@ -212,7 +212,7 @@ public class TestJobHistoryEventHandler {
 
   @Test
   @Timeout(50000)
-  void testUnflushedTimer() throws Exception {
+  public void testUnflushedTimer() throws Exception {
     TestParams t = new TestParams();
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, t.workDir);
@@ -256,7 +256,7 @@ public class TestJobHistoryEventHandler {
 
   @Test
   @Timeout(50000)
-  void testBatchedFlushJobEndMultiplier() throws Exception {
+  public void testBatchedFlushJobEndMultiplier() throws Exception {
     TestParams t = new TestParams();
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, t.workDir);
@@ -302,7 +302,7 @@ public class TestJobHistoryEventHandler {
   // In case of all types of events, process Done files if it's last AM retry
   @Test
   @Timeout(50000)
-  void testProcessDoneFilesOnLastAMRetry() throws Exception {
+  public void testProcessDoneFilesOnLastAMRetry() throws Exception {
     TestParams t = new TestParams(true);
     Configuration conf = new Configuration();
 
@@ -349,7 +349,7 @@ public class TestJobHistoryEventHandler {
   // Skip processing Done files in case of ERROR, if it's not last AM retry
   @Test
   @Timeout(50000)
-  void testProcessDoneFilesNotLastAMRetry() throws Exception {
+  public void testProcessDoneFilesNotLastAMRetry() throws Exception {
     TestParams t = new TestParams(false);
     Configuration conf = new Configuration();
     JHEvenHandlerForTest realJheh =
@@ -394,7 +394,7 @@ public class TestJobHistoryEventHandler {
   }
 
   @Test
-  void testPropertyRedactionForJHS() throws Exception {
+  public void testPropertyRedactionForJHS() throws Exception {
     final Configuration conf = new Configuration();
 
     String sensitivePropertyName = "aws.fake.credentials.name";
@@ -464,7 +464,7 @@ public class TestJobHistoryEventHandler {
 
   @Test
   @Timeout(50000)
-  void testDefaultFsIsUsedForHistory() throws Exception {
+  public void testDefaultFsIsUsedForHistory() throws Exception {
     // Create default configuration pointing to the minicluster
     Configuration conf = new Configuration();
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY,
@@ -509,7 +509,7 @@ public class TestJobHistoryEventHandler {
   }
 
   @Test
-  void testGetHistoryIntermediateDoneDirForUser() throws IOException {
+  public void testGetHistoryIntermediateDoneDirForUser() throws IOException {
     // Test relative path
     Configuration conf = new Configuration();
     conf.set(JHAdminConfig.MR_HISTORY_INTERMEDIATE_DONE_DIR,
@@ -538,7 +538,7 @@ public class TestJobHistoryEventHandler {
   // test AMStartedEvent for submitTime and startTime
   @Test
   @Timeout(50000)
-  void testAMStartedEvent() throws Exception {
+  public void testAMStartedEvent() throws Exception {
     TestParams t = new TestParams();
     Configuration conf = new Configuration();
 
@@ -581,7 +581,7 @@ public class TestJobHistoryEventHandler {
   // stored to the Timeline store
   @Test
   @Timeout(50000)
-  void testTimelineEventHandling() throws Exception {
+  public void testTimelineEventHandling() throws Exception {
     TestParams t = new TestParams(RunningAppContext.class, false);
     Configuration conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.TIMELINE_SERVICE_ENABLED, true);
@@ -753,7 +753,7 @@ public class TestJobHistoryEventHandler {
 
   @Test
   @Timeout(50000)
-  void testCountersToJSON() throws Exception {
+  public void testCountersToJSON() throws Exception {
     JobHistoryEventHandler jheh = new JobHistoryEventHandler(null, 0);
     Counters counters = new Counters();
     CounterGroup group1 = counters.addGroup("DOCTORS",
@@ -790,7 +790,7 @@ public class TestJobHistoryEventHandler {
 
   @Test
   @Timeout(50000)
-  void testCountersToJSONEmpty() throws Exception {
+  public void testCountersToJSONEmpty() throws Exception {
     JobHistoryEventHandler jheh = new JobHistoryEventHandler(null, 0);
     Counters counters = null;
     JsonNode jsonNode = JobHistoryEventUtils.countersToJSON(counters);
@@ -906,7 +906,7 @@ public class TestJobHistoryEventHandler {
    * a JobUnsuccessfulEvent for jobs which were still running (so that they may
    * show up in the JobHistoryServer)
    */
-  void testSigTermedFunctionality() throws IOException {
+  public void testSigTermedFunctionality() throws IOException {
     AppContext mockedContext = Mockito.mock(AppContext.class);
     JHEventHandlerForSigtermTest jheh =
       new JHEventHandlerForSigtermTest(mockedContext, 0);
@@ -955,7 +955,7 @@ public class TestJobHistoryEventHandler {
 
   @Test
   @Timeout(50000)
-  void testSetTrackingURLAfterHistoryIsWritten() throws Exception {
+  public void testSetTrackingURLAfterHistoryIsWritten() throws Exception {
     TestParams t = new TestParams(true);
     Configuration conf = new Configuration();
 
@@ -987,7 +987,7 @@ public class TestJobHistoryEventHandler {
 
   @Test
   @Timeout(50000)
-  void testDontSetTrackingURLIfHistoryWriteFailed() throws Exception {
+  public void testDontSetTrackingURLIfHistoryWriteFailed() throws Exception {
     TestParams t = new TestParams(true);
     Configuration conf = new Configuration();
 
@@ -1019,7 +1019,7 @@ public class TestJobHistoryEventHandler {
   }
   @Test
   @Timeout(50000)
-  void testDontSetTrackingURLIfHistoryWriteThrows() throws Exception {
+  public void testDontSetTrackingURLIfHistoryWriteThrows() throws Exception {
     TestParams t = new TestParams(true);
     Configuration conf = new Configuration();
 
@@ -1056,7 +1056,7 @@ public class TestJobHistoryEventHandler {
 
   @Test
   @Timeout(50000)
-  void testJobHistoryFilePermissions() throws Exception {
+  public void testJobHistoryFilePermissions() throws Exception {
     TestParams t = new TestParams(true);
     Configuration conf = new Configuration();
     String setFilePermission = "777";

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestJobSummary.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestJobSummary.java
@@ -59,7 +59,7 @@ public class TestJobSummary {
   }
 
   @Test
-  void testEscapeJobSummary() {
+  public void testEscapeJobSummary() {
     // verify newlines are escaped
     summary.setJobName("aa\rbb\ncc\r\ndd");
     String out = summary.getJobSummaryString();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestJobSummary.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestJobSummary.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.mapreduce.jobhistory;
 
 import org.apache.hadoop.mapreduce.v2.api.records.JobId;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +34,7 @@ public class TestJobSummary {
       LoggerFactory.getLogger(TestJobSummary.class);
   private JobSummary summary = new JobSummary();
 
-  @Before
+  @BeforeEach
   public void before() {
     JobId mockJobId = mock(JobId.class);
     when(mockJobId.toString()).thenReturn("testJobId");
@@ -59,13 +59,13 @@ public class TestJobSummary {
   }
 
   @Test
-  public void testEscapeJobSummary() {
+  void testEscapeJobSummary() {
     // verify newlines are escaped
     summary.setJobName("aa\rbb\ncc\r\ndd");
     String out = summary.getJobSummaryString();
     LOG.info("summary: " + out);
-    Assert.assertFalse(out.contains("\r"));
-    Assert.assertFalse(out.contains("\n"));
-    Assert.assertTrue(out.contains("aa\\rbb\\ncc\\r\\ndd"));
+    Assertions.assertFalse(out.contains("\r"));
+    Assertions.assertFalse(out.contains("\n"));
+    Assertions.assertTrue(out.contains("aa\\rbb\\ncc\\r\\ndd"));
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/api/records/TestTaskAttemptReport.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/api/records/TestTaskAttemptReport.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestTaskAttemptReport {
 
   @Test
-  void testSetRawCounters() {
+  public void testSetRawCounters() {
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
     report.setRawCounters(rCounters);
@@ -43,7 +43,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  void testBuildImplicitRawCounters() {
+  public void testBuildImplicitRawCounters() {
     TaskAttemptReportPBImpl report = new TaskAttemptReportPBImpl();
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
     report.setRawCounters(rCounters);
@@ -53,7 +53,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  void testCountersOverRawCounters() {
+  public void testCountersOverRawCounters() {
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
     Counters altCounters = TypeConverter.toYarn(rCounters);
@@ -66,7 +66,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  void testUninitializedCounters() {
+  public void testUninitializedCounters() {
     // Create basic class
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     // Verify properties initialized to null
@@ -75,7 +75,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  void testSetRawCountersToNull() {
+  public void testSetRawCountersToNull() {
     // Create basic class
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     // Set raw counters to null
@@ -87,7 +87,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  void testSetCountersToNull() {
+  public void testSetCountersToNull() {
     // Create basic class
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     // Set raw counters to null
@@ -98,7 +98,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  void testSetNonNullCountersToNull() {
+  public void testSetNonNullCountersToNull() {
     // Create basic class
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     // Set raw counters
@@ -114,7 +114,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  void testSetNonNullRawCountersToNull() {
+  public void testSetNonNullRawCountersToNull() {
     // Create basic class
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     // Set raw counters

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/api/records/TestTaskAttemptReport.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/api/records/TestTaskAttemptReport.java
@@ -24,17 +24,17 @@ import org.apache.hadoop.mapreduce.v2.app.MockJobs;
 import org.apache.hadoop.mapreduce.v2.proto.MRProtos;
 import org.apache.hadoop.yarn.util.Records;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestTaskAttemptReport {
 
   @Test
-  public void testSetRawCounters() {
+  void testSetRawCounters() {
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
     report.setRawCounters(rCounters);
@@ -43,7 +43,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  public void testBuildImplicitRawCounters() {
+  void testBuildImplicitRawCounters() {
     TaskAttemptReportPBImpl report = new TaskAttemptReportPBImpl();
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
     report.setRawCounters(rCounters);
@@ -53,7 +53,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  public void testCountersOverRawCounters() {
+  void testCountersOverRawCounters() {
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
     Counters altCounters = TypeConverter.toYarn(rCounters);
@@ -66,7 +66,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  public void testUninitializedCounters() {
+  void testUninitializedCounters() {
     // Create basic class
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     // Verify properties initialized to null
@@ -75,7 +75,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  public void testSetRawCountersToNull() {
+  void testSetRawCountersToNull() {
     // Create basic class
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     // Set raw counters to null
@@ -87,7 +87,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  public void testSetCountersToNull() {
+  void testSetCountersToNull() {
     // Create basic class
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     // Set raw counters to null
@@ -98,7 +98,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  public void testSetNonNullCountersToNull() {
+  void testSetNonNullCountersToNull() {
     // Create basic class
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     // Set raw counters
@@ -114,7 +114,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  public void testSetNonNullRawCountersToNull() {
+  void testSetNonNullRawCountersToNull() {
     // Create basic class
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     // Set raw counters

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/api/records/TestTaskReport.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/api/records/TestTaskReport.java
@@ -24,17 +24,17 @@ import org.apache.hadoop.mapreduce.v2.app.MockJobs;
 import org.apache.hadoop.mapreduce.v2.proto.MRProtos;
 import org.apache.hadoop.yarn.util.Records;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestTaskReport {
 
   @Test
-  public void testSetRawCounters() {
+  void testSetRawCounters() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
@@ -46,7 +46,7 @@ public class TestTaskReport {
   }
 
   @Test
-  public void testBuildImplicitRawCounters() {
+  void testBuildImplicitRawCounters() {
     // Create basic class
     TaskReportPBImpl report = new TaskReportPBImpl();
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
@@ -58,7 +58,7 @@ public class TestTaskReport {
   }
 
   @Test
-  public void testCountersOverRawCounters() {
+  void testCountersOverRawCounters() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
@@ -75,7 +75,7 @@ public class TestTaskReport {
   }
 
   @Test
-  public void testUninitializedCounters() {
+  void testUninitializedCounters() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     // Verify properties initialized to null
@@ -84,7 +84,7 @@ public class TestTaskReport {
   }
 
   @Test
-  public void testSetRawCountersToNull() {
+  void testSetRawCountersToNull() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     // Set raw counters to null
@@ -96,7 +96,7 @@ public class TestTaskReport {
   }
 
   @Test
-  public void testSetCountersToNull() {
+  void testSetCountersToNull() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     // Set raw counters to null
@@ -107,7 +107,7 @@ public class TestTaskReport {
   }
 
   @Test
-  public void testSetNonNullCountersToNull() {
+  void testSetNonNullCountersToNull() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     // Set raw counters
@@ -123,7 +123,7 @@ public class TestTaskReport {
   }
 
   @Test
-  public void testSetNonNullRawCountersToNull() {
+  void testSetNonNullRawCountersToNull() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     // Set raw counters

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/api/records/TestTaskReport.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/api/records/TestTaskReport.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestTaskReport {
 
   @Test
-  void testSetRawCounters() {
+  public void testSetRawCounters() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
@@ -46,7 +46,7 @@ public class TestTaskReport {
   }
 
   @Test
-  void testBuildImplicitRawCounters() {
+  public void testBuildImplicitRawCounters() {
     // Create basic class
     TaskReportPBImpl report = new TaskReportPBImpl();
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
@@ -58,7 +58,7 @@ public class TestTaskReport {
   }
 
   @Test
-  void testCountersOverRawCounters() {
+  public void testCountersOverRawCounters() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
@@ -75,7 +75,7 @@ public class TestTaskReport {
   }
 
   @Test
-  void testUninitializedCounters() {
+  public void testUninitializedCounters() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     // Verify properties initialized to null
@@ -84,7 +84,7 @@ public class TestTaskReport {
   }
 
   @Test
-  void testSetRawCountersToNull() {
+  public void testSetRawCountersToNull() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     // Set raw counters to null
@@ -96,7 +96,7 @@ public class TestTaskReport {
   }
 
   @Test
-  void testSetCountersToNull() {
+  public void testSetCountersToNull() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     // Set raw counters to null
@@ -107,7 +107,7 @@ public class TestTaskReport {
   }
 
   @Test
-  void testSetNonNullCountersToNull() {
+  public void testSetNonNullCountersToNull() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     // Set raw counters
@@ -123,7 +123,7 @@ public class TestTaskReport {
   }
 
   @Test
-  void testSetNonNullRawCountersToNull() {
+  public void testSetNonNullRawCountersToNull() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     // Set raw counters

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MRApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MRApp.java
@@ -98,7 +98,7 @@ import org.apache.hadoop.yarn.state.StateMachine;
 import org.apache.hadoop.yarn.state.StateMachineFactory;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.SystemClock;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -326,8 +326,8 @@ public class MRApp extends MRAppMaster {
       iState = job.getInternalState();
     }
     LOG.info("Job {} Internal State is : {}", job.getID(), iState);
-    Assert.assertEquals("Task Internal state is not correct (timedout)",
-        finalState, iState);
+    Assertions.assertEquals(finalState, iState,
+        "Task Internal state is not correct (timedout)");
   }
 
   public void waitForInternalState(TaskImpl task,
@@ -339,8 +339,8 @@ public class MRApp extends MRAppMaster {
       iState = task.getInternalState();
     }
     LOG.info("Task {} Internal State is : {}", task.getID(), iState);
-    Assert.assertEquals("Task Internal state is not correct (timedout)",
-        finalState, iState);
+    Assertions.assertEquals(finalState, iState,
+        "Task Internal state is not correct (timedout)");
   }
 
   public void waitForInternalState(TaskAttemptImpl attempt,
@@ -352,8 +352,8 @@ public class MRApp extends MRAppMaster {
       iState = attempt.getInternalState();
     }
     LOG.info("TaskAttempt {} Internal State is : {}", attempt.getID(), iState);
-    Assert.assertEquals("TaskAttempt Internal state is not correct (timedout)",
-        finalState, iState);
+    Assertions.assertEquals(finalState, iState,
+        "TaskAttempt Internal state is not correct (timedout)");
   }
 
   public void waitForState(TaskAttempt attempt, 
@@ -367,9 +367,8 @@ public class MRApp extends MRAppMaster {
     }
     LOG.info("TaskAttempt {} State is : {}", attempt.getID(),
         report.getTaskAttemptState());
-    Assert.assertEquals("TaskAttempt state is not correct (timedout)",
-        finalState,
-        report.getTaskAttemptState());
+    Assertions.assertEquals(finalState, report.getTaskAttemptState(),
+        "TaskAttempt state is not correct (timedout)");
   }
 
   public void waitForState(Task task, TaskState finalState) throws Exception {
@@ -381,8 +380,8 @@ public class MRApp extends MRAppMaster {
       report = task.getReport();
     }
     LOG.info("Task {} State is : {}", task.getID(), report.getTaskState());
-    Assert.assertEquals("Task state is not correct (timedout)", finalState,
-        report.getTaskState());
+    Assertions.assertEquals(finalState, report.getTaskState(),
+        "Task state is not correct (timedout)");
   }
 
   public void waitForState(Job job, JobState finalState) throws Exception {
@@ -394,14 +393,14 @@ public class MRApp extends MRAppMaster {
       Thread.sleep(WAIT_FOR_STATE_INTERVAL);
     }
     LOG.info("Job {} State is : {}", job.getID(), report.getJobState());
-    Assert.assertEquals("Job state is not correct (timedout)", finalState, 
-        job.getState());
+    Assertions.assertEquals(finalState, job.getState(),
+        "Job state is not correct (timedout)");
   }
 
   public void waitForState(Service.STATE finalState) throws Exception {
     if (finalState == Service.STATE.STOPPED) {
-       Assert.assertTrue("Timeout while waiting for MRApp to stop",
-           waitForServiceToStop(20 * 1000));
+      Assertions.assertTrue(waitForServiceToStop(20 * 1000),
+          "Timeout while waiting for MRApp to stop");
     } else {
       int timeoutSecs = 0;
       while (!finalState.equals(getServiceState())
@@ -409,8 +408,8 @@ public class MRApp extends MRAppMaster {
         Thread.sleep(WAIT_FOR_STATE_INTERVAL);
       }
       LOG.info("MRApp State is : {}", getServiceState());
-      Assert.assertEquals("MRApp state is not correct (timedout)", finalState,
-          getServiceState());
+      Assertions.assertEquals(finalState, getServiceState(),
+          "MRApp state is not correct (timedout)");
     }
   }
 
@@ -419,22 +418,23 @@ public class MRApp extends MRAppMaster {
       JobReport jobReport = job.getReport();
       LOG.info("Job start time :{}", jobReport.getStartTime());
       LOG.info("Job finish time :", jobReport.getFinishTime());
-      Assert.assertTrue("Job start time is not less than finish time",
-          jobReport.getStartTime() <= jobReport.getFinishTime());
-      Assert.assertTrue("Job finish time is in future",
-          jobReport.getFinishTime() <= System.currentTimeMillis());
+      Assertions.assertTrue(jobReport.getStartTime() <= jobReport.getFinishTime(),
+          "Job start time is not less than finish time");
+      Assertions.assertTrue(jobReport.getFinishTime() <= System.currentTimeMillis(),
+          "Job finish time is in future");
       for (Task task : job.getTasks().values()) {
         TaskReport taskReport = task.getReport();
         LOG.info("Task {} start time : {}", task.getID(),
             taskReport.getStartTime());
         LOG.info("Task {} finish time : {}", task.getID(),
             taskReport.getFinishTime());
-        Assert.assertTrue("Task start time is not less than finish time",
-            taskReport.getStartTime() <= taskReport.getFinishTime());
+        Assertions.assertTrue(taskReport.getStartTime() <= taskReport.getFinishTime(),
+            "Task start time is not less than finish time");
         for (TaskAttempt attempt : task.getAttempts().values()) {
           TaskAttemptReport attemptReport = attempt.getReport();
-          Assert.assertTrue("Attempt start time is not less than finish time",
-              attemptReport.getStartTime() <= attemptReport.getFinishTime());
+          Assertions.assertTrue(attemptReport.getStartTime() <=
+                  attemptReport.getFinishTime(),
+              "Attempt start time is not less than finish time");
         }
       }
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MRAppBenchmark.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MRAppBenchmark.java
@@ -199,7 +199,7 @@ public class MRAppBenchmark {
 
   @Test
   @Timeout(60000)
-  void benchmark1() throws Exception {
+  public void benchmark1() throws Exception {
     int maps = 100; // Adjust for benchmarking. Start with thousands.
     int reduces = 0;
     System.out.println("Running benchmark with maps:"+maps +
@@ -279,7 +279,7 @@ public class MRAppBenchmark {
 
   @Test
   @Timeout(60000)
-  void benchmark2() throws Exception {
+  public void benchmark2() throws Exception {
     int maps = 100; // Adjust for benchmarking, start with a couple of thousands
     int reduces = 50;
     int maxConcurrentRunningTasks = 500;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MRAppBenchmark.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MRAppBenchmark.java
@@ -56,7 +56,8 @@ import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 
 public class MRAppBenchmark {
@@ -196,8 +197,9 @@ public class MRAppBenchmark {
     }
   }
 
-  @Test(timeout = 60000)
-  public void benchmark1() throws Exception {
+  @Test
+  @Timeout(60000)
+  void benchmark1() throws Exception {
     int maps = 100; // Adjust for benchmarking. Start with thousands.
     int reduces = 0;
     System.out.println("Running benchmark with maps:"+maps +
@@ -275,8 +277,9 @@ public class MRAppBenchmark {
     });
   }
 
-  @Test(timeout = 60000)
-  public void benchmark2() throws Exception {
+  @Test
+  @Timeout(60000)
+  void benchmark2() throws Exception {
     int maps = 100; // Adjust for benchmarking, start with a couple of thousands
     int reduces = 50;
     int maxConcurrentRunningTasks = 500;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestAMInfos.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestAMInfos.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 public class TestAMInfos {
 
   @Test
-  void testAMInfosWithoutRecoveryEnabled() throws Exception {
+  public void testAMInfosWithoutRecoveryEnabled() throws Exception {
     int runCount = 0;
     MRApp app =
         new MRAppWithHistory(1, 0, false, this.getClass().getName(), true,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestAMInfos.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestAMInfos.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.mapreduce.v2.app;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.MRJobConfig;
@@ -33,12 +33,12 @@ import org.apache.hadoop.mapreduce.v2.app.TestRecovery.MRAppWithHistory;
 import org.apache.hadoop.mapreduce.v2.app.job.Job;
 import org.apache.hadoop.mapreduce.v2.app.job.Task;
 import org.apache.hadoop.mapreduce.v2.app.job.TaskAttempt;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestAMInfos {
 
   @Test
-  public void testAMInfosWithoutRecoveryEnabled() throws Exception {
+  void testAMInfosWithoutRecoveryEnabled() throws Exception {
     int runCount = 0;
     MRApp app =
         new MRAppWithHistory(1, 0, false, this.getClass().getName(), true,
@@ -50,7 +50,7 @@ public class TestAMInfos {
 
     long am1StartTime = app.getAllAMInfos().get(0).getStartTime();
 
-    Assert.assertEquals("No of tasks not correct", 1, job.getTasks().size());
+    Assertions.assertEquals(1, job.getTasks().size(), "No of tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask = it.next();
     app.waitForState(mapTask, TaskState.RUNNING);
@@ -71,14 +71,14 @@ public class TestAMInfos {
     conf.setBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, false);
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("No of tasks not correct", 1, job.getTasks().size());
+    Assertions.assertEquals(1, job.getTasks().size(), "No of tasks not correct");
     it = job.getTasks().values().iterator();
     mapTask = it.next();
     // There should be two AMInfos
     List<AMInfo> amInfos = app.getAllAMInfos();
-    Assert.assertEquals(2, amInfos.size());
+    Assertions.assertEquals(2, amInfos.size());
     AMInfo amInfoOne = amInfos.get(0);
-    Assert.assertEquals(am1StartTime, amInfoOne.getStartTime());
+    Assertions.assertEquals(am1StartTime, amInfoOne.getStartTime());
     app.stop();
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestCheckpointPreemptionPolicy.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestCheckpointPreemptionPolicy.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.yarn.api.records.PreemptionMessage;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
@@ -58,8 +58,8 @@ import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.Allocation;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestCheckpointPreemptionPolicy {
 
@@ -77,7 +77,7 @@ public class TestCheckpointPreemptionPolicy {
 
   private int minAlloc = 1024;
 
-  @Before
+  @BeforeEach
   @SuppressWarnings("rawtypes") // mocked generics
   public void setup() {
     ApplicationId appId = ApplicationId.newInstance(200, 1);
@@ -110,7 +110,7 @@ public class TestCheckpointPreemptionPolicy {
   }
 
   @Test
-  public void testStrictPreemptionContract() {
+  void testStrictPreemptionContract() {
 
     final Map<ContainerId,TaskAttemptId> containers = assignedContainers;
     AMPreemptionPolicy.Context mPctxt = new AMPreemptionPolicy.Context() {
@@ -153,7 +153,7 @@ public class TestCheckpointPreemptionPolicy {
 
 
   @Test
-  public void testPreemptionContract() {
+  void testPreemptionContract() {
     final Map<ContainerId,TaskAttemptId> containers = assignedContainers;
     AMPreemptionPolicy.Context mPctxt = new AMPreemptionPolicy.Context() {
       @Override

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestCheckpointPreemptionPolicy.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestCheckpointPreemptionPolicy.java
@@ -110,7 +110,7 @@ public class TestCheckpointPreemptionPolicy {
   }
 
   @Test
-  void testStrictPreemptionContract() {
+  public void testStrictPreemptionContract() {
 
     final Map<ContainerId,TaskAttemptId> containers = assignedContainers;
     AMPreemptionPolicy.Context mPctxt = new AMPreemptionPolicy.Context() {
@@ -153,7 +153,7 @@ public class TestCheckpointPreemptionPolicy {
 
 
   @Test
-  void testPreemptionContract() {
+  public void testPreemptionContract() {
     final Map<ContainerId,TaskAttemptId> containers = assignedContainers;
     AMPreemptionPolicy.Context mPctxt = new AMPreemptionPolicy.Context() {
       @Override

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestFail.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestFail.java
@@ -24,7 +24,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.hadoop.mapreduce.v2.app.job.event.TaskAttemptFailEvent;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.TaskAttemptListenerImpl;
@@ -48,7 +48,7 @@ import org.apache.hadoop.mapreduce.v2.app.rm.preemption.AMPreemptionPolicy;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.client.api.impl.ContainerManagementProtocolProxy.ContainerManagementProtocolProxyData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the state machine with respect to Job/Task/TaskAttempt failure 
@@ -60,7 +60,7 @@ public class TestFail {
   @Test
   //First attempt is failed and second attempt is passed
   //The job succeeds.
-  public void testFailTask() throws Exception {
+  void testFailTask() throws Exception {
     MRApp app = new MockFirstFailingAttemptMRApp(1, 0);
     Configuration conf = new Configuration();
     // this test requires two task attempts, but uberization overrides max to 1
@@ -68,24 +68,24 @@ public class TestFail {
     Job job = app.submit(conf);
     app.waitForState(job, JobState.SUCCEEDED);
     Map<TaskId,Task> tasks = job.getTasks();
-    Assert.assertEquals("Num tasks is not correct", 1, tasks.size());
+    Assertions.assertEquals(1, tasks.size(), "Num tasks is not correct");
     Task task = tasks.values().iterator().next();
-    Assert.assertEquals("Task state not correct", TaskState.SUCCEEDED,
-        task.getReport().getTaskState());
+    Assertions.assertEquals(TaskState.SUCCEEDED, task.getReport().getTaskState(),
+        "Task state not correct");
     Map<TaskAttemptId, TaskAttempt> attempts =
         tasks.values().iterator().next().getAttempts();
-    Assert.assertEquals("Num attempts is not correct", 2, attempts.size());
+    Assertions.assertEquals(2, attempts.size(), "Num attempts is not correct");
     //one attempt must be failed 
     //and another must have succeeded
     Iterator<TaskAttempt> it = attempts.values().iterator();
-    Assert.assertEquals("Attempt state not correct", TaskAttemptState.FAILED,
-        it.next().getReport().getTaskAttemptState());
-    Assert.assertEquals("Attempt state not correct", TaskAttemptState.SUCCEEDED,
-        it.next().getReport().getTaskAttemptState());
+    Assertions.assertEquals(TaskAttemptState.FAILED,
+        it.next().getReport().getTaskAttemptState(), "Attempt state not correct");
+    Assertions.assertEquals(TaskAttemptState.SUCCEEDED,
+        it.next().getReport().getTaskAttemptState(), "Attempt state not correct");
   }
 
   @Test
-  public void testMapFailureMaxPercent() throws Exception {
+  void testMapFailureMaxPercent() throws Exception {
     MRApp app = new MockFirstFailingTaskMRApp(4, 0);
     Configuration conf = new Configuration();
     
@@ -114,7 +114,7 @@ public class TestFail {
   }
 
   @Test
-  public void testReduceFailureMaxPercent() throws Exception {
+  void testReduceFailureMaxPercent() throws Exception {
     MRApp app = new MockFirstFailingTaskMRApp(2, 4);
     Configuration conf = new Configuration();
     
@@ -148,7 +148,7 @@ public class TestFail {
 
   @Test
   //All Task attempts are timed out, leading to Job failure
-  public void testTimedOutTask() throws Exception {
+  void testTimedOutTask() throws Exception {
     MRApp app = new TimeOutTaskMRApp(1, 0);
     Configuration conf = new Configuration();
     int maxAttempts = 2;
@@ -159,22 +159,22 @@ public class TestFail {
     Job job = app.submit(conf);
     app.waitForState(job, JobState.FAILED);
     Map<TaskId,Task> tasks = job.getTasks();
-    Assert.assertEquals("Num tasks is not correct", 1, tasks.size());
+    Assertions.assertEquals(1, tasks.size(), "Num tasks is not correct");
     Task task = tasks.values().iterator().next();
-    Assert.assertEquals("Task state not correct", TaskState.FAILED,
-        task.getReport().getTaskState());
+    Assertions.assertEquals(TaskState.FAILED,
+        task.getReport().getTaskState(), "Task state not correct");
     Map<TaskAttemptId, TaskAttempt> attempts =
         tasks.values().iterator().next().getAttempts();
-    Assert.assertEquals("Num attempts is not correct", maxAttempts,
-        attempts.size());
+    Assertions.assertEquals(maxAttempts,
+        attempts.size(), "Num attempts is not correct");
     for (TaskAttempt attempt : attempts.values()) {
-      Assert.assertEquals("Attempt state not correct", TaskAttemptState.FAILED,
-          attempt.getReport().getTaskAttemptState());
+      Assertions.assertEquals(TaskAttemptState.FAILED,
+          attempt.getReport().getTaskAttemptState(), "Attempt state not correct");
     }
   }
 
   @Test
-  public void testTaskFailWithUnusedContainer() throws Exception {
+  void testTaskFailWithUnusedContainer() throws Exception {
     MRApp app = new MRAppWithFailingTaskAndUnusedContainer();
     Configuration conf = new Configuration();
     int maxAttempts = 1;
@@ -185,13 +185,14 @@ public class TestFail {
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     Map<TaskId, Task> tasks = job.getTasks();
-    Assert.assertEquals("Num tasks is not correct", 1, tasks.size());
+    Assertions.assertEquals(1, tasks.size(),
+        "Num tasks is not correct");
     Task task = tasks.values().iterator().next();
     app.waitForState(task, TaskState.SCHEDULED);
     Map<TaskAttemptId, TaskAttempt> attempts = tasks.values().iterator()
         .next().getAttempts();
-    Assert.assertEquals("Num attempts is not correct", maxAttempts, attempts
-        .size());
+    Assertions.assertEquals(maxAttempts, attempts.size(),
+        "Num attempts is not correct");
     TaskAttempt attempt = attempts.values().iterator().next();
     app.waitForInternalState((TaskAttemptImpl) attempt,
         TaskAttemptStateInternal.ASSIGNED);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestFail.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestFail.java
@@ -60,7 +60,7 @@ public class TestFail {
   @Test
   //First attempt is failed and second attempt is passed
   //The job succeeds.
-  void testFailTask() throws Exception {
+  public void testFailTask() throws Exception {
     MRApp app = new MockFirstFailingAttemptMRApp(1, 0);
     Configuration conf = new Configuration();
     // this test requires two task attempts, but uberization overrides max to 1
@@ -85,7 +85,7 @@ public class TestFail {
   }
 
   @Test
-  void testMapFailureMaxPercent() throws Exception {
+  public void testMapFailureMaxPercent() throws Exception {
     MRApp app = new MockFirstFailingTaskMRApp(4, 0);
     Configuration conf = new Configuration();
     
@@ -114,7 +114,7 @@ public class TestFail {
   }
 
   @Test
-  void testReduceFailureMaxPercent() throws Exception {
+  public void testReduceFailureMaxPercent() throws Exception {
     MRApp app = new MockFirstFailingTaskMRApp(2, 4);
     Configuration conf = new Configuration();
     
@@ -148,7 +148,7 @@ public class TestFail {
 
   @Test
   //All Task attempts are timed out, leading to Job failure
-  void testTimedOutTask() throws Exception {
+  public void testTimedOutTask() throws Exception {
     MRApp app = new TimeOutTaskMRApp(1, 0);
     Configuration conf = new Configuration();
     int maxAttempts = 2;
@@ -174,7 +174,7 @@ public class TestFail {
   }
 
   @Test
-  void testTaskFailWithUnusedContainer() throws Exception {
+  public void testTaskFailWithUnusedContainer() throws Exception {
     MRApp app = new MRAppWithFailingTaskAndUnusedContainer();
     Configuration conf = new Configuration();
     int maxAttempts = 1;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestFetchFailure.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestFetchFailure.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.mapreduce.v2.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,13 +50,13 @@ import org.apache.hadoop.mapreduce.v2.app.job.event.TaskAttemptEventType;
 import org.apache.hadoop.mapreduce.v2.app.job.event.TaskAttemptStatusUpdateEvent;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.yarn.event.EventHandler;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestFetchFailure {
 
   @Test
-  public void testFetchFailure() throws Exception {
+  void testFetchFailure() throws Exception {
     MRApp app = new MRApp(1, 1, false, this.getClass().getName(), true);
     Configuration conf = new Configuration();
     // map -> reduce -> fetch-failure -> map retry is incompatible with
@@ -65,8 +65,8 @@ public class TestFetchFailure {
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     //all maps would be running
-    Assert.assertEquals("Num tasks not correct",
-       2, job.getTasks().size());
+    Assertions.assertEquals(2, job.getTasks().size(),
+        "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask = it.next();
     Task reduceTask = it.next();
@@ -97,10 +97,10 @@ public class TestFetchFailure {
 
     TaskAttemptCompletionEvent[] events =
       job.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals("Num completion events not correct",
-        1, events.length);
-    Assert.assertEquals("Event status not correct",
-        TaskAttemptCompletionEventStatus.SUCCEEDED, events[0].getStatus());
+    Assertions.assertEquals(1, events.length,
+        "Num completion events not correct");
+    Assertions.assertEquals(TaskAttemptCompletionEventStatus.SUCCEEDED,
+        events[0].getStatus(), "Event status not correct");
     
     // wait for reduce to start running
     app.waitForState(reduceTask, TaskState.RUNNING);
@@ -117,11 +117,11 @@ public class TestFetchFailure {
     app.waitForState(mapTask, TaskState.RUNNING);
     
     //map attempt must have become FAILED
-    Assert.assertEquals("Map TaskAttempt state not correct",
-        TaskAttemptState.FAILED, mapAttempt1.getState());
+    Assertions.assertEquals(TaskAttemptState.FAILED, mapAttempt1.getState(),
+        "Map TaskAttempt state not correct");
 
-    Assert.assertEquals("Num attempts in Map Task not correct",
-        2, mapTask.getAttempts().size());
+    Assertions.assertEquals(2, mapTask.getAttempts().size(),
+        "Num attempts in Map Task not correct");
     
     Iterator<TaskAttempt> atIt = mapTask.getAttempts().values().iterator();
     atIt.next();
@@ -144,39 +144,41 @@ public class TestFetchFailure {
     app.waitForState(job, JobState.SUCCEEDED);
     
     //previous completion event now becomes obsolete
-    Assert.assertEquals("Event status not correct",
-        TaskAttemptCompletionEventStatus.OBSOLETE, events[0].getStatus());
+    Assertions.assertEquals(TaskAttemptCompletionEventStatus.OBSOLETE,
+        events[0].getStatus(), "Event status not correct");
     
     events = job.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals("Num completion events not correct",
-        4, events.length);
-    Assert.assertEquals("Event map attempt id not correct",
-        mapAttempt1.getID(), events[0].getAttemptId());
-    Assert.assertEquals("Event map attempt id not correct",
-        mapAttempt1.getID(), events[1].getAttemptId());
-    Assert.assertEquals("Event map attempt id not correct",
-        mapAttempt2.getID(), events[2].getAttemptId());
-    Assert.assertEquals("Event redude attempt id not correct",
-        reduceAttempt.getID(), events[3].getAttemptId());
-    Assert.assertEquals("Event status not correct for map attempt1",
-        TaskAttemptCompletionEventStatus.OBSOLETE, events[0].getStatus());
-    Assert.assertEquals("Event status not correct for map attempt1",
-        TaskAttemptCompletionEventStatus.FAILED, events[1].getStatus());
-    Assert.assertEquals("Event status not correct for map attempt2",
-        TaskAttemptCompletionEventStatus.SUCCEEDED, events[2].getStatus());
-    Assert.assertEquals("Event status not correct for reduce attempt1",
-        TaskAttemptCompletionEventStatus.SUCCEEDED, events[3].getStatus());
+    Assertions.assertEquals(4, events.length,
+        "Num completion events not correct");
+    Assertions.assertEquals(mapAttempt1.getID(), events[0].getAttemptId(),
+        "Event map attempt id not correct");
+    Assertions.assertEquals(mapAttempt1.getID(), events[1].getAttemptId(),
+        "Event map attempt id not correct");
+    Assertions.assertEquals(mapAttempt2.getID(), events[2].getAttemptId(),
+        "Event map attempt id not correct");
+    Assertions.assertEquals(reduceAttempt.getID(), events[3].getAttemptId(),
+        "Event redude attempt id not correct");
+    Assertions.assertEquals(TaskAttemptCompletionEventStatus.OBSOLETE,
+        events[0].getStatus(), "Event status not correct for map attempt1");
+    Assertions.assertEquals(TaskAttemptCompletionEventStatus.FAILED,
+        events[1].getStatus(), "Event status not correct for map attempt1");
+    Assertions.assertEquals(TaskAttemptCompletionEventStatus.SUCCEEDED,
+        events[2].getStatus(), "Event status not correct for map attempt2");
+    Assertions.assertEquals(TaskAttemptCompletionEventStatus.SUCCEEDED,
+        events[3].getStatus(), "Event status not correct for reduce attempt1");
 
     TaskCompletionEvent mapEvents[] =
         job.getMapAttemptCompletionEvents(0, 2);
     TaskCompletionEvent convertedEvents[] = TypeConverter.fromYarn(events);
-    Assert.assertEquals("Incorrect number of map events", 2, mapEvents.length);
-    Assert.assertArrayEquals("Unexpected map events",
-        Arrays.copyOfRange(convertedEvents, 0, 2), mapEvents);
+    Assertions.assertEquals(2, mapEvents.length,
+        "Incorrect number of map events");
+    Assertions.assertArrayEquals(Arrays.copyOfRange(convertedEvents, 0, 2),
+        mapEvents, "Unexpected map events");
     mapEvents = job.getMapAttemptCompletionEvents(2, 200);
-    Assert.assertEquals("Incorrect number of map events", 1, mapEvents.length);
-    Assert.assertEquals("Unexpected map event", convertedEvents[2],
-        mapEvents[0]);
+    Assertions.assertEquals(1, mapEvents.length,
+        "Incorrect number of map events");
+    Assertions.assertEquals(convertedEvents[2], mapEvents[0],
+        "Unexpected map event");
   }
   
   /**
@@ -187,7 +189,7 @@ public class TestFetchFailure {
    * the AM re-runs the maps from scratch.
    */
   @Test
-  public void testFetchFailureWithRecovery() throws Exception {
+  void testFetchFailureWithRecovery() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(1, 1, false, this.getClass().getName(), true, ++runCount);
     Configuration conf = new Configuration();
@@ -197,8 +199,8 @@ public class TestFetchFailure {
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     //all maps would be running
-    Assert.assertEquals("Num tasks not correct",
-        2, job.getTasks().size());
+    Assertions.assertEquals(2, job.getTasks().size(),
+        "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask = it.next();
     Task reduceTask = it.next();
@@ -218,10 +220,10 @@ public class TestFetchFailure {
 
     TaskAttemptCompletionEvent[] events = 
       job.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals("Num completion events not correct",
-        1, events.length);
-    Assert.assertEquals("Event status not correct",
-        TaskAttemptCompletionEventStatus.SUCCEEDED, events[0].getStatus());
+    Assertions.assertEquals(1, events.length,
+        "Num completion events not correct");
+    Assertions.assertEquals(TaskAttemptCompletionEventStatus.SUCCEEDED,
+        events[0].getStatus(), "Event status not correct");
 
     // wait for reduce to start running
     app.waitForState(reduceTask, TaskState.RUNNING);
@@ -250,8 +252,8 @@ public class TestFetchFailure {
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     //all maps would be running
-    Assert.assertEquals("Num tasks not correct",
-        2, job.getTasks().size());
+    Assertions.assertEquals(2, job.getTasks().size(),
+        "Num tasks not correct");
     it = job.getTasks().values().iterator();
     mapTask = it.next();
     reduceTask = it.next();
@@ -277,11 +279,12 @@ public class TestFetchFailure {
 
     app.waitForState(job, JobState.SUCCEEDED);
     events = job.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals("Num completion events not correct", 2, events.length);
+    Assertions.assertEquals(2, events.length,
+        "Num completion events not correct");
   }
   
   @Test
-  public void testFetchFailureMultipleReduces() throws Exception {
+  void testFetchFailureMultipleReduces() throws Exception {
     MRApp app = new MRApp(1, 3, false, this.getClass().getName(), true);
     Configuration conf = new Configuration();
     // map -> reduce -> fetch-failure -> map retry is incompatible with
@@ -290,8 +293,8 @@ public class TestFetchFailure {
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     //all maps would be running
-    Assert.assertEquals("Num tasks not correct",
-       4, job.getTasks().size());
+    Assertions.assertEquals(4, job.getTasks().size(),
+        "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask = it.next();
     Task reduceTask = it.next();
@@ -313,10 +316,10 @@ public class TestFetchFailure {
     
     TaskAttemptCompletionEvent[] events = 
       job.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals("Num completion events not correct",
-        1, events.length);
-    Assert.assertEquals("Event status not correct",
-        TaskAttemptCompletionEventStatus.SUCCEEDED, events[0].getStatus());
+    Assertions.assertEquals(1, events.length,
+        "Num completion events not correct");
+    Assertions.assertEquals(TaskAttemptCompletionEventStatus.SUCCEEDED, events[0].getStatus(),
+        "Event status not correct");
     
     // wait for reduce to start running
     app.waitForState(reduceTask, TaskState.RUNNING);
@@ -354,16 +357,16 @@ public class TestFetchFailure {
     app.waitForState(mapTask, TaskState.RUNNING);
     
     //map attempt must have become FAILED
-    Assert.assertEquals("Map TaskAttempt state not correct",
-        TaskAttemptState.FAILED, mapAttempt1.getState());
+    Assertions.assertEquals(TaskAttemptState.FAILED, mapAttempt1.getState(),
+        "Map TaskAttempt state not correct");
 
     assertThat(mapAttempt1.getDiagnostics().get(0))
         .isEqualTo("Too many fetch failures. Failing the attempt. "
             + "Last failure reported by "
             + reduceAttempt3.getID().toString() + " from host host3");
 
-    Assert.assertEquals("Num attempts in Map Task not correct",
-        2, mapTask.getAttempts().size());
+    Assertions.assertEquals(2, mapTask.getAttempts().size(),
+        "Num attempts in Map Task not correct");
     
     Iterator<TaskAttempt> atIt = mapTask.getAttempts().values().iterator();
     atIt.next();
@@ -396,39 +399,40 @@ public class TestFetchFailure {
     app.waitForState(job, JobState.SUCCEEDED);
     
     //previous completion event now becomes obsolete
-    Assert.assertEquals("Event status not correct",
-        TaskAttemptCompletionEventStatus.OBSOLETE, events[0].getStatus());
+    Assertions.assertEquals(TaskAttemptCompletionEventStatus.OBSOLETE, events[0].getStatus(),
+        "Event status not correct");
     
     events = job.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals("Num completion events not correct",
-        6, events.length);
-    Assert.assertEquals("Event map attempt id not correct",
-        mapAttempt1.getID(), events[0].getAttemptId());
-    Assert.assertEquals("Event map attempt id not correct",
-        mapAttempt1.getID(), events[1].getAttemptId());
-    Assert.assertEquals("Event map attempt id not correct",
-        mapAttempt2.getID(), events[2].getAttemptId());
-    Assert.assertEquals("Event reduce attempt id not correct",
-        reduceAttempt.getID(), events[3].getAttemptId());
-    Assert.assertEquals("Event status not correct for map attempt1",
-        TaskAttemptCompletionEventStatus.OBSOLETE, events[0].getStatus());
-    Assert.assertEquals("Event status not correct for map attempt1",
-        TaskAttemptCompletionEventStatus.FAILED, events[1].getStatus());
-    Assert.assertEquals("Event status not correct for map attempt2",
-        TaskAttemptCompletionEventStatus.SUCCEEDED, events[2].getStatus());
-    Assert.assertEquals("Event status not correct for reduce attempt1",
-        TaskAttemptCompletionEventStatus.SUCCEEDED, events[3].getStatus());
+    Assertions.assertEquals(6, events.length,
+        "Num completion events not correct");
+    Assertions.assertEquals(mapAttempt1.getID(), events[0].getAttemptId(),
+        "Event map attempt id not correct");
+    Assertions.assertEquals(mapAttempt1.getID(), events[1].getAttemptId(),
+        "Event map attempt id not correct");
+    Assertions.assertEquals(mapAttempt2.getID(), events[2].getAttemptId(),
+        "Event map attempt id not correct");
+    Assertions.assertEquals(reduceAttempt.getID(), events[3].getAttemptId(),
+        "Event reduce attempt id not correct");
+    Assertions.assertEquals(TaskAttemptCompletionEventStatus.OBSOLETE,
+        events[0].getStatus(), "Event status not correct for map attempt1");
+    Assertions.assertEquals(TaskAttemptCompletionEventStatus.FAILED,
+        events[1].getStatus(), "Event status not correct for map attempt1");
+    Assertions.assertEquals(TaskAttemptCompletionEventStatus.SUCCEEDED,
+        events[2].getStatus(), "Event status not correct for map attempt2");
+    Assertions.assertEquals(TaskAttemptCompletionEventStatus.SUCCEEDED,
+        events[3].getStatus(), "Event status not correct for reduce attempt1");
 
     TaskCompletionEvent mapEvents[] =
         job.getMapAttemptCompletionEvents(0, 2);
     TaskCompletionEvent convertedEvents[] = TypeConverter.fromYarn(events);
-    Assert.assertEquals("Incorrect number of map events", 2, mapEvents.length);
-    Assert.assertArrayEquals("Unexpected map events",
-        Arrays.copyOfRange(convertedEvents, 0, 2), mapEvents);
+    Assertions.assertEquals(2, mapEvents.length,
+        "Incorrect number of map events");
+    Assertions.assertArrayEquals(Arrays.copyOfRange(convertedEvents, 0, 2),
+        mapEvents, "Unexpected map events");
     mapEvents = job.getMapAttemptCompletionEvents(2, 200);
-    Assert.assertEquals("Incorrect number of map events", 1, mapEvents.length);
-    Assert.assertEquals("Unexpected map event", convertedEvents[2],
-        mapEvents[0]);
+    Assertions.assertEquals(1, mapEvents.length, "Incorrect number of map events");
+    Assertions.assertEquals(convertedEvents[2], mapEvents[0],
+        "Unexpected map event");
   }
 
   private void updateStatus(MRApp app, TaskAttempt attempt, Phase phase) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestFetchFailure.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestFetchFailure.java
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.Test;
 public class TestFetchFailure {
 
   @Test
-  void testFetchFailure() throws Exception {
+  public void testFetchFailure() throws Exception {
     MRApp app = new MRApp(1, 1, false, this.getClass().getName(), true);
     Configuration conf = new Configuration();
     // map -> reduce -> fetch-failure -> map retry is incompatible with
@@ -189,7 +189,7 @@ public class TestFetchFailure {
    * the AM re-runs the maps from scratch.
    */
   @Test
-  void testFetchFailureWithRecovery() throws Exception {
+  public void testFetchFailureWithRecovery() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(1, 1, false, this.getClass().getName(), true, ++runCount);
     Configuration conf = new Configuration();
@@ -284,7 +284,7 @@ public class TestFetchFailure {
   }
   
   @Test
-  void testFetchFailureMultipleReduces() throws Exception {
+  public void testFetchFailureMultipleReduces() throws Exception {
     MRApp app = new MRApp(1, 3, false, this.getClass().getName(), true);
     Configuration conf = new Configuration();
     // map -> reduce -> fetch-failure -> map retry is incompatible with

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestJobEndNotifier.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestJobEndNotifier.java
@@ -148,7 +148,7 @@ public class TestJobEndNotifier extends JobEndNotifier {
    * Test that setting parameters has the desired effect
    */
   @Test
-  void checkConfiguration() {
+  public void checkConfiguration() {
     Configuration conf = new Configuration();
     testNumRetries(conf);
     testWaitInterval(conf);
@@ -166,7 +166,7 @@ public class TestJobEndNotifier extends JobEndNotifier {
 
   //Check retries happen as intended
   @Test
-  void testNotifyRetries() throws InterruptedException {
+  public void testNotifyRetries() throws InterruptedException {
     JobConf conf = new JobConf();
     conf.set(MRJobConfig.MR_JOB_END_RETRY_ATTEMPTS, "0");
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_MAX_ATTEMPTS, "1");
@@ -232,18 +232,18 @@ public class TestJobEndNotifier extends JobEndNotifier {
   }
 
   @Test
-  void testNotificationOnLastRetryNormalShutdown() throws Exception {
+  public void testNotificationOnLastRetryNormalShutdown() throws Exception {
     testNotificationOnLastRetry(false);
   }
 
   @Test
-  void testNotificationOnLastRetryShutdownWithRuntimeException()
+  public void testNotificationOnLastRetryShutdownWithRuntimeException()
       throws Exception {
     testNotificationOnLastRetry(true);
   }
 
   @Test
-  void testAbsentNotificationOnNotLastRetryUnregistrationFailure()
+  public void testAbsentNotificationOnNotLastRetryUnregistrationFailure()
       throws Exception {
     HttpServer2 server = startHttpServer();
     MRApp app = spy(new MRAppWithCustomContainerAllocator(2, 2, false,
@@ -270,7 +270,7 @@ public class TestJobEndNotifier extends JobEndNotifier {
   }
 
   @Test
-  void testNotificationOnLastRetryUnregistrationFailure()
+  public void testNotificationOnLastRetryUnregistrationFailure()
       throws Exception {
     HttpServer2 server = startHttpServer();
     MRApp app = spy(new MRAppWithCustomContainerAllocator(2, 2, false,
@@ -303,7 +303,7 @@ public class TestJobEndNotifier extends JobEndNotifier {
   }
 
   @Test
-  void testCustomNotifierClass() throws InterruptedException {
+  public void testCustomNotifierClass() throws InterruptedException {
     JobConf conf = new JobConf();
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_URL,
              "http://example.com?jobId=$jobId&jobStatus=$jobStatus");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestJobEndNotifier.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestJobEndNotifier.java
@@ -59,8 +59,8 @@ import org.apache.hadoop.mapreduce.v2.app.rm.RMCommunicator;
 import org.apache.hadoop.mapreduce.v2.app.rm.RMHeartbeatHandler;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests job end notification
@@ -74,18 +74,18 @@ public class TestJobEndNotifier extends JobEndNotifier {
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_MAX_ATTEMPTS, "0");
     conf.set(MRJobConfig.MR_JOB_END_RETRY_ATTEMPTS, "10");
     setConf(conf);
-    Assert.assertTrue("Expected numTries to be 0, but was " + numTries,
-      numTries == 0 );
+    Assertions.assertTrue(numTries == 0,
+        "Expected numTries to be 0, but was " + numTries);
 
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_MAX_ATTEMPTS, "1");
     setConf(conf);
-    Assert.assertTrue("Expected numTries to be 1, but was " + numTries,
-      numTries == 1 );
+    Assertions.assertTrue(numTries == 1,
+        "Expected numTries to be 1, but was " + numTries);
 
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_MAX_ATTEMPTS, "20");
     setConf(conf);
-    Assert.assertTrue("Expected numTries to be 11, but was " + numTries,
-      numTries == 11 ); //11 because number of _retries_ is 10
+    Assertions.assertTrue(numTries == 11 , "Expected numTries to be 11, but was "
+            + numTries); //11 because number of _retries_ is 10
   }
 
   //Test maximum retry interval is capped by
@@ -94,53 +94,53 @@ public class TestJobEndNotifier extends JobEndNotifier {
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_MAX_RETRY_INTERVAL, "5000");
     conf.set(MRJobConfig.MR_JOB_END_RETRY_INTERVAL, "1000");
     setConf(conf);
-    Assert.assertTrue("Expected waitInterval to be 1000, but was "
-      + waitInterval, waitInterval == 1000);
+    Assertions.assertTrue(waitInterval == 1000,
+        "Expected waitInterval to be 1000, but was " + waitInterval);
 
     conf.set(MRJobConfig.MR_JOB_END_RETRY_INTERVAL, "10000");
     setConf(conf);
-    Assert.assertTrue("Expected waitInterval to be 5000, but was "
-      + waitInterval, waitInterval == 5000);
+    Assertions.assertTrue(waitInterval == 5000,
+        "Expected waitInterval to be 5000, but was " + waitInterval);
 
     //Test negative numbers are set to default
     conf.set(MRJobConfig.MR_JOB_END_RETRY_INTERVAL, "-10");
     setConf(conf);
-    Assert.assertTrue("Expected waitInterval to be 5000, but was "
-      + waitInterval, waitInterval == 5000);
+    Assertions.assertTrue(waitInterval == 5000,
+        "Expected waitInterval to be 5000, but was " + waitInterval);
   }
 
   private void testTimeout(Configuration conf) {
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_TIMEOUT, "1000");
     setConf(conf);
-    Assert.assertTrue("Expected timeout to be 1000, but was "
-      + timeout, timeout == 1000);
+    Assertions.assertTrue(timeout == 1000,
+        "Expected timeout to be 1000, but was " + timeout);
   }
 
   private void testProxyConfiguration(Configuration conf) {
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "somehost");
     setConf(conf);
-    Assert.assertTrue("Proxy shouldn't be set because port wasn't specified",
-      proxyToUse.type() == Proxy.Type.DIRECT);
+    Assertions.assertTrue(proxyToUse.type() == Proxy.Type.DIRECT,
+        "Proxy shouldn't be set because port wasn't specified");
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "somehost:someport");
     setConf(conf);
-    Assert.assertTrue("Proxy shouldn't be set because port wasn't numeric",
-      proxyToUse.type() == Proxy.Type.DIRECT);
+    Assertions.assertTrue(proxyToUse.type() == Proxy.Type.DIRECT,
+        "Proxy shouldn't be set because port wasn't numeric");
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "somehost:1000");
     setConf(conf);
-    Assert.assertEquals("Proxy should have been set but wasn't ",
-      "HTTP @ somehost:1000", proxyToUse.toString());
+    Assertions.assertEquals("HTTP @ somehost:1000", proxyToUse.toString(),
+        "Proxy should have been set but wasn't ");
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "socks@somehost:1000");
     setConf(conf);
-    Assert.assertEquals("Proxy should have been socks but wasn't ",
-      "SOCKS @ somehost:1000", proxyToUse.toString());
+    Assertions.assertEquals("SOCKS @ somehost:1000", proxyToUse.toString(),
+        "Proxy should have been socks but wasn't ");
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "SOCKS@somehost:1000");
     setConf(conf);
-    Assert.assertEquals("Proxy should have been socks but wasn't ",
-      "SOCKS @ somehost:1000", proxyToUse.toString());
+    Assertions.assertEquals("SOCKS @ somehost:1000", proxyToUse.toString(),
+        "Proxy should have been socks but wasn't ");
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "sfafn@somehost:1000");
     setConf(conf);
-    Assert.assertEquals("Proxy should have been http but wasn't ",
-      "HTTP @ somehost:1000", proxyToUse.toString());
+    Assertions.assertEquals("HTTP @ somehost:1000", proxyToUse.toString(),
+        "Proxy should have been http but wasn't ");
     
   }
 
@@ -148,7 +148,7 @@ public class TestJobEndNotifier extends JobEndNotifier {
    * Test that setting parameters has the desired effect
    */
   @Test
-  public void checkConfiguration() {
+  void checkConfiguration() {
     Configuration conf = new Configuration();
     testNumRetries(conf);
     testWaitInterval(conf);
@@ -166,7 +166,7 @@ public class TestJobEndNotifier extends JobEndNotifier {
 
   //Check retries happen as intended
   @Test
-  public void testNotifyRetries() throws InterruptedException {
+  void testNotifyRetries() throws InterruptedException {
     JobConf conf = new JobConf();
     conf.set(MRJobConfig.MR_JOB_END_RETRY_ATTEMPTS, "0");
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_MAX_ATTEMPTS, "1");
@@ -181,10 +181,10 @@ public class TestJobEndNotifier extends JobEndNotifier {
     this.setConf(conf);
     this.notify(jobReport);
     long endTime = System.currentTimeMillis();
-    Assert.assertEquals("Only 1 try was expected but was : "
-      + this.notificationCount, 1, this.notificationCount);
-    Assert.assertTrue("Should have taken more than 5 seconds it took "
-      + (endTime - startTime), endTime - startTime > 5000);
+    Assertions.assertEquals(1, this.notificationCount,
+        "Only 1 try was expected but was : " + this.notificationCount);
+    Assertions.assertTrue(endTime - startTime > 5000,
+        "Should have taken more than 5 seconds it took " + (endTime - startTime));
 
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_MAX_ATTEMPTS, "3");
     conf.set(MRJobConfig.MR_JOB_END_RETRY_ATTEMPTS, "3");
@@ -196,10 +196,10 @@ public class TestJobEndNotifier extends JobEndNotifier {
     this.setConf(conf);
     this.notify(jobReport);
     endTime = System.currentTimeMillis();
-    Assert.assertEquals("Only 3 retries were expected but was : "
-      + this.notificationCount, 3, this.notificationCount);
-    Assert.assertTrue("Should have taken more than 9 seconds it took "
-      + (endTime - startTime), endTime - startTime > 9000);
+    Assertions.assertEquals(3, this.notificationCount,
+        "Only 3 retries were expected but was : " + this.notificationCount);
+    Assertions.assertTrue(endTime - startTime > 9000,
+        "Should have taken more than 9 seconds it took " + (endTime - startTime));
 
   }
 
@@ -222,28 +222,28 @@ public class TestJobEndNotifier extends JobEndNotifier {
       doThrow(runtimeException).when(app).stop();
     }
     app.shutDownJob();
-    Assert.assertTrue(app.isLastAMRetry());
-    Assert.assertEquals(1, JobEndServlet.calledTimes);
-    Assert.assertEquals("jobid=" + job.getID() + "&status=SUCCEEDED",
+    Assertions.assertTrue(app.isLastAMRetry());
+    Assertions.assertEquals(1, JobEndServlet.calledTimes);
+    Assertions.assertEquals("jobid=" + job.getID() + "&status=SUCCEEDED",
         JobEndServlet.requestUri.getQuery());
-    Assert.assertEquals(JobState.SUCCEEDED.toString(),
+    Assertions.assertEquals(JobState.SUCCEEDED.toString(),
         JobEndServlet.foundJobState);
     server.stop();
   }
 
   @Test
-  public void testNotificationOnLastRetryNormalShutdown() throws Exception {
+  void testNotificationOnLastRetryNormalShutdown() throws Exception {
     testNotificationOnLastRetry(false);
   }
 
   @Test
-  public void testNotificationOnLastRetryShutdownWithRuntimeException()
+  void testNotificationOnLastRetryShutdownWithRuntimeException()
       throws Exception {
     testNotificationOnLastRetry(true);
   }
 
   @Test
-  public void testAbsentNotificationOnNotLastRetryUnregistrationFailure()
+  void testAbsentNotificationOnNotLastRetryUnregistrationFailure()
       throws Exception {
     HttpServer2 server = startHttpServer();
     MRApp app = spy(new MRAppWithCustomContainerAllocator(2, 2, false,
@@ -262,15 +262,15 @@ public class TestJobEndNotifier extends JobEndNotifier {
     app.shutDownJob();
     // Not the last AM attempt. So user should that the job is still running.
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertFalse(app.isLastAMRetry());
-    Assert.assertEquals(0, JobEndServlet.calledTimes);
-    Assert.assertNull(JobEndServlet.requestUri);
-    Assert.assertNull(JobEndServlet.foundJobState);
+    Assertions.assertFalse(app.isLastAMRetry());
+    Assertions.assertEquals(0, JobEndServlet.calledTimes);
+    Assertions.assertNull(JobEndServlet.requestUri);
+    Assertions.assertNull(JobEndServlet.foundJobState);
     server.stop();
   }
 
   @Test
-  public void testNotificationOnLastRetryUnregistrationFailure()
+  void testNotificationOnLastRetryUnregistrationFailure()
       throws Exception {
     HttpServer2 server = startHttpServer();
     MRApp app = spy(new MRAppWithCustomContainerAllocator(2, 2, false,
@@ -294,16 +294,16 @@ public class TestJobEndNotifier extends JobEndNotifier {
     // Unregistration fails: isLastAMRetry is recalculated, this is
     ///reboot will stop service internally, we don't need to shutdown twice
     app.waitForServiceToStop(10000);
-    Assert.assertFalse(app.isLastAMRetry());
+    Assertions.assertFalse(app.isLastAMRetry());
     // Since it's not last retry, JobEndServlet didn't called
-    Assert.assertEquals(0, JobEndServlet.calledTimes);
-    Assert.assertNull(JobEndServlet.requestUri);
-    Assert.assertNull(JobEndServlet.foundJobState);
+    Assertions.assertEquals(0, JobEndServlet.calledTimes);
+    Assertions.assertNull(JobEndServlet.requestUri);
+    Assertions.assertNull(JobEndServlet.foundJobState);
     server.stop();
   }
 
   @Test
-  public void testCustomNotifierClass() throws InterruptedException {
+  void testCustomNotifierClass() throws InterruptedException {
     JobConf conf = new JobConf();
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_URL,
              "http://example.com?jobId=$jobId&jobStatus=$jobStatus");
@@ -321,7 +321,7 @@ public class TestJobEndNotifier extends JobEndNotifier {
     this.notify(jobReport);
     final URL urlToNotify = CustomNotifier.urlToNotify;
 
-    Assert.assertEquals("http://example.com?jobId=mock-Id&jobStatus=SUCCEEDED",
+    Assertions.assertEquals("http://example.com?jobId=mock-Id&jobStatus=SUCCEEDED",
                         urlToNotify.toString());
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestKill.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestKill.java
@@ -58,7 +58,7 @@ import org.junit.jupiter.api.Test;
 public class TestKill {
 
   @Test
-  void testKillJob() throws Exception {
+  public void testKillJob() throws Exception {
     final CountDownLatch latch = new CountDownLatch(1);
     
     MRApp app = new BlockingMRApp(1, 0, latch);
@@ -97,7 +97,7 @@ public class TestKill {
   }
 
   @Test
-  void testKillTask() throws Exception {
+  public void testKillTask() throws Exception {
     final CountDownLatch latch = new CountDownLatch(1);
     MRApp app = new BlockingMRApp(2, 0, latch);
     //this will start the job but job won't complete as Task is blocked
@@ -145,7 +145,7 @@ public class TestKill {
   }
 
   @Test
-  void testKillTaskWait() throws Exception {
+  public void testKillTaskWait() throws Exception {
     final Dispatcher dispatcher = new AsyncDispatcher() {
       private TaskAttemptEvent cachedKillEvent;
       @Override
@@ -220,7 +220,7 @@ public class TestKill {
   }
 
   @Test
-  void testKillTaskWaitKillJobAfterTA_DONE() throws Exception {
+  public void testKillTaskWaitKillJobAfterTA_DONE() throws Exception {
     CountDownLatch latch = new CountDownLatch(1);
     final Dispatcher dispatcher = new MyAsyncDispatch(latch, TaskAttemptEventType.TA_DONE);
     MRApp app = new MRApp(1, 1, false, this.getClass().getName(), true) {
@@ -269,7 +269,7 @@ public class TestKill {
 
 
   @Test
-  void testKillTaskWaitKillJobBeforeTA_DONE() throws Exception {
+  public void testKillTaskWaitKillJobBeforeTA_DONE() throws Exception {
     CountDownLatch latch = new CountDownLatch(1);
     final Dispatcher dispatcher = new MyAsyncDispatch(latch, JobEventType.JOB_KILL);
     MRApp app = new MRApp(1, 1, false, this.getClass().getName(), true) {
@@ -363,7 +363,7 @@ public class TestKill {
   }
 
   @Test
-  void testKillTaskAttempt() throws Exception {
+  public void testKillTaskAttempt() throws Exception {
     final CountDownLatch latch = new CountDownLatch(1);
     MRApp app = new BlockingMRApp(2, 0, latch);
     //this will start the job but job won't complete as Task is blocked

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestKill.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestKill.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 import org.apache.hadoop.service.Service;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.v2.api.records.JobId;
@@ -48,7 +48,7 @@ import org.apache.hadoop.mapreduce.v2.app.job.impl.JobImpl;
 import org.apache.hadoop.yarn.event.AsyncDispatcher;
 import org.apache.hadoop.yarn.event.Dispatcher;
 import org.apache.hadoop.yarn.event.Event;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the state machine with respect to Job/Task/TaskAttempt kill scenarios.
@@ -58,7 +58,7 @@ import org.junit.Test;
 public class TestKill {
 
   @Test
-  public void testKillJob() throws Exception {
+  void testKillJob() throws Exception {
     final CountDownLatch latch = new CountDownLatch(1);
     
     MRApp app = new BlockingMRApp(1, 0, latch);
@@ -83,22 +83,21 @@ public class TestKill {
     app.waitForState(Service.STATE.STOPPED);
 
     Map<TaskId,Task> tasks = job.getTasks();
-    Assert.assertEquals("No of tasks is not correct", 1, 
-        tasks.size());
+    Assertions.assertEquals(1, tasks.size(),
+        "No of tasks is not correct");
     Task task = tasks.values().iterator().next();
-    Assert.assertEquals("Task state not correct", TaskState.KILLED, 
-        task.getReport().getTaskState());
+    Assertions.assertEquals(TaskState.KILLED,
+        task.getReport().getTaskState(), "Task state not correct");
     Map<TaskAttemptId, TaskAttempt> attempts = 
       tasks.values().iterator().next().getAttempts();
-    Assert.assertEquals("No of attempts is not correct", 1, 
-        attempts.size());
+    Assertions.assertEquals(1, attempts.size(), "No of attempts is not correct");
     Iterator<TaskAttempt> it = attempts.values().iterator();
-    Assert.assertEquals("Attempt state not correct", TaskAttemptState.KILLED, 
-          it.next().getReport().getTaskAttemptState());
+    Assertions.assertEquals(TaskAttemptState.KILLED,
+          it.next().getReport().getTaskAttemptState(), "Attempt state not correct");
   }
 
   @Test
-  public void testKillTask() throws Exception {
+  void testKillTask() throws Exception {
     final CountDownLatch latch = new CountDownLatch(1);
     MRApp app = new BlockingMRApp(2, 0, latch);
     //this will start the job but job won't complete as Task is blocked
@@ -107,8 +106,8 @@ public class TestKill {
     //wait and vailidate for Job to become RUNNING
     app.waitForInternalState((JobImpl) job, JobStateInternal.RUNNING);
     Map<TaskId,Task> tasks = job.getTasks();
-    Assert.assertEquals("No of tasks is not correct", 2, 
-        tasks.size());
+    Assertions.assertEquals(2, tasks.size(),
+        "No of tasks is not correct");
     Iterator<Task> it = tasks.values().iterator();
     Task task1 = it.next();
     Task task2 = it.next();
@@ -125,28 +124,28 @@ public class TestKill {
     
     //first Task is killed and second is Succeeded
     //Job is succeeded
-    
-    Assert.assertEquals("Task state not correct", TaskState.KILLED, 
-        task1.getReport().getTaskState());
-    Assert.assertEquals("Task state not correct", TaskState.SUCCEEDED, 
-        task2.getReport().getTaskState());
+
+    Assertions.assertEquals(TaskState.KILLED, task1.getReport().getTaskState(),
+        "Task state not correct");
+    Assertions.assertEquals(TaskState.SUCCEEDED, task2.getReport().getTaskState(),
+        "Task state not correct");
     Map<TaskAttemptId, TaskAttempt> attempts = task1.getAttempts();
-    Assert.assertEquals("No of attempts is not correct", 1, 
-        attempts.size());
+    Assertions.assertEquals(1, attempts.size(),
+        "No of attempts is not correct");
     Iterator<TaskAttempt> iter = attempts.values().iterator();
-    Assert.assertEquals("Attempt state not correct", TaskAttemptState.KILLED, 
-          iter.next().getReport().getTaskAttemptState());
+    Assertions.assertEquals(TaskAttemptState.KILLED,
+          iter.next().getReport().getTaskAttemptState(), "Attempt state not correct");
 
     attempts = task2.getAttempts();
-    Assert.assertEquals("No of attempts is not correct", 1, 
-        attempts.size());
+    Assertions.assertEquals(1, attempts.size(),
+        "No of attempts is not correct");
     iter = attempts.values().iterator();
-    Assert.assertEquals("Attempt state not correct", TaskAttemptState.SUCCEEDED, 
-          iter.next().getReport().getTaskAttemptState());
+    Assertions.assertEquals(TaskAttemptState.SUCCEEDED,
+          iter.next().getReport().getTaskAttemptState(), "Attempt state not correct");
   }
 
   @Test
-  public void testKillTaskWait() throws Exception {
+  void testKillTaskWait() throws Exception {
     final Dispatcher dispatcher = new AsyncDispatcher() {
       private TaskAttemptEvent cachedKillEvent;
       @Override
@@ -194,7 +193,8 @@ public class TestKill {
     Job job = app.submit(new Configuration());
     JobId jobId = app.getJobId();
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("Num tasks not correct", 2, job.getTasks().size());
+    Assertions.assertEquals(2, job.getTasks().size(),
+        "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask = it.next();
     Task reduceTask = it.next();
@@ -220,7 +220,7 @@ public class TestKill {
   }
 
   @Test
-  public void testKillTaskWaitKillJobAfterTA_DONE() throws Exception {
+  void testKillTaskWaitKillJobAfterTA_DONE() throws Exception {
     CountDownLatch latch = new CountDownLatch(1);
     final Dispatcher dispatcher = new MyAsyncDispatch(latch, TaskAttemptEventType.TA_DONE);
     MRApp app = new MRApp(1, 1, false, this.getClass().getName(), true) {
@@ -232,7 +232,8 @@ public class TestKill {
     Job job = app.submit(new Configuration());
     JobId jobId = app.getJobId();
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("Num tasks not correct", 2, job.getTasks().size());
+    Assertions.assertEquals(2, job.getTasks().size(),
+        "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask = it.next();
     Task reduceTask = it.next();
@@ -268,7 +269,7 @@ public class TestKill {
 
 
   @Test
-  public void testKillTaskWaitKillJobBeforeTA_DONE() throws Exception {
+  void testKillTaskWaitKillJobBeforeTA_DONE() throws Exception {
     CountDownLatch latch = new CountDownLatch(1);
     final Dispatcher dispatcher = new MyAsyncDispatch(latch, JobEventType.JOB_KILL);
     MRApp app = new MRApp(1, 1, false, this.getClass().getName(), true) {
@@ -280,7 +281,8 @@ public class TestKill {
     Job job = app.submit(new Configuration());
     JobId jobId = app.getJobId();
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("Num tasks not correct", 2, job.getTasks().size());
+    Assertions.assertEquals(2, job.getTasks().size(),
+        "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask = it.next();
     Task reduceTask = it.next();
@@ -361,7 +363,7 @@ public class TestKill {
   }
 
   @Test
-  public void testKillTaskAttempt() throws Exception {
+  void testKillTaskAttempt() throws Exception {
     final CountDownLatch latch = new CountDownLatch(1);
     MRApp app = new BlockingMRApp(2, 0, latch);
     //this will start the job but job won't complete as Task is blocked
@@ -370,8 +372,8 @@ public class TestKill {
     //wait and vailidate for Job to become RUNNING
     app.waitForState(job, JobState.RUNNING);
     Map<TaskId,Task> tasks = job.getTasks();
-    Assert.assertEquals("No of tasks is not correct", 2, 
-        tasks.size());
+    Assertions.assertEquals(2, tasks.size(),
+        "No of tasks is not correct");
     Iterator<Task> it = tasks.values().iterator();
     Task task1 = it.next();
     Task task2 = it.next();
@@ -394,26 +396,26 @@ public class TestKill {
     
     //first Task will have two attempts 1st is killed, 2nd Succeeds
     //both Tasks and Job succeeds
-    Assert.assertEquals("Task state not correct", TaskState.SUCCEEDED, 
-        task1.getReport().getTaskState());
-    Assert.assertEquals("Task state not correct", TaskState.SUCCEEDED, 
-        task2.getReport().getTaskState());
+    Assertions.assertEquals(TaskState.SUCCEEDED,
+        task1.getReport().getTaskState(), "Task state not correct");
+    Assertions.assertEquals(TaskState.SUCCEEDED,
+        task2.getReport().getTaskState(), "Task state not correct");
  
     Map<TaskAttemptId, TaskAttempt> attempts = task1.getAttempts();
-    Assert.assertEquals("No of attempts is not correct", 2, 
-        attempts.size());
+    Assertions.assertEquals(2, attempts.size(),
+        "No of attempts is not correct");
     Iterator<TaskAttempt> iter = attempts.values().iterator();
-    Assert.assertEquals("Attempt state not correct", TaskAttemptState.KILLED, 
-          iter.next().getReport().getTaskAttemptState());
-    Assert.assertEquals("Attempt state not correct", TaskAttemptState.SUCCEEDED, 
-        iter.next().getReport().getTaskAttemptState());
+    Assertions.assertEquals(TaskAttemptState.KILLED,
+        iter.next().getReport().getTaskAttemptState(), "Attempt state not correct");
+    Assertions.assertEquals(TaskAttemptState.SUCCEEDED,
+        iter.next().getReport().getTaskAttemptState(), "Attempt state not correct");
     
     attempts = task2.getAttempts();
-    Assert.assertEquals("No of attempts is not correct", 1, 
-        attempts.size());
+    Assertions.assertEquals(1, attempts.size(),
+        "No of attempts is not correct");
     iter = attempts.values().iterator();
-    Assert.assertEquals("Attempt state not correct", TaskAttemptState.SUCCEEDED, 
-          iter.next().getReport().getTaskAttemptState());
+    Assertions.assertEquals(TaskAttemptState.SUCCEEDED,
+          iter.next().getReport().getTaskAttemptState(), "Attempt state not correct");
   }
 
   static class BlockingMRApp extends MRApp {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestKillAMPreemptionPolicy.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestKillAMPreemptionPolicy.java
@@ -47,7 +47,7 @@ import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestKillAMPreemptionPolicy {
   private final RecordFactory recordFactory = RecordFactoryProvider
@@ -55,7 +55,7 @@ public class TestKillAMPreemptionPolicy {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testKillAMPreemptPolicy() {
+  void testKillAMPreemptPolicy() {
 
     ApplicationId appId = ApplicationId.newInstance(123456789, 1);
     ContainerId container = ContainerId.newContainerId(

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestKillAMPreemptionPolicy.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestKillAMPreemptionPolicy.java
@@ -55,7 +55,7 @@ public class TestKillAMPreemptionPolicy {
 
   @SuppressWarnings("unchecked")
   @Test
-  void testKillAMPreemptPolicy() {
+  public void testKillAMPreemptPolicy() {
 
     ApplicationId appId = ApplicationId.newInstance(123456789, 1);
     ContainerId container = ContainerId.newContainerId(

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRApp.java
@@ -78,7 +78,7 @@ import org.mockito.Mockito;
 public class TestMRApp {
 
   @Test
-  void testMapReduce() throws Exception {
+  public void testMapReduce() throws Exception {
     MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.SUCCEEDED);
@@ -87,7 +87,7 @@ public class TestMRApp {
   }
 
   @Test
-  void testZeroMaps() throws Exception {
+  public void testZeroMaps() throws Exception {
     MRApp app = new MRApp(0, 1, true, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.SUCCEEDED);
@@ -95,14 +95,14 @@ public class TestMRApp {
   }
   
   @Test
-  void testZeroMapReduces() throws Exception{
+  public void testZeroMapReduces() throws Exception{
     MRApp app = new MRApp(0, 0, true, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.SUCCEEDED);
   }
   
   @Test
-  void testCommitPending() throws Exception {
+  public void testCommitPending() throws Exception {
     MRApp app = new MRApp(1, 0, false, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.RUNNING);
@@ -206,7 +206,7 @@ public class TestMRApp {
    * re-run information is preserved across AM restart
    */
   @Test
-  void testUpdatedNodes() throws Exception {
+  public void testUpdatedNodes() throws Exception {
     int runCount = 0;
     AsyncDispatcher dispatcher = new AsyncDispatcher();
     dispatcher.init(new Configuration());
@@ -469,7 +469,7 @@ public class TestMRApp {
   }
 
   @Test
-  void testJobError() throws Exception {
+  public void testJobError() throws Exception {
     MRApp app = new MRApp(1, 0, false, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.RUNNING);
@@ -490,7 +490,7 @@ public class TestMRApp {
 
   @SuppressWarnings("resource")
   @Test
-  void testJobSuccess() throws Exception {
+  public void testJobSuccess() throws Exception {
     MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true, false);
     JobImpl job = (JobImpl) app.submit(new Configuration());
     app.waitForInternalState(job, JobStateInternal.SUCCEEDED);
@@ -502,7 +502,7 @@ public class TestMRApp {
   }
 
   @Test
-  void testJobRebootNotLastRetryOnUnregistrationFailure()
+  public void testJobRebootNotLastRetryOnUnregistrationFailure()
       throws Exception {
     MRApp app = new MRApp(1, 0, false, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
@@ -523,7 +523,7 @@ public class TestMRApp {
   }
 
   @Test
-  void testJobRebootOnLastRetryOnUnregistrationFailure()
+  public void testJobRebootOnLastRetryOnUnregistrationFailure()
       throws Exception {
     // make startCount as 2 since this is last retry which equals to
     // DEFAULT_MAX_AM_RETRY
@@ -567,7 +567,7 @@ public class TestMRApp {
   }
 
   @Test
-  void testCountersOnJobFinish() throws Exception {
+  public void testCountersOnJobFinish() throws Exception {
     MRAppWithSpiedJob app =
         new MRAppWithSpiedJob(1, 1, true, this.getClass().getName(), true);
     JobImpl job = (JobImpl)app.submit(new Configuration());
@@ -582,7 +582,7 @@ public class TestMRApp {
   }
 
   @Test
-  void checkJobStateTypeConversion() {
+  public void checkJobStateTypeConversion() {
     //verify that all states can be converted without 
     // throwing an exception
     for (JobState state : JobState.values()) {
@@ -591,7 +591,7 @@ public class TestMRApp {
   }
 
   @Test
-  void checkTaskStateTypeConversion() {
+  public void checkTaskStateTypeConversion() {
     //verify that all states can be converted without 
     // throwing an exception
     for (TaskState state : TaskState.values()) {
@@ -601,7 +601,7 @@ public class TestMRApp {
 
   private Container containerObtainedByContainerLauncher;
   @Test
-  void testContainerPassThrough() throws Exception {
+  public void testContainerPassThrough() throws Exception {
     MRApp app = new MRApp(0, 1, true, this.getClass().getName(), true) {
       @Override
       protected ContainerLauncher createContainerLauncher(AppContext context) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRApp.java
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import java.util.function.Supplier;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.MRJobConfig;
@@ -68,7 +68,7 @@ import org.apache.hadoop.yarn.event.AsyncDispatcher;
 import org.apache.hadoop.yarn.event.Dispatcher;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -78,16 +78,16 @@ import org.mockito.Mockito;
 public class TestMRApp {
 
   @Test
-  public void testMapReduce() throws Exception {
+  void testMapReduce() throws Exception {
     MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
-    Assert.assertEquals(System.getProperty("user.name"),job.getUserName());
+    Assertions.assertEquals(System.getProperty("user.name"),job.getUserName());
   }
 
   @Test
-  public void testZeroMaps() throws Exception {
+  void testZeroMaps() throws Exception {
     MRApp app = new MRApp(0, 1, true, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.SUCCEEDED);
@@ -95,18 +95,18 @@ public class TestMRApp {
   }
   
   @Test
-  public void testZeroMapReduces() throws Exception{
+  void testZeroMapReduces() throws Exception{
     MRApp app = new MRApp(0, 0, true, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.SUCCEEDED);
   }
   
   @Test
-  public void testCommitPending() throws Exception {
+  void testCommitPending() throws Exception {
     MRApp app = new MRApp(1, 0, false, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("Num tasks not correct", 1, job.getTasks().size());
+    Assertions.assertEquals(1, job.getTasks().size(), "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task task = it.next();
     app.waitForState(task, TaskState.RUNNING);
@@ -151,7 +151,7 @@ public class TestMRApp {
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     //all maps would be running
-    Assert.assertEquals("Num tasks not correct", 3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(), "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask1 = it.next();
     Task mapTask2 = it.next();
@@ -170,8 +170,8 @@ public class TestMRApp {
     app.waitForState(task2Attempt, TaskAttemptState.RUNNING);
     
     // reduces must be in NEW state
-    Assert.assertEquals("Reduce Task state not correct",
-        TaskState.NEW, reduceTask.getReport().getTaskState());
+    Assertions.assertEquals(TaskState.NEW,
+        reduceTask.getReport().getTaskState(), "Reduce Task state not correct");
     
     //send the done signal to the 1st map task
     app.getContext().getEventHandler().handle(
@@ -206,7 +206,7 @@ public class TestMRApp {
    * re-run information is preserved across AM restart
    */
   @Test
-  public void testUpdatedNodes() throws Exception {
+  void testUpdatedNodes() throws Exception {
     int runCount = 0;
     AsyncDispatcher dispatcher = new AsyncDispatcher();
     dispatcher.init(new Configuration());
@@ -224,7 +224,8 @@ public class TestMRApp {
 
     final Job job1 = app.submit(conf);
     app.waitForState(job1, JobState.RUNNING);
-    Assert.assertEquals("Num tasks not correct", 4, job1.getTasks().size());
+    Assertions.assertEquals(4, job1.getTasks().size(),
+        "Num tasks not correct");
     Iterator<Task> it = job1.getTasks().values().iterator();
     Task mapTask1 = it.next();
     Task mapTask2 = it.next();
@@ -239,7 +240,7 @@ public class TestMRApp {
         .next();
     NodeId node1 = task1Attempt.getNodeId();
     NodeId node2 = task2Attempt.getNodeId();
-    Assert.assertEquals(node1, node2);
+    Assertions.assertEquals(node1, node2);
 
     // send the done signal to the task
     app.getContext()
@@ -271,8 +272,8 @@ public class TestMRApp {
 
     TaskAttemptCompletionEvent[] events = job1.getTaskAttemptCompletionEvents
         (0, 100);
-    Assert.assertEquals("Expecting 2 completion events for success", 2,
-        events.length);
+    Assertions.assertEquals(2, events.length,
+        "Expecting 2 completion events for success");
 
     // send updated nodes info
     ArrayList<NodeReport> updatedNodes = new ArrayList<NodeReport>();
@@ -297,8 +298,8 @@ public class TestMRApp {
     }, checkIntervalMillis, waitForMillis);
 
     events = job1.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals("Expecting 2 more completion events for killed", 4,
-        events.length);
+    Assertions.assertEquals(4, events.length,
+        "Expecting 2 more completion events for killed");
     // 2 map task attempts which were killed above should be requested from
     // container allocator with the previous map task marked as failed. If
     // this happens allocator will request the container for this mapper from
@@ -335,8 +336,8 @@ public class TestMRApp {
     }, checkIntervalMillis, waitForMillis);
 
     events = job1.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals("Expecting 1 more completion events for success", 5,
-        events.length);
+    Assertions.assertEquals(5, events.length,
+        "Expecting 1 more completion events for success");
 
     // Crash the app again.
     app.stop();
@@ -351,7 +352,8 @@ public class TestMRApp {
 
     final Job job2 = app.submit(conf);
     app.waitForState(job2, JobState.RUNNING);
-    Assert.assertEquals("No of tasks not correct", 4, job2.getTasks().size());
+    Assertions.assertEquals(4, job2.getTasks().size(),
+        "No of tasks not correct");
     it = job2.getTasks().values().iterator();
     mapTask1 = it.next();
     mapTask2 = it.next();
@@ -372,9 +374,8 @@ public class TestMRApp {
     }, checkIntervalMillis, waitForMillis);
 
     events = job2.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals(
-        "Expecting 2 completion events for killed & success of map1", 2,
-        events.length);
+    Assertions.assertEquals(2, events.length,
+        "Expecting 2 completion events for killed & success of map1");
 
     task2Attempt = mapTask2.getAttempts().values().iterator().next();
     app.getContext()
@@ -394,8 +395,8 @@ public class TestMRApp {
     }, checkIntervalMillis, waitForMillis);
 
     events = job2.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals("Expecting 1 more completion events for success", 3,
-        events.length);
+    Assertions.assertEquals(3, events.length,
+        "Expecting 1 more completion events for success");
 
     app.waitForState(reduceTask1, TaskState.RUNNING);
     app.waitForState(reduceTask2, TaskState.RUNNING);
@@ -433,8 +434,8 @@ public class TestMRApp {
       }
     }, checkIntervalMillis, waitForMillis);
     events = job2.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals("Expecting 2 more completion events for reduce success",
-        5, events.length);
+    Assertions.assertEquals(5, events.length,
+        "Expecting 2 more completion events for reduce success");
 
     // job succeeds
     app.waitForState(job2, JobState.SUCCEEDED);
@@ -468,11 +469,12 @@ public class TestMRApp {
   }
 
   @Test
-  public void testJobError() throws Exception {
+  void testJobError() throws Exception {
     MRApp app = new MRApp(1, 0, false, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("Num tasks not correct", 1, job.getTasks().size());
+    Assertions.assertEquals(1, job.getTasks().size(),
+        "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task task = it.next();
     app.waitForState(task, TaskState.RUNNING);
@@ -488,24 +490,25 @@ public class TestMRApp {
 
   @SuppressWarnings("resource")
   @Test
-  public void testJobSuccess() throws Exception {
+  void testJobSuccess() throws Exception {
     MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true, false);
     JobImpl job = (JobImpl) app.submit(new Configuration());
     app.waitForInternalState(job, JobStateInternal.SUCCEEDED);
     // AM is not unregistered
-    Assert.assertEquals(JobState.RUNNING, job.getState());
+    Assertions.assertEquals(JobState.RUNNING, job.getState());
     // imitate that AM is unregistered
     app.successfullyUnregistered.set(true);
     app.waitForState(job, JobState.SUCCEEDED);
   }
 
   @Test
-  public void testJobRebootNotLastRetryOnUnregistrationFailure()
+  void testJobRebootNotLastRetryOnUnregistrationFailure()
       throws Exception {
     MRApp app = new MRApp(1, 0, false, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("Num tasks not correct", 1, job.getTasks().size());
+    Assertions.assertEquals(1, job.getTasks().size(),
+        "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task task = it.next();
     app.waitForState(task, TaskState.RUNNING);
@@ -520,7 +523,7 @@ public class TestMRApp {
   }
 
   @Test
-  public void testJobRebootOnLastRetryOnUnregistrationFailure()
+  void testJobRebootOnLastRetryOnUnregistrationFailure()
       throws Exception {
     // make startCount as 2 since this is last retry which equals to
     // DEFAULT_MAX_AM_RETRY
@@ -530,7 +533,8 @@ public class TestMRApp {
     Configuration conf = new Configuration();
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("Num tasks not correct", 1, job.getTasks().size());
+    Assertions.assertEquals(1, job.getTasks().size(),
+        "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task task = it.next();
     app.waitForState(task, TaskState.RUNNING);
@@ -563,7 +567,7 @@ public class TestMRApp {
   }
 
   @Test
-  public void testCountersOnJobFinish() throws Exception {
+  void testCountersOnJobFinish() throws Exception {
     MRAppWithSpiedJob app =
         new MRAppWithSpiedJob(1, 1, true, this.getClass().getName(), true);
     JobImpl job = (JobImpl)app.submit(new Configuration());
@@ -578,7 +582,7 @@ public class TestMRApp {
   }
 
   @Test
-  public void checkJobStateTypeConversion() {
+  void checkJobStateTypeConversion() {
     //verify that all states can be converted without 
     // throwing an exception
     for (JobState state : JobState.values()) {
@@ -587,7 +591,7 @@ public class TestMRApp {
   }
 
   @Test
-  public void checkTaskStateTypeConversion() {
+  void checkTaskStateTypeConversion() {
     //verify that all states can be converted without 
     // throwing an exception
     for (TaskState state : TaskState.values()) {
@@ -597,7 +601,7 @@ public class TestMRApp {
 
   private Container containerObtainedByContainerLauncher;
   @Test
-  public void testContainerPassThrough() throws Exception {
+  void testContainerPassThrough() throws Exception {
     MRApp app = new MRApp(0, 1, true, this.getClass().getName(), true) {
       @Override
       protected ContainerLauncher createContainerLauncher(AppContext context) {
@@ -624,7 +628,7 @@ public class TestMRApp {
         (TaskAttemptImpl) taskAttempts.iterator().next();
     // Container from RM should pass through to the launcher. Container object
     // should be the same.
-   Assert.assertTrue(taskAttempt.container 
+   Assertions.assertTrue(taskAttempt.container
      == containerObtainedByContainerLauncher);
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRAppComponentDependencies.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRAppComponentDependencies.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.mapreduce.v2.app;
 
 import java.io.IOException;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.jobhistory.JobHistoryEvent;
@@ -35,12 +35,14 @@ import org.apache.hadoop.mapreduce.v2.app.job.impl.JobImpl;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestMRAppComponentDependencies {
 
-  @Test(timeout = 20000)
-  public void testComponentStopOrder() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testComponentStopOrder() throws Exception {
     @SuppressWarnings("resource")
     TestMRApp app = new TestMRApp(1, 1, true, this.getClass().getName(), true);
     JobImpl job = (JobImpl) app.submit(new Configuration());
@@ -54,8 +56,8 @@ public class TestMRAppComponentDependencies {
     }
 
     // assert JobHistoryEventHandlerStopped and then clientServiceStopped
-    Assert.assertEquals(1, app.JobHistoryEventHandlerStopped);
-    Assert.assertEquals(2, app.clientServiceStopped);
+    Assertions.assertEquals(1, app.JobHistoryEventHandlerStopped);
+    Assertions.assertEquals(2, app.clientServiceStopped);
   }
 
   private final class TestMRApp extends MRApp {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRAppComponentDependencies.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRAppComponentDependencies.java
@@ -42,7 +42,7 @@ public class TestMRAppComponentDependencies {
 
   @Test
   @Timeout(20000)
-  void testComponentStopOrder() throws Exception {
+  public void testComponentStopOrder() throws Exception {
     @SuppressWarnings("resource")
     TestMRApp app = new TestMRApp(1, 1, true, this.getClass().getName(), true);
     JobImpl job = (JobImpl) app.submit(new Configuration());

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRAppMaster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRAppMaster.java
@@ -18,9 +18,9 @@
 package org.apache.hadoop.mapreduce.v2.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileContext;
@@ -84,10 +84,11 @@ import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.event.Level;
@@ -104,7 +105,7 @@ public class TestMRAppMaster {
   static String stagingDir = new Path(testDir, "staging").toString();
   private static FileContext localFS = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws AccessControlException,
       FileNotFoundException, IllegalArgumentException, IOException {
     //Do not error out if metrics are inited multiple times
@@ -116,7 +117,7 @@ public class TestMRAppMaster {
     new File(testDir.toString()).mkdir();
   }
 
-  @Before
+  @BeforeEach
   public void prepare() throws IOException {
     File dir = new File(stagingDir);
     if(dir.exists()) {
@@ -125,13 +126,13 @@ public class TestMRAppMaster {
     dir.mkdirs();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws IOException {
     localFS.delete(testDir, true);
   }
 
   @Test
-  public void testMRAppMasterForDifferentUser() throws IOException,
+  void testMRAppMasterForDifferentUser() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000001";
     String containerIdStr = "container_1317529182569_0004_000001_1";
@@ -153,7 +154,7 @@ public class TestMRAppMaster {
   }
 
   @Test
-  public void testMRAppMasterMidLock() throws IOException,
+  void testMRAppMasterMidLock() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -192,7 +193,7 @@ public class TestMRAppMaster {
   }
 
   @Test
-  public void testMRAppMasterJobLaunchTime() throws IOException,
+  void testMRAppMasterJobLaunchTime() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -226,12 +227,12 @@ public class TestMRAppMaster {
             "host", -1, -1, System.currentTimeMillis());
     MRAppMaster.initAndStartAppMaster(appMaster, conf, userName);
     appMaster.stop();
-    assertTrue("Job launch time should not be negative.",
-            appMaster.jobLaunchTime.get() >= 0);
+    assertTrue(appMaster.jobLaunchTime.get() >= 0,
+        "Job launch time should not be negative.");
   }
 
   @Test
-  public void testMRAppMasterSuccessLock() throws IOException,
+  void testMRAppMasterSuccessLock() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -269,7 +270,7 @@ public class TestMRAppMaster {
   }
 
   @Test
-  public void testMRAppMasterFailLock() throws IOException,
+  void testMRAppMasterFailLock() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -307,7 +308,7 @@ public class TestMRAppMaster {
   }
 
   @Test
-  public void testMRAppMasterMissingStaging() throws IOException,
+  void testMRAppMasterMissingStaging() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -343,7 +344,8 @@ public class TestMRAppMaster {
     appMaster.stop();
   }
 
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(30000)
   public void testMRAppMasterMaxAppAttempts() throws IOException,
       InterruptedException {
     // No matter what's the maxAppAttempt or attempt id, the isLastRetry always
@@ -368,8 +370,8 @@ public class TestMRAppMaster {
           new MRAppMasterTest(applicationAttemptId, containerId, "host", -1, -1,
               System.currentTimeMillis(), false, true);
       MRAppMaster.initAndStartAppMaster(appMaster, conf, userName);
-      assertEquals("isLastAMRetry is correctly computed.", expectedBools[i],
-          appMaster.isLastAMRetry());
+      assertEquals(expectedBools[i], appMaster.isLastAMRetry(),
+          "isLastAMRetry is correctly computed.");
     }
   }
 
@@ -407,7 +409,7 @@ public class TestMRAppMaster {
   }
 
   @Test
-  public void testMRAppMasterCredentials() throws Exception {
+  void testMRAppMasterCredentials() throws Exception {
 
     GenericTestUtils.setRootLogLevel(Level.DEBUG);
 
@@ -465,44 +467,44 @@ public class TestMRAppMaster {
 
     // Now validate the task credentials
     Credentials appMasterCreds = appMaster.getCredentials();
-    Assert.assertNotNull(appMasterCreds);
-    Assert.assertEquals(1, appMasterCreds.numberOfSecretKeys());
-    Assert.assertEquals(1, appMasterCreds.numberOfTokens());
+    Assertions.assertNotNull(appMasterCreds);
+    Assertions.assertEquals(1, appMasterCreds.numberOfSecretKeys());
+    Assertions.assertEquals(1, appMasterCreds.numberOfTokens());
 
     // Validate the tokens - app token should not be present
     Token<? extends TokenIdentifier> usedToken =
         appMasterCreds.getToken(tokenAlias);
-    Assert.assertNotNull(usedToken);
-    Assert.assertEquals(storedToken, usedToken);
+    Assertions.assertNotNull(usedToken);
+    Assertions.assertEquals(storedToken, usedToken);
 
     // Validate the keys
     byte[] usedKey = appMasterCreds.getSecretKey(keyAlias);
-    Assert.assertNotNull(usedKey);
-    Assert.assertEquals("mySecretKey", new String(usedKey));
+    Assertions.assertNotNull(usedKey);
+    Assertions.assertEquals("mySecretKey", new String(usedKey));
 
     // The credentials should also be added to conf so that OuputCommitter can
     // access it - app token should not be present
     Credentials confCredentials = conf.getCredentials();
-    Assert.assertEquals(1, confCredentials.numberOfSecretKeys());
-    Assert.assertEquals(1, confCredentials.numberOfTokens());
-    Assert.assertEquals(storedToken, confCredentials.getToken(tokenAlias));
-    Assert.assertEquals("mySecretKey",
+    Assertions.assertEquals(1, confCredentials.numberOfSecretKeys());
+    Assertions.assertEquals(1, confCredentials.numberOfTokens());
+    Assertions.assertEquals(storedToken, confCredentials.getToken(tokenAlias));
+    Assertions.assertEquals("mySecretKey",
       new String(confCredentials.getSecretKey(keyAlias)));
 
     // Verify the AM's ugi - app token should be present
     Credentials ugiCredentials = appMaster.getUgi().getCredentials();
-    Assert.assertEquals(1, ugiCredentials.numberOfSecretKeys());
-    Assert.assertEquals(2, ugiCredentials.numberOfTokens());
-    Assert.assertEquals(storedToken, ugiCredentials.getToken(tokenAlias));
-    Assert.assertEquals(appToken, ugiCredentials.getToken(appTokenService));
-    Assert.assertEquals("mySecretKey",
+    Assertions.assertEquals(1, ugiCredentials.numberOfSecretKeys());
+    Assertions.assertEquals(2, ugiCredentials.numberOfTokens());
+    Assertions.assertEquals(storedToken, ugiCredentials.getToken(tokenAlias));
+    Assertions.assertEquals(appToken, ugiCredentials.getToken(appTokenService));
+    Assertions.assertEquals("mySecretKey",
       new String(ugiCredentials.getSecretKey(keyAlias)));
 
 
   }
 
   @Test
-  public void testMRAppMasterShutDownJob() throws Exception,
+  void testMRAppMasterShutDownJob() throws Exception,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -525,10 +527,10 @@ public class TestMRAppMaster {
     doNothing().when(appMaster).serviceStop();
     // Test normal shutdown.
     appMaster.shutDownJob();
-    Assert.assertTrue("Expected shutDownJob to terminate.",
-                      ExitUtil.terminateCalled());
-    Assert.assertEquals("Expected shutDownJob to exit with status code of 0.",
-        0, ExitUtil.getFirstExitException().status);
+    Assertions.assertTrue(ExitUtil.terminateCalled(),
+        "Expected shutDownJob to terminate.");
+    Assertions.assertEquals(0, ExitUtil.getFirstExitException().status,
+        "Expected shutDownJob to exit with status code of 0.");
 
     // Test shutdown with exception.
     ExitUtil.resetFirstExitException();
@@ -536,10 +538,10 @@ public class TestMRAppMaster {
     doThrow(new RuntimeException(msg))
             .when(appMaster).notifyIsLastAMRetry(anyBoolean());
     appMaster.shutDownJob();
-    assertTrue("Expected message from ExitUtil.ExitException to be " + msg,
-        ExitUtil.getFirstExitException().getMessage().contains(msg));
-    Assert.assertEquals("Expected shutDownJob to exit with status code of 1.",
-        1, ExitUtil.getFirstExitException().status);
+    assertTrue(ExitUtil.getFirstExitException().getMessage().contains(msg),
+        "Expected message from ExitUtil.ExitException to be " + msg);
+    Assertions.assertEquals(1, ExitUtil.getFirstExitException().status,
+        "Expected shutDownJob to exit with status code of 1.");
   }
 
   private void verifyFailedStatus(MRAppMasterTest appMaster,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRAppMaster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRAppMaster.java
@@ -132,7 +132,7 @@ public class TestMRAppMaster {
   }
 
   @Test
-  void testMRAppMasterForDifferentUser() throws IOException,
+  public void testMRAppMasterForDifferentUser() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000001";
     String containerIdStr = "container_1317529182569_0004_000001_1";
@@ -154,7 +154,7 @@ public class TestMRAppMaster {
   }
 
   @Test
-  void testMRAppMasterMidLock() throws IOException,
+  public void testMRAppMasterMidLock() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -193,7 +193,7 @@ public class TestMRAppMaster {
   }
 
   @Test
-  void testMRAppMasterJobLaunchTime() throws IOException,
+  public void testMRAppMasterJobLaunchTime() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -232,7 +232,7 @@ public class TestMRAppMaster {
   }
 
   @Test
-  void testMRAppMasterSuccessLock() throws IOException,
+  public void testMRAppMasterSuccessLock() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -270,7 +270,7 @@ public class TestMRAppMaster {
   }
 
   @Test
-  void testMRAppMasterFailLock() throws IOException,
+  public void testMRAppMasterFailLock() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -308,7 +308,7 @@ public class TestMRAppMaster {
   }
 
   @Test
-  void testMRAppMasterMissingStaging() throws IOException,
+  public void testMRAppMasterMissingStaging() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -409,7 +409,7 @@ public class TestMRAppMaster {
   }
 
   @Test
-  void testMRAppMasterCredentials() throws Exception {
+  public void testMRAppMasterCredentials() throws Exception {
 
     GenericTestUtils.setRootLogLevel(Level.DEBUG);
 
@@ -504,7 +504,7 @@ public class TestMRAppMaster {
   }
 
   @Test
-  void testMRAppMasterShutDownJob() throws Exception,
+  public void testMRAppMasterShutDownJob() throws Exception,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRClientService.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRClientService.java
@@ -77,7 +77,7 @@ public class TestMRClientService {
   private static RecordFactory recordFactory = RecordFactoryProvider.getRecordFactory(null);
   
   @Test
-  void test() throws Exception {
+  public void test() throws Exception {
     MRAppWithClientService app = new MRAppWithClientService(1, 0, false);
     Configuration conf = new Configuration();
     Job job = app.submit(conf);
@@ -202,7 +202,7 @@ public class TestMRClientService {
   }
 
   @Test
-  void testViewAclOnlyCannotModify() throws Exception {
+  public void testViewAclOnlyCannotModify() throws Exception {
     final MRAppWithClientService app = new MRAppWithClientService(1, 0, false);
     final Configuration conf = new Configuration();
     conf.setBoolean(MRConfig.MR_ACLS_ENABLED, true);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRClientService.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRClientService.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.mapreduce.v2.app;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
@@ -26,7 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.JobACL;
@@ -70,19 +70,20 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.ipc.YarnRPC;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestMRClientService {
 
   private static RecordFactory recordFactory = RecordFactoryProvider.getRecordFactory(null);
   
   @Test
-  public void test() throws Exception {
+  void test() throws Exception {
     MRAppWithClientService app = new MRAppWithClientService(1, 0, false);
     Configuration conf = new Configuration();
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("Num tasks not correct", 1, job.getTasks().size());
+    Assertions.assertEquals(1, job.getTasks().size(),
+        "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task task = it.next();
     app.waitForState(task, TaskState.RUNNING);
@@ -116,8 +117,8 @@ public class TestMRClientService {
     GetCountersRequest gcRequest =
         recordFactory.newRecordInstance(GetCountersRequest.class);    
     gcRequest.setJobId(job.getID());
-    Assert.assertNotNull("Counters is null",
-        proxy.getCounters(gcRequest).getCounters());
+    Assertions.assertNotNull(proxy.getCounters(gcRequest).getCounters(),
+        "Counters is null");
 
     GetJobReportRequest gjrRequest =
         recordFactory.newRecordInstance(GetJobReportRequest.class);
@@ -131,14 +132,14 @@ public class TestMRClientService {
     gtaceRequest.setJobId(job.getID());
     gtaceRequest.setFromEventId(0);
     gtaceRequest.setMaxEvents(10);
-    Assert.assertNotNull("TaskCompletionEvents is null", 
-        proxy.getTaskAttemptCompletionEvents(gtaceRequest).getCompletionEventList());
+    Assertions.assertNotNull(proxy.getTaskAttemptCompletionEvents(gtaceRequest).
+        getCompletionEventList(), "TaskCompletionEvents is null");
 
     GetDiagnosticsRequest gdRequest =
         recordFactory.newRecordInstance(GetDiagnosticsRequest.class);
     gdRequest.setTaskAttemptId(attempt.getID());
-    Assert.assertNotNull("Diagnostics is null", 
-        proxy.getDiagnostics(gdRequest).getDiagnosticsList());
+    Assertions.assertNotNull(proxy.getDiagnostics(gdRequest).
+        getDiagnosticsList(), "Diagnostics is null");
 
     GetTaskAttemptReportRequest gtarRequest =
         recordFactory.newRecordInstance(GetTaskAttemptReportRequest.class);
@@ -151,31 +152,32 @@ public class TestMRClientService {
     GetTaskReportRequest gtrRequest =
         recordFactory.newRecordInstance(GetTaskReportRequest.class);
     gtrRequest.setTaskId(task.getID());
-    Assert.assertNotNull("TaskReport is null", 
-        proxy.getTaskReport(gtrRequest).getTaskReport());
+    Assertions.assertNotNull(proxy.getTaskReport(gtrRequest).getTaskReport(),
+        "TaskReport is null");
 
     GetTaskReportsRequest gtreportsRequest =
         recordFactory.newRecordInstance(GetTaskReportsRequest.class);
     gtreportsRequest.setJobId(job.getID());
     gtreportsRequest.setTaskType(TaskType.MAP);
-    Assert.assertNotNull("TaskReports for map is null", 
-        proxy.getTaskReports(gtreportsRequest).getTaskReportList());
+    Assertions.assertNotNull(proxy.getTaskReports(gtreportsRequest)
+        .getTaskReportList(), "TaskReports for map is null");
 
     gtreportsRequest =
         recordFactory.newRecordInstance(GetTaskReportsRequest.class);
     gtreportsRequest.setJobId(job.getID());
     gtreportsRequest.setTaskType(TaskType.REDUCE);
-    Assert.assertNotNull("TaskReports for reduce is null", 
-        proxy.getTaskReports(gtreportsRequest).getTaskReportList());
+    Assertions.assertNotNull(proxy.getTaskReports(gtreportsRequest).getTaskReportList(),
+        "TaskReports for reduce is null");
 
     List<String> diag = proxy.getDiagnostics(gdRequest).getDiagnosticsList();
-    Assert.assertEquals("Num diagnostics not correct", 1 , diag.size());
-    Assert.assertEquals("Diag 1 not correct",
-        diagnostic1, diag.get(0).toString());
+    Assertions.assertEquals(1 , diag.size(),
+        "Num diagnostics not correct");
+    Assertions.assertEquals(diagnostic1, diag.get(0).toString(),
+        "Diag 1 not correct");
 
     TaskReport taskReport = proxy.getTaskReport(gtrRequest).getTaskReport();
-    Assert.assertEquals("Num diagnostics not correct", 1,
-        taskReport.getDiagnosticsCount());
+    Assertions.assertEquals(1, taskReport.getDiagnosticsCount(),
+        "Num diagnostics not correct");
 
     //send the done signal to the task
     app.getContext().getEventHandler().handle(
@@ -200,14 +202,15 @@ public class TestMRClientService {
   }
 
   @Test
-  public void testViewAclOnlyCannotModify() throws Exception {
+  void testViewAclOnlyCannotModify() throws Exception {
     final MRAppWithClientService app = new MRAppWithClientService(1, 0, false);
     final Configuration conf = new Configuration();
     conf.setBoolean(MRConfig.MR_ACLS_ENABLED, true);
     conf.set(MRJobConfig.JOB_ACL_VIEW_JOB, "viewonlyuser");
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("Num tasks not correct", 1, job.getTasks().size());
+    Assertions.assertEquals(1, job.getTasks().size(),
+        "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task task = it.next();
     app.waitForState(task, TaskState.RUNNING);
@@ -217,10 +220,10 @@ public class TestMRClientService {
     UserGroupInformation viewOnlyUser =
         UserGroupInformation.createUserForTesting(
             "viewonlyuser", new String[] {});
-    Assert.assertTrue("viewonlyuser cannot view job",
-        job.checkAccess(viewOnlyUser, JobACL.VIEW_JOB));
-    Assert.assertFalse("viewonlyuser can modify job",
-        job.checkAccess(viewOnlyUser, JobACL.MODIFY_JOB));
+    Assertions.assertTrue(job.checkAccess(viewOnlyUser, JobACL.VIEW_JOB),
+        "viewonlyuser cannot view job");
+    Assertions.assertFalse(job.checkAccess(viewOnlyUser, JobACL.MODIFY_JOB),
+        "viewonlyuser can modify job");
     MRClientProtocol client = viewOnlyUser.doAs(
         new PrivilegedExceptionAction<MRClientProtocol>() {
           @Override
@@ -273,28 +276,28 @@ public class TestMRClientService {
   }
 
   private void verifyJobReport(JobReport jr) {
-    Assert.assertNotNull("JobReport is null", jr);
+    Assertions.assertNotNull(jr, "JobReport is null");
     List<AMInfo> amInfos = jr.getAMInfos();
-    Assert.assertEquals(1, amInfos.size());
-    Assert.assertEquals(JobState.RUNNING, jr.getJobState());
+    Assertions.assertEquals(1, amInfos.size());
+    Assertions.assertEquals(JobState.RUNNING, jr.getJobState());
     AMInfo amInfo = amInfos.get(0);
-    Assert.assertEquals(MRApp.NM_HOST, amInfo.getNodeManagerHost());
-    Assert.assertEquals(MRApp.NM_PORT, amInfo.getNodeManagerPort());
-    Assert.assertEquals(MRApp.NM_HTTP_PORT, amInfo.getNodeManagerHttpPort());
-    Assert.assertEquals(1, amInfo.getAppAttemptId().getAttemptId());
-    Assert.assertEquals(1, amInfo.getContainerId().getApplicationAttemptId()
+    Assertions.assertEquals(MRApp.NM_HOST, amInfo.getNodeManagerHost());
+    Assertions.assertEquals(MRApp.NM_PORT, amInfo.getNodeManagerPort());
+    Assertions.assertEquals(MRApp.NM_HTTP_PORT, amInfo.getNodeManagerHttpPort());
+    Assertions.assertEquals(1, amInfo.getAppAttemptId().getAttemptId());
+    Assertions.assertEquals(1, amInfo.getContainerId().getApplicationAttemptId()
         .getAttemptId());
-    Assert.assertTrue(amInfo.getStartTime() > 0);
-    Assert.assertFalse(jr.isUber());
+    Assertions.assertTrue(amInfo.getStartTime() > 0);
+    Assertions.assertFalse(jr.isUber());
   }
   
   private void verifyTaskAttemptReport(TaskAttemptReport tar) {
-    Assert.assertEquals(TaskAttemptState.RUNNING, tar.getTaskAttemptState());
-    Assert.assertNotNull("TaskAttemptReport is null", tar);
-    Assert.assertEquals(MRApp.NM_HOST, tar.getNodeManagerHost());
-    Assert.assertEquals(MRApp.NM_PORT, tar.getNodeManagerPort());
-    Assert.assertEquals(MRApp.NM_HTTP_PORT, tar.getNodeManagerHttpPort());
-    Assert.assertEquals(1, tar.getContainerId().getApplicationAttemptId()
+    Assertions.assertEquals(TaskAttemptState.RUNNING, tar.getTaskAttemptState());
+    Assertions.assertNotNull(tar, "TaskAttemptReport is null");
+    Assertions.assertEquals(MRApp.NM_HOST, tar.getNodeManagerHost());
+    Assertions.assertEquals(MRApp.NM_PORT, tar.getNodeManagerPort());
+    Assertions.assertEquals(MRApp.NM_HTTP_PORT, tar.getNodeManagerHttpPort());
+    Assertions.assertEquals(1, tar.getContainerId().getApplicationAttemptId()
         .getAttemptId());
   }
   

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRecovery.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRecovery.java
@@ -145,7 +145,7 @@ public class TestRecovery {
    * @throws Exception
    */
   @Test
-  void testCrashed() throws Exception {
+  public void testCrashed() throws Exception {
 
     int runCount = 0;
     long am1StartTimeEst = System.currentTimeMillis();
@@ -359,7 +359,7 @@ public class TestRecovery {
    * @throws Exception
    */
   @Test
-  void testCrashOfMapsOnlyJob() throws Exception {
+  public void testCrashOfMapsOnlyJob() throws Exception {
     int runCount = 0;
     MRApp app =
         new MRAppWithHistory(3, 0, false, this.getClass().getName(), true,
@@ -503,7 +503,7 @@ public class TestRecovery {
    * @throws Exception
    */
   @Test
-  void testRecoverySuccessUsingCustomOutputCommitter() throws Exception {
+  public void testRecoverySuccessUsingCustomOutputCommitter() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(3, 0, false, this.getClass().getName(),
         true, ++runCount);
@@ -608,7 +608,7 @@ public class TestRecovery {
   }
 
   @Test
-  void testRecoveryWithSpillEncryption() throws Exception {
+  public void testRecoveryWithSpillEncryption() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(1, 1, false, this.getClass().getName(),
         true, ++runCount) {
@@ -682,7 +682,7 @@ public class TestRecovery {
    * @throws Exception
    */
   @Test
-  void testRecoveryFailsUsingCustomOutputCommitter() throws Exception {
+  public void testRecoveryFailsUsingCustomOutputCommitter() throws Exception {
     int runCount = 0;
     MRApp app =
         new MRAppWithHistory(3, 0, false, this.getClass().getName(), true,
@@ -801,7 +801,7 @@ public class TestRecovery {
   }
 
   @Test
-  void testMultipleCrashes() throws Exception {
+  public void testMultipleCrashes() throws Exception {
 
     int runCount = 0;
     MRApp app =
@@ -931,7 +931,7 @@ public class TestRecovery {
   }
 
   @Test
-  void testOutputRecovery() throws Exception {
+  public void testOutputRecovery() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(1, 2, false, this.getClass().getName(),
         true, ++runCount);
@@ -1040,7 +1040,7 @@ public class TestRecovery {
   }
 
   @Test
-  void testPreviousJobOutputCleanedWhenNoRecovery() throws Exception {
+  public void testPreviousJobOutputCleanedWhenNoRecovery() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(1, 2, false, this.getClass().getName(),
         true, ++runCount);
@@ -1072,7 +1072,7 @@ public class TestRecovery {
   }
 
   @Test
-  void testPreviousJobIsNotCleanedWhenRecovery()
+  public void testPreviousJobIsNotCleanedWhenRecovery()
       throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(1, 2, false, this.getClass().getName(),
@@ -1109,7 +1109,7 @@ public class TestRecovery {
   }
 
   @Test
-  void testOutputRecoveryMapsOnly() throws Exception {
+  public void testOutputRecoveryMapsOnly() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(2, 1, false, this.getClass().getName(),
         true, ++runCount);
@@ -1224,7 +1224,7 @@ public class TestRecovery {
   }
   
   @Test
-  void testRecoveryWithOldCommiter() throws Exception {
+  public void testRecoveryWithOldCommiter() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(1, 2, false, this.getClass().getName(),
         true, ++runCount);
@@ -1341,7 +1341,7 @@ public class TestRecovery {
    * @throws Exception
    */
   @Test
-  void testSpeculative() throws Exception {
+  public void testSpeculative() throws Exception {
 
     int runCount = 0;
     long am1StartTimeEst = System.currentTimeMillis();
@@ -1495,7 +1495,7 @@ public class TestRecovery {
 
   @Test
   @Timeout(30000)
-  void testRecoveryWithoutShuffleSecret() throws Exception {
+  public void testRecoveryWithoutShuffleSecret() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppNoShuffleSecret(2, 1, false,
         this.getClass().getName(), true, ++runCount);
@@ -1603,7 +1603,7 @@ public class TestRecovery {
   }
 
   @Test
-  void testRecoverySuccessAttempt() {
+  public void testRecoverySuccessAttempt() {
     LOG.info("--- START: testRecoverySuccessAttempt ---");
 
     long clusterTimestamp = System.currentTimeMillis();
@@ -1660,7 +1660,7 @@ public class TestRecovery {
   }
 
   @Test
-  void testRecoveryAllFailAttempts() {
+  public void testRecoveryAllFailAttempts() {
     LOG.info("--- START: testRecoveryAllFailAttempts ---");
 
     long clusterTimestamp = System.currentTimeMillis();
@@ -1718,7 +1718,7 @@ public class TestRecovery {
   }
 
   @Test
-  void testRecoveryTaskSuccessAllAttemptsFail() {
+  public void testRecoveryTaskSuccessAllAttemptsFail() {
     LOG.info("--- START:  testRecoveryTaskSuccessAllAttemptsFail ---");
 
     long clusterTimestamp = System.currentTimeMillis();
@@ -1777,7 +1777,7 @@ public class TestRecovery {
   }
 
   @Test
-  void testRecoveryTaskSuccessAllAttemptsSucceed() {
+  public void testRecoveryTaskSuccessAllAttemptsSucceed() {
     LOG.info("--- START:  testRecoveryTaskSuccessAllAttemptsFail ---");
 
     long clusterTimestamp = System.currentTimeMillis();
@@ -1834,7 +1834,7 @@ public class TestRecovery {
   }
 
   @Test
-  void testRecoveryAllAttemptsKilled() {
+  public void testRecoveryAllAttemptsKilled() {
     LOG.info("--- START:  testRecoveryAllAttemptsKilled ---");
 
     long clusterTimestamp = System.currentTimeMillis();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRecovery.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRecovery.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.mapreduce.v2.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.mapreduce.util.MRJobConfUtil;
 import org.apache.hadoop.mapreduce.v2.app.job.event.TaskAttemptFailEvent;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -107,8 +107,9 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.SystemClock;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -126,7 +127,7 @@ public class TestRecovery {
   private Text val1 = new Text("val1");
   private Text val2 = new Text("val2");
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() throws Exception {
     // setup the test root directory
     testRootDir =
@@ -144,7 +145,7 @@ public class TestRecovery {
    * @throws Exception
    */
   @Test
-  public void testCrashed() throws Exception {
+  void testCrashed() throws Exception {
 
     int runCount = 0;
     long am1StartTimeEst = System.currentTimeMillis();
@@ -158,8 +159,8 @@ public class TestRecovery {
     app.waitForState(job, JobState.RUNNING);
     long jobStartTime = job.getReport().getStartTime();
     //all maps would be running
-    Assert.assertEquals("No of tasks not correct",
-       3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask1 = it.next();
     Task mapTask2 = it.next();
@@ -192,7 +193,7 @@ public class TestRecovery {
       Thread.sleep(2000);
       LOG.info("Waiting for next attempt to start");
     }
-    Assert.assertEquals(2, mapTask1.getAttempts().size());
+    Assertions.assertEquals(2, mapTask1.getAttempts().size());
     Iterator<TaskAttempt> itr = mapTask1.getAttempts().values().iterator();
     itr.next();
     TaskAttempt task1Attempt2 = itr.next();
@@ -213,7 +214,7 @@ public class TestRecovery {
       Thread.sleep(2000);
       LOG.info("Waiting for next attempt to start");
     }
-    Assert.assertEquals(3, mapTask1.getAttempts().size());
+    Assertions.assertEquals(3, mapTask1.getAttempts().size());
     itr = mapTask1.getAttempts().values().iterator();
     itr.next();
     itr.next();
@@ -234,7 +235,7 @@ public class TestRecovery {
       Thread.sleep(2000);
       LOG.info("Waiting for next attempt to start");
     }
-    Assert.assertEquals(4, mapTask1.getAttempts().size());
+    Assertions.assertEquals(4, mapTask1.getAttempts().size());
     itr = mapTask1.getAttempts().values().iterator();
     itr.next();
     itr.next();
@@ -272,8 +273,8 @@ public class TestRecovery {
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     //all maps would be running
-    Assert.assertEquals("No of tasks not correct",
-       3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     it = job.getTasks().values().iterator();
     mapTask1 = it.next();
     mapTask2 = it.next();
@@ -308,29 +309,29 @@ public class TestRecovery {
     
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
-    Assert.assertEquals("Job Start time not correct",
-        jobStartTime, job.getReport().getStartTime());
-    Assert.assertEquals("Task Start time not correct",
-        task1StartTime, mapTask1.getReport().getStartTime());
-    Assert.assertEquals("Task Finish time not correct",
-        task1FinishTime, mapTask1.getReport().getFinishTime());
-    Assert.assertEquals(2, job.getAMInfos().size());
+    Assertions.assertEquals(jobStartTime, job.getReport().getStartTime(),
+        "Job Start time not correct");
+    Assertions.assertEquals(task1StartTime, mapTask1.getReport().getStartTime(),
+        "Task Start time not correct");
+    Assertions.assertEquals(task1FinishTime, mapTask1.getReport().getFinishTime(),
+        "Task Finish time not correct");
+    Assertions.assertEquals(2, job.getAMInfos().size());
     int attemptNum = 1;
     // Verify AMInfo
     for (AMInfo amInfo : job.getAMInfos()) {
-      Assert.assertEquals(attemptNum++, amInfo.getAppAttemptId()
+      Assertions.assertEquals(attemptNum++, amInfo.getAppAttemptId()
           .getAttemptId());
-      Assert.assertEquals(amInfo.getAppAttemptId(), amInfo.getContainerId()
+      Assertions.assertEquals(amInfo.getAppAttemptId(), amInfo.getContainerId()
           .getApplicationAttemptId());
-      Assert.assertEquals(MRApp.NM_HOST, amInfo.getNodeManagerHost());
-      Assert.assertEquals(MRApp.NM_PORT, amInfo.getNodeManagerPort());
-      Assert.assertEquals(MRApp.NM_HTTP_PORT, amInfo.getNodeManagerHttpPort());
+      Assertions.assertEquals(MRApp.NM_HOST, amInfo.getNodeManagerHost());
+      Assertions.assertEquals(MRApp.NM_PORT, amInfo.getNodeManagerPort());
+      Assertions.assertEquals(MRApp.NM_HTTP_PORT, amInfo.getNodeManagerHttpPort());
     }
     long am1StartTimeReal = job.getAMInfos().get(0).getStartTime();
     long am2StartTimeReal = job.getAMInfos().get(1).getStartTime();
-    Assert.assertTrue(am1StartTimeReal >= am1StartTimeEst
+    Assertions.assertTrue(am1StartTimeReal >= am1StartTimeEst
         && am1StartTimeReal <= am2StartTimeEst);
-    Assert.assertTrue(am2StartTimeReal >= am2StartTimeEst
+    Assertions.assertTrue(am2StartTimeReal >= am2StartTimeEst
         && am2StartTimeReal <= System.currentTimeMillis());
     // TODO Add verification of additional data from jobHistory - whatever was
     // available in the failed attempt should be available here
@@ -358,7 +359,7 @@ public class TestRecovery {
    * @throws Exception
    */
   @Test
-  public void testCrashOfMapsOnlyJob() throws Exception {
+  void testCrashOfMapsOnlyJob() throws Exception {
     int runCount = 0;
     MRApp app =
         new MRAppWithHistory(3, 0, false, this.getClass().getName(), true,
@@ -371,7 +372,7 @@ public class TestRecovery {
     app.waitForState(job, JobState.RUNNING);
 
     // all maps would be running
-    Assert.assertEquals("No of tasks not correct", 3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(), "No of tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask1 = it.next();
     Task mapTask2 = it.next();
@@ -429,7 +430,7 @@ public class TestRecovery {
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
 
-    Assert.assertEquals("No of tasks not correct", 3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(), "No of tasks not correct");
     it = job.getTasks().values().iterator();
     mapTask1 = it.next();
     mapTask2 = it.next();
@@ -502,7 +503,7 @@ public class TestRecovery {
    * @throws Exception
    */
   @Test
-  public void testRecoverySuccessUsingCustomOutputCommitter() throws Exception {
+  void testRecoverySuccessUsingCustomOutputCommitter() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(3, 0, false, this.getClass().getName(),
         true, ++runCount);
@@ -516,7 +517,7 @@ public class TestRecovery {
     app.waitForState(job, JobState.RUNNING);
 
     // all maps would be running
-    Assert.assertEquals("No of tasks not correct", 3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(), "No of tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask1 = it.next();
     Task mapTask2 = it.next();
@@ -575,7 +576,7 @@ public class TestRecovery {
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
 
-    Assert.assertEquals("No of tasks not correct", 3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(), "No of tasks not correct");
     it = job.getTasks().values().iterator();
     mapTask1 = it.next();
     mapTask2 = it.next();
@@ -607,7 +608,7 @@ public class TestRecovery {
   }
 
   @Test
-  public void testRecoveryWithSpillEncryption() throws Exception {
+  void testRecoveryWithSpillEncryption() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(1, 1, false, this.getClass().getName(),
         true, ++runCount) {
@@ -641,8 +642,9 @@ public class TestRecovery {
     app = new MRAppWithHistory(1, 1, false, this.getClass().getName(), false,
         ++runCount);
     Job jobAttempt2 = app.submit(conf);
-    Assert.assertTrue("Recovery from previous job attempt is processed even " +
-        "though intermediate data encryption is enabled.", !app.recovered());
+    Assertions.assertTrue(!app.recovered(),
+        "Recovery from previous job attempt is processed even " +
+            "though intermediate data encryption is enabled.");
 
     // The map task succeeded from previous job attempt will not be recovered
     // because the data spill encryption is enabled.
@@ -680,7 +682,7 @@ public class TestRecovery {
    * @throws Exception
    */
   @Test
-  public void testRecoveryFailsUsingCustomOutputCommitter() throws Exception {
+  void testRecoveryFailsUsingCustomOutputCommitter() throws Exception {
     int runCount = 0;
     MRApp app =
         new MRAppWithHistory(3, 0, false, this.getClass().getName(), true,
@@ -694,7 +696,7 @@ public class TestRecovery {
     app.waitForState(job, JobState.RUNNING);
 
     // all maps would be running
-    Assert.assertEquals("No of tasks not correct", 3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(), "No of tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask1 = it.next();
     Task mapTask2 = it.next();
@@ -753,7 +755,7 @@ public class TestRecovery {
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
 
-    Assert.assertEquals("No of tasks not correct", 3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(), "No of tasks not correct");
     it = job.getTasks().values().iterator();
     mapTask1 = it.next();
     mapTask2 = it.next();
@@ -799,7 +801,7 @@ public class TestRecovery {
   }
 
   @Test
-  public void testMultipleCrashes() throws Exception {
+  void testMultipleCrashes() throws Exception {
 
     int runCount = 0;
     MRApp app =
@@ -813,8 +815,8 @@ public class TestRecovery {
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     //all maps would be running
-    Assert.assertEquals("No of tasks not correct",
-       3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask1 = it.next();
     Task mapTask2 = it.next();
@@ -833,8 +835,8 @@ public class TestRecovery {
     app.waitForState(task2Attempt, TaskAttemptState.RUNNING);
     
     // reduces must be in NEW state
-    Assert.assertEquals("Reduce Task state not correct",
-        TaskState.RUNNING, reduceTask.getReport().getTaskState());
+    Assertions.assertEquals(TaskState.RUNNING, reduceTask.getReport().getTaskState(),
+        "Reduce Task state not correct");
 
     //send the done signal to the 1st map
     app.getContext().getEventHandler().handle(
@@ -862,8 +864,8 @@ public class TestRecovery {
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     //all maps would be running
-    Assert.assertEquals("No of tasks not correct",
-       3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     it = job.getTasks().values().iterator();
     mapTask1 = it.next();
     mapTask2 = it.next();
@@ -905,8 +907,8 @@ public class TestRecovery {
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     //all maps would be running
-    Assert.assertEquals("No of tasks not correct",
-       3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     it = job.getTasks().values().iterator();
     mapTask1 = it.next();
     mapTask2 = it.next();
@@ -929,7 +931,7 @@ public class TestRecovery {
   }
 
   @Test
-  public void testOutputRecovery() throws Exception {
+  void testOutputRecovery() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(1, 2, false, this.getClass().getName(),
         true, ++runCount);
@@ -940,8 +942,8 @@ public class TestRecovery {
     conf.set(FileOutputFormat.OUTDIR, outputDir.toString());
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("No of tasks not correct",
-       3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask1 = it.next();
     Task reduceTask1 = it.next();
@@ -966,7 +968,7 @@ public class TestRecovery {
     app.waitForState(mapTask1, TaskState.SUCCEEDED);
 
     // Verify the shuffle-port
-    Assert.assertEquals(5467, task1Attempt1.getShufflePort());
+    Assertions.assertEquals(5467, task1Attempt1.getShufflePort());
     
     app.waitForState(reduceTask1, TaskState.RUNNING);
     TaskAttempt reduce1Attempt1 = reduceTask1.getAttempts().values().iterator().next();
@@ -998,8 +1000,8 @@ public class TestRecovery {
     conf.setBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, false);
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("No of tasks not correct",
-       3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     it = job.getTasks().values().iterator();
     mapTask1 = it.next();
     reduceTask1 = it.next();
@@ -1010,7 +1012,7 @@ public class TestRecovery {
 
     // Verify the shuffle-port after recovery
     task1Attempt1 = mapTask1.getAttempts().values().iterator().next();
-    Assert.assertEquals(5467, task1Attempt1.getShufflePort());
+    Assertions.assertEquals(5467, task1Attempt1.getShufflePort());
     
     // first reduce will be recovered, no need to send done
     app.waitForState(reduceTask1, TaskState.SUCCEEDED); 
@@ -1038,7 +1040,7 @@ public class TestRecovery {
   }
 
   @Test
-  public void testPreviousJobOutputCleanedWhenNoRecovery() throws Exception {
+  void testPreviousJobOutputCleanedWhenNoRecovery() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(1, 2, false, this.getClass().getName(),
         true, ++runCount);
@@ -1051,7 +1053,7 @@ public class TestRecovery {
     conf.set(FileOutputFormat.OUTDIR, outputDir.toString());
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("No of tasks not correct", 3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(), "No of tasks not correct");
     //stop the app before the job completes.
     app.stop();
     app.close();
@@ -1061,16 +1063,16 @@ public class TestRecovery {
         ++runCount);
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("No of tasks not correct", 3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(), "No of tasks not correct");
     TestFileOutputCommitter committer = (
         TestFileOutputCommitter) app.getCommitter();
-    assertTrue("commiter.abortJob() has not been called",
-        committer.isAbortJobCalled());
+    assertTrue(committer.isAbortJobCalled(),
+        "commiter.abortJob() has not been called");
     app.close();
   }
 
   @Test
-  public void testPreviousJobIsNotCleanedWhenRecovery()
+  void testPreviousJobIsNotCleanedWhenRecovery()
       throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(1, 2, false, this.getClass().getName(),
@@ -1086,7 +1088,8 @@ public class TestRecovery {
     conf.set(FileOutputFormat.OUTDIR, outputDir.toString());
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("No of tasks not correct", 3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     //stop the app before the job completes.
     app.stop();
     app.close();
@@ -1096,16 +1099,17 @@ public class TestRecovery {
         ++runCount);
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("No of tasks not correct", 3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     TestFileOutputCommitter committer = (
         TestFileOutputCommitter) app.getCommitter();
-    assertFalse("commiter.abortJob() has been called",
-        committer.isAbortJobCalled());
+    assertFalse(committer.isAbortJobCalled(),
+        "commiter.abortJob() has been called");
     app.close();
   }
 
   @Test
-  public void testOutputRecoveryMapsOnly() throws Exception {
+  void testOutputRecoveryMapsOnly() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(2, 1, false, this.getClass().getName(),
         true, ++runCount);
@@ -1116,8 +1120,8 @@ public class TestRecovery {
     conf.set(FileOutputFormat.OUTDIR, outputDir.toString());
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("No of tasks not correct",
-       3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask1 = it.next();
     Task mapTask2 = it.next();
@@ -1147,7 +1151,7 @@ public class TestRecovery {
     app.waitForState(mapTask1, TaskState.SUCCEEDED);
 
     // Verify the shuffle-port
-    Assert.assertEquals(5467, task1Attempt1.getShufflePort());
+    Assertions.assertEquals(5467, task1Attempt1.getShufflePort());
 
     //stop the app before the job completes.
     app.stop();
@@ -1164,8 +1168,8 @@ public class TestRecovery {
     conf.setBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, false);
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("No of tasks not correct",
-       3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     it = job.getTasks().values().iterator();
     mapTask1 = it.next();
     mapTask2 = it.next();
@@ -1176,7 +1180,7 @@ public class TestRecovery {
 
     // Verify the shuffle-port after recovery
     task1Attempt1 = mapTask1.getAttempts().values().iterator().next();
-    Assert.assertEquals(5467, task1Attempt1.getShufflePort());
+    Assertions.assertEquals(5467, task1Attempt1.getShufflePort());
     
     app.waitForState(mapTask2, TaskState.RUNNING);
     
@@ -1197,7 +1201,7 @@ public class TestRecovery {
     app.waitForState(mapTask2, TaskState.SUCCEEDED);
 
     // Verify the shuffle-port
-    Assert.assertEquals(5467, task2Attempt1.getShufflePort());
+    Assertions.assertEquals(5467, task2Attempt1.getShufflePort());
     
     app.waitForState(reduceTask1, TaskState.RUNNING);
     TaskAttempt reduce1Attempt1 = reduceTask1.getAttempts().values().iterator().next();
@@ -1220,7 +1224,7 @@ public class TestRecovery {
   }
   
   @Test
-  public void testRecoveryWithOldCommiter() throws Exception {
+  void testRecoveryWithOldCommiter() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppWithHistory(1, 2, false, this.getClass().getName(),
         true, ++runCount);
@@ -1231,8 +1235,8 @@ public class TestRecovery {
     conf.set(FileOutputFormat.OUTDIR, outputDir.toString());
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("No of tasks not correct",
-       3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask1 = it.next();
     Task reduceTask1 = it.next();
@@ -1257,7 +1261,7 @@ public class TestRecovery {
     app.waitForState(mapTask1, TaskState.SUCCEEDED);
 
     // Verify the shuffle-port
-    Assert.assertEquals(5467, task1Attempt1.getShufflePort());
+    Assertions.assertEquals(5467, task1Attempt1.getShufflePort());
     
     app.waitForState(reduceTask1, TaskState.RUNNING);
     TaskAttempt reduce1Attempt1 = reduceTask1.getAttempts().values().iterator().next();
@@ -1289,8 +1293,8 @@ public class TestRecovery {
     conf.setBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, false);
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("No of tasks not correct",
-       3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     it = job.getTasks().values().iterator();
     mapTask1 = it.next();
     reduceTask1 = it.next();
@@ -1301,7 +1305,7 @@ public class TestRecovery {
 
     // Verify the shuffle-port after recovery
     task1Attempt1 = mapTask1.getAttempts().values().iterator().next();
-    Assert.assertEquals(5467, task1Attempt1.getShufflePort());
+    Assertions.assertEquals(5467, task1Attempt1.getShufflePort());
     
     // first reduce will be recovered, no need to send done
     app.waitForState(reduceTask1, TaskState.SUCCEEDED); 
@@ -1337,7 +1341,7 @@ public class TestRecovery {
    * @throws Exception
    */
   @Test
-  public void testSpeculative() throws Exception {
+  void testSpeculative() throws Exception {
 
     int runCount = 0;
     long am1StartTimeEst = System.currentTimeMillis();
@@ -1351,8 +1355,8 @@ public class TestRecovery {
     app.waitForState(job, JobState.RUNNING);
     long jobStartTime = job.getReport().getStartTime();
     //all maps would be running
-    Assert.assertEquals("No of tasks not correct",
-       3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
 
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask1 = it.next();
@@ -1425,8 +1429,8 @@ public class TestRecovery {
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     //all maps would be running
-    Assert.assertEquals("No of tasks not correct",
-       3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     it = job.getTasks().values().iterator();
     mapTask1 = it.next();
     mapTask2 = it.next();
@@ -1462,36 +1466,36 @@ public class TestRecovery {
 
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
-    Assert.assertEquals("Job Start time not correct",
-        jobStartTime, job.getReport().getStartTime());
-    Assert.assertEquals("Task Start time not correct",
-        task1StartTime, mapTask1.getReport().getStartTime());
-    Assert.assertEquals("Task Finish time not correct",
-        task1FinishTime, mapTask1.getReport().getFinishTime());
-    Assert.assertEquals(2, job.getAMInfos().size());
+    Assertions.assertEquals(jobStartTime, job.getReport().getStartTime(),
+        "Job Start time not correct");
+    Assertions.assertEquals(task1StartTime, mapTask1.getReport().getStartTime(),
+        "Task Start time not correct");
+    Assertions.assertEquals(task1FinishTime, mapTask1.getReport().getFinishTime(),
+        "Task Finish time not correct");
+    Assertions.assertEquals(2, job.getAMInfos().size());
     int attemptNum = 1;
     // Verify AMInfo
     for (AMInfo amInfo : job.getAMInfos()) {
-      Assert.assertEquals(attemptNum++, amInfo.getAppAttemptId()
+      Assertions.assertEquals(attemptNum++, amInfo.getAppAttemptId()
           .getAttemptId());
-      Assert.assertEquals(amInfo.getAppAttemptId(), amInfo.getContainerId()
+      Assertions.assertEquals(amInfo.getAppAttemptId(), amInfo.getContainerId()
           .getApplicationAttemptId());
-      Assert.assertEquals(MRApp.NM_HOST, amInfo.getNodeManagerHost());
-      Assert.assertEquals(MRApp.NM_PORT, amInfo.getNodeManagerPort());
-      Assert.assertEquals(MRApp.NM_HTTP_PORT, amInfo.getNodeManagerHttpPort());
+      Assertions.assertEquals(MRApp.NM_HOST, amInfo.getNodeManagerHost());
+      Assertions.assertEquals(MRApp.NM_PORT, amInfo.getNodeManagerPort());
+      Assertions.assertEquals(MRApp.NM_HTTP_PORT, amInfo.getNodeManagerHttpPort());
     }
     long am1StartTimeReal = job.getAMInfos().get(0).getStartTime();
     long am2StartTimeReal = job.getAMInfos().get(1).getStartTime();
-    Assert.assertTrue(am1StartTimeReal >= am1StartTimeEst
+    Assertions.assertTrue(am1StartTimeReal >= am1StartTimeEst
         && am1StartTimeReal <= am2StartTimeEst);
-    Assert.assertTrue(am2StartTimeReal >= am2StartTimeEst
+    Assertions.assertTrue(am2StartTimeReal >= am2StartTimeEst
         && am2StartTimeReal <= System.currentTimeMillis());
 
   }
 
-  @Test(timeout=30000)
-  public void testRecoveryWithoutShuffleSecret() throws Exception {
-
+  @Test
+  @Timeout(30000)
+  void testRecoveryWithoutShuffleSecret() throws Exception {
     int runCount = 0;
     MRApp app = new MRAppNoShuffleSecret(2, 1, false,
         this.getClass().getName(), true, ++runCount);
@@ -1503,8 +1507,8 @@ public class TestRecovery {
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     //all maps would be running
-    Assert.assertEquals("No of tasks not correct",
-       3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask1 = it.next();
     Task mapTask2 = it.next();
@@ -1550,8 +1554,8 @@ public class TestRecovery {
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     //all maps would be running
-    Assert.assertEquals("No of tasks not correct",
-       3, job.getTasks().size());
+    Assertions.assertEquals(3, job.getTasks().size(),
+        "No of tasks not correct");
     it = job.getTasks().values().iterator();
     mapTask1 = it.next();
     mapTask2 = it.next();
@@ -1599,7 +1603,7 @@ public class TestRecovery {
   }
 
   @Test
-  public void testRecoverySuccessAttempt() {
+  void testRecoverySuccessAttempt() {
     LOG.info("--- START: testRecoverySuccessAttempt ---");
 
     long clusterTimestamp = System.currentTimeMillis();
@@ -1656,7 +1660,7 @@ public class TestRecovery {
   }
 
   @Test
-  public void testRecoveryAllFailAttempts() {
+  void testRecoveryAllFailAttempts() {
     LOG.info("--- START: testRecoveryAllFailAttempts ---");
 
     long clusterTimestamp = System.currentTimeMillis();
@@ -1714,7 +1718,7 @@ public class TestRecovery {
   }
 
   @Test
-  public void testRecoveryTaskSuccessAllAttemptsFail() {
+  void testRecoveryTaskSuccessAllAttemptsFail() {
     LOG.info("--- START:  testRecoveryTaskSuccessAllAttemptsFail ---");
 
     long clusterTimestamp = System.currentTimeMillis();
@@ -1773,7 +1777,7 @@ public class TestRecovery {
   }
 
   @Test
-  public void testRecoveryTaskSuccessAllAttemptsSucceed() {
+  void testRecoveryTaskSuccessAllAttemptsSucceed() {
     LOG.info("--- START:  testRecoveryTaskSuccessAllAttemptsFail ---");
 
     long clusterTimestamp = System.currentTimeMillis();
@@ -1830,7 +1834,7 @@ public class TestRecovery {
   }
 
   @Test
-  public void testRecoveryAllAttemptsKilled() {
+  void testRecoveryAllAttemptsKilled() {
     LOG.info("--- START:  testRecoveryAllAttemptsKilled ---");
 
     long clusterTimestamp = System.currentTimeMillis();
@@ -1890,16 +1894,16 @@ public class TestRecovery {
       ArgumentCaptor<Event> arg, List<EventType> expectedJobHistoryEvents,
       long expectedMapLaunches, long expectedFailedMaps) {
 
-    assertEquals("Final State of Task", finalState, checkTask.getState());
+    assertEquals(finalState, checkTask.getState(), "Final State of Task");
 
     Map<TaskAttemptId, TaskAttempt> recoveredAttempts =
         checkTask.getAttempts();
-    assertEquals("Expected Number of Task Attempts",
-        finalAttemptStates.size(), recoveredAttempts.size());
+    assertEquals(finalAttemptStates.size(), recoveredAttempts.size(),
+        "Expected Number of Task Attempts");
     for (TaskAttemptID taID : finalAttemptStates.keySet()) {
-      assertEquals("Expected Task Attempt State",
-          finalAttemptStates.get(taID),
-          recoveredAttempts.get(TypeConverter.toYarn(taID)).getState());
+      assertEquals(finalAttemptStates.get(taID),
+          recoveredAttempts.get(TypeConverter.toYarn(taID)).getState(),
+          "Expected Task Attempt State");
     }
 
     Iterator<Event> ie = arg.getAllValues().iterator();
@@ -1947,12 +1951,12 @@ public class TestRecovery {
       }
     }
     assertTrue(jobTaskEventReceived || (finalState == TaskState.RUNNING));
-    assertEquals("Did not process all expected JobHistoryEvents",
-        0, expectedJobHistoryEvents.size());
-    assertEquals("Expected Map Launches",
-        expectedMapLaunches, totalLaunchedMaps);
-    assertEquals("Expected Failed Maps",
-        expectedFailedMaps, totalFailedMaps);
+    assertEquals(0, expectedJobHistoryEvents.size(),
+        "Did not process all expected JobHistoryEvents");
+    assertEquals(expectedMapLaunches, totalLaunchedMaps,
+        "Expected Map Launches");
+    assertEquals(expectedFailedMaps, totalFailedMaps,
+        "Expected Failed Maps");
   }
 
   private MapTaskImpl getMockMapTask(long clusterTimestamp, EventHandler eh) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRuntimeEstimators.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRuntimeEstimators.java
@@ -78,8 +78,8 @@ import org.apache.hadoop.yarn.security.client.ClientToAMTokenSecretManager;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.ControlledClock;
 import org.apache.hadoop.yarn.util.SystemClock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -152,16 +152,16 @@ public class TestRuntimeEstimators {
     conf.setDouble(MRJobConfig.SPECULATIVECAP_TOTAL_TASKS, 0.001);
     conf.setInt(MRJobConfig.SPECULATIVE_MINIMUM_ALLOWED_TASKS, 5);
     speculator = new DefaultSpeculator(conf, myAppContext, estimator, clock);
-    Assert.assertEquals("wrong SPECULATIVE_RETRY_AFTER_NO_SPECULATE value",
-        500L, speculator.getSoonestRetryAfterNoSpeculate());
-    Assert.assertEquals("wrong SPECULATIVE_RETRY_AFTER_SPECULATE value",
-        5000L, speculator.getSoonestRetryAfterSpeculate());
+    Assertions.assertEquals(500L, speculator.getSoonestRetryAfterNoSpeculate(),
+        "wrong SPECULATIVE_RETRY_AFTER_NO_SPECULATE value");
+    Assertions.assertEquals(5000L, speculator.getSoonestRetryAfterSpeculate(),
+        "wrong SPECULATIVE_RETRY_AFTER_SPECULATE value");
     assertThat(speculator.getProportionRunningTasksSpeculatable())
         .isCloseTo(0.1, offset(0.00001));
     assertThat(speculator.getProportionTotalTasksSpeculatable())
         .isCloseTo(0.001, offset(0.00001));
-    Assert.assertEquals("wrong SPECULATIVE_MINIMUM_ALLOWED_TASKS value",
-        5, speculator.getMinimumAllowedSpeculativeTasks());
+    Assertions.assertEquals(5, speculator.getMinimumAllowedSpeculativeTasks(),
+        "wrong SPECULATIVE_MINIMUM_ALLOWED_TASKS value");
 
     dispatcher.register(Speculator.EventType.class, speculator);
 
@@ -244,25 +244,25 @@ public class TestRuntimeEstimators {
       }
     }
 
-    Assert.assertEquals("We got the wrong number of successful speculations.",
-        expectedSpeculations, successfulSpeculations.get());
+    Assertions.assertEquals(expectedSpeculations, successfulSpeculations.get(),
+        "We got the wrong number of successful speculations.");
   }
 
   @Test
-  public void testLegacyEstimator() throws Exception {
+  void testLegacyEstimator() throws Exception {
     TaskRuntimeEstimator specificEstimator = new LegacyTaskRuntimeEstimator();
     coreTestEstimator(specificEstimator, 3);
   }
 
   @Test
-  public void testExponentialEstimator() throws Exception {
+  void testExponentialEstimator() throws Exception {
     TaskRuntimeEstimator specificEstimator
         = new ExponentiallySmoothedTaskRuntimeEstimator();
     coreTestEstimator(specificEstimator, 3);
   }
 
   @Test
-  public void testSimpleExponentialEstimator() throws Exception {
+  void testSimpleExponentialEstimator() throws Exception {
     TaskRuntimeEstimator specificEstimator
         = new SimpleExponentialTaskRuntimeEstimator();
     coreTestEstimator(specificEstimator, 3);
@@ -279,8 +279,8 @@ public class TestRuntimeEstimators {
       TaskId taskID = event.getTaskID();
       Task task = myJob.getTask(taskID);
 
-      Assert.assertEquals
-          ("Wrong type event", TaskEventType.T_ADD_SPEC_ATTEMPT, event.getType());
+      Assertions.assertEquals
+          (TaskEventType.T_ADD_SPEC_ATTEMPT, event.getType(), "Wrong type event");
 
       System.out.println("SpeculationRequestEventHandler.handle adds a speculation task for " + taskID);
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRuntimeEstimators.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRuntimeEstimators.java
@@ -249,20 +249,20 @@ public class TestRuntimeEstimators {
   }
 
   @Test
-  void testLegacyEstimator() throws Exception {
+  public void testLegacyEstimator() throws Exception {
     TaskRuntimeEstimator specificEstimator = new LegacyTaskRuntimeEstimator();
     coreTestEstimator(specificEstimator, 3);
   }
 
   @Test
-  void testExponentialEstimator() throws Exception {
+  public void testExponentialEstimator() throws Exception {
     TaskRuntimeEstimator specificEstimator
         = new ExponentiallySmoothedTaskRuntimeEstimator();
     coreTestEstimator(specificEstimator, 3);
   }
 
   @Test
-  void testSimpleExponentialEstimator() throws Exception {
+  public void testSimpleExponentialEstimator() throws Exception {
     TaskRuntimeEstimator specificEstimator
         = new SimpleExponentialTaskRuntimeEstimator();
     coreTestEstimator(specificEstimator, 3);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestStagingCleanup.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestStagingCleanup.java
@@ -85,7 +85,7 @@ import org.junit.jupiter.api.Timeout;
    }
 
    @Test
-   void testDeletionofStagingOnUnregistrationFailure()
+   public void testDeletionofStagingOnUnregistrationFailure()
        throws IOException {
      testDeletionofStagingOnUnregistrationFailure(2, false);
      testDeletionofStagingOnUnregistrationFailure(1, false);
@@ -122,7 +122,7 @@ import org.junit.jupiter.api.Timeout;
    }
 
    @Test
-   void testDeletionofStaging() throws IOException {
+   public void testDeletionofStaging() throws IOException {
      conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
      fs = mock(FileSystem.class);
      when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
@@ -149,7 +149,7 @@ import org.junit.jupiter.api.Timeout;
 
    @Test
    @Timeout(30000)
-   void testNoDeletionofStagingOnReboot() throws IOException {
+   public void testNoDeletionofStagingOnReboot() throws IOException {
      conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
      fs = mock(FileSystem.class);
      when(fs.delete(any(Path.class),anyBoolean())).thenReturn(true);
@@ -201,7 +201,7 @@ import org.junit.jupiter.api.Timeout;
    
    @Test
    @Timeout(30000)
-   void testDeletionofStagingOnKill() throws IOException {
+   public void testDeletionofStagingOnKill() throws IOException {
      conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
      fs = mock(FileSystem.class);
      when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
@@ -257,7 +257,7 @@ import org.junit.jupiter.api.Timeout;
    }
 
    @Test
-   void testByPreserveFailedStaging() throws IOException {
+   public void testByPreserveFailedStaging() throws IOException {
      conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
      // TODO: Decide which failed task files that should
      // be kept are in application log directory.
@@ -286,7 +286,7 @@ import org.junit.jupiter.api.Timeout;
    }
 
    @Test
-   void testPreservePatternMatchedStaging() throws IOException {
+   public void testPreservePatternMatchedStaging() throws IOException {
      conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
      // The staging files that are matched to the pattern
      // should not be deleted
@@ -314,7 +314,7 @@ import org.junit.jupiter.api.Timeout;
    }
 
   @Test
-  void testNotPreserveNotPatternMatchedStaging() throws IOException {
+  public void testNotPreserveNotPatternMatchedStaging() throws IOException {
     conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
     conf.set(MRJobConfig.PRESERVE_FILES_PATTERN, "NotMatching");
     fs = mock(FileSystem.class);
@@ -342,7 +342,7 @@ import org.junit.jupiter.api.Timeout;
   }
 
   @Test
-  void testPreservePatternMatchedAndFailedStaging() throws IOException {
+  public void testPreservePatternMatchedAndFailedStaging() throws IOException {
     conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
     // When RESERVE_FILES_PATTERN and PRESERVE_FAILED_TASK_FILES are set,
     // files in staging dir are always kept.
@@ -589,7 +589,7 @@ import org.junit.jupiter.api.Timeout;
 
   @Test
   @Timeout(20000)
-  void testStagingCleanupOrder() throws Exception {
+  public void testStagingCleanupOrder() throws Exception {
     MRAppTestCleanup app = new MRAppTestCleanup(1, 1, true,
         this.getClass().getName(), true);
     JobImpl job = (JobImpl)app.submit(new Configuration());

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestStagingCleanup.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestStagingCleanup.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.mapreduce.v2.app;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
@@ -61,9 +61,10 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 
 /**
@@ -78,13 +79,13 @@ import org.junit.Test;
    private final static RecordFactory recordFactory = RecordFactoryProvider.
        getRecordFactory(null);
 
-   @After
+   @AfterEach
    public void tearDown() {
      conf.setBoolean(MRJobConfig.PRESERVE_FAILED_TASK_FILES, false);
    }
 
    @Test
-   public void testDeletionofStagingOnUnregistrationFailure()
+   void testDeletionofStagingOnUnregistrationFailure()
        throws IOException {
      testDeletionofStagingOnUnregistrationFailure(2, false);
      testDeletionofStagingOnUnregistrationFailure(1, false);
@@ -121,7 +122,7 @@ import org.junit.Test;
    }
 
    @Test
-   public void testDeletionofStaging() throws IOException {
+   void testDeletionofStaging() throws IOException {
      conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
      fs = mock(FileSystem.class);
      when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
@@ -135,7 +136,7 @@ import org.junit.Test;
      JobId jobid = recordFactory.newRecordInstance(JobId.class);
      jobid.setAppId(appId);
      ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
-     Assert.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
+     Assertions.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
      MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc,
          JobStateInternal.RUNNING, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
      appMaster.init(conf);
@@ -146,8 +147,9 @@ import org.junit.Test;
      verify(fs).delete(stagingJobPath, true);
    }
 
-   @Test (timeout = 30000)
-   public void testNoDeletionofStagingOnReboot() throws IOException {
+   @Test
+   @Timeout(30000)
+   void testNoDeletionofStagingOnReboot() throws IOException {
      conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
      fs = mock(FileSystem.class);
      when(fs.delete(any(Path.class),anyBoolean())).thenReturn(true);
@@ -158,7 +160,7 @@ import org.junit.Test;
          0);
      ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(appId, 1);
      ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
-     Assert.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
+     Assertions.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
      MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc,
          JobStateInternal.REBOOT, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
      appMaster.init(conf);
@@ -197,8 +199,9 @@ import org.junit.Test;
      verify(fs).delete(stagingJobPath, true);
    }
    
-   @Test (timeout = 30000)
-   public void testDeletionofStagingOnKill() throws IOException {
+   @Test
+   @Timeout(30000)
+   void testDeletionofStagingOnKill() throws IOException {
      conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
      fs = mock(FileSystem.class);
      when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
@@ -215,7 +218,7 @@ import org.junit.Test;
      MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc);
      appMaster.init(conf);
      //simulate the process being killed
-     MRAppMaster.MRAppMasterShutdownHook hook = 
+     MRAppMaster.MRAppMasterShutdownHook hook =
        new MRAppMaster.MRAppMasterShutdownHook(appMaster);
      hook.run();
      verify(fs, times(0)).delete(stagingJobPath, true);
@@ -242,18 +245,19 @@ import org.junit.Test;
      ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
      MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc); //no retry
      appMaster.init(conf);
-     assertTrue("appMaster.isLastAMRetry() is false", appMaster.isLastAMRetry());
+     assertTrue(appMaster.isLastAMRetry(),
+         "appMaster.isLastAMRetry() is false");
      //simulate the process being killed
      MRAppMaster.MRAppMasterShutdownHook hook = 
        new MRAppMaster.MRAppMasterShutdownHook(appMaster);
      hook.run();
-     assertTrue("MRAppMaster isn't stopped",
-                appMaster.isInState(Service.STATE.STOPPED));
+     assertTrue(appMaster.isInState(Service.STATE.STOPPED),
+         "MRAppMaster isn't stopped");
      verify(fs).delete(stagingJobPath, true);
    }
 
    @Test
-   public void testByPreserveFailedStaging() throws IOException {
+   void testByPreserveFailedStaging() throws IOException {
      conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
      // TODO: Decide which failed task files that should
      // be kept are in application log directory.
@@ -270,7 +274,7 @@ import org.junit.Test;
      JobId jobid = recordFactory.newRecordInstance(JobId.class);
      jobid.setAppId(appId);
      ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
-     Assert.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
+     Assertions.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
      MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc,
              JobStateInternal.FAILED, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
      appMaster.init(conf);
@@ -282,7 +286,7 @@ import org.junit.Test;
    }
 
    @Test
-   public void testPreservePatternMatchedStaging() throws IOException {
+   void testPreservePatternMatchedStaging() throws IOException {
      conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
      // The staging files that are matched to the pattern
      // should not be deleted
@@ -298,7 +302,7 @@ import org.junit.Test;
      JobId jobid = recordFactory.newRecordInstance(JobId.class);
      jobid.setAppId(appId);
      ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
-     Assert.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
+     Assertions.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
      MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc,
              JobStateInternal.RUNNING, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
      appMaster.init(conf);
@@ -310,7 +314,7 @@ import org.junit.Test;
    }
 
   @Test
-  public void testNotPreserveNotPatternMatchedStaging() throws IOException {
+  void testNotPreserveNotPatternMatchedStaging() throws IOException {
     conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
     conf.set(MRJobConfig.PRESERVE_FILES_PATTERN, "NotMatching");
     fs = mock(FileSystem.class);
@@ -324,7 +328,7 @@ import org.junit.Test;
     JobId jobid = recordFactory.newRecordInstance(JobId.class);
     jobid.setAppId(appId);
     ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
-    Assert.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
+    Assertions.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
     MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc,
             JobStateInternal.RUNNING, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
     appMaster.init(conf);
@@ -338,7 +342,7 @@ import org.junit.Test;
   }
 
   @Test
-  public void testPreservePatternMatchedAndFailedStaging() throws IOException {
+  void testPreservePatternMatchedAndFailedStaging() throws IOException {
     conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
     // When RESERVE_FILES_PATTERN and PRESERVE_FAILED_TASK_FILES are set,
     // files in staging dir are always kept.
@@ -355,7 +359,7 @@ import org.junit.Test;
     JobId jobid = recordFactory.newRecordInstance(JobId.class);
     jobid.setAppId(appId);
     ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
-    Assert.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
+    Assertions.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
     MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc,
             JobStateInternal.RUNNING, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
     appMaster.init(conf);
@@ -583,8 +587,9 @@ import org.junit.Test;
     };
   }
 
-  @Test(timeout=20000)
-  public void testStagingCleanupOrder() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testStagingCleanupOrder() throws Exception {
     MRAppTestCleanup app = new MRAppTestCleanup(1, 1, true,
         this.getClass().getName(), true);
     JobImpl job = (JobImpl)app.submit(new Configuration());
@@ -598,7 +603,7 @@ import org.junit.Test;
     }
 
     // assert ContainerAllocatorStopped and then tagingDirCleanedup
-    Assert.assertEquals(1, app.ContainerAllocatorStopped);
-    Assert.assertEquals(2, app.stagingDirCleanedup);
+    Assertions.assertEquals(1, app.ContainerAllocatorStopped);
+    Assertions.assertEquals(2, app.stagingDirCleanedup);
   }
  }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestTaskHeartbeatHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestTaskHeartbeatHandler.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.mapreduce.v2.app;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -40,8 +40,8 @@ import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.ControlledClock;
 import org.apache.hadoop.yarn.util.SystemClock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
@@ -51,7 +51,7 @@ public class TestTaskHeartbeatHandler {
   
   @SuppressWarnings("unchecked")
   @Test
-  public void testTaskTimeout() throws InterruptedException {
+  void testTaskTimeout() throws InterruptedException {
     EventHandler mockHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     TaskHeartbeatHandler hb = new TaskHeartbeatHandler(mockHandler, clock, 1);
@@ -85,7 +85,7 @@ public class TestTaskHeartbeatHandler {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void testTaskTimeoutDisable() throws InterruptedException {
+  void testTaskTimeoutDisable() throws InterruptedException {
     EventHandler mockHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     TaskHeartbeatHandler hb = new TaskHeartbeatHandler(mockHandler, clock, 1);
@@ -125,7 +125,7 @@ public class TestTaskHeartbeatHandler {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testTaskStuck() throws InterruptedException {
+  void testTaskStuck() throws InterruptedException {
     EventHandler mockHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     TaskHeartbeatHandler hb = new TaskHeartbeatHandler(mockHandler, clock, 1);
@@ -169,7 +169,7 @@ public class TestTaskHeartbeatHandler {
    * report interval is set bigger than the task timeout in the configuration.
    */
   @Test
-  public void testTaskTimeoutConfigSmallerThanTaskProgressReportInterval() {
+  void testTaskTimeoutConfigSmallerThanTaskProgressReportInterval() {
     testTaskTimeoutWrtProgressReportInterval(1000L, 5000L);
   }
 
@@ -178,7 +178,7 @@ public class TestTaskHeartbeatHandler {
    * report interval is set smaller than the task timeout in the configuration.
    */
   @Test
-  public void testTaskTimeoutConfigBiggerThanTaskProgressReportInterval() {
+  void testTaskTimeoutConfigBiggerThanTaskProgressReportInterval() {
     testTaskTimeoutWrtProgressReportInterval(5000L, 1000L);
   }
 
@@ -187,7 +187,7 @@ public class TestTaskHeartbeatHandler {
    * report interval is not set in the configuration.
    */
   @Test
-  public void testTaskTimeoutConfigWithoutTaskProgressReportInterval() {
+  void testTaskTimeoutConfigWithoutTaskProgressReportInterval() {
     final long taskTimeoutConfiged = 2000L;
 
     final Configuration conf = new Configuration();
@@ -198,7 +198,7 @@ public class TestTaskHeartbeatHandler {
   }
 
   @Test
-  public void testTaskUnregistered() throws Exception {
+  void testTaskUnregistered() throws Exception {
     EventHandler mockHandler = mock(EventHandler.class);
     ControlledClock clock = new ControlledClock();
     clock.setTime(0);
@@ -214,11 +214,11 @@ public class TestTaskHeartbeatHandler {
       JobId jobId = MRBuilderUtils.newJobId(appId, 4);
       TaskId tid = MRBuilderUtils.newTaskId(jobId, 3, TaskType.MAP);
       final TaskAttemptId taid = MRBuilderUtils.newTaskAttemptId(tid, 2);
-      Assert.assertFalse(hb.hasRecentlyUnregistered(taid));
+      Assertions.assertFalse(hb.hasRecentlyUnregistered(taid));
       hb.register(taid);
-      Assert.assertFalse(hb.hasRecentlyUnregistered(taid));
+      Assertions.assertFalse(hb.hasRecentlyUnregistered(taid));
       hb.unregister(taid);
-      Assert.assertTrue(hb.hasRecentlyUnregistered(taid));
+      Assertions.assertTrue(hb.hasRecentlyUnregistered(taid));
       long unregisterTimeout = conf.getLong(MRJobConfig.TASK_EXIT_TIMEOUT,
           MRJobConfig.TASK_EXIT_TIMEOUT_DEFAULT);
       clock.setTime(unregisterTimeout + 1);
@@ -260,7 +260,7 @@ public class TestTaskHeartbeatHandler {
         new TaskHeartbeatHandler(null, SystemClock.getInstance(), 1);
     hb.init(conf);
 
-    Assert.assertTrue("The value of the task timeout is incorrect.",
-        hb.getTaskTimeOut() == expectedTimeout);
+    Assertions.assertTrue(hb.getTaskTimeOut() == expectedTimeout,
+        "The value of the task timeout is incorrect.");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestTaskHeartbeatHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestTaskHeartbeatHandler.java
@@ -51,7 +51,7 @@ public class TestTaskHeartbeatHandler {
   
   @SuppressWarnings("unchecked")
   @Test
-  void testTaskTimeout() throws InterruptedException {
+  public void testTaskTimeout() throws InterruptedException {
     EventHandler mockHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     TaskHeartbeatHandler hb = new TaskHeartbeatHandler(mockHandler, clock, 1);
@@ -85,7 +85,7 @@ public class TestTaskHeartbeatHandler {
 
   @Test
   @SuppressWarnings("unchecked")
-  void testTaskTimeoutDisable() throws InterruptedException {
+  public void testTaskTimeoutDisable() throws InterruptedException {
     EventHandler mockHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     TaskHeartbeatHandler hb = new TaskHeartbeatHandler(mockHandler, clock, 1);
@@ -125,7 +125,7 @@ public class TestTaskHeartbeatHandler {
 
   @SuppressWarnings("unchecked")
   @Test
-  void testTaskStuck() throws InterruptedException {
+  public void testTaskStuck() throws InterruptedException {
     EventHandler mockHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     TaskHeartbeatHandler hb = new TaskHeartbeatHandler(mockHandler, clock, 1);
@@ -169,7 +169,7 @@ public class TestTaskHeartbeatHandler {
    * report interval is set bigger than the task timeout in the configuration.
    */
   @Test
-  void testTaskTimeoutConfigSmallerThanTaskProgressReportInterval() {
+  public void testTaskTimeoutConfigSmallerThanTaskProgressReportInterval() {
     testTaskTimeoutWrtProgressReportInterval(1000L, 5000L);
   }
 
@@ -178,7 +178,7 @@ public class TestTaskHeartbeatHandler {
    * report interval is set smaller than the task timeout in the configuration.
    */
   @Test
-  void testTaskTimeoutConfigBiggerThanTaskProgressReportInterval() {
+  public void testTaskTimeoutConfigBiggerThanTaskProgressReportInterval() {
     testTaskTimeoutWrtProgressReportInterval(5000L, 1000L);
   }
 
@@ -187,7 +187,7 @@ public class TestTaskHeartbeatHandler {
    * report interval is not set in the configuration.
    */
   @Test
-  void testTaskTimeoutConfigWithoutTaskProgressReportInterval() {
+  public void testTaskTimeoutConfigWithoutTaskProgressReportInterval() {
     final long taskTimeoutConfiged = 2000L;
 
     final Configuration conf = new Configuration();
@@ -198,7 +198,7 @@ public class TestTaskHeartbeatHandler {
   }
 
   @Test
-  void testTaskUnregistered() throws Exception {
+  public void testTaskUnregistered() throws Exception {
     EventHandler mockHandler = mock(EventHandler.class);
     ControlledClock clock = new ControlledClock();
     clock.setTime(0);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/commit/TestCommitterEventHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/commit/TestCommitterEventHandler.java
@@ -111,7 +111,7 @@ public class TestCommitterEventHandler {
   }
   
   @Test
-  void testCommitWindow() throws Exception {
+  public void testCommitWindow() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -224,7 +224,7 @@ public class TestCommitterEventHandler {
   }
 
   @Test
-  void testBasic() throws Exception {
+  public void testBasic() throws Exception {
     AppContext mockContext = mock(AppContext.class);
     OutputCommitter mockCommitter = mock(OutputCommitter.class);
     Clock mockClock = mock(Clock.class);
@@ -272,7 +272,7 @@ public class TestCommitterEventHandler {
   }
 
   @Test
-  void testFailure() throws Exception {
+  public void testFailure() throws Exception {
     AppContext mockContext = mock(AppContext.class);
     OutputCommitter mockCommitter = mock(OutputCommitter.class);
     Clock mockClock = mock(Clock.class);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/commit/TestCommitterEventHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/commit/TestCommitterEventHandler.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.JobContext;
@@ -39,7 +39,7 @@ import org.apache.hadoop.mapreduce.v2.app.rm.RMHeartbeatHandler;
 import org.apache.hadoop.yarn.event.AsyncDispatcher;
 import org.apache.hadoop.yarn.event.EventHandler;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.io.File;
@@ -62,9 +62,9 @@ import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.SystemClock;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestCommitterEventHandler {
   public static class WaitForItHandler implements EventHandler<Event> {
@@ -95,13 +95,13 @@ public class TestCommitterEventHandler {
   
   static String stagingDir = "target/test-staging/";
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {    
     File dir = new File(stagingDir);
     stagingDir = dir.getAbsolutePath();
   }
 
-  @Before
+  @BeforeEach
   public void cleanup() throws IOException {
     File dir = new File(stagingDir);
     if(dir.exists()) {
@@ -111,7 +111,7 @@ public class TestCommitterEventHandler {
   }
   
   @Test
-  public void testCommitWindow() throws Exception {
+  void testCommitWindow() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -146,11 +146,11 @@ public class TestCommitterEventHandler {
       Thread.sleep(10);
       timeToWaitMs -= 10;
     }
-    Assert.assertEquals("committer did not register a heartbeat callback",
-        1, rmhh.getNumCallbacks());
+    Assertions.assertEquals(1, rmhh.getNumCallbacks(),
+        "committer did not register a heartbeat callback");
     verify(committer, never()).commitJob(any(JobContext.class));
-    Assert.assertEquals("committer should not have committed",
-        0, jeh.numCommitCompletedEvents);
+    Assertions.assertEquals(0, jeh.numCommitCompletedEvents,
+        "committer should not have committed");
 
     // set a fresh heartbeat and verify commit completes
     rmhh.setLastHeartbeatTime(clock.getTime());
@@ -159,8 +159,8 @@ public class TestCommitterEventHandler {
       Thread.sleep(10);
       timeToWaitMs -= 10;
     }
-    Assert.assertEquals("committer did not complete commit after RM hearbeat",
-        1, jeh.numCommitCompletedEvents);
+    Assertions.assertEquals(1, jeh.numCommitCompletedEvents,
+        "committer did not complete commit after RM hearbeat");
     verify(committer, times(1)).commitJob(any());
 
     //Clean up so we can try to commit again (Don't do this at home)
@@ -174,8 +174,8 @@ public class TestCommitterEventHandler {
       Thread.sleep(10);
       timeToWaitMs -= 10;
     }
-    Assert.assertEquals("committer did not commit",
-        2, jeh.numCommitCompletedEvents);
+    Assertions.assertEquals(2, jeh.numCommitCompletedEvents,
+        "committer did not commit");
     verify(committer, times(2)).commitJob(any());
 
     ceh.stop();
@@ -224,7 +224,7 @@ public class TestCommitterEventHandler {
   }
 
   @Test
-  public void testBasic() throws Exception {
+  void testBasic() throws Exception {
     AppContext mockContext = mock(AppContext.class);
     OutputCommitter mockCommitter = mock(OutputCommitter.class);
     Clock mockClock = mock(Clock.class);
@@ -262,9 +262,9 @@ public class TestCommitterEventHandler {
       assertNotNull(e);
       assertTrue(e instanceof JobCommitCompletedEvent);
       FileSystem fs = FileSystem.get(conf);
-      assertTrue(startCommitFile.toString(), fs.exists(startCommitFile));
-      assertTrue(endCommitSuccessFile.toString(), fs.exists(endCommitSuccessFile));
-      assertFalse(endCommitFailureFile.toString(), fs.exists(endCommitFailureFile));
+      assertTrue(fs.exists(startCommitFile), startCommitFile.toString());
+      assertTrue(fs.exists(endCommitSuccessFile), endCommitSuccessFile.toString());
+      assertFalse(fs.exists(endCommitFailureFile), endCommitFailureFile.toString());
       verify(mockCommitter).commitJob(any(JobContext.class));
     } finally {
       handler.stop();
@@ -272,7 +272,7 @@ public class TestCommitterEventHandler {
   }
 
   @Test
-  public void testFailure() throws Exception {
+  void testFailure() throws Exception {
     AppContext mockContext = mock(AppContext.class);
     OutputCommitter mockCommitter = mock(OutputCommitter.class);
     Clock mockClock = mock(Clock.class);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestJobImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestJobImpl.java
@@ -137,7 +137,7 @@ public class TestJobImpl {
   }
   
   @Test
-  void testJobNoTasks() {
+  public void testJobNoTasks() {
     Configuration conf = new Configuration();
     conf.setInt(MRJobConfig.NUM_REDUCES, 0);
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
@@ -178,7 +178,7 @@ public class TestJobImpl {
 
   @Test
   @Timeout(20000)
-  void testCommitJobFailsJob() throws Exception {
+  public void testCommitJobFailsJob() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -204,7 +204,7 @@ public class TestJobImpl {
 
   @Test
   @Timeout(20000)
-  void testCheckJobCompleteSuccess() throws Exception {
+  public void testCheckJobCompleteSuccess() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     DrainDispatcher dispatcher = new DrainDispatcher();
@@ -257,7 +257,7 @@ public class TestJobImpl {
 
   @Test
   @Timeout(20000)
-  void testRebootedDuringSetup() throws Exception {
+  public void testRebootedDuringSetup() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -301,7 +301,7 @@ public class TestJobImpl {
 
   @Test
   @Timeout(20000)
-  void testRebootedDuringCommit() throws Exception {
+  public void testRebootedDuringCommit() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     conf.setInt(MRJobConfig.MR_AM_MAX_ATTEMPTS, 2);
@@ -336,7 +336,7 @@ public class TestJobImpl {
 
   @Test
   @Timeout(20000)
-  void testKilledDuringSetup() throws Exception {
+  public void testKilledDuringSetup() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -374,7 +374,7 @@ public class TestJobImpl {
 
   @Test
   @Timeout(20000)
-  void testKilledDuringCommit() throws Exception {
+  public void testKilledDuringCommit() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -399,7 +399,7 @@ public class TestJobImpl {
   }
 
   @Test
-  void testAbortJobCalledAfterKillingTasks() throws IOException {
+  public void testAbortJobCalledAfterKillingTasks() throws IOException {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     conf.set(MRJobConfig.MR_AM_COMMITTER_CANCEL_TIMEOUT_MS, "1000");
@@ -432,7 +432,7 @@ public class TestJobImpl {
 
   @Test
   @Timeout(10000)
-  void testFailAbortDoesntHang() throws IOException {
+  public void testFailAbortDoesntHang() throws IOException {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     conf.set(MRJobConfig.MR_AM_COMMITTER_CANCEL_TIMEOUT_MS, "1000");
@@ -471,7 +471,7 @@ public class TestJobImpl {
 
   @Test
   @Timeout(20000)
-  void testKilledDuringFailAbort() throws Exception {
+  public void testKilledDuringFailAbort() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -514,7 +514,7 @@ public class TestJobImpl {
 
   @Test
   @Timeout(20000)
-  void testKilledDuringKillAbort() throws Exception {
+  public void testKilledDuringKillAbort() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     // not initializing dispatcher to avoid potential race condition between
@@ -558,7 +558,7 @@ public class TestJobImpl {
 
   @Test
   @Timeout(20000)
-  void testUnusableNodeTransition() throws Exception {
+  public void testUnusableNodeTransition() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     conf.setInt(MRJobConfig.NUM_REDUCES, 1);
@@ -645,13 +645,13 @@ public class TestJobImpl {
   }
 
   @Test
-  void testJobNCompletedWhenAllReducersAreFinished()
+  public void testJobNCompletedWhenAllReducersAreFinished()
       throws Exception {
     testJobCompletionWhenReducersAreFinished(true);
   }
 
   @Test
-  void testJobNotCompletedWhenAllReducersAreFinished()
+  public void testJobNotCompletedWhenAllReducersAreFinished()
       throws Exception {
     testJobCompletionWhenReducersAreFinished(false);
   }
@@ -730,7 +730,7 @@ public class TestJobImpl {
   }
 
   @Test
-  void testCheckAccess() {
+  public void testCheckAccess() {
     // Create two unique users
     String user1 = System.getProperty("user.name");
     String user2 = user1 + "1234";
@@ -798,7 +798,7 @@ public class TestJobImpl {
   }
 
   @Test
-  void testReportDiagnostics() throws Exception {
+  public void testReportDiagnostics() throws Exception {
     JobID jobID = JobID.forName("job_1234567890000_0001");
     JobId jobId = TypeConverter.toYarn(jobID);
     final String diagMsg = "some diagnostic message";
@@ -832,7 +832,7 @@ public class TestJobImpl {
   }
 
   @Test
-  void testUberDecision() throws Exception {
+  public void testUberDecision() throws Exception {
 
     // with default values, no of maps is 2
     Configuration conf = new Configuration();
@@ -911,7 +911,7 @@ public class TestJobImpl {
   }
 
   @Test
-  void testTransitionsAtFailed() throws IOException {
+  public void testTransitionsAtFailed() throws IOException {
     Configuration conf = new Configuration();
     AsyncDispatcher dispatcher = new AsyncDispatcher();
     dispatcher.init(conf);
@@ -952,7 +952,7 @@ public class TestJobImpl {
 
   static final String EXCEPTIONMSG = "Splits max exceeded";
   @Test
-  void testMetaInfoSizeOverMax() throws Exception {
+  public void testMetaInfoSizeOverMax() throws Exception {
     Configuration conf = new Configuration();
     JobID jobID = JobID.forName("job_1234567890000_0001");
     JobId jobId = TypeConverter.toYarn(jobID);
@@ -980,7 +980,7 @@ public class TestJobImpl {
   }
 
   @Test
-  void testJobPriorityUpdate() throws Exception {
+  public void testJobPriorityUpdate() throws Exception {
     Configuration conf = new Configuration();
     AsyncDispatcher dispatcher = new AsyncDispatcher();
     dispatcher.init(conf);
@@ -1014,7 +1014,7 @@ public class TestJobImpl {
   }
 
   @Test
-  void testCleanupSharedCacheUploadPolicies() {
+  public void testCleanupSharedCacheUploadPolicies() {
     Configuration config = new Configuration();
     Map<String, Boolean> archivePolicies = new HashMap<>();
     archivePolicies.put("archive1", true);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestJobImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestJobImpl.java
@@ -105,10 +105,11 @@ import org.apache.hadoop.yarn.state.StateMachine;
 import org.apache.hadoop.yarn.state.StateMachineFactory;
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.util.SystemClock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 
@@ -120,13 +121,13 @@ public class TestJobImpl {
   
   static String stagingDir = "target/test-staging/";
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {    
     File dir = new File(stagingDir);
     stagingDir = dir.getAbsolutePath();
   }
 
-  @Before
+  @BeforeEach
   public void cleanup() throws IOException {
     File dir = new File(stagingDir);
     if(dir.exists()) {
@@ -136,7 +137,7 @@ public class TestJobImpl {
   }
   
   @Test
-  public void testJobNoTasks() {
+  void testJobNoTasks() {
     Configuration conf = new Configuration();
     conf.setInt(MRJobConfig.NUM_REDUCES, 0);
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
@@ -169,14 +170,15 @@ public class TestJobImpl {
     dispatcher.stop();
     commitHandler.stop();
     try {
-      Assert.assertTrue(jseHandler.getAssertValue());
+      Assertions.assertTrue(jseHandler.getAssertValue());
     } catch (InterruptedException e) {
-      Assert.fail("Workflow related attributes are not tested properly");
+      Assertions.fail("Workflow related attributes are not tested properly");
     }
   }
 
-  @Test(timeout=20000)
-  public void testCommitJobFailsJob() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testCommitJobFailsJob() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -200,8 +202,9 @@ public class TestJobImpl {
     commitHandler.stop();
   }
 
-  @Test(timeout=20000)
-  public void testCheckJobCompleteSuccess() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testCheckJobCompleteSuccess() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     DrainDispatcher dispatcher = new DrainDispatcher();
@@ -239,7 +242,7 @@ public class TestJobImpl {
         JobEventType.JOB_TASK_ATTEMPT_COMPLETED));
     assertJobState(job, JobStateInternal.SUCCEEDED);
 
-    job.handle(new JobEvent(job.getID(), 
+    job.handle(new JobEvent(job.getID(),
         JobEventType.JOB_MAP_TASK_RESCHEDULED));
     assertJobState(job, JobStateInternal.SUCCEEDED);
 
@@ -247,13 +250,14 @@ public class TestJobImpl {
         JobEventType.JOB_TASK_COMPLETED));
     dispatcher.await();
     assertJobState(job, JobStateInternal.SUCCEEDED);
-    
+
     dispatcher.stop();
     commitHandler.stop();
   }
 
-  @Test(timeout=20000)
-  public void testRebootedDuringSetup() throws Exception{
+  @Test
+  @Timeout(20000)
+  void testRebootedDuringSetup() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -289,14 +293,15 @@ public class TestJobImpl {
     assertJobState(job, JobStateInternal.REBOOT);
     // return the external state as RUNNING since otherwise JobClient will
     // exit when it polls the AM for job state
-    Assert.assertEquals(JobState.RUNNING, job.getState());
+    Assertions.assertEquals(JobState.RUNNING, job.getState());
 
     dispatcher.stop();
     commitHandler.stop();
   }
 
-  @Test(timeout=20000)
-  public void testRebootedDuringCommit() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testRebootedDuringCommit() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     conf.setInt(MRJobConfig.MR_AM_MAX_ATTEMPTS, 2);
@@ -321,16 +326,17 @@ public class TestJobImpl {
     job.handle(new JobEvent(job.getID(), JobEventType.JOB_AM_REBOOT));
     assertJobState(job, JobStateInternal.REBOOT);
     // return the external state as ERROR since this is last retry.
-    Assert.assertEquals(JobState.RUNNING, job.getState());
+    Assertions.assertEquals(JobState.RUNNING, job.getState());
     when(mockContext.hasSuccessfullyUnregistered()).thenReturn(true);
-    Assert.assertEquals(JobState.ERROR, job.getState());
+    Assertions.assertEquals(JobState.ERROR, job.getState());
 
     dispatcher.stop();
     commitHandler.stop();
   }
 
-  @Test(timeout=20000)
-  public void testKilledDuringSetup() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testKilledDuringSetup() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -366,8 +372,9 @@ public class TestJobImpl {
     commitHandler.stop();
   }
 
-  @Test(timeout=20000)
-  public void testKilledDuringCommit() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testKilledDuringCommit() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -392,7 +399,7 @@ public class TestJobImpl {
   }
 
   @Test
-  public void testAbortJobCalledAfterKillingTasks() throws IOException {
+  void testAbortJobCalledAfterKillingTasks() throws IOException {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     conf.set(MRJobConfig.MR_AM_COMMITTER_CANCEL_TIMEOUT_MS, "1000");
@@ -423,8 +430,9 @@ public class TestJobImpl {
     dispatcher.stop();
   }
 
-  @Test (timeout=10000)
-  public void testFailAbortDoesntHang() throws IOException {
+  @Test
+  @Timeout(10000)
+  void testFailAbortDoesntHang() throws IOException {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     conf.set(MRJobConfig.MR_AM_COMMITTER_CANCEL_TIMEOUT_MS, "1000");
@@ -461,8 +469,9 @@ public class TestJobImpl {
     dispatcher.stop();
   }
 
-  @Test(timeout=20000)
-  public void testKilledDuringFailAbort() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testKilledDuringFailAbort() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -503,8 +512,9 @@ public class TestJobImpl {
     commitHandler.stop();
   }
 
-  @Test(timeout=20000)
-  public void testKilledDuringKillAbort() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testKilledDuringKillAbort() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     // not initializing dispatcher to avoid potential race condition between
@@ -546,8 +556,9 @@ public class TestJobImpl {
     commitHandler.stop();
   }
 
-  @Test(timeout=20000)
-  public void testUnusableNodeTransition() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testUnusableNodeTransition() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     conf.setInt(MRJobConfig.NUM_REDUCES, 1);
@@ -599,7 +610,7 @@ public class TestJobImpl {
         job.handle(new JobTaskAttemptCompletedEvent(tce));
         // complete the task itself
         job.handle(new JobTaskEvent(taskId, TaskState.SUCCEEDED));
-        Assert.assertEquals(JobState.RUNNING, job.getState());
+        Assertions.assertEquals(JobState.RUNNING, job.getState());
       }
     }
 
@@ -634,13 +645,13 @@ public class TestJobImpl {
   }
 
   @Test
-  public void testJobNCompletedWhenAllReducersAreFinished()
+  void testJobNCompletedWhenAllReducersAreFinished()
       throws Exception {
     testJobCompletionWhenReducersAreFinished(true);
   }
 
   @Test
-  public void testJobNotCompletedWhenAllReducersAreFinished()
+  void testJobNotCompletedWhenAllReducersAreFinished()
       throws Exception {
     testJobCompletionWhenReducersAreFinished(false);
   }
@@ -699,13 +710,13 @@ public class TestJobImpl {
      * much value. Instead, we validate the T_KILL events.
      */
     if (killMappers) {
-      Assert.assertEquals("Number of killed events", 2, killedEvents.size());
-      Assert.assertEquals("AttemptID", "task_1234567890000_0001_m_000000",
-          killedEvents.get(0).getTaskID().toString());
-      Assert.assertEquals("AttemptID", "task_1234567890000_0001_m_000001",
-          killedEvents.get(1).getTaskID().toString());
+      Assertions.assertEquals(2, killedEvents.size(), "Number of killed events");
+      Assertions.assertEquals("task_1234567890000_0001_m_000000",
+          killedEvents.get(0).getTaskID().toString(), "AttemptID");
+      Assertions.assertEquals("task_1234567890000_0001_m_000001",
+          killedEvents.get(1).getTaskID().toString(), "AttemptID");
     } else {
-      Assert.assertEquals("Number of killed events", 0, killedEvents.size());
+      Assertions.assertEquals(0, killedEvents.size(), "Number of killed events");
     }
   }
 
@@ -719,7 +730,7 @@ public class TestJobImpl {
   }
 
   @Test
-  public void testCheckAccess() {
+  void testCheckAccess() {
     // Create two unique users
     String user1 = System.getProperty("user.name");
     String user2 = user1 + "1234";
@@ -738,8 +749,8 @@ public class TestJobImpl {
     // Verify access
     JobImpl job1 = new JobImpl(jobId, null, conf1, null, null, null, null, null,
         null, null, null, true, user1, 0, null, null, null, null);
-    Assert.assertTrue(job1.checkAccess(ugi1, JobACL.VIEW_JOB));
-    Assert.assertFalse(job1.checkAccess(ugi2, JobACL.VIEW_JOB));
+    Assertions.assertTrue(job1.checkAccess(ugi1, JobACL.VIEW_JOB));
+    Assertions.assertFalse(job1.checkAccess(ugi2, JobACL.VIEW_JOB));
 
     // Setup configuration access to the user1 (owner) and user2
     Configuration conf2 = new Configuration();
@@ -749,8 +760,8 @@ public class TestJobImpl {
     // Verify access
     JobImpl job2 = new JobImpl(jobId, null, conf2, null, null, null, null, null,
         null, null, null, true, user1, 0, null, null, null, null);
-    Assert.assertTrue(job2.checkAccess(ugi1, JobACL.VIEW_JOB));
-    Assert.assertTrue(job2.checkAccess(ugi2, JobACL.VIEW_JOB));
+    Assertions.assertTrue(job2.checkAccess(ugi1, JobACL.VIEW_JOB));
+    Assertions.assertTrue(job2.checkAccess(ugi2, JobACL.VIEW_JOB));
 
     // Setup configuration access with security enabled and access to all
     Configuration conf3 = new Configuration();
@@ -760,8 +771,8 @@ public class TestJobImpl {
     // Verify access
     JobImpl job3 = new JobImpl(jobId, null, conf3, null, null, null, null, null,
         null, null, null, true, user1, 0, null, null, null, null);
-    Assert.assertTrue(job3.checkAccess(ugi1, JobACL.VIEW_JOB));
-    Assert.assertTrue(job3.checkAccess(ugi2, JobACL.VIEW_JOB));
+    Assertions.assertTrue(job3.checkAccess(ugi1, JobACL.VIEW_JOB));
+    Assertions.assertTrue(job3.checkAccess(ugi2, JobACL.VIEW_JOB));
 
     // Setup configuration access without security enabled
     Configuration conf4 = new Configuration();
@@ -771,8 +782,8 @@ public class TestJobImpl {
     // Verify access
     JobImpl job4 = new JobImpl(jobId, null, conf4, null, null, null, null, null,
         null, null, null, true, user1, 0, null, null, null, null);
-    Assert.assertTrue(job4.checkAccess(ugi1, JobACL.VIEW_JOB));
-    Assert.assertTrue(job4.checkAccess(ugi2, JobACL.VIEW_JOB));
+    Assertions.assertTrue(job4.checkAccess(ugi1, JobACL.VIEW_JOB));
+    Assertions.assertTrue(job4.checkAccess(ugi2, JobACL.VIEW_JOB));
 
     // Setup configuration access without security enabled
     Configuration conf5 = new Configuration();
@@ -782,12 +793,12 @@ public class TestJobImpl {
     // Verify access
     JobImpl job5 = new JobImpl(jobId, null, conf5, null, null, null, null, null,
         null, null, null, true, user1, 0, null, null, null, null);
-    Assert.assertTrue(job5.checkAccess(ugi1, null));
-    Assert.assertTrue(job5.checkAccess(ugi2, null));
+    Assertions.assertTrue(job5.checkAccess(ugi1, null));
+    Assertions.assertTrue(job5.checkAccess(ugi2, null));
   }
 
   @Test
-  public void testReportDiagnostics() throws Exception {
+  void testReportDiagnostics() throws Exception {
     JobID jobID = JobID.forName("job_1234567890000_0001");
     JobId jobId = TypeConverter.toYarn(jobID);
     final String diagMsg = "some diagnostic message";
@@ -804,8 +815,8 @@ public class TestJobImpl {
         mrAppMetrics, null, true, null, 0, null, mockContext, null, null);
     job.handle(diagUpdateEvent);
     String diagnostics = job.getReport().getDiagnostics();
-    Assert.assertNotNull(diagnostics);
-    Assert.assertTrue(diagnostics.contains(diagMsg));
+    Assertions.assertNotNull(diagnostics);
+    Assertions.assertTrue(diagnostics.contains(diagMsg));
 
     job = new JobImpl(jobId, Records
         .newRecord(ApplicationAttemptId.class), new Configuration(),
@@ -816,23 +827,23 @@ public class TestJobImpl {
     job.handle(new JobEvent(jobId, JobEventType.JOB_KILL));
     job.handle(diagUpdateEvent);
     diagnostics = job.getReport().getDiagnostics();
-    Assert.assertNotNull(diagnostics);
-    Assert.assertTrue(diagnostics.contains(diagMsg));
+    Assertions.assertNotNull(diagnostics);
+    Assertions.assertTrue(diagnostics.contains(diagMsg));
   }
 
   @Test
-  public void testUberDecision() throws Exception {
+  void testUberDecision() throws Exception {
 
     // with default values, no of maps is 2
     Configuration conf = new Configuration();
     boolean isUber = testUberDecision(conf);
-    Assert.assertFalse(isUber);
+    Assertions.assertFalse(isUber);
 
     // enable uber mode, no of maps is 2
     conf = new Configuration();
     conf.setBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, true);
     isUber = testUberDecision(conf);
-    Assert.assertTrue(isUber);
+    Assertions.assertTrue(isUber);
 
     // enable uber mode, no of maps is 2, no of reduces is 1 and uber task max
     // reduces is 0
@@ -841,7 +852,7 @@ public class TestJobImpl {
     conf.setInt(MRJobConfig.JOB_UBERTASK_MAXREDUCES, 0);
     conf.setInt(MRJobConfig.NUM_REDUCES, 1);
     isUber = testUberDecision(conf);
-    Assert.assertFalse(isUber);
+    Assertions.assertFalse(isUber);
 
     // enable uber mode, no of maps is 2, no of reduces is 1 and uber task max
     // reduces is 1
@@ -850,14 +861,14 @@ public class TestJobImpl {
     conf.setInt(MRJobConfig.JOB_UBERTASK_MAXREDUCES, 1);
     conf.setInt(MRJobConfig.NUM_REDUCES, 1);
     isUber = testUberDecision(conf);
-    Assert.assertTrue(isUber);
+    Assertions.assertTrue(isUber);
 
     // enable uber mode, no of maps is 2 and uber task max maps is 0
     conf = new Configuration();
     conf.setBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, true);
     conf.setInt(MRJobConfig.JOB_UBERTASK_MAXMAPS, 1);
     isUber = testUberDecision(conf);
-    Assert.assertFalse(isUber);
+    Assertions.assertFalse(isUber);
     
  // enable uber mode of 0 reducer no matter how much memory assigned to reducer
     conf = new Configuration();
@@ -866,7 +877,7 @@ public class TestJobImpl {
     conf.setInt(MRJobConfig.REDUCE_MEMORY_MB, 2048);
     conf.setInt(MRJobConfig.REDUCE_CPU_VCORES, 10);
     isUber = testUberDecision(conf);
-    Assert.assertTrue(isUber);
+    Assertions.assertTrue(isUber);
   }
 
   private boolean testUberDecision(Configuration conf) {
@@ -900,7 +911,7 @@ public class TestJobImpl {
   }
 
   @Test
-  public void testTransitionsAtFailed() throws IOException {
+  void testTransitionsAtFailed() throws IOException {
     Configuration conf = new Configuration();
     AsyncDispatcher dispatcher = new AsyncDispatcher();
     dispatcher.init(conf);
@@ -931,9 +942,9 @@ public class TestJobImpl {
     assertJobState(job, JobStateInternal.FAILED);
     job.handle(new JobEvent(jobId, JobEventType.JOB_TASK_ATTEMPT_FETCH_FAILURE));
     assertJobState(job, JobStateInternal.FAILED);
-    Assert.assertEquals(JobState.RUNNING, job.getState());
+    Assertions.assertEquals(JobState.RUNNING, job.getState());
     when(mockContext.hasSuccessfullyUnregistered()).thenReturn(true);
-    Assert.assertEquals(JobState.FAILED, job.getState());
+    Assertions.assertEquals(JobState.FAILED, job.getState());
 
     dispatcher.stop();
     commitHandler.stop();
@@ -941,7 +952,7 @@ public class TestJobImpl {
 
   static final String EXCEPTIONMSG = "Splits max exceeded";
   @Test
-  public void testMetaInfoSizeOverMax() throws Exception {
+  void testMetaInfoSizeOverMax() throws Exception {
     Configuration conf = new Configuration();
     JobID jobID = JobID.forName("job_1234567890000_0001");
     JobId jobId = TypeConverter.toYarn(jobID);
@@ -960,16 +971,16 @@ public class TestJobImpl {
     JobEvent mockJobEvent = mock(JobEvent.class);
 
     JobStateInternal jobSI = initTransition.transition(job, mockJobEvent);
-    Assert.assertTrue("When init fails, return value from InitTransition.transition should equal NEW.",
-                      jobSI.equals(JobStateInternal.NEW));
-    Assert.assertTrue("Job diagnostics should contain YarnRuntimeException",
-                      job.getDiagnostics().toString().contains("YarnRuntimeException"));
-    Assert.assertTrue("Job diagnostics should contain " + EXCEPTIONMSG,
-                      job.getDiagnostics().toString().contains(EXCEPTIONMSG));
+    Assertions.assertTrue(jobSI.equals(JobStateInternal.NEW),
+        "When init fails, return value from InitTransition.transition should equal NEW.");
+    Assertions.assertTrue(job.getDiagnostics().toString().contains("YarnRuntimeException"),
+        "Job diagnostics should contain YarnRuntimeException");
+    Assertions.assertTrue(job.getDiagnostics().toString().contains(EXCEPTIONMSG),
+        "Job diagnostics should contain " + EXCEPTIONMSG);
   }
 
   @Test
-  public void testJobPriorityUpdate() throws Exception {
+  void testJobPriorityUpdate() throws Exception {
     Configuration conf = new Configuration();
     AsyncDispatcher dispatcher = new AsyncDispatcher();
     dispatcher.init(conf);
@@ -986,7 +997,7 @@ public class TestJobImpl {
     assertJobState(job, JobStateInternal.SETUP);
     // Update priority of job to 5, and it will be updated
     job.setJobPriority(submittedPriority);
-    Assert.assertEquals(submittedPriority, job.getReport().getJobPriority());
+    Assertions.assertEquals(submittedPriority, job.getReport().getJobPriority());
 
     job.handle(new JobSetupCompletedEvent(jobId));
     assertJobState(job, JobStateInternal.RUNNING);
@@ -996,14 +1007,14 @@ public class TestJobImpl {
     job.setJobPriority(updatedPriority);
     assertJobState(job, JobStateInternal.RUNNING);
     Priority jobPriority = job.getReport().getJobPriority();
-    Assert.assertNotNull(jobPriority);
+    Assertions.assertNotNull(jobPriority);
 
     // Verify whether changed priority is same as what is set in Job.
-    Assert.assertEquals(updatedPriority, jobPriority);
+    Assertions.assertEquals(updatedPriority, jobPriority);
   }
 
   @Test
-  public void testCleanupSharedCacheUploadPolicies() {
+  void testCleanupSharedCacheUploadPolicies() {
     Configuration config = new Configuration();
     Map<String, Boolean> archivePolicies = new HashMap<>();
     archivePolicies.put("archive1", true);
@@ -1013,14 +1024,14 @@ public class TestJobImpl {
     filePolicies.put("file1", true);
     filePolicies.put("jar1", true);
     Job.setFileSharedCacheUploadPolicies(config, filePolicies);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2, Job.getArchiveSharedCacheUploadPolicies(config).size());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2, Job.getFileSharedCacheUploadPolicies(config).size());
     JobImpl.cleanupSharedCacheUploadPolicies(config);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0, Job.getArchiveSharedCacheUploadPolicies(config).size());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0, Job.getFileSharedCacheUploadPolicies(config).size());
   }
 
@@ -1088,14 +1099,14 @@ public class TestJobImpl {
       job.handle(new JobTaskEvent(
           MRBuilderUtils.newTaskId(job.getID(), 1, TaskType.MAP),
           TaskState.SUCCEEDED));
-      Assert.assertEquals(JobState.RUNNING, job.getState());
+      Assertions.assertEquals(JobState.RUNNING, job.getState());
     }
     int numReduces = job.getTotalReduces();
     for (int i = 0; i < numReduces; ++i) {
       job.handle(new JobTaskEvent(
           MRBuilderUtils.newTaskId(job.getID(), 1, TaskType.MAP),
           TaskState.SUCCEEDED));
-      Assert.assertEquals(JobState.RUNNING, job.getState());
+      Assertions.assertEquals(JobState.RUNNING, job.getState());
     }
   }
 
@@ -1109,7 +1120,7 @@ public class TestJobImpl {
         break;
       }
     }
-    Assert.assertEquals(state, job.getInternalState());
+    Assertions.assertEquals(state, job.getInternalState());
   }
 
   private void createSpiedMapTasks(Map<NodeReport, TaskId>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestMapReduceChildJVM.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestMapReduceChildJVM.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import org.apache.hadoop.mapreduce.TaskType;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
@@ -37,7 +37,8 @@ import org.apache.hadoop.mapreduce.v2.app.launcher.ContainerLauncherEvent;
 import org.apache.hadoop.mapreduce.v2.app.launcher.ContainerRemoteLaunchEvent;
 import org.apache.hadoop.mapreduce.v2.util.MRApps;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,9 +47,8 @@ public class TestMapReduceChildJVM {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestMapReduceChildJVM.class);
 
-  @Test (timeout = 30000)
-  public void testCommandLine() throws Exception {
-
+  @Test
+  void testCommandLine() throws Exception {
     MyMRApp app = new MyMRApp(1, 0, true, this.getClass().getName(), true);
     Configuration conf = new Configuration();
     conf.setBoolean(MRConfig.MAPREDUCE_APP_SUBMISSION_CROSS_PLATFORM, true);
@@ -56,7 +56,7 @@ public class TestMapReduceChildJVM {
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "[" + MRApps.crossPlatformify("JAVA_HOME") + "/bin/java" +
       " -Djava.net.preferIPv4Stack=true" +
       " -Dhadoop.metrics.log.level=WARN " +
@@ -71,25 +71,27 @@ public class TestMapReduceChildJVM {
       " 0" +
       " 1><LOG_DIR>/stdout" +
       " 2><LOG_DIR>/stderr ]", app.launchCmdList.get(0));
-    
-    Assert.assertTrue("HADOOP_ROOT_LOGGER not set for job",
-      app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"));
-    Assert.assertEquals("INFO,console",
+
+    Assertions.assertTrue(app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"),
+        "HADOOP_ROOT_LOGGER not set for job");
+    Assertions.assertEquals("INFO,console",
       app.cmdEnvironment.get("HADOOP_ROOT_LOGGER"));
-    Assert.assertTrue("HADOOP_CLIENT_OPTS not set for job",
-      app.cmdEnvironment.containsKey("HADOOP_CLIENT_OPTS"));
-    Assert.assertEquals("", app.cmdEnvironment.get("HADOOP_CLIENT_OPTS"));
+    Assertions.assertTrue(app.cmdEnvironment.containsKey("HADOOP_CLIENT_OPTS"),
+        "HADOOP_CLIENT_OPTS not set for job");
+    Assertions.assertEquals("", app.cmdEnvironment.get("HADOOP_CLIENT_OPTS"));
   }
 
-  @Test (timeout = 30000)
-  public void testReduceCommandLineWithSeparateShuffle() throws Exception {
+  @Test
+  @Timeout(30000)
+  void testReduceCommandLineWithSeparateShuffle() throws Exception {
     final Configuration conf = new Configuration();
     conf.setBoolean(MRJobConfig.REDUCE_SEPARATE_SHUFFLE_LOG, true);
     testReduceCommandLine(conf);
   }
 
-  @Test (timeout = 30000)
-  public void testReduceCommandLineWithSeparateCRLAShuffle() throws Exception {
+  @Test
+  @Timeout(30000)
+  void testReduceCommandLineWithSeparateCRLAShuffle() throws Exception {
     final Configuration conf = new Configuration();
     conf.setBoolean(MRJobConfig.REDUCE_SEPARATE_SHUFFLE_LOG, true);
     conf.setLong(MRJobConfig.SHUFFLE_LOG_KB, 1L);
@@ -97,8 +99,9 @@ public class TestMapReduceChildJVM {
     testReduceCommandLine(conf);
   }
 
-  @Test (timeout = 30000)
-  public void testReduceCommandLine() throws Exception {
+  @Test
+  @Timeout(30000)
+  void testReduceCommandLine() throws Exception {
     final Configuration conf = new Configuration();
     testReduceCommandLine(conf);
   }
@@ -119,7 +122,7 @@ public class TestMapReduceChildJVM {
         ? "shuffleCRLA"
         : "shuffleCLA";
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "[" + MRApps.crossPlatformify("JAVA_HOME") + "/bin/java" +
             " -Djava.net.preferIPv4Stack=true" +
             " -Dhadoop.metrics.log.level=WARN " +
@@ -139,17 +142,18 @@ public class TestMapReduceChildJVM {
             " 1><LOG_DIR>/stdout" +
             " 2><LOG_DIR>/stderr ]", app.launchCmdList.get(0));
 
-    Assert.assertTrue("HADOOP_ROOT_LOGGER not set for job",
-        app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"));
-    Assert.assertEquals("INFO,console",
+    Assertions.assertTrue(app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"),
+        "HADOOP_ROOT_LOGGER not set for job");
+    Assertions.assertEquals("INFO,console",
         app.cmdEnvironment.get("HADOOP_ROOT_LOGGER"));
-    Assert.assertTrue("HADOOP_CLIENT_OPTS not set for job",
-        app.cmdEnvironment.containsKey("HADOOP_CLIENT_OPTS"));
-    Assert.assertEquals("", app.cmdEnvironment.get("HADOOP_CLIENT_OPTS"));
+    Assertions.assertTrue(app.cmdEnvironment.containsKey("HADOOP_CLIENT_OPTS"),
+        "HADOOP_CLIENT_OPTS not set for job");
+    Assertions.assertEquals("", app.cmdEnvironment.get("HADOOP_CLIENT_OPTS"));
   }
   
-  @Test (timeout = 30000)
-  public void testCommandLineWithLog4JConifg() throws Exception {
+  @Test
+  @Timeout(30000)
+  void testCommandLineWithLog4JConifg() throws Exception {
 
     MyMRApp app = new MyMRApp(1, 0, true, this.getClass().getName(), true);
     Configuration conf = new Configuration();
@@ -161,7 +165,7 @@ public class TestMapReduceChildJVM {
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "[" + MRApps.crossPlatformify("JAVA_HOME") + "/bin/java" +
       " -Djava.net.preferIPv4Stack=true" +
       " -Dhadoop.metrics.log.level=WARN " +
@@ -179,7 +183,7 @@ public class TestMapReduceChildJVM {
   }
 
   @Test
-  public void testAutoHeapSizes() throws Exception {
+  void testAutoHeapSizes() throws Exception {
     // Don't specify heap size or memory-mb
     testAutoHeapSize(-1, -1, null);
 
@@ -203,10 +207,10 @@ public class TestMapReduceChildJVM {
         MRJobConfig.DEFAULT_HEAP_MEMORY_MB_RATIO);
 
     // Verify map and reduce java opts are not set by default
-    Assert.assertNull("Default map java opts!",
-        conf.get(MRJobConfig.MAP_JAVA_OPTS));
-    Assert.assertNull("Default reduce java opts!",
-        conf.get(MRJobConfig.REDUCE_JAVA_OPTS));
+    Assertions.assertNull(conf.get(MRJobConfig.MAP_JAVA_OPTS),
+        "Default map java opts!");
+    Assertions.assertNull(conf.get(MRJobConfig.REDUCE_JAVA_OPTS),
+        "Default reduce java opts!");
     // Set the memory-mbs and java-opts
     if (mapMb > 0) {
       conf.setInt(MRJobConfig.MAP_MEMORY_MB, mapMb);
@@ -242,8 +246,8 @@ public class TestMapReduceChildJVM {
             : MRJobConfig.REDUCE_JAVA_OPTS);
         heapMb = JobConf.parseMaximumHeapSizeMB(javaOpts);
       }
-      Assert.assertEquals("Incorrect heapsize in the command opts",
-          heapMb, JobConf.parseMaximumHeapSizeMB(cmd));
+      Assertions.assertEquals(heapMb, JobConf.parseMaximumHeapSizeMB(cmd),
+          "Incorrect heapsize in the command opts");
     }
   }
 
@@ -278,7 +282,7 @@ public class TestMapReduceChildJVM {
   }
   
   @Test
-  public void testEnvironmentVariables() throws Exception {
+  void testEnvironmentVariables() throws Exception {
     MyMRApp app = new MyMRApp(1, 0, true, this.getClass().getName(), true);
     Configuration conf = new Configuration();
     conf.set(JobConf.MAPRED_MAP_TASK_ENV, "HADOOP_CLIENT_OPTS=test");
@@ -288,13 +292,13 @@ public class TestMapReduceChildJVM {
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
     
-    Assert.assertTrue("HADOOP_ROOT_LOGGER not set for job",
-        app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"));
-    Assert.assertEquals("WARN,console",
+    Assertions.assertTrue(app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"),
+        "HADOOP_ROOT_LOGGER not set for job");
+    Assertions.assertEquals("WARN,console",
         app.cmdEnvironment.get("HADOOP_ROOT_LOGGER"));
-    Assert.assertTrue("HADOOP_CLIENT_OPTS not set for job",
-        app.cmdEnvironment.containsKey("HADOOP_CLIENT_OPTS"));
-    Assert.assertEquals("test", app.cmdEnvironment.get("HADOOP_CLIENT_OPTS"));
+    Assertions.assertTrue(app.cmdEnvironment.containsKey("HADOOP_CLIENT_OPTS"),
+        "HADOOP_CLIENT_OPTS not set for job");
+    Assertions.assertEquals("test", app.cmdEnvironment.get("HADOOP_CLIENT_OPTS"));
 
     // Try one more.
     app = new MyMRApp(1, 0, true, this.getClass().getName(), true);
@@ -304,9 +308,9 @@ public class TestMapReduceChildJVM {
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
     
-    Assert.assertTrue("HADOOP_ROOT_LOGGER not set for job",
-        app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"));
-    Assert.assertEquals("trace",
+    Assertions.assertTrue(app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"),
+        "HADOOP_ROOT_LOGGER not set for job");
+    Assertions.assertEquals("trace",
         app.cmdEnvironment.get("HADOOP_ROOT_LOGGER"));
 
     // Try one using the mapreduce.task.env.var=value syntax
@@ -318,9 +322,9 @@ public class TestMapReduceChildJVM {
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
 
-    Assert.assertTrue("HADOOP_ROOT_LOGGER not set for job",
-        app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"));
-    Assert.assertEquals("DEBUG,console",
+    Assertions.assertTrue(app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"),
+        "HADOOP_ROOT_LOGGER not set for job");
+    Assertions.assertEquals("DEBUG,console",
         app.cmdEnvironment.get("HADOOP_ROOT_LOGGER"));
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestMapReduceChildJVM.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestMapReduceChildJVM.java
@@ -48,7 +48,7 @@ public class TestMapReduceChildJVM {
       LoggerFactory.getLogger(TestMapReduceChildJVM.class);
 
   @Test
-  void testCommandLine() throws Exception {
+  public void testCommandLine() throws Exception {
     MyMRApp app = new MyMRApp(1, 0, true, this.getClass().getName(), true);
     Configuration conf = new Configuration();
     conf.setBoolean(MRConfig.MAPREDUCE_APP_SUBMISSION_CROSS_PLATFORM, true);
@@ -83,7 +83,7 @@ public class TestMapReduceChildJVM {
 
   @Test
   @Timeout(30000)
-  void testReduceCommandLineWithSeparateShuffle() throws Exception {
+  public void testReduceCommandLineWithSeparateShuffle() throws Exception {
     final Configuration conf = new Configuration();
     conf.setBoolean(MRJobConfig.REDUCE_SEPARATE_SHUFFLE_LOG, true);
     testReduceCommandLine(conf);
@@ -91,7 +91,7 @@ public class TestMapReduceChildJVM {
 
   @Test
   @Timeout(30000)
-  void testReduceCommandLineWithSeparateCRLAShuffle() throws Exception {
+  public void testReduceCommandLineWithSeparateCRLAShuffle() throws Exception {
     final Configuration conf = new Configuration();
     conf.setBoolean(MRJobConfig.REDUCE_SEPARATE_SHUFFLE_LOG, true);
     conf.setLong(MRJobConfig.SHUFFLE_LOG_KB, 1L);
@@ -101,7 +101,7 @@ public class TestMapReduceChildJVM {
 
   @Test
   @Timeout(30000)
-  void testReduceCommandLine() throws Exception {
+  public void testReduceCommandLine() throws Exception {
     final Configuration conf = new Configuration();
     testReduceCommandLine(conf);
   }
@@ -153,7 +153,7 @@ public class TestMapReduceChildJVM {
   
   @Test
   @Timeout(30000)
-  void testCommandLineWithLog4JConifg() throws Exception {
+  public void testCommandLineWithLog4JConifg() throws Exception {
 
     MyMRApp app = new MyMRApp(1, 0, true, this.getClass().getName(), true);
     Configuration conf = new Configuration();
@@ -183,7 +183,7 @@ public class TestMapReduceChildJVM {
   }
 
   @Test
-  void testAutoHeapSizes() throws Exception {
+  public void testAutoHeapSizes() throws Exception {
     // Don't specify heap size or memory-mb
     testAutoHeapSize(-1, -1, null);
 
@@ -282,7 +282,7 @@ public class TestMapReduceChildJVM {
   }
   
   @Test
-  void testEnvironmentVariables() throws Exception {
+  public void testEnvironmentVariables() throws Exception {
     MyMRApp app = new MyMRApp(1, 0, true, this.getClass().getName(), true);
     Configuration conf = new Configuration();
     conf.set(JobConf.MAPRED_MAP_TASK_ENV, "HADOOP_CLIENT_OPTS=test");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestMapReduceChildJVM.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestMapReduceChildJVM.java
@@ -48,6 +48,7 @@ public class TestMapReduceChildJVM {
       LoggerFactory.getLogger(TestMapReduceChildJVM.class);
 
   @Test
+  @Timeout(30000)
   public void testCommandLine() throws Exception {
     MyMRApp app = new MyMRApp(1, 0, true, this.getClass().getName(), true);
     Configuration conf = new Configuration();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestShuffleProvider.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestShuffleProvider.java
@@ -53,13 +53,13 @@ import org.apache.hadoop.yarn.server.api.AuxiliaryService;
 import org.apache.hadoop.yarn.server.api.ApplicationInitializationContext;
 import org.apache.hadoop.yarn.server.api.ApplicationTerminationContext;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.Test;
-import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 public class TestShuffleProvider {
 
   @Test
-  public void testShuffleProviders() throws Exception {
+  void testShuffleProviders() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 1);
     JobId jobId = MRBuilderUtils.newJobId(appId, 1);
     TaskId taskId = MRBuilderUtils.newTaskId(jobId, 1, TaskType.MAP);
@@ -110,9 +110,12 @@ public class TestShuffleProvider {
             credentials);
 
     Map<String, ByteBuffer> serviceDataMap = launchCtx.getServiceData();
-    Assert.assertNotNull("TestShuffleHandler1 is missing", serviceDataMap.get(TestShuffleHandler1.MAPREDUCE_TEST_SHUFFLE_SERVICEID));
-    Assert.assertNotNull("TestShuffleHandler2 is missing", serviceDataMap.get(TestShuffleHandler2.MAPREDUCE_TEST_SHUFFLE_SERVICEID));
-    Assert.assertTrue("mismatch number of services in map", serviceDataMap.size() == 3); // 2 that we entered + 1 for the built-in shuffle-provider
+    Assertions.assertNotNull(serviceDataMap.get(TestShuffleHandler1.MAPREDUCE_TEST_SHUFFLE_SERVICEID),
+        "TestShuffleHandler1 is missing");
+    Assertions.assertNotNull(serviceDataMap.get(TestShuffleHandler2.MAPREDUCE_TEST_SHUFFLE_SERVICEID),
+        "TestShuffleHandler2 is missing");
+    Assertions.assertTrue(serviceDataMap.size() == 3,
+        "mismatch number of services in map"); // 2 that we entered + 1 for the built-in shuffle-provider
   }
 
   static public class StubbedFS extends RawLocalFileSystem {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestShuffleProvider.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestShuffleProvider.java
@@ -59,7 +59,7 @@ import org.junit.jupiter.api.Assertions;
 public class TestShuffleProvider {
 
   @Test
-  void testShuffleProviders() throws Exception {
+  public void testShuffleProviders() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 1);
     JobId jobId = MRBuilderUtils.newJobId(appId, 1);
     TaskId taskId = MRBuilderUtils.newTaskId(jobId, 1, TaskType.MAP);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
@@ -20,9 +20,10 @@ package org.apache.hadoop.mapreduce.v2.app.job.impl;
 
 import static org.apache.hadoop.test.GenericTestUtils.waitFor;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -41,10 +42,10 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.mapreduce.v2.app.job.event.TaskAttemptFailEvent;
 import org.apache.hadoop.yarn.util.resource.CustomResourceTypesConfigurationProvider;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -111,7 +112,7 @@ import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
@@ -151,23 +152,23 @@ public class TestTaskAttempt{
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupBeforeClass() {
     ResourceUtils.resetResourceTypes(new Configuration());
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     TaskAttemptImpl.RESOURCE_REQUEST_CACHE.clear();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     ResourceUtils.resetResourceTypes(new Configuration());
   }
 
   @Test
-  public void testMRAppHistoryForMap() throws Exception {
+  void testMRAppHistoryForMap() throws Exception {
     MRApp app = null;
     try {
       app = new FailingAttemptsMRApp(1, 0);
@@ -178,7 +179,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testMRAppHistoryForReduce() throws Exception {
+  void testMRAppHistoryForReduce() throws Exception {
     MRApp app = null;
     try {
       app = new FailingAttemptsMRApp(0, 1);
@@ -189,7 +190,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testMRAppHistoryForTAFailedInAssigned() throws Exception {
+  void testMRAppHistoryForTAFailedInAssigned() throws Exception {
     // test TA_CONTAINER_LAUNCH_FAILED for map
     FailingAttemptsDuringAssignedMRApp app = null;
 
@@ -268,7 +269,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testSingleRackRequest() throws Exception {
+  void testSingleRackRequest() throws Exception {
     TaskAttemptImpl.RequestContainerTransition rct =
         new TaskAttemptImpl.RequestContainerTransition(false);
 
@@ -289,7 +290,7 @@ public class TestTaskAttempt{
     ArgumentCaptor<Event> arg = ArgumentCaptor.forClass(Event.class);
     verify(eventHandler, times(2)).handle(arg.capture());
     if (!(arg.getAllValues().get(1) instanceof ContainerRequestEvent)) {
-      Assert.fail("Second Event not of type ContainerRequestEvent");
+      Assertions.fail("Second Event not of type ContainerRequestEvent");
     }
     ContainerRequestEvent cre =
         (ContainerRequestEvent) arg.getAllValues().get(1);
@@ -299,7 +300,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testHostResolveAttempt() throws Exception {
+  void testHostResolveAttempt() throws Exception {
     TaskAttemptImpl.RequestContainerTransition rct =
         new TaskAttemptImpl.RequestContainerTransition(false);
 
@@ -323,7 +324,7 @@ public class TestTaskAttempt{
     ArgumentCaptor<Event> arg = ArgumentCaptor.forClass(Event.class);
     verify(eventHandler, times(2)).handle(arg.capture());
     if (!(arg.getAllValues().get(1) instanceof ContainerRequestEvent)) {
-      Assert.fail("Second Event not of type ContainerRequestEvent");
+      Assertions.fail("Second Event not of type ContainerRequestEvent");
     }
     Map<String, Boolean> expected = new HashMap<String, Boolean>();
     expected.put("host1", true);
@@ -339,7 +340,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testMillisCountersUpdate() throws Exception {
+  void testMillisCountersUpdate() throws Exception {
     verifyMillisCounters(Resource.newInstance(1024, 1), 512);
     verifyMillisCounters(Resource.newInstance(2048, 4), 1024);
     verifyMillisCounters(Resource.newInstance(10240, 8), 2048);
@@ -361,16 +362,16 @@ public class TestTaskAttempt{
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     Map<TaskId, Task> tasks = job.getTasks();
-    Assert.assertEquals("Num tasks is not correct", 2, tasks.size());
+    Assertions.assertEquals(2, tasks.size(), "Num tasks is not correct");
     Iterator<Task> taskIter = tasks.values().iterator();
     Task mTask = taskIter.next();
     app.waitForState(mTask, TaskState.RUNNING);
     Task rTask = taskIter.next();
     app.waitForState(rTask, TaskState.RUNNING);
     Map<TaskAttemptId, TaskAttempt> mAttempts = mTask.getAttempts();
-    Assert.assertEquals("Num attempts is not correct", 1, mAttempts.size());
+    Assertions.assertEquals(1, mAttempts.size(), "Num attempts is not correct");
     Map<TaskAttemptId, TaskAttempt> rAttempts = rTask.getAttempts();
-    Assert.assertEquals("Num attempts is not correct", 1, rAttempts.size());
+    Assertions.assertEquals(1, rAttempts.size(), "Num attempts is not correct");
     TaskAttempt mta = mAttempts.values().iterator().next();
     TaskAttempt rta = rAttempts.values().iterator().next();
     app.waitForState(mta, TaskAttemptState.RUNNING);
@@ -392,21 +393,21 @@ public class TestTaskAttempt{
 
     int memoryMb = (int) containerResource.getMemorySize();
     int vcores = containerResource.getVirtualCores();
-    Assert.assertEquals((int) Math.ceil((float) memoryMb / minContainerSize),
+    Assertions.assertEquals((int) Math.ceil((float) memoryMb / minContainerSize),
         counters.findCounter(JobCounter.SLOTS_MILLIS_MAPS).getValue());
-    Assert.assertEquals((int) Math.ceil((float) memoryMb / minContainerSize),
+    Assertions.assertEquals((int) Math.ceil((float) memoryMb / minContainerSize),
         counters.findCounter(JobCounter.SLOTS_MILLIS_REDUCES).getValue());
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         counters.findCounter(JobCounter.MILLIS_MAPS).getValue());
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         counters.findCounter(JobCounter.MILLIS_REDUCES).getValue());
-    Assert.assertEquals(memoryMb,
+    Assertions.assertEquals(memoryMb,
         counters.findCounter(JobCounter.MB_MILLIS_MAPS).getValue());
-    Assert.assertEquals(memoryMb,
+    Assertions.assertEquals(memoryMb,
         counters.findCounter(JobCounter.MB_MILLIS_REDUCES).getValue());
-    Assert.assertEquals(vcores,
+    Assertions.assertEquals(vcores,
         counters.findCounter(JobCounter.VCORES_MILLIS_MAPS).getValue());
-    Assert.assertEquals(vcores,
+    Assertions.assertEquals(vcores,
         counters.findCounter(JobCounter.VCORES_MILLIS_REDUCES).getValue());
   }
 
@@ -452,23 +453,25 @@ public class TestTaskAttempt{
     app.waitForState(job, JobState.FAILED);
     Map<TaskId, Task> tasks = job.getTasks();
 
-    Assert.assertEquals("Num tasks is not correct", 1, tasks.size());
+    Assertions.assertEquals(1, tasks.size(),
+        "Num tasks is not correct");
     Task task = tasks.values().iterator().next();
-    Assert.assertEquals("Task state not correct", TaskState.FAILED, task
-        .getReport().getTaskState());
+    Assertions.assertEquals(TaskState.FAILED, task.getReport().getTaskState(),
+        "Task state not correct");
     Map<TaskAttemptId, TaskAttempt> attempts = tasks.values().iterator().next()
         .getAttempts();
-    Assert.assertEquals("Num attempts is not correct", 4, attempts.size());
+    Assertions.assertEquals(4, attempts.size(),
+        "Num attempts is not correct");
 
     Iterator<TaskAttempt> it = attempts.values().iterator();
     TaskAttemptReport report = it.next().getReport();
-    Assert.assertEquals("Attempt state not correct", TaskAttemptState.FAILED,
-        report.getTaskAttemptState());
-    Assert.assertEquals("Diagnostic Information is not Correct",
-        "Test Diagnostic Event", report.getDiagnosticInfo());
+    Assertions.assertEquals(TaskAttemptState.FAILED, report.getTaskAttemptState(),
+        "Attempt state not correct");
+    Assertions.assertEquals("Test Diagnostic Event", report.getDiagnosticInfo(),
+        "Diagnostic Information is not Correct");
     report = it.next().getReport();
-    Assert.assertEquals("Attempt state not correct", TaskAttemptState.FAILED,
-        report.getTaskAttemptState());
+    Assertions.assertEquals(TaskAttemptState.FAILED, report.getTaskAttemptState(),
+        "Attempt state not correct ");
   }
 
   private void testTaskAttemptAssignedFailHistory
@@ -477,8 +480,8 @@ public class TestTaskAttempt{
     Job job = app.submit(conf);
     app.waitForState(job, JobState.FAILED);
     Map<TaskId, Task> tasks = job.getTasks();
-    Assert.assertTrue("No Ta Started JH Event", app.getTaStartJHEvent());
-    Assert.assertTrue("No Ta Failed JH Event", app.getTaFailedJHEvent());
+    Assertions.assertTrue(app.getTaStartJHEvent(), "No Ta Started JH Event");
+    Assertions.assertTrue(app.getTaFailedJHEvent(), "No Ta Failed JH Event");
   }
 
   private void testTaskAttemptAssignedKilledHistory
@@ -518,8 +521,8 @@ public class TestTaskAttempt{
           if (event.getType() == org.apache.hadoop.mapreduce.jobhistory.EventType.MAP_ATTEMPT_FAILED) {
             TaskAttemptUnsuccessfulCompletion datum = (TaskAttemptUnsuccessfulCompletion) event
                 .getHistoryEvent().getDatum();
-            Assert.assertEquals("Diagnostic Information is not Correct",
-                "Test Diagnostic Event", datum.get(8).toString());
+            Assertions.assertEquals("Test Diagnostic Event", datum.get(8).toString(),
+                "Diagnostic Information is not Correct");
           }
         }
       };
@@ -593,7 +596,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testLaunchFailedWhileKilling() throws Exception {
+  void testLaunchFailedWhileKilling() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
       ApplicationAttemptId.newInstance(appId, 0);
@@ -638,12 +641,12 @@ public class TestTaskAttempt{
     taImpl.handle(new TaskAttemptEvent(attemptId,
         TaskAttemptEventType.TA_CONTAINER_LAUNCH_FAILED));
     assertFalse(eventHandler.internalError);
-    assertEquals("Task attempt is not assigned on the local node", 
-        Locality.NODE_LOCAL, taImpl.getLocality());
+    assertEquals(Locality.NODE_LOCAL, taImpl.getLocality(),
+        "Task attempt is not assigned on the local node");
   }
 
   @Test
-  public void testContainerCleanedWhileRunning() throws Exception {
+  void testContainerCleanedWhileRunning() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
       ApplicationAttemptId.newInstance(appId, 0);
@@ -695,14 +698,14 @@ public class TestTaskAttempt{
         .isEqualTo(TaskAttemptState.RUNNING);
     taImpl.handle(new TaskAttemptEvent(attemptId,
         TaskAttemptEventType.TA_CONTAINER_CLEANED));
-    assertFalse("InternalError occurred trying to handle TA_CONTAINER_CLEANED",
-        eventHandler.internalError);
-    assertEquals("Task attempt is not assigned on the local rack",
-        Locality.RACK_LOCAL, taImpl.getLocality());
+    assertFalse(eventHandler.internalError,
+        "InternalError occurred trying to handle TA_CONTAINER_CLEANED");
+    assertEquals(Locality.RACK_LOCAL, taImpl.getLocality(),
+        "Task attempt is not assigned on the local rack");
   }
 
   @Test
-  public void testContainerCleanedWhileCommitting() throws Exception {
+  void testContainerCleanedWhileCommitting() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
       ApplicationAttemptId.newInstance(appId, 0);
@@ -757,14 +760,14 @@ public class TestTaskAttempt{
         .isEqualTo(TaskAttemptState.COMMIT_PENDING);
     taImpl.handle(new TaskAttemptEvent(attemptId,
         TaskAttemptEventType.TA_CONTAINER_CLEANED));
-    assertFalse("InternalError occurred trying to handle TA_CONTAINER_CLEANED",
-        eventHandler.internalError);
-    assertEquals("Task attempt is assigned locally", Locality.OFF_SWITCH,
-        taImpl.getLocality());
+    assertFalse(eventHandler.internalError,
+        "InternalError occurred trying to handle TA_CONTAINER_CLEANED");
+    assertEquals(Locality.OFF_SWITCH,taImpl.getLocality(),
+        "Task attempt is assigned locally");
   }
 
   @Test
-  public void testDoubleTooManyFetchFailure() throws Exception {
+  void testDoubleTooManyFetchFailure() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
       ApplicationAttemptId.newInstance(appId, 0);
@@ -832,14 +835,14 @@ public class TestTaskAttempt{
     assertThat(taImpl.getState())
         .withFailMessage("Task attempt is not in FAILED state, still")
         .isEqualTo(TaskAttemptState.FAILED);
-    assertFalse("InternalError occurred trying to handle TA_CONTAINER_CLEANED",
-        eventHandler.internalError);
+    assertFalse(eventHandler.internalError,
+        "InternalError occurred trying to handle TA_CONTAINER_CLEANED");
   }
 
 
 
   @Test
-  public void testAppDiagnosticEventOnUnassignedTask() {
+  void testAppDiagnosticEventOnUnassignedTask() {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
         appId, 0);
@@ -883,21 +886,20 @@ public class TestTaskAttempt{
         TaskAttemptEventType.TA_SCHEDULE));
     taImpl.handle(new TaskAttemptDiagnosticsUpdateEvent(attemptId,
         "Task got killed"));
-    assertFalse(
-        "InternalError occurred trying to handle TA_DIAGNOSTICS_UPDATE on assigned task",
-        eventHandler.internalError);
+    assertFalse(eventHandler.internalError,
+        "InternalError occurred trying to handle TA_DIAGNOSTICS_UPDATE on assigned task");
     try {
       taImpl.handle(new TaskAttemptEvent(attemptId,
           TaskAttemptEventType.TA_KILL));
-      Assert.assertTrue("No exception on UNASSIGNED STATE KILL event", true);
+      Assertions.assertTrue(true, "No exception on UNASSIGNED STATE KILL event");
     } catch (Exception e) {
-      Assert.assertFalse(
-          "Exception not expected for UNASSIGNED STATE KILL event", true);
+      Assertions.assertFalse(true,
+          "Exception not expected for UNASSIGNED STATE KILL event");
     }
   }
 
   @Test
-  public void testTooManyFetchFailureAfterKill() throws Exception {
+  void testTooManyFetchFailureAfterKill() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
       ApplicationAttemptId.newInstance(appId, 0);
@@ -962,12 +964,12 @@ public class TestTaskAttempt{
     assertThat(taImpl.getState())
         .withFailMessage("Task attempt is not in KILLED state, still")
         .isEqualTo(TaskAttemptState.KILLED);
-    assertFalse("InternalError occurred trying to handle TA_CONTAINER_CLEANED",
-      eventHandler.internalError);
+    assertFalse(eventHandler.internalError,
+        "InternalError occurred trying to handle TA_CONTAINER_CLEANED");
   }
 
   @Test
-  public void testAppDiagnosticEventOnNewTask() {
+  void testAppDiagnosticEventOnNewTask() {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
         appId, 0);
@@ -1009,13 +1011,12 @@ public class TestTaskAttempt{
     when(container.getNodeHttpAddress()).thenReturn("localhost:0");
     taImpl.handle(new TaskAttemptDiagnosticsUpdateEvent(attemptId,
         "Task got killed"));
-    assertFalse(
-        "InternalError occurred trying to handle TA_DIAGNOSTICS_UPDATE on assigned task",
-        eventHandler.internalError);
+    assertFalse(eventHandler.internalError,
+        "InternalError occurred trying to handle TA_DIAGNOSTICS_UPDATE on assigned task");
   }
     
   @Test
-  public void testFetchFailureAttemptFinishTime() throws Exception{
+  void testFetchFailureAttemptFinishTime() throws Exception{
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
     ApplicationAttemptId.newInstance(appId, 0);
@@ -1072,8 +1073,8 @@ public class TestTaskAttempt{
         .withFailMessage("Task attempt is not in SUCCEEDED state")
         .isEqualTo(TaskAttemptState.SUCCEEDED);
 
-    assertTrue("Task Attempt finish time is not greater than 0",
-        taImpl.getFinishTime() > 0);
+    assertTrue(taImpl.getFinishTime() > 0,
+        "Task Attempt finish time is not greater than 0");
 
     Long finishTime = taImpl.getFinishTime();
     Thread.sleep(5);
@@ -1084,9 +1085,9 @@ public class TestTaskAttempt{
         .withFailMessage("Task attempt is not in FAILED state")
         .isEqualTo(TaskAttemptState.FAILED);
 
-    assertEquals("After TA_TOO_MANY_FETCH_FAILURE,"
-        + " Task attempt finish time is not the same ",
-        finishTime, Long.valueOf(taImpl.getFinishTime()));
+    assertEquals(finishTime, Long.valueOf(taImpl.getFinishTime()),
+        "After TA_TOO_MANY_FETCH_FAILURE,"
+            + " Task attempt finish time is not the same ");
   }
 
   private void containerKillBeforeAssignment(boolean scheduleAttempt)
@@ -1114,7 +1115,7 @@ public class TestTaskAttempt{
     assertThat(taImpl.getInternalState())
         .withFailMessage("Task attempt's internal state is not KILLED")
         .isEqualTo(TaskAttemptStateInternal.KILLED);
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
     TaskEvent event = eventHandler.lastTaskEvent;
     assertEquals(TaskEventType.T_ATTEMPT_KILLED, event.getType());
     // In NEW state, new map attempt should not be rescheduled.
@@ -1122,17 +1123,17 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testContainerKillOnNew() throws Exception {
+  void testContainerKillOnNew() throws Exception {
     containerKillBeforeAssignment(false);
   }
 
   @Test
-  public void testContainerKillOnUnassigned() throws Exception {
+  void testContainerKillOnUnassigned() throws Exception {
     containerKillBeforeAssignment(true);
   }
 
   @Test
-  public void testContainerKillAfterAssigned() throws Exception {
+  void testContainerKillAfterAssigned() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId,
         0);
@@ -1188,7 +1189,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testContainerKillWhileRunning() throws Exception {
+  void testContainerKillWhileRunning() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId,
         0);
@@ -1238,15 +1239,15 @@ public class TestTaskAttempt{
         .isEqualTo(TaskAttemptState.RUNNING);
     taImpl.handle(new TaskAttemptEvent(attemptId,
         TaskAttemptEventType.TA_KILL));
-    assertFalse("InternalError occurred trying to handle TA_KILL",
-        eventHandler.internalError);
+    assertFalse(eventHandler.internalError,
+        "InternalError occurred trying to handle TA_KILL");
     assertThat(taImpl.getInternalState())
         .withFailMessage("Task should be in KILL_CONTAINER_CLEANUP state")
         .isEqualTo(TaskAttemptStateInternal.KILL_CONTAINER_CLEANUP);
   }
 
   @Test
-  public void testContainerKillWhileCommitPending() throws Exception {
+  void testContainerKillWhileCommitPending() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId,
         0);
@@ -1301,15 +1302,15 @@ public class TestTaskAttempt{
         .isEqualTo(TaskAttemptStateInternal.COMMIT_PENDING);
     taImpl.handle(new TaskAttemptEvent(attemptId,
         TaskAttemptEventType.TA_KILL));
-    assertFalse("InternalError occurred trying to handle TA_KILL",
-        eventHandler.internalError);
+    assertFalse(eventHandler.internalError,
+        "InternalError occurred trying to handle TA_KILL");
     assertThat(taImpl.getInternalState())
         .withFailMessage("Task should be in KILL_CONTAINER_CLEANUP state")
         .isEqualTo(TaskAttemptStateInternal.KILL_CONTAINER_CLEANUP);
   }
 
   @Test
-  public void testKillMapTaskWhileSuccessFinishing() throws Exception {
+  void testKillMapTaskWhileSuccessFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1348,47 +1349,45 @@ public class TestTaskAttempt{
         .withFailMessage("Task attempt is not in KILLED state")
         .isEqualTo(TaskAttemptState.KILLED);
 
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   @Test
-  public void testKillMapOnlyTaskWhileSuccessFinishing() throws Exception {
+  void testKillMapOnlyTaskWhileSuccessFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createMapOnlyTaskAttemptImpl(eventHandler);
 
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_DONE));
 
-    assertEquals("Task attempt is not in SUCCEEDED state",
-        TaskAttemptState.SUCCEEDED, taImpl.getState());
-    assertEquals("Task attempt's internal state is not " +
-            "SUCCESS_FINISHING_CONTAINER",
-        TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptState.SUCCEEDED, taImpl.getState(),
+        "Task attempt is not in SUCCEEDED state");
+    assertEquals(TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
+        taImpl.getInternalState(), "Task attempt's internal state is not " +
+            "SUCCESS_FINISHING_CONTAINER");
 
     // If the map only task is killed when it is in SUCCESS_FINISHING_CONTAINER
     // state, the state will move to SUCCESS_CONTAINER_CLEANUP
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_KILL));
-    assertEquals("Task attempt is not in SUCCEEDED state",
-        TaskAttemptState.SUCCEEDED, taImpl.getState());
-    assertEquals("Task attempt's internal state is not " +
-            "SUCCESS_CONTAINER_CLEANUP",
-        TaskAttemptStateInternal.SUCCESS_CONTAINER_CLEANUP,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptState.SUCCEEDED, taImpl.getState(),
+        "Task attempt is not in SUCCEEDED state");
+    assertEquals(TaskAttemptStateInternal.SUCCESS_CONTAINER_CLEANUP,
+        taImpl.getInternalState(), "Task attempt's internal state is not " +
+            "SUCCESS_CONTAINER_CLEANUP");
 
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_CONTAINER_CLEANED));
-    assertEquals("Task attempt is not in SUCCEEDED state",
-        TaskAttemptState.SUCCEEDED, taImpl.getState());
-    assertEquals("Task attempt's internal state is not SUCCEEDED state",
-        TaskAttemptStateInternal.SUCCEEDED, taImpl.getInternalState());
+    assertEquals(TaskAttemptState.SUCCEEDED, taImpl.getState(),
+        "Task attempt is not in SUCCEEDED state");
+    assertEquals(TaskAttemptStateInternal.SUCCEEDED, taImpl.getInternalState(),
+        "Task attempt's internal state is not SUCCEEDED state");
 
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   @Test
-  public void testKillMapTaskAfterSuccess() throws Exception {
+  void testKillMapTaskAfterSuccess() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1414,7 +1413,7 @@ public class TestTaskAttempt{
     assertThat(taImpl.getInternalState())
         .withFailMessage("Task attempt's internal state is not KILLED")
         .isEqualTo(TaskAttemptStateInternal.KILLED);
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
     TaskEvent event = eventHandler.lastTaskEvent;
     assertEquals(TaskEventType.T_ATTEMPT_KILLED, event.getType());
     // Send an attempt killed event to TaskImpl forwarding the same reschedule
@@ -1430,28 +1429,27 @@ public class TestTaskAttempt{
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_DONE));
 
-    assertEquals("Task attempt is not in SUCCEEDED state",
-        TaskAttemptState.SUCCEEDED, taImpl.getState());
-    assertEquals("Task attempt's internal state is not " +
-            "SUCCESS_FINISHING_CONTAINER",
-        TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptState.SUCCEEDED, taImpl.getState(),
+        "Task attempt is not in SUCCEEDED state");
+    assertEquals(TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
+        taImpl.getInternalState(), "Task attempt's internal state is not " +
+            "SUCCESS_FINISHING_CONTAINER");
 
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_CONTAINER_CLEANED));
     // Succeeded
     taImpl.handle(new TaskAttemptKillEvent(taImpl.getID(),"", true));
-    assertEquals("Task attempt is not in SUCCEEDED state",
-        TaskAttemptState.SUCCEEDED, taImpl.getState());
-    assertEquals("Task attempt's internal state is not SUCCEEDED",
-        TaskAttemptStateInternal.SUCCEEDED, taImpl.getInternalState());
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertEquals(TaskAttemptState.SUCCEEDED, taImpl.getState(),
+        "Task attempt is not in SUCCEEDED state");
+    assertEquals(TaskAttemptStateInternal.SUCCEEDED, taImpl.getInternalState(),
+        "Task attempt's internal state is not SUCCEEDED");
+    assertFalse(eventHandler.internalError, "InternalError occurred");
     TaskEvent event = eventHandler.lastTaskEvent;
     assertEquals(TaskEventType.T_ATTEMPT_SUCCEEDED, event.getType());
   }
 
   @Test
-  public void testKillMapTaskWhileFailFinishing() throws Exception {
+  void testKillMapTaskWhileFailFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1498,11 +1496,11 @@ public class TestTaskAttempt{
         .withFailMessage("Task attempt is not in FAILED state")
         .isEqualTo(TaskAttemptState.FAILED);
 
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   @Test
-  public void testFailMapTaskByClient() throws Exception {
+  void testFailMapTaskByClient() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1531,11 +1529,11 @@ public class TestTaskAttempt{
         .withFailMessage("Task attempt is not in FAILED state")
         .isEqualTo(TaskAttemptState.FAILED);
 
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   @Test
-  public void testTaskAttemptDiagnosticEventOnFinishing() throws Exception {
+  void testTaskAttemptDiagnosticEventOnFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1561,11 +1559,11 @@ public class TestTaskAttempt{
             "SUCCESS_FINISHING_CONTAINER")
         .isEqualTo(TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER);
 
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   @Test
-  public void testTimeoutWhileSuccessFinishing() throws Exception {
+  void testTimeoutWhileSuccessFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1592,11 +1590,11 @@ public class TestTaskAttempt{
                 "SUCCESS_CONTAINER_CLEANUP")
             .isEqualTo(TaskAttemptStateInternal.SUCCESS_CONTAINER_CLEANUP);
 
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   @Test
-  public void testTimeoutWhileFailFinishing() throws Exception {
+  void testTimeoutWhileFailFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1619,11 +1617,11 @@ public class TestTaskAttempt{
             "FAIL_CONTAINER_CLEANUP")
         .isEqualTo(TaskAttemptStateInternal.FAIL_CONTAINER_CLEANUP);
 
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   @Test
-  public void testMapperCustomResourceTypes() {
+  void testMapperCustomResourceTypes() {
     initResourceTypes();
     EventHandler eventHandler = mock(EventHandler.class);
     TaskSplitMetaInfo taskSplitMetaInfo = new TaskSplitMetaInfo();
@@ -1636,13 +1634,13 @@ public class TestTaskAttempt{
     ResourceInformation resourceInfo =
         getResourceInfoFromContainerRequest(taImpl, eventHandler).
         getResourceInformation(CUSTOM_RESOURCE_NAME);
-    assertEquals("Expecting the default unit (G)",
-        "G", resourceInfo.getUnits());
+    assertEquals("G", resourceInfo.getUnits(),
+        "Expecting the default unit (G)");
     assertEquals(7L, resourceInfo.getValue());
   }
 
   @Test
-  public void testReducerCustomResourceTypes() {
+  void testReducerCustomResourceTypes() {
     initResourceTypes();
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
@@ -1654,13 +1652,13 @@ public class TestTaskAttempt{
     ResourceInformation resourceInfo =
         getResourceInfoFromContainerRequest(taImpl, eventHandler).
         getResourceInformation(CUSTOM_RESOURCE_NAME);
-    assertEquals("Expecting the specified unit (m)",
-        "m", resourceInfo.getUnits());
+    assertEquals("m", resourceInfo.getUnits(),
+        "Expecting the specified unit (m)");
     assertEquals(3L, resourceInfo.getValue());
   }
 
   @Test
-  public void testReducerMemoryRequestViaMapreduceReduceMemoryMb() {
+  void testReducerMemoryRequestViaMapreduceReduceMemoryMb() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     JobConf jobConf = new JobConf();
@@ -1674,7 +1672,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testReducerMemoryRequestViaMapreduceReduceResourceMemory() {
+  void testReducerMemoryRequestViaMapreduceReduceResourceMemory() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     JobConf jobConf = new JobConf();
@@ -1689,7 +1687,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testReducerMemoryRequestDefaultMemory() {
+  void testReducerMemoryRequestDefaultMemory() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     TaskAttemptImpl taImpl =
@@ -1701,7 +1699,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testReducerMemoryRequestWithoutUnits() {
+  void testReducerMemoryRequestWithoutUnits() {
     Clock clock = SystemClock.getInstance();
     for (String memoryResourceName : ImmutableList.of(
         MRJobConfig.RESOURCE_TYPE_NAME_MEMORY,
@@ -1720,7 +1718,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testReducerMemoryRequestOverriding() {
+  void testReducerMemoryRequestOverriding() {
     for (String memoryName : ImmutableList.of(
         MRJobConfig.RESOURCE_TYPE_NAME_MEMORY,
         MRJobConfig.RESOURCE_TYPE_ALTERNATIVE_NAME_MEMORY)) {
@@ -1752,22 +1750,24 @@ public class TestTaskAttempt{
     }
   }
 
-  @Test(expected=IllegalArgumentException.class)
-  public void testReducerMemoryRequestMultipleName() {
-    EventHandler eventHandler = mock(EventHandler.class);
-    Clock clock = SystemClock.getInstance();
-    JobConf jobConf = new JobConf();
-    for (String memoryName : ImmutableList.of(
-        MRJobConfig.RESOURCE_TYPE_NAME_MEMORY,
-        MRJobConfig.RESOURCE_TYPE_ALTERNATIVE_NAME_MEMORY)) {
-      jobConf.set(MRJobConfig.REDUCE_RESOURCE_TYPE_PREFIX + memoryName,
-          "3Gi");
-    }
-    createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
+  @Test
+  void testReducerMemoryRequestMultipleName() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      EventHandler eventHandler = mock(EventHandler.class);
+      Clock clock = SystemClock.getInstance();
+      JobConf jobConf = new JobConf();
+      for (String memoryName : ImmutableList.of(
+          MRJobConfig.RESOURCE_TYPE_NAME_MEMORY,
+          MRJobConfig.RESOURCE_TYPE_ALTERNATIVE_NAME_MEMORY)) {
+        jobConf.set(MRJobConfig.REDUCE_RESOURCE_TYPE_PREFIX + memoryName,
+            "3Gi");
+      }
+      createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
+    });
   }
 
   @Test
-  public void testReducerCpuRequestViaMapreduceReduceCpuVcores() {
+  void testReducerCpuRequestViaMapreduceReduceCpuVcores() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     JobConf jobConf = new JobConf();
@@ -1781,7 +1781,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testReducerCpuRequestViaMapreduceReduceResourceVcores() {
+  void testReducerCpuRequestViaMapreduceReduceResourceVcores() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     JobConf jobConf = new JobConf();
@@ -1796,7 +1796,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testReducerCpuRequestDefaultMemory() {
+  void testReducerCpuRequestDefaultMemory() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     TaskAttemptImpl taImpl =
@@ -1808,7 +1808,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testReducerCpuRequestOverriding() {
+  void testReducerCpuRequestOverriding() {
     TestAppender testAppender = new TestAppender();
     final Logger logger = Logger.getLogger(TaskAttemptImpl.class);
     try {
@@ -1853,25 +1853,28 @@ public class TestTaskAttempt{
         containerRequestEvents.add((ContainerRequestEvent) e);
       }
     }
-    assertEquals("Expected one ContainerRequestEvent after scheduling "
-        + "task attempt", 1, containerRequestEvents.size());
+    assertEquals(1, containerRequestEvents.size(),
+        "Expected one ContainerRequestEvent after scheduling "
+            + "task attempt");
 
     return containerRequestEvents.get(0).getCapability();
   }
 
-  @Test(expected=IllegalArgumentException.class)
-  public void testReducerCustomResourceTypeWithInvalidUnit() {
-    initResourceTypes();
-    EventHandler eventHandler = mock(EventHandler.class);
-    Clock clock = SystemClock.getInstance();
-    JobConf jobConf = new JobConf();
-    jobConf.set(MRJobConfig.REDUCE_RESOURCE_TYPE_PREFIX
-        + CUSTOM_RESOURCE_NAME, "3z");
-    createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
+  @Test
+  void testReducerCustomResourceTypeWithInvalidUnit() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      initResourceTypes();
+      EventHandler eventHandler = mock(EventHandler.class);
+      Clock clock = SystemClock.getInstance();
+      JobConf jobConf = new JobConf();
+      jobConf.set(MRJobConfig.REDUCE_RESOURCE_TYPE_PREFIX
+          + CUSTOM_RESOURCE_NAME, "3z");
+      createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
+    });
   }
 
   @Test
-  public void testKillingTaskWhenContainerCleanup() {
+  void testKillingTaskWhenContainerCleanup() {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
     TaskId maptaskId = MRBuilderUtils.newTaskId(taImpl.getID().getTaskId()
@@ -1882,26 +1885,23 @@ public class TestTaskAttempt{
     // move in two steps to the desired state (cannot get there directly)
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_DONE));
-    assertEquals("Task attempt's internal state is not " +
-        "SUCCESS_FINISHING_CONTAINER",
-        TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
+        taImpl.getInternalState(), "Task attempt's internal state is not " +
+            "SUCCESS_FINISHING_CONTAINER");
 
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_TIMED_OUT));
-    assertEquals("Task attempt's internal state is not " +
-        "SUCCESS_CONTAINER_CLEANUP",
-        TaskAttemptStateInternal.SUCCESS_CONTAINER_CLEANUP,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptStateInternal.SUCCESS_CONTAINER_CLEANUP,
+        taImpl.getInternalState(), "Task attempt's internal state is not " +
+            "SUCCESS_CONTAINER_CLEANUP");
 
     taImpl.handle(new TaskAttemptKillEvent(mapTAId, "", true));
-    assertEquals("Task attempt is not in KILLED state",
-        TaskAttemptState.KILLED,
-        taImpl.getState());
+    assertEquals(TaskAttemptState.KILLED,
+        taImpl.getState(), "Task attempt is not in KILLED state");
   }
 
   @Test
-  public void testTooManyFetchFailureWhileContainerCleanup() {
+  void testTooManyFetchFailureWhileContainerCleanup() {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
     TaskId reducetaskId = MRBuilderUtils.newTaskId(taImpl.getID().getTaskId()
@@ -1912,24 +1912,21 @@ public class TestTaskAttempt{
     // move in two steps to the desired state (cannot get there directly)
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_DONE));
-    assertEquals("Task attempt's internal state is not " +
-        "SUCCESS_FINISHING_CONTAINER",
-        TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
+        taImpl.getInternalState(), "Task attempt's internal state is not " +
+            "SUCCESS_FINISHING_CONTAINER");
 
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_TIMED_OUT));
-    assertEquals("Task attempt's internal state is not " +
-        "SUCCESS_CONTAINER_CLEANUP",
-        TaskAttemptStateInternal.SUCCESS_CONTAINER_CLEANUP,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptStateInternal.SUCCESS_CONTAINER_CLEANUP,
+        taImpl.getInternalState(), "Task attempt's internal state is not " +
+            "SUCCESS_CONTAINER_CLEANUP");
 
     taImpl.handle(new TaskAttemptTooManyFetchFailureEvent(taImpl.getID(),
         reduceTAId, "Host"));
-    assertEquals("Task attempt is not in FAILED state",
-        TaskAttemptState.FAILED,
-        taImpl.getState());
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertEquals(TaskAttemptState.FAILED,
+        taImpl.getState(), "Task attempt is not in FAILED state");
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   private void initResourceTypes() {
@@ -1940,7 +1937,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testTooManyFetchFailureWhileSuccessFinishing() throws Exception {
+  void testTooManyFetchFailureWhileSuccessFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
     TaskId reducetaskId = MRBuilderUtils.newTaskId(taImpl.getID().getTaskId()
@@ -1951,17 +1948,15 @@ public class TestTaskAttempt{
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_DONE));
 
-    assertEquals("Task attempt's internal state is not " +
-        "SUCCESS_FINISHING_CONTAINER",
-        TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
+        taImpl.getInternalState(), "Task attempt's internal state is not " +
+            "SUCCESS_FINISHING_CONTAINER");
 
     taImpl.handle(new TaskAttemptTooManyFetchFailureEvent(taImpl.getID(),
         reduceTAId, "Host"));
-    assertEquals("Task attempt is not in FAILED state",
-        TaskAttemptState.FAILED,
-        taImpl.getState());
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertEquals(TaskAttemptState.FAILED,
+        taImpl.getState(), "Task attempt is not in FAILED state");
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   private void setupTaskAttemptFinishingMonitor(

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
@@ -168,7 +168,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testMRAppHistoryForMap() throws Exception {
+  public void testMRAppHistoryForMap() throws Exception {
     MRApp app = null;
     try {
       app = new FailingAttemptsMRApp(1, 0);
@@ -179,7 +179,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testMRAppHistoryForReduce() throws Exception {
+  public void testMRAppHistoryForReduce() throws Exception {
     MRApp app = null;
     try {
       app = new FailingAttemptsMRApp(0, 1);
@@ -190,7 +190,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testMRAppHistoryForTAFailedInAssigned() throws Exception {
+  public void testMRAppHistoryForTAFailedInAssigned() throws Exception {
     // test TA_CONTAINER_LAUNCH_FAILED for map
     FailingAttemptsDuringAssignedMRApp app = null;
 
@@ -269,7 +269,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testSingleRackRequest() throws Exception {
+  public void testSingleRackRequest() throws Exception {
     TaskAttemptImpl.RequestContainerTransition rct =
         new TaskAttemptImpl.RequestContainerTransition(false);
 
@@ -300,7 +300,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testHostResolveAttempt() throws Exception {
+  public void testHostResolveAttempt() throws Exception {
     TaskAttemptImpl.RequestContainerTransition rct =
         new TaskAttemptImpl.RequestContainerTransition(false);
 
@@ -340,7 +340,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testMillisCountersUpdate() throws Exception {
+  public void testMillisCountersUpdate() throws Exception {
     verifyMillisCounters(Resource.newInstance(1024, 1), 512);
     verifyMillisCounters(Resource.newInstance(2048, 4), 1024);
     verifyMillisCounters(Resource.newInstance(10240, 8), 2048);
@@ -596,7 +596,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testLaunchFailedWhileKilling() throws Exception {
+  public void testLaunchFailedWhileKilling() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
       ApplicationAttemptId.newInstance(appId, 0);
@@ -646,7 +646,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testContainerCleanedWhileRunning() throws Exception {
+  public void testContainerCleanedWhileRunning() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
       ApplicationAttemptId.newInstance(appId, 0);
@@ -705,7 +705,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testContainerCleanedWhileCommitting() throws Exception {
+  public void testContainerCleanedWhileCommitting() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
       ApplicationAttemptId.newInstance(appId, 0);
@@ -767,7 +767,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testDoubleTooManyFetchFailure() throws Exception {
+  public void testDoubleTooManyFetchFailure() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
       ApplicationAttemptId.newInstance(appId, 0);
@@ -842,7 +842,7 @@ public class TestTaskAttempt{
 
 
   @Test
-  void testAppDiagnosticEventOnUnassignedTask() {
+  public void testAppDiagnosticEventOnUnassignedTask() {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
         appId, 0);
@@ -899,7 +899,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testTooManyFetchFailureAfterKill() throws Exception {
+  public void testTooManyFetchFailureAfterKill() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
       ApplicationAttemptId.newInstance(appId, 0);
@@ -969,7 +969,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testAppDiagnosticEventOnNewTask() {
+  public void testAppDiagnosticEventOnNewTask() {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
         appId, 0);
@@ -1016,7 +1016,7 @@ public class TestTaskAttempt{
   }
     
   @Test
-  void testFetchFailureAttemptFinishTime() throws Exception{
+  public void testFetchFailureAttemptFinishTime() throws Exception{
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
     ApplicationAttemptId.newInstance(appId, 0);
@@ -1123,17 +1123,17 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testContainerKillOnNew() throws Exception {
+  public void testContainerKillOnNew() throws Exception {
     containerKillBeforeAssignment(false);
   }
 
   @Test
-  void testContainerKillOnUnassigned() throws Exception {
+  public void testContainerKillOnUnassigned() throws Exception {
     containerKillBeforeAssignment(true);
   }
 
   @Test
-  void testContainerKillAfterAssigned() throws Exception {
+  public void testContainerKillAfterAssigned() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId,
         0);
@@ -1189,7 +1189,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testContainerKillWhileRunning() throws Exception {
+  public void testContainerKillWhileRunning() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId,
         0);
@@ -1247,7 +1247,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testContainerKillWhileCommitPending() throws Exception {
+  public void testContainerKillWhileCommitPending() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId,
         0);
@@ -1310,7 +1310,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testKillMapTaskWhileSuccessFinishing() throws Exception {
+  public void testKillMapTaskWhileSuccessFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1353,7 +1353,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testKillMapOnlyTaskWhileSuccessFinishing() throws Exception {
+  public void testKillMapOnlyTaskWhileSuccessFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createMapOnlyTaskAttemptImpl(eventHandler);
 
@@ -1387,7 +1387,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testKillMapTaskAfterSuccess() throws Exception {
+  public void testKillMapTaskAfterSuccess() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1449,7 +1449,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testKillMapTaskWhileFailFinishing() throws Exception {
+  public void testKillMapTaskWhileFailFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1500,7 +1500,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testFailMapTaskByClient() throws Exception {
+  public void testFailMapTaskByClient() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1533,7 +1533,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testTaskAttemptDiagnosticEventOnFinishing() throws Exception {
+  public void testTaskAttemptDiagnosticEventOnFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1563,7 +1563,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testTimeoutWhileSuccessFinishing() throws Exception {
+  public void testTimeoutWhileSuccessFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1594,7 +1594,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testTimeoutWhileFailFinishing() throws Exception {
+  public void testTimeoutWhileFailFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1621,7 +1621,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testMapperCustomResourceTypes() {
+  public void testMapperCustomResourceTypes() {
     initResourceTypes();
     EventHandler eventHandler = mock(EventHandler.class);
     TaskSplitMetaInfo taskSplitMetaInfo = new TaskSplitMetaInfo();
@@ -1640,7 +1640,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testReducerCustomResourceTypes() {
+  public void testReducerCustomResourceTypes() {
     initResourceTypes();
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
@@ -1658,7 +1658,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testReducerMemoryRequestViaMapreduceReduceMemoryMb() {
+  public void testReducerMemoryRequestViaMapreduceReduceMemoryMb() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     JobConf jobConf = new JobConf();
@@ -1672,7 +1672,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testReducerMemoryRequestViaMapreduceReduceResourceMemory() {
+  public void testReducerMemoryRequestViaMapreduceReduceResourceMemory() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     JobConf jobConf = new JobConf();
@@ -1687,7 +1687,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testReducerMemoryRequestDefaultMemory() {
+  public void testReducerMemoryRequestDefaultMemory() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     TaskAttemptImpl taImpl =
@@ -1699,7 +1699,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testReducerMemoryRequestWithoutUnits() {
+  public void testReducerMemoryRequestWithoutUnits() {
     Clock clock = SystemClock.getInstance();
     for (String memoryResourceName : ImmutableList.of(
         MRJobConfig.RESOURCE_TYPE_NAME_MEMORY,
@@ -1718,7 +1718,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testReducerMemoryRequestOverriding() {
+  public void testReducerMemoryRequestOverriding() {
     for (String memoryName : ImmutableList.of(
         MRJobConfig.RESOURCE_TYPE_NAME_MEMORY,
         MRJobConfig.RESOURCE_TYPE_ALTERNATIVE_NAME_MEMORY)) {
@@ -1751,7 +1751,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testReducerMemoryRequestMultipleName() {
+  public void testReducerMemoryRequestMultipleName() {
     assertThrows(IllegalArgumentException.class, () -> {
       EventHandler eventHandler = mock(EventHandler.class);
       Clock clock = SystemClock.getInstance();
@@ -1767,7 +1767,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testReducerCpuRequestViaMapreduceReduceCpuVcores() {
+  public void testReducerCpuRequestViaMapreduceReduceCpuVcores() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     JobConf jobConf = new JobConf();
@@ -1781,7 +1781,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testReducerCpuRequestViaMapreduceReduceResourceVcores() {
+  public void testReducerCpuRequestViaMapreduceReduceResourceVcores() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     JobConf jobConf = new JobConf();
@@ -1796,7 +1796,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testReducerCpuRequestDefaultMemory() {
+  public void testReducerCpuRequestDefaultMemory() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     TaskAttemptImpl taImpl =
@@ -1808,7 +1808,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testReducerCpuRequestOverriding() {
+  public void testReducerCpuRequestOverriding() {
     TestAppender testAppender = new TestAppender();
     final Logger logger = Logger.getLogger(TaskAttemptImpl.class);
     try {
@@ -1861,7 +1861,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testReducerCustomResourceTypeWithInvalidUnit() {
+  public void testReducerCustomResourceTypeWithInvalidUnit() {
     assertThrows(IllegalArgumentException.class, () -> {
       initResourceTypes();
       EventHandler eventHandler = mock(EventHandler.class);
@@ -1874,7 +1874,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testKillingTaskWhenContainerCleanup() {
+  public void testKillingTaskWhenContainerCleanup() {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
     TaskId maptaskId = MRBuilderUtils.newTaskId(taImpl.getID().getTaskId()
@@ -1901,7 +1901,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testTooManyFetchFailureWhileContainerCleanup() {
+  public void testTooManyFetchFailureWhileContainerCleanup() {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
     TaskId reducetaskId = MRBuilderUtils.newTaskId(taImpl.getID().getTaskId()
@@ -1937,7 +1937,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  void testTooManyFetchFailureWhileSuccessFinishing() throws Exception {
+  public void testTooManyFetchFailureWhileSuccessFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
     TaskId reducetaskId = MRBuilderUtils.newTaskId(taImpl.getID().getTaskId()

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttemptContainerRequest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttemptContainerRequest.java
@@ -69,7 +69,7 @@ public class TestTaskAttemptContainerRequest {
   }
 
   @Test
-  void testAttemptContainerRequest() throws Exception {
+  public void testAttemptContainerRequest() throws Exception {
     final Text SECRET_KEY_ALIAS = new Text("secretkeyalias");
     final byte[] SECRET_KEY = ("secretkey").getBytes();
     Map<ApplicationAccessType, String> acls =

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttemptContainerRequest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttemptContainerRequest.java
@@ -27,8 +27,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileStatus;
@@ -58,18 +58,18 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.util.SystemClock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings({"rawtypes"})
 public class TestTaskAttemptContainerRequest {
 
-  @After
+  @AfterEach
   public void cleanup() {
     UserGroupInformation.reset();
   }
 
   @Test
-  public void testAttemptContainerRequest() throws Exception {
+  void testAttemptContainerRequest() throws Exception {
     final Text SECRET_KEY_ALIAS = new Text("secretkeyalias");
     final byte[] SECRET_KEY = ("secretkey").getBytes();
     Map<ApplicationAccessType, String> acls =
@@ -114,7 +114,8 @@ public class TestTaskAttemptContainerRequest {
             mock(WrappedJvmID.class), taListener,
             credentials);
 
-    Assert.assertEquals("ACLs mismatch", acls, launchCtx.getApplicationACLs());
+    Assertions.assertEquals(acls, launchCtx.getApplicationACLs(),
+        "ACLs mismatch");
     Credentials launchCredentials = new Credentials();
 
     DataInputByteBuffer dibb = new DataInputByteBuffer();
@@ -125,17 +126,18 @@ public class TestTaskAttemptContainerRequest {
     for (Token<? extends TokenIdentifier> token : credentials.getAllTokens()) {
       Token<? extends TokenIdentifier> launchToken =
           launchCredentials.getToken(token.getService());
-      Assert.assertNotNull("Token " + token.getService() + " is missing",
-          launchToken);
-      Assert.assertEquals("Token " + token.getService() + " mismatch",
-          token, launchToken);
+      Assertions.assertNotNull(launchToken,
+          "Token " + token.getService() + " is missing");
+      Assertions.assertEquals(token, launchToken,
+          "Token " + token.getService() + " mismatch");
     }
 
     // verify the secret key is in the launch context
-    Assert.assertNotNull("Secret key missing",
-        launchCredentials.getSecretKey(SECRET_KEY_ALIAS));
-    Assert.assertTrue("Secret key mismatch", Arrays.equals(SECRET_KEY,
-        launchCredentials.getSecretKey(SECRET_KEY_ALIAS)));
+    Assertions.assertNotNull(launchCredentials.getSecretKey(SECRET_KEY_ALIAS),
+        "Secret key missing");
+    Assertions.assertTrue(Arrays.equals(SECRET_KEY,
+        launchCredentials.getSecretKey(SECRET_KEY_ALIAS)),
+        "Secret key mismatch");
   }
 
   static public class StubbedFS extends RawLocalFileSystem {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskImpl.java
@@ -399,7 +399,7 @@ public class TestTaskImpl {
   }
   
   @Test
-  void testInit() {
+  public void testInit() {
     LOG.info("--- START: testInit ---");
     mockTask = createMockTask(TaskType.MAP);        
     assertTaskNewState();
@@ -410,7 +410,7 @@ public class TestTaskImpl {
   /**
    * {@link TaskState#NEW}->{@link TaskState#SCHEDULED}
    */
-  void testScheduleTask() {
+  public void testScheduleTask() {
     LOG.info("--- START: testScheduleTask ---");
     mockTask = createMockTask(TaskType.MAP);        
     TaskId taskId = getNewTaskID();
@@ -421,7 +421,7 @@ public class TestTaskImpl {
   /**
    * {@link TaskState#SCHEDULED}->{@link TaskState#KILL_WAIT}
    */
-  void testKillScheduledTask() {
+  public void testKillScheduledTask() {
     LOG.info("--- START: testKillScheduledTask ---");
     mockTask = createMockTask(TaskType.MAP);        
     TaskId taskId = getNewTaskID();
@@ -434,7 +434,7 @@ public class TestTaskImpl {
    * Kill attempt
    * {@link TaskState#SCHEDULED}->{@link TaskState#SCHEDULED}
    */
-  void testKillScheduledTaskAttempt() {
+  public void testKillScheduledTaskAttempt() {
     LOG.info("--- START: testKillScheduledTaskAttempt ---");
     mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
@@ -449,7 +449,7 @@ public class TestTaskImpl {
    * Launch attempt
    * {@link TaskState#SCHEDULED}->{@link TaskState#RUNNING}
    */
-  void testLaunchTaskAttempt() {
+  public void testLaunchTaskAttempt() {
     LOG.info("--- START: testLaunchTaskAttempt ---");
     mockTask = createMockTask(TaskType.MAP);        
     TaskId taskId = getNewTaskID();
@@ -462,7 +462,7 @@ public class TestTaskImpl {
    * Kill running attempt
    * {@link TaskState#RUNNING}->{@link TaskState#RUNNING} 
    */
-  void testKillRunningTaskAttempt() {
+  public void testKillRunningTaskAttempt() {
     LOG.info("--- START: testKillRunningTaskAttempt ---");
     mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
@@ -474,7 +474,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  void testKillSuccessfulTask() {
+  public void testKillSuccessfulTask() {
     LOG.info("--- START: testKillSuccesfulTask ---");
     mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
@@ -493,7 +493,7 @@ public class TestTaskImpl {
    * Kill map attempt for succeeded map task
    * {@link TaskState#SUCCEEDED}->{@link TaskState#SCHEDULED}
    */
-  void testKillAttemptForSuccessfulTask() {
+  public void testKillAttemptForSuccessfulTask() {
     LOG.info("--- START: testKillAttemptForSuccessfulTask ---");
     mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
@@ -510,8 +510,8 @@ public class TestTaskImpl {
     assertTaskScheduledState();
   }
 
-  @Test 
-  void testTaskProgress() {
+  @Test
+  public void testTaskProgress() {
     LOG.info("--- START: testTaskProgress ---");
     mockTask = createMockTask(TaskType.MAP);        
         
@@ -551,7 +551,7 @@ public class TestTaskImpl {
 
   
   @Test
-  void testKillDuringTaskAttemptCommit() {
+  public void testKillDuringTaskAttemptCommit() {
     mockTask = createMockTask(TaskType.REDUCE);        
     TaskId taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
@@ -568,7 +568,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  void testFailureDuringTaskAttemptCommit() {
+  public void testFailureDuringTaskAttemptCommit() {
     mockTask = createMockTask(TaskType.MAP);        
     TaskId taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
@@ -630,43 +630,43 @@ public class TestTaskImpl {
   }
   
   @Test
-  void testMapSpeculativeTaskAttemptSucceedsEvenIfFirstFails() {
+  public void testMapSpeculativeTaskAttemptSucceedsEvenIfFirstFails() {
     mockTask = createMockTask(TaskType.MAP);        
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_FAILED);
   }
 
   @Test
-  void testReduceSpeculativeTaskAttemptSucceedsEvenIfFirstFails() {
+  public void testReduceSpeculativeTaskAttemptSucceedsEvenIfFirstFails() {
     mockTask = createMockTask(TaskType.REDUCE);        
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_FAILED);
   }
   
   @Test
-  void testMapSpeculativeTaskAttemptSucceedsEvenIfFirstIsKilled() {
+  public void testMapSpeculativeTaskAttemptSucceedsEvenIfFirstIsKilled() {
     mockTask = createMockTask(TaskType.MAP);        
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_KILLED);
   }
 
   @Test
-  void testReduceSpeculativeTaskAttemptSucceedsEvenIfFirstIsKilled() {
+  public void testReduceSpeculativeTaskAttemptSucceedsEvenIfFirstIsKilled() {
     mockTask = createMockTask(TaskType.REDUCE);        
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_KILLED);
   }
 
   @Test
-  void testMultipleTaskAttemptsSucceed() {
+  public void testMultipleTaskAttemptsSucceed() {
     mockTask = createMockTask(TaskType.MAP);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_SUCCEEDED);
   }
 
   @Test
-  void testCommitAfterSucceeds() {
+  public void testCommitAfterSucceeds() {
     mockTask = createMockTask(TaskType.REDUCE);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_COMMIT_PENDING);
   }
 
   @Test
-  void testSpeculativeMapFetchFailure() {
+  public void testSpeculativeMapFetchFailure() {
     // Setup a scenario where speculative task wins, first attempt killed
     mockTask = createMockTask(TaskType.MAP);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_KILLED);
@@ -681,7 +681,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  void testSpeculativeMapMultipleSucceedFetchFailure() {
+  public void testSpeculativeMapMultipleSucceedFetchFailure() {
     // Setup a scenario where speculative task wins, first attempt succeeds
     mockTask = createMockTask(TaskType.MAP);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_SUCCEEDED);
@@ -696,7 +696,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  void testSpeculativeMapFailedFetchFailure() {
+  public void testSpeculativeMapFailedFetchFailure() {
     // Setup a scenario where speculative task wins, first attempt succeeds
     mockTask = createMockTask(TaskType.MAP);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_FAILED);
@@ -711,7 +711,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  void testFailedTransitions() {
+  public void testFailedTransitions() {
     mockTask = new MockTaskImpl(jobId, partition, dispatcher.getEventHandler(),
         remoteJobConfFile, conf, taskAttemptListener, jobToken,
         credentials, clock, startCount, metrics, appContext, TaskType.MAP) {
@@ -789,7 +789,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  void testFailedTransitionWithHangingSpeculativeMap() {
+  public void testFailedTransitionWithHangingSpeculativeMap() {
     mockTask = new MockTaskImpl(jobId, partition, new PartialAttemptEventHandler(),
         remoteJobConfFile, conf, taskAttemptListener, jobToken,
         credentials, clock, startCount, metrics, appContext, TaskType.MAP) {
@@ -840,7 +840,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  void testCountersWithSpeculation() {
+  public void testCountersWithSpeculation() {
     mockTask = new MockTaskImpl(jobId, partition, dispatcher.getEventHandler(),
         remoteJobConfFile, conf, taskAttemptListener, jobToken,
         credentials, clock, startCount, metrics, appContext, TaskType.MAP) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskImpl.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.mapreduce.v2.app.job.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,9 +65,9 @@ import org.apache.hadoop.yarn.event.InlineDispatcher;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.util.SystemClock;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -234,7 +234,7 @@ public class TestTaskImpl {
     
   }
   
-  @Before 
+  @BeforeEach
   @SuppressWarnings("unchecked")
   public void setup() {
      dispatcher = new InlineDispatcher();
@@ -273,7 +273,7 @@ public class TestTaskImpl {
         startCount, metrics, appContext, taskType);
   }
 
-  @After 
+  @AfterEach
   public void teardown() {
     taskAttempts.clear();
   }
@@ -399,7 +399,7 @@ public class TestTaskImpl {
   }
   
   @Test
-  public void testInit() {
+  void testInit() {
     LOG.info("--- START: testInit ---");
     mockTask = createMockTask(TaskType.MAP);        
     assertTaskNewState();
@@ -410,7 +410,7 @@ public class TestTaskImpl {
   /**
    * {@link TaskState#NEW}->{@link TaskState#SCHEDULED}
    */
-  public void testScheduleTask() {
+  void testScheduleTask() {
     LOG.info("--- START: testScheduleTask ---");
     mockTask = createMockTask(TaskType.MAP);        
     TaskId taskId = getNewTaskID();
@@ -421,7 +421,7 @@ public class TestTaskImpl {
   /**
    * {@link TaskState#SCHEDULED}->{@link TaskState#KILL_WAIT}
    */
-  public void testKillScheduledTask() {
+  void testKillScheduledTask() {
     LOG.info("--- START: testKillScheduledTask ---");
     mockTask = createMockTask(TaskType.MAP);        
     TaskId taskId = getNewTaskID();
@@ -434,7 +434,7 @@ public class TestTaskImpl {
    * Kill attempt
    * {@link TaskState#SCHEDULED}->{@link TaskState#SCHEDULED}
    */
-  public void testKillScheduledTaskAttempt() {
+  void testKillScheduledTaskAttempt() {
     LOG.info("--- START: testKillScheduledTaskAttempt ---");
     mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
@@ -449,7 +449,7 @@ public class TestTaskImpl {
    * Launch attempt
    * {@link TaskState#SCHEDULED}->{@link TaskState#RUNNING}
    */
-  public void testLaunchTaskAttempt() {
+  void testLaunchTaskAttempt() {
     LOG.info("--- START: testLaunchTaskAttempt ---");
     mockTask = createMockTask(TaskType.MAP);        
     TaskId taskId = getNewTaskID();
@@ -462,7 +462,7 @@ public class TestTaskImpl {
    * Kill running attempt
    * {@link TaskState#RUNNING}->{@link TaskState#RUNNING} 
    */
-  public void testKillRunningTaskAttempt() {
+  void testKillRunningTaskAttempt() {
     LOG.info("--- START: testKillRunningTaskAttempt ---");
     mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
@@ -474,7 +474,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  public void testKillSuccessfulTask() {
+  void testKillSuccessfulTask() {
     LOG.info("--- START: testKillSuccesfulTask ---");
     mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
@@ -493,7 +493,7 @@ public class TestTaskImpl {
    * Kill map attempt for succeeded map task
    * {@link TaskState#SUCCEEDED}->{@link TaskState#SCHEDULED}
    */
-  public void testKillAttemptForSuccessfulTask() {
+  void testKillAttemptForSuccessfulTask() {
     LOG.info("--- START: testKillAttemptForSuccessfulTask ---");
     mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
@@ -511,7 +511,7 @@ public class TestTaskImpl {
   }
 
   @Test 
-  public void testTaskProgress() {
+  void testTaskProgress() {
     LOG.info("--- START: testTaskProgress ---");
     mockTask = createMockTask(TaskType.MAP);        
         
@@ -551,7 +551,7 @@ public class TestTaskImpl {
 
   
   @Test
-  public void testKillDuringTaskAttemptCommit() {
+  void testKillDuringTaskAttemptCommit() {
     mockTask = createMockTask(TaskType.REDUCE);        
     TaskId taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
@@ -568,7 +568,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  public void testFailureDuringTaskAttemptCommit() {
+  void testFailureDuringTaskAttemptCommit() {
     mockTask = createMockTask(TaskType.MAP);        
     TaskId taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
@@ -587,10 +587,10 @@ public class TestTaskImpl {
     mockTask.handle(new TaskTAttemptEvent(getLastAttempt().getAttemptId(), 
         TaskEventType.T_ATTEMPT_SUCCEEDED));
     
-    assertFalse("First attempt should not commit",
-        mockTask.canCommit(taskAttempts.get(0).getAttemptId()));
-    assertTrue("Second attempt should commit",
-        mockTask.canCommit(getLastAttempt().getAttemptId()));
+    assertFalse(mockTask.canCommit(taskAttempts.get(0).getAttemptId()),
+        "First attempt should not commit");
+    assertTrue(mockTask.canCommit(getLastAttempt().getAttemptId()),
+        "Second attempt should commit");
 
     assertTaskSucceededState();
   }
@@ -630,43 +630,43 @@ public class TestTaskImpl {
   }
   
   @Test
-  public void testMapSpeculativeTaskAttemptSucceedsEvenIfFirstFails() {
+  void testMapSpeculativeTaskAttemptSucceedsEvenIfFirstFails() {
     mockTask = createMockTask(TaskType.MAP);        
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_FAILED);
   }
 
   @Test
-  public void testReduceSpeculativeTaskAttemptSucceedsEvenIfFirstFails() {
+  void testReduceSpeculativeTaskAttemptSucceedsEvenIfFirstFails() {
     mockTask = createMockTask(TaskType.REDUCE);        
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_FAILED);
   }
   
   @Test
-  public void testMapSpeculativeTaskAttemptSucceedsEvenIfFirstIsKilled() {
+  void testMapSpeculativeTaskAttemptSucceedsEvenIfFirstIsKilled() {
     mockTask = createMockTask(TaskType.MAP);        
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_KILLED);
   }
 
   @Test
-  public void testReduceSpeculativeTaskAttemptSucceedsEvenIfFirstIsKilled() {
+  void testReduceSpeculativeTaskAttemptSucceedsEvenIfFirstIsKilled() {
     mockTask = createMockTask(TaskType.REDUCE);        
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_KILLED);
   }
 
   @Test
-  public void testMultipleTaskAttemptsSucceed() {
+  void testMultipleTaskAttemptsSucceed() {
     mockTask = createMockTask(TaskType.MAP);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_SUCCEEDED);
   }
 
   @Test
-  public void testCommitAfterSucceeds() {
+  void testCommitAfterSucceeds() {
     mockTask = createMockTask(TaskType.REDUCE);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_COMMIT_PENDING);
   }
 
   @Test
-  public void testSpeculativeMapFetchFailure() {
+  void testSpeculativeMapFetchFailure() {
     // Setup a scenario where speculative task wins, first attempt killed
     mockTask = createMockTask(TaskType.MAP);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_KILLED);
@@ -681,7 +681,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  public void testSpeculativeMapMultipleSucceedFetchFailure() {
+  void testSpeculativeMapMultipleSucceedFetchFailure() {
     // Setup a scenario where speculative task wins, first attempt succeeds
     mockTask = createMockTask(TaskType.MAP);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_SUCCEEDED);
@@ -696,7 +696,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  public void testSpeculativeMapFailedFetchFailure() {
+  void testSpeculativeMapFailedFetchFailure() {
     // Setup a scenario where speculative task wins, first attempt succeeds
     mockTask = createMockTask(TaskType.MAP);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_FAILED);
@@ -711,7 +711,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  public void testFailedTransitions() {
+  void testFailedTransitions() {
     mockTask = new MockTaskImpl(jobId, partition, dispatcher.getEventHandler(),
         remoteJobConfFile, conf, taskAttemptListener, jobToken,
         credentials, clock, startCount, metrics, appContext, TaskType.MAP) {
@@ -789,7 +789,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  public void testFailedTransitionWithHangingSpeculativeMap() {
+  void testFailedTransitionWithHangingSpeculativeMap() {
     mockTask = new MockTaskImpl(jobId, partition, new PartialAttemptEventHandler(),
         remoteJobConfFile, conf, taskAttemptListener, jobToken,
         credentials, clock, startCount, metrics, appContext, TaskType.MAP) {
@@ -840,7 +840,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  public void testCountersWithSpeculation() {
+  void testCountersWithSpeculation() {
     mockTask = new MockTaskImpl(jobId, partition, dispatcher.getEventHandler(),
         remoteJobConfFile, conf, taskAttemptListener, jobToken,
         credentials, clock, startCount, metrics, appContext, TaskType.MAP) {
@@ -879,7 +879,8 @@ public class TestTaskImpl {
     baseAttempt.setProgress(1.0f);
 
     Counters taskCounters = mockTask.getCounters();
-    assertEquals("wrong counters for task", specAttemptCounters, taskCounters);
+    assertEquals(specAttemptCounters, taskCounters,
+        "wrong counters for task");
   }
 
   public static class MockTaskAttemptEventHandler implements EventHandler {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/launcher/TestContainerLauncher.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/launcher/TestContainerLauncher.java
@@ -44,7 +44,7 @@ import org.apache.hadoop.yarn.api.protocolrecords.ResourceLocalizationRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.ResourceLocalizationResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.RestartContainerResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.RollbackResponse;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.ipc.Server;
@@ -93,7 +93,8 @@ import org.apache.hadoop.yarn.security.ContainerTokenIdentifier;
 import org.apache.hadoop.yarn.server.api.records.MasterKey;
 import org.apache.hadoop.yarn.server.nodemanager.security.NMTokenSecretManagerInNM;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,9 +108,9 @@ public class TestContainerLauncher {
   static final Logger LOG =
       LoggerFactory.getLogger(TestContainerLauncher.class);
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(10000)
   public void testPoolSize() throws InterruptedException {
-
     ApplicationId appId = ApplicationId.newInstance(12345, 67);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
       appId, 3);
@@ -127,10 +128,10 @@ public class TestContainerLauncher {
     // No events yet
     assertThat(containerLauncher.initialPoolSize).isEqualTo(
         MRJobConfig.DEFAULT_MR_AM_CONTAINERLAUNCHER_THREADPOOL_INITIAL_SIZE);
-    Assert.assertEquals(0, threadPool.getPoolSize());
-    Assert.assertEquals(containerLauncher.initialPoolSize,
+    Assertions.assertEquals(0, threadPool.getPoolSize());
+    Assertions.assertEquals(containerLauncher.initialPoolSize,
       threadPool.getCorePoolSize());
-    Assert.assertNull(containerLauncher.foundErrors);
+    Assertions.assertNull(containerLauncher.foundErrors);
 
     containerLauncher.expectedCorePoolSize = containerLauncher.initialPoolSize;
     for (int i = 0; i < 10; i++) {
@@ -141,8 +142,8 @@ public class TestContainerLauncher {
         ContainerLauncher.EventType.CONTAINER_REMOTE_LAUNCH));
     }
     waitForEvents(containerLauncher, 10);
-    Assert.assertEquals(10, threadPool.getPoolSize());
-    Assert.assertNull(containerLauncher.foundErrors);
+    Assertions.assertEquals(10, threadPool.getPoolSize());
+    Assertions.assertNull(containerLauncher.foundErrors);
 
     // Same set of hosts, so no change
     containerLauncher.finishEventHandling = true;
@@ -153,7 +154,7 @@ public class TestContainerLauncher {
           + ". Timeout is " + timeOut);
       Thread.sleep(1000);
     }
-    Assert.assertEquals(10, containerLauncher.numEventsProcessed.get());
+    Assertions.assertEquals(10, containerLauncher.numEventsProcessed.get());
     containerLauncher.finishEventHandling = false;
     for (int i = 0; i < 10; i++) {
       ContainerId containerId = ContainerId.newContainerId(appAttemptId,
@@ -165,8 +166,8 @@ public class TestContainerLauncher {
         ContainerLauncher.EventType.CONTAINER_REMOTE_LAUNCH));
     }
     waitForEvents(containerLauncher, 20);
-    Assert.assertEquals(10, threadPool.getPoolSize());
-    Assert.assertNull(containerLauncher.foundErrors);
+    Assertions.assertEquals(10, threadPool.getPoolSize());
+    Assertions.assertNull(containerLauncher.foundErrors);
 
     // Different hosts, there should be an increase in core-thread-pool size to
     // 21(11hosts+10buffer)
@@ -179,8 +180,8 @@ public class TestContainerLauncher {
       containerId, "host11:1234", null,
       ContainerLauncher.EventType.CONTAINER_REMOTE_LAUNCH));
     waitForEvents(containerLauncher, 21);
-    Assert.assertEquals(11, threadPool.getPoolSize());
-    Assert.assertNull(containerLauncher.foundErrors);
+    Assertions.assertEquals(11, threadPool.getPoolSize());
+    Assertions.assertNull(containerLauncher.foundErrors);
 
     containerLauncher.stop();
 
@@ -194,7 +195,8 @@ public class TestContainerLauncher {
     assertThat(containerLauncher.initialPoolSize).isEqualTo(20);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(5000)
   public void testPoolLimits() throws InterruptedException {
     ApplicationId appId = ApplicationId.newInstance(12345, 67);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
@@ -222,8 +224,8 @@ public class TestContainerLauncher {
         ContainerLauncher.EventType.CONTAINER_REMOTE_LAUNCH));
     }
     waitForEvents(containerLauncher, 10);
-    Assert.assertEquals(10, threadPool.getPoolSize());
-    Assert.assertNull(containerLauncher.foundErrors);
+    Assertions.assertEquals(10, threadPool.getPoolSize());
+    Assertions.assertNull(containerLauncher.foundErrors);
 
     // 4 more different hosts, but thread pool size should be capped at 12
     containerLauncher.expectedCorePoolSize = 12 ;
@@ -233,14 +235,14 @@ public class TestContainerLauncher {
         ContainerLauncher.EventType.CONTAINER_REMOTE_LAUNCH));
     }
     waitForEvents(containerLauncher, 12);
-    Assert.assertEquals(12, threadPool.getPoolSize());
-    Assert.assertNull(containerLauncher.foundErrors);
+    Assertions.assertEquals(12, threadPool.getPoolSize());
+    Assertions.assertNull(containerLauncher.foundErrors);
 
     // Make some threads ideal so that remaining events are also done.
     containerLauncher.finishEventHandling = true;
     waitForEvents(containerLauncher, 14);
-    Assert.assertEquals(12, threadPool.getPoolSize());
-    Assert.assertNull(containerLauncher.foundErrors);
+    Assertions.assertEquals(12, threadPool.getPoolSize());
+    Assertions.assertNull(containerLauncher.foundErrors);
 
     containerLauncher.stop();
   }
@@ -254,13 +256,13 @@ public class TestContainerLauncher {
           + ". It is now " + containerLauncher.numEventsProcessing.get());
       Thread.sleep(1000);
     }
-    Assert.assertEquals(expectedNumEvents,
+    Assertions.assertEquals(expectedNumEvents,
       containerLauncher.numEventsProcessing.get());
   }
 
-  @Test(timeout = 15000)
+  @Test
+  @Timeout(15000)
   public void testSlowNM() throws Exception {
-
     conf = new Configuration();
     int maxAttempts = 1;
     conf.setInt(MRJobConfig.MAP_MAX_ATTEMPTS, maxAttempts);
@@ -290,15 +292,16 @@ public class TestContainerLauncher {
     app.waitForState(job, JobState.RUNNING);
 
     Map<TaskId, Task> tasks = job.getTasks();
-    Assert.assertEquals("Num tasks is not correct", 1, tasks.size());
+    Assertions.assertEquals(1, tasks.size(),
+          "Num tasks is not correct");
 
     Task task = tasks.values().iterator().next();
     app.waitForState(task, TaskState.SCHEDULED);
 
     Map<TaskAttemptId, TaskAttempt> attempts = tasks.values().iterator()
         .next().getAttempts();
-      Assert.assertEquals("Num attempts is not correct", maxAttempts,
-          attempts.size());
+      Assertions.assertEquals(maxAttempts, attempts.size(),
+          "Num attempts is not correct");
 
     TaskAttempt attempt = attempts.values().iterator().next();
       app.waitForInternalState((TaskAttemptImpl) attempt,
@@ -309,9 +312,9 @@ public class TestContainerLauncher {
     String diagnostics = attempt.getDiagnostics().toString();
     LOG.info("attempt.getDiagnostics: " + diagnostics);
 
-      Assert.assertTrue(diagnostics.contains("Container launch failed for "
+      Assertions.assertTrue(diagnostics.contains("Container launch failed for "
           + "container_0_0000_01_000000 : "));
-      Assert
+      Assertions
           .assertTrue(diagnostics
               .contains("java.net.SocketTimeoutException: 3000 millis timeout while waiting for channel"));
 
@@ -440,7 +443,7 @@ public class TestContainerLauncher {
           MRApp.newContainerTokenIdentifier(request.getContainerToken());
 
       // Validate that the container is what RM is giving.
-      Assert.assertEquals(MRApp.NM_HOST + ":" + MRApp.NM_PORT,
+      Assertions.assertEquals(MRApp.NM_HOST + ":" + MRApp.NM_PORT,
         containerTokenIdentifier.getNmHostAddress());
 
       StartContainersResponse response = recordFactory

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/launcher/TestContainerLauncherImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/launcher/TestContainerLauncherImpl.java
@@ -79,8 +79,9 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.security.ContainerTokenIdentifier;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,7 +95,7 @@ public class TestContainerLauncherImpl {
   private Map<String, ByteBuffer> serviceResponse =
       new HashMap<String, ByteBuffer>();
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     serviceResponse.clear();
     serviceResponse.put(ShuffleHandler.MAPREDUCE_SHUFFLE_SERVICEID,
@@ -168,8 +169,9 @@ public class TestContainerLauncherImpl {
     return MRBuilderUtils.newTaskAttemptId(tID, id);
   }
   
-  @Test(timeout = 5000)
-  public void testHandle() throws Exception {
+  @Test
+  @Timeout(5000)
+  void testHandle() throws Exception {
     LOG.info("STARTING testHandle");
     AppContext mockContext = mock(AppContext.class);
     @SuppressWarnings("unchecked")
@@ -226,8 +228,9 @@ public class TestContainerLauncherImpl {
     }
   }
   
-  @Test(timeout = 5000)
-  public void testOutOfOrder() throws Exception {
+  @Test
+  @Timeout(5000)
+  void testOutOfOrder() throws Exception {
     LOG.info("STARTING testOutOfOrder");
     AppContext mockContext = mock(AppContext.class);
     @SuppressWarnings("unchecked")
@@ -300,8 +303,9 @@ public class TestContainerLauncherImpl {
     }
   }
 
-  @Test(timeout = 5000)
-  public void testMyShutdown() throws Exception {
+  @Test
+  @Timeout(5000)
+  void testMyShutdown() throws Exception {
     LOG.info("in test Shutdown");
 
     AppContext mockContext = mock(AppContext.class);
@@ -352,7 +356,8 @@ public class TestContainerLauncherImpl {
   }
   
   @SuppressWarnings({ "rawtypes", "unchecked" })
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(5000)
   public void testContainerCleaned() throws Exception {
     LOG.info("STARTING testContainerCleaned");
     

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/launcher/TestContainerLauncherImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/launcher/TestContainerLauncherImpl.java
@@ -171,7 +171,7 @@ public class TestContainerLauncherImpl {
   
   @Test
   @Timeout(5000)
-  void testHandle() throws Exception {
+  public void testHandle() throws Exception {
     LOG.info("STARTING testHandle");
     AppContext mockContext = mock(AppContext.class);
     @SuppressWarnings("unchecked")
@@ -230,7 +230,7 @@ public class TestContainerLauncherImpl {
   
   @Test
   @Timeout(5000)
-  void testOutOfOrder() throws Exception {
+  public void testOutOfOrder() throws Exception {
     LOG.info("STARTING testOutOfOrder");
     AppContext mockContext = mock(AppContext.class);
     @SuppressWarnings("unchecked")
@@ -305,7 +305,7 @@ public class TestContainerLauncherImpl {
 
   @Test
   @Timeout(5000)
-  void testMyShutdown() throws Exception {
+  public void testMyShutdown() throws Exception {
     LOG.info("in test Shutdown");
 
     AppContext mockContext = mock(AppContext.class);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/local/TestLocalContainerAllocator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/local/TestLocalContainerAllocator.java
@@ -76,7 +76,7 @@ import org.mockito.ArgumentCaptor;
 public class TestLocalContainerAllocator {
 
   @Test
-  void testRMConnectionRetry() throws Exception {
+  public void testRMConnectionRetry() throws Exception {
     // verify the connection exception is thrown
     // if we haven't exhausted the retry interval
     ApplicationMasterProtocol mockScheduler =
@@ -113,7 +113,7 @@ public class TestLocalContainerAllocator {
   }
 
   @Test
-  void testAllocResponseId() throws Exception {
+  public void testAllocResponseId() throws Exception {
     ApplicationMasterProtocol scheduler = new MockScheduler();
     Configuration conf = new Configuration();
     LocalContainerAllocator lca =
@@ -128,7 +128,7 @@ public class TestLocalContainerAllocator {
   }
 
   @Test
-  void testAMRMTokenUpdate() throws Exception {
+  public void testAMRMTokenUpdate() throws Exception {
     Configuration conf = new Configuration();
     ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(
         ApplicationId.newInstance(1, 1), 1);
@@ -182,7 +182,7 @@ public class TestLocalContainerAllocator {
   }
 
   @Test
-  void testAllocatedContainerResourceIsNotNull() {
+  public void testAllocatedContainerResourceIsNotNull() {
     ArgumentCaptor<TaskAttemptContainerAssignedEvent> containerAssignedCaptor
         = ArgumentCaptor.forClass(TaskAttemptContainerAssignedEvent.class);
     @SuppressWarnings("unchecked")

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/local/TestLocalContainerAllocator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/local/TestLocalContainerAllocator.java
@@ -69,14 +69,14 @@ import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.ipc.RPCUtil;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class TestLocalContainerAllocator {
 
   @Test
-  public void testRMConnectionRetry() throws Exception {
+  void testRMConnectionRetry() throws Exception {
     // verify the connection exception is thrown
     // if we haven't exhausted the retry interval
     ApplicationMasterProtocol mockScheduler =
@@ -90,7 +90,7 @@ public class TestLocalContainerAllocator {
     lca.start();
     try {
       lca.heartbeat();
-      Assert.fail("heartbeat was supposed to throw");
+      Assertions.fail("heartbeat was supposed to throw");
     } catch (YarnException e) {
       // YarnException is expected
     } finally {
@@ -104,7 +104,7 @@ public class TestLocalContainerAllocator {
     lca.start();
     try {
       lca.heartbeat();
-      Assert.fail("heartbeat was supposed to throw");
+      Assertions.fail("heartbeat was supposed to throw");
     } catch (YarnRuntimeException e) {
       // YarnRuntimeException is expected
     } finally {
@@ -113,7 +113,7 @@ public class TestLocalContainerAllocator {
   }
 
   @Test
-  public void testAllocResponseId() throws Exception {
+  void testAllocResponseId() throws Exception {
     ApplicationMasterProtocol scheduler = new MockScheduler();
     Configuration conf = new Configuration();
     LocalContainerAllocator lca =
@@ -128,7 +128,7 @@ public class TestLocalContainerAllocator {
   }
 
   @Test
-  public void testAMRMTokenUpdate() throws Exception {
+  void testAMRMTokenUpdate() throws Exception {
     Configuration conf = new Configuration();
     ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(
         ApplicationId.newInstance(1, 1), 1);
@@ -172,18 +172,17 @@ public class TestLocalContainerAllocator {
       }
     }
 
-    Assert.assertEquals("too many AMRM tokens", 1, tokenCount);
-    Assert.assertArrayEquals("token identifier not updated",
-        newToken.getIdentifier(), ugiToken.getIdentifier());
-    Assert.assertArrayEquals("token password not updated",
-        newToken.getPassword(), ugiToken.getPassword());
-    Assert.assertEquals("AMRM token service not updated",
-        new Text(ClientRMProxy.getAMRMTokenService(conf)),
-        ugiToken.getService());
+    Assertions.assertEquals(1, tokenCount, "too many AMRM tokens");
+    Assertions.assertArrayEquals(newToken.getIdentifier(), ugiToken.getIdentifier(),
+        "token identifier not updated");
+    Assertions.assertArrayEquals(newToken.getPassword(), ugiToken.getPassword(),
+        "token password not updated");
+    Assertions.assertEquals(new Text(ClientRMProxy.getAMRMTokenService(conf)),
+        ugiToken.getService(), "AMRM token service not updated");
   }
 
   @Test
-  public void testAllocatedContainerResourceIsNotNull() {
+  void testAllocatedContainerResourceIsNotNull() {
     ArgumentCaptor<TaskAttemptContainerAssignedEvent> containerAssignedCaptor
         = ArgumentCaptor.forClass(TaskAttemptContainerAssignedEvent.class);
     @SuppressWarnings("unchecked")
@@ -202,7 +201,7 @@ public class TestLocalContainerAllocator {
     verify(eventHandler, times(1)).handle(containerAssignedCaptor.capture());
     Container container = containerAssignedCaptor.getValue().getContainer();
     Resource containerResource = container.getResource();
-    Assert.assertNotNull(containerResource);
+    Assertions.assertNotNull(containerResource);
     assertThat(containerResource.getMemorySize()).isEqualTo(0);
     assertThat(containerResource.getVirtualCores()).isEqualTo(0);
   }
@@ -282,8 +281,8 @@ public class TestLocalContainerAllocator {
     @Override
     public AllocateResponse allocate(AllocateRequest request)
         throws YarnException, IOException {
-      Assert.assertEquals("response ID mismatch",
-          responseId, request.getResponseId());
+      Assertions.assertEquals(responseId, request.getResponseId(),
+          "response ID mismatch");
       ++responseId;
       org.apache.hadoop.yarn.api.records.Token yarnToken = null;
       if (amToken != null) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/metrics/TestMRAppMetrics.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/metrics/TestMRAppMetrics.java
@@ -25,19 +25,20 @@ import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import static org.apache.hadoop.test.MetricsAsserts.*;
 
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.*;
 
 public class TestMRAppMetrics {
 
-  @After
+  @AfterEach
   public void tearDown() {
     DefaultMetricsSystem.shutdown();
   }
 
-  @Test public void testNames() {
+  @Test
+  void testNames() {
     Job job = mock(Job.class);
     Task mapTask = mock(Task.class);
     when(mapTask.getType()).thenReturn(TaskType.MAP);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/metrics/TestMRAppMetrics.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/metrics/TestMRAppMetrics.java
@@ -38,7 +38,7 @@ public class TestMRAppMetrics {
   }
 
   @Test
-  void testNames() {
+  public void testNames() {
     Job job = mock(Job.class);
     Task mapTask = mock(Task.class);
     when(mapTask.getType()).thenReturn(TaskType.MAP);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMCommunicator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMCommunicator.java
@@ -48,7 +48,7 @@ public class TestRMCommunicator {
 
   @Test
   @Timeout(2000)
-  void testRMContainerAllocatorExceptionIsHandled() throws Exception {
+  public void testRMContainerAllocatorExceptionIsHandled() throws Exception {
     ClientService mockClientService = mock(ClientService.class);
     AppContext mockContext = mock(AppContext.class);
     MockRMCommunicator mockRMCommunicator =
@@ -69,7 +69,7 @@ public class TestRMCommunicator {
   }
 
   @Test
-  void testRMContainerAllocatorYarnRuntimeExceptionIsHandled()
+  public void testRMContainerAllocatorYarnRuntimeExceptionIsHandled()
       throws Exception {
     ClientService mockClientService = mock(ClientService.class);
     AppContext mockContext = mock(AppContext.class);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMCommunicator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMCommunicator.java
@@ -69,6 +69,7 @@ public class TestRMCommunicator {
   }
 
   @Test
+  @Timeout(2000)
   public void testRMContainerAllocatorYarnRuntimeExceptionIsHandled()
       throws Exception {
     ClientService mockClientService = mock(ClientService.class);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMCommunicator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMCommunicator.java
@@ -23,7 +23,8 @@ import org.apache.hadoop.mapreduce.v2.app.client.ClientService;
 import org.apache.hadoop.mapreduce.v2.app.rm.RMCommunicator.AllocatorRunnable;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.util.Clock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.stubbing.Answer;
 
 import static org.mockito.Mockito.doThrow;
@@ -45,8 +46,9 @@ public class TestRMCommunicator {
     }
   }
 
-  @Test(timeout = 2000)
-  public void testRMContainerAllocatorExceptionIsHandled() throws Exception {
+  @Test
+  @Timeout(2000)
+  void testRMContainerAllocatorExceptionIsHandled() throws Exception {
     ClientService mockClientService = mock(ClientService.class);
     AppContext mockContext = mock(AppContext.class);
     MockRMCommunicator mockRMCommunicator =
@@ -66,8 +68,8 @@ public class TestRMCommunicator {
     testRunnable.run();
   }
 
-  @Test(timeout = 2000)
-  public void testRMContainerAllocatorYarnRuntimeExceptionIsHandled()
+  @Test
+  void testRMContainerAllocatorYarnRuntimeExceptionIsHandled()
       throws Exception {
     ClientService mockClientService = mock(ClientService.class);
     AppContext mockContext = mock(AppContext.class);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMContainerAllocator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMContainerAllocator.java
@@ -183,7 +183,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testSimple() throws Exception {
+  public void testSimple() throws Exception {
 
     LOG.info("Running testSimple");
 
@@ -266,7 +266,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testMapNodeLocality() throws Exception {
+  public void testMapNodeLocality() throws Exception {
     // test checks that ordering of allocated containers list from the RM does
     // not affect the map->container assignment done by the AM. If there is a
     // node local container available for a map then it should be assigned to
@@ -352,7 +352,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testResource() throws Exception {
+  public void testResource() throws Exception {
 
     LOG.info("Running testResource");
 
@@ -419,7 +419,7 @@ public class TestRMContainerAllocator {
 
   @Test
   @Timeout(30000)
-  void testReducerRampdownDiagnostics() throws Exception {
+  public void testReducerRampdownDiagnostics() throws Exception {
     LOG.info("Running tesReducerRampdownDiagnostics");
 
     final Configuration conf = new Configuration();
@@ -523,7 +523,7 @@ public class TestRMContainerAllocator {
 
   @Test
   @Timeout(30000)
-  void testNonAggressivelyPreemptReducers() throws Exception {
+  public void testNonAggressivelyPreemptReducers() throws Exception {
     LOG.info("Running testNonAggressivelyPreemptReducers");
 
     final int preemptThreshold = 2; //sec
@@ -586,7 +586,7 @@ public class TestRMContainerAllocator {
 
   @Test
   @Timeout(30000)
-  void testUnconditionalPreemptReducers() throws Exception {
+  public void testUnconditionalPreemptReducers() throws Exception {
     LOG.info("Running testForcePreemptReducers");
 
     int forcePreemptThresholdSecs = 2;
@@ -651,7 +651,7 @@ public class TestRMContainerAllocator {
 
   @Test
   @Timeout(30000)
-  void testExcessReduceContainerAssign() throws Exception {
+  public void testExcessReduceContainerAssign() throws Exception {
     final Configuration conf = new Configuration();
     conf.setFloat(MRJobConfig.COMPLETED_MAPS_FOR_REDUCE_SLOWSTART, 0.0f);
     final MyResourceManager2 rm = new MyResourceManager2(conf);
@@ -699,7 +699,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testMapReduceAllocationWithNodeLabelExpression() throws Exception {
+  public void testMapReduceAllocationWithNodeLabelExpression() throws Exception {
 
     LOG.info("Running testMapReduceAllocationWithNodeLabelExpression");
     Configuration conf = new Configuration();
@@ -788,7 +788,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testUpdateCollectorInfo() throws Exception {
+  public void testUpdateCollectorInfo() throws Exception {
     LOG.info("Running testUpdateCollectorInfo");
     Configuration conf = new Configuration();
     conf.setBoolean(YarnConfiguration.TIMELINE_SERVICE_ENABLED, true);
@@ -878,7 +878,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testMapReduceScheduling() throws Exception {
+  public void testMapReduceScheduling() throws Exception {
 
     LOG.info("Running testMapReduceScheduling");
 
@@ -1008,7 +1008,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testReportedAppProgress() throws Exception {
+  public void testReportedAppProgress() throws Exception {
 
     LOG.info("Running testReportedAppProgress");
 
@@ -1160,7 +1160,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testReportedAppProgressWithOnlyMaps() throws Exception {
+  public void testReportedAppProgressWithOnlyMaps() throws Exception {
 
     LOG.info("Running testReportedAppProgressWithOnlyMaps");
 
@@ -1258,7 +1258,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testUpdatedNodes() throws Exception {
+  public void testUpdatedNodes() throws Exception {
     Configuration conf = new Configuration();
     MyResourceManager rm = new MyResourceManager(conf);
     rm.start();
@@ -1345,7 +1345,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testBlackListedNodes() throws Exception {
+  public void testBlackListedNodes() throws Exception {
 
     LOG.info("Running testBlackListedNodes");
 
@@ -1455,7 +1455,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testIgnoreBlacklisting() throws Exception {
+  public void testIgnoreBlacklisting() throws Exception {
     LOG.info("Running testIgnoreBlacklisting");
 
     Configuration conf = new Configuration();
@@ -1651,7 +1651,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testBlackListedNodesWithSchedulingToThatNode() throws Exception {
+  public void testBlackListedNodesWithSchedulingToThatNode() throws Exception {
     LOG.info("Running testBlackListedNodesWithSchedulingToThatNode");
 
     Configuration conf = new Configuration();
@@ -2184,7 +2184,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testIfApplicationPriorityIsNotSet() {
+  public void testIfApplicationPriorityIsNotSet() {
     Job mockJob = mock(Job.class);
     RMCommunicator communicator = mock(RMCommunicator.class);
     ClientService service = mock(ClientService.class);
@@ -2198,7 +2198,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testReduceScheduling() throws Exception {
+  public void testReduceScheduling() throws Exception {
     int totalMaps = 10;
     int succeededMaps = 1;
     int scheduledMaps = 10;
@@ -2336,7 +2336,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testCompletedTasksRecalculateSchedule() throws Exception {
+  public void testCompletedTasksRecalculateSchedule() throws Exception {
     LOG.info("Running testCompletedTasksRecalculateSchedule");
 
     Configuration conf = new Configuration();
@@ -2381,7 +2381,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testHeartbeatHandler() throws Exception {
+  public void testHeartbeatHandler() throws Exception {
     LOG.info("Running testHeartbeatHandler");
 
     Configuration conf = new Configuration();
@@ -2442,7 +2442,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testCompletedContainerEvent() {
+  public void testCompletedContainerEvent() {
     RMContainerAllocator allocator = new RMContainerAllocator(
         mock(ClientService.class), mock(AppContext.class),
         new NoopAMPreemptionPolicy());
@@ -2512,7 +2512,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testUnregistrationOnlyIfRegistered() throws Exception {
+  public void testUnregistrationOnlyIfRegistered() throws Exception {
     Configuration conf = new Configuration();
     final MyResourceManager rm = new MyResourceManager(conf);
     rm.start();
@@ -2567,7 +2567,7 @@ public class TestRMContainerAllocator {
   // and another containerRequest(event5)
   // Step-6 : RM allocates containers i.e event3,event4 and cRequest5
   @Test
-  void testRMContainerAllocatorResendsRequestsOnRMRestart()
+  public void testRMContainerAllocatorResendsRequestsOnRMRestart()
       throws Exception {
 
     Configuration conf = new Configuration();
@@ -2749,7 +2749,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testUnsupportedMapContainerRequirement() throws Exception {
+  public void testUnsupportedMapContainerRequirement() throws Exception {
     final Resource maxContainerSupported = Resource.newInstance(1, 1);
 
     final ApplicationId appId = ApplicationId.newInstance(1, 1);
@@ -2788,7 +2788,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testUnsupportedReduceContainerRequirement() throws Exception {
+  public void testUnsupportedReduceContainerRequirement() throws Exception {
     final Resource maxContainerSupported = Resource.newInstance(1, 1);
 
     final ApplicationId appId = ApplicationId.newInstance(1, 1);
@@ -2831,7 +2831,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testRMUnavailable()
+  public void testRMUnavailable()
       throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(
@@ -2876,7 +2876,7 @@ public class TestRMContainerAllocator {
 
   @Test
   @Timeout(60000)
-  void testAMRMTokenUpdate() throws Exception {
+  public void testAMRMTokenUpdate() throws Exception {
     LOG.info("Running testAMRMTokenUpdate");
 
     final String rmAddr = "somermaddress:1234";
@@ -2961,7 +2961,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testConcurrentTaskLimitsDisabledIfSmaller() throws Exception {
+  public void testConcurrentTaskLimitsDisabledIfSmaller() throws Exception {
     final int MAP_COUNT = 1;
     final int REDUCE_COUNT = 1;
     final int MAP_LIMIT = 1;
@@ -3025,7 +3025,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testConcurrentTaskLimits() throws Exception {
+  public void testConcurrentTaskLimits() throws Exception {
     final int MAP_COUNT = 5;
     final int REDUCE_COUNT = 2;
     final int MAP_LIMIT = 3;
@@ -3156,7 +3156,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testAttemptNotFoundCausesRMCommunicatorException()
+  public void testAttemptNotFoundCausesRMCommunicatorException()
       throws Exception {
     assertThrows(RMContainerAllocationException.class, () -> {
       Configuration conf = new Configuration();
@@ -3192,7 +3192,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testUpdateAskOnRampDownAllReduces() throws Exception {
+  public void testUpdateAskOnRampDownAllReduces() throws Exception {
     LOG.info("Running testUpdateAskOnRampDownAllReduces");
     Configuration conf = new Configuration();
     MyResourceManager rm = new MyResourceManager(conf);
@@ -3323,7 +3323,7 @@ public class TestRMContainerAllocator {
    * right order while processing finished containers.
    */
   @Test
-  void testHandlingFinishedContainers() {
+  public void testHandlingFinishedContainers() {
     EventHandler eventHandler = mock(EventHandler.class);
 
     AppContext context = mock(RunningAppContext.class);
@@ -3362,7 +3362,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  void testAvoidAskMoreReducersWhenReducerPreemptionIsRequired()
+  public void testAvoidAskMoreReducersWhenReducerPreemptionIsRequired()
       throws Exception {
     LOG.info("Running testAvoidAskMoreReducersWhenReducerPreemptionIsRequired");
     Configuration conf = new Configuration();
@@ -3496,7 +3496,7 @@ public class TestRMContainerAllocator {
    * calculating headroom.
    */
   @Test
-  void testExcludeSchedReducesFromHeadroom() throws Exception {
+  public void testExcludeSchedReducesFromHeadroom() throws Exception {
     LOG.info("Running testExcludeSchedReducesFromHeadroom");
     Configuration conf = new Configuration();
     conf.setInt(MRJobConfig.MR_JOB_REDUCER_UNCONDITIONAL_PREEMPT_DELAY_SEC, -1);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMContainerAllocator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMContainerAllocator.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.mapreduce.v2.app.rm;
 import static org.apache.hadoop.mapreduce.v2.app.rm.ContainerRequestCreator.createRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -148,12 +149,13 @@ import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.ControlledClock;
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.util.SystemClock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Supplier;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.InOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -166,7 +168,7 @@ public class TestRMContainerAllocator {
   static final RecordFactory recordFactory = RecordFactoryProvider
       .getRecordFactory(null);
 
-  @Before
+  @BeforeEach
   public void setup() {
     MyContainerAllocator.getJobUpdatedNodeEvents().clear();
     MyContainerAllocator.getTaskAttemptKillEvents().clear();
@@ -175,13 +177,13 @@ public class TestRMContainerAllocator {
     UserGroupInformation.setLoginUser(null);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     DefaultMetricsSystem.shutdown();
   }
 
   @Test
-  public void testSimple() throws Exception {
+  void testSimple() throws Exception {
 
     LOG.info("Running testSimple");
 
@@ -230,8 +232,8 @@ public class TestRMContainerAllocator {
     // as nodes are not added, no allocations
     List<TaskAttemptContainerAssignedEvent> assigned = allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
-    Assert.assertEquals(4, rm.getMyFifoScheduler().lastAsk.size());
+    Assertions.assertEquals(0, assigned.size(), "No of assignments must be 0");
+    Assertions.assertEquals(4, rm.getMyFifoScheduler().lastAsk.size());
 
     // send another request with different resource and priority
     ContainerRequestEvent event3 = ContainerRequestCreator.createRequest(jobId,
@@ -242,8 +244,8 @@ public class TestRMContainerAllocator {
     // as nodes are not added, no allocations
     assigned = allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
-    Assert.assertEquals(3, rm.getMyFifoScheduler().lastAsk.size());
+    Assertions.assertEquals(0, assigned.size(), "No of assignments must be 0");
+    Assertions.assertEquals(3, rm.getMyFifoScheduler().lastAsk.size());
 
     // update resources in scheduler
     nodeManager1.nodeHeartbeat(true); // Node heartbeat
@@ -253,18 +255,18 @@ public class TestRMContainerAllocator {
 
     assigned = allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals(0, rm.getMyFifoScheduler().lastAsk.size());
+    Assertions.assertEquals(0, rm.getMyFifoScheduler().lastAsk.size());
     checkAssignments(new ContainerRequestEvent[] {event1, event2, event3},
         assigned, false);
 
     // check that the assigned container requests are cancelled
     allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals(5, rm.getMyFifoScheduler().lastAsk.size());
+    Assertions.assertEquals(5, rm.getMyFifoScheduler().lastAsk.size());
   }
 
   @Test
-  public void testMapNodeLocality() throws Exception {
+  void testMapNodeLocality() throws Exception {
     // test checks that ordering of allocated containers list from the RM does
     // not affect the map->container assignment done by the AM. If there is a
     // node local container available for a map then it should be assigned to
@@ -322,7 +324,7 @@ public class TestRMContainerAllocator {
     // as nodes are not added, no allocations
     List<TaskAttemptContainerAssignedEvent> assigned = allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(), "No of assignments must be 0");
 
     // update resources in scheduler
     // Node heartbeat from rack-local first. This makes node h3 the first in the
@@ -341,7 +343,7 @@ public class TestRMContainerAllocator {
     for(TaskAttemptContainerAssignedEvent event : assigned) {
       if(event.getTaskAttemptID().equals(event3.getAttemptID())) {
         assigned.remove(event);
-        Assert.assertEquals("h3", event.getContainer().getNodeId().getHost());
+        Assertions.assertEquals("h3", event.getContainer().getNodeId().getHost());
         break;
       }
     }
@@ -350,7 +352,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  public void testResource() throws Exception {
+  void testResource() throws Exception {
 
     LOG.info("Running testResource");
 
@@ -401,7 +403,7 @@ public class TestRMContainerAllocator {
     // as nodes are not added, no allocations
     List<TaskAttemptContainerAssignedEvent> assigned = allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(), "No of assignments must be 0");
 
     // update resources in scheduler
     nodeManager1.nodeHeartbeat(true); // Node heartbeat
@@ -415,8 +417,9 @@ public class TestRMContainerAllocator {
         assigned, false);
   }
 
-  @Test(timeout = 30000)
-  public void testReducerRampdownDiagnostics() throws Exception {
+  @Test
+  @Timeout(30000)
+  void testReducerRampdownDiagnostics() throws Exception {
     LOG.info("Running tesReducerRampdownDiagnostics");
 
     final Configuration conf = new Configuration();
@@ -466,11 +469,12 @@ public class TestRMContainerAllocator {
     }
     final String killEventMessage = allocator.getTaskAttemptKillEvents().get(0)
         .getMessage();
-    Assert.assertTrue("No reducer rampDown preemption message",
-        killEventMessage.contains(RMContainerAllocator.RAMPDOWN_DIAGNOSTIC));
+    Assertions.assertTrue(killEventMessage.contains(RMContainerAllocator.RAMPDOWN_DIAGNOSTIC),
+        "No reducer rampDown preemption message");
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(30000)
   public void testPreemptReducers() throws Exception {
     LOG.info("Running testPreemptReducers");
 
@@ -513,12 +517,13 @@ public class TestRMContainerAllocator {
         mock(Container.class));
 
     allocator.preemptReducesIfNeeded();
-    Assert.assertEquals("The reducer is not preempted",
-        1, assignedRequests.preemptionWaitingReduces.size());
+    Assertions.assertEquals(1, assignedRequests.preemptionWaitingReduces.size(),
+        "The reducer is not preempted");
   }
 
-  @Test(timeout = 30000)
-  public void testNonAggressivelyPreemptReducers() throws Exception {
+  @Test
+  @Timeout(30000)
+  void testNonAggressivelyPreemptReducers() throws Exception {
     LOG.info("Running testNonAggressivelyPreemptReducers");
 
     final int preemptThreshold = 2; //sec
@@ -570,17 +575,18 @@ public class TestRMContainerAllocator {
 
     clock.setTime(clock.getTime() + 1);
     allocator.preemptReducesIfNeeded();
-    Assert.assertEquals("The reducer is aggressively preeempted", 0,
-        assignedRequests.preemptionWaitingReduces.size());
+    Assertions.assertEquals(0, assignedRequests.preemptionWaitingReduces.size(),
+        "The reducer is aggressively preeempted");
 
     clock.setTime(clock.getTime() + (preemptThreshold) * 1000);
     allocator.preemptReducesIfNeeded();
-    Assert.assertEquals("The reducer is not preeempted", 1,
-            assignedRequests.preemptionWaitingReduces.size());
+    Assertions.assertEquals(1, assignedRequests.preemptionWaitingReduces.size(),
+        "The reducer is not preeempted");
   }
 
-  @Test(timeout = 30000)
-  public void testUnconditionalPreemptReducers() throws Exception {
+  @Test
+  @Timeout(30000)
+  void testUnconditionalPreemptReducers() throws Exception {
     LOG.info("Running testForcePreemptReducers");
 
     int forcePreemptThresholdSecs = 2;
@@ -634,18 +640,19 @@ public class TestRMContainerAllocator {
 
     clock.setTime(clock.getTime() + 1);
     allocator.preemptReducesIfNeeded();
-    Assert.assertEquals("The reducer is preeempted too soon", 0,
-        assignedRequests.preemptionWaitingReduces.size());
+    Assertions.assertEquals(0, assignedRequests.preemptionWaitingReduces.size(),
+        "The reducer is preeempted too soon");
 
     clock.setTime(clock.getTime() + 1000 * forcePreemptThresholdSecs);
     allocator.preemptReducesIfNeeded();
-    Assert.assertEquals("The reducer is not preeempted", 1,
-        assignedRequests.preemptionWaitingReduces.size());
+    Assertions.assertEquals(1, assignedRequests.preemptionWaitingReduces.size(),
+        "The reducer is not preeempted");
   }
 
-  @Test(timeout = 30000)
-  public void testExcessReduceContainerAssign() throws Exception {
-  final Configuration conf = new Configuration();
+  @Test
+  @Timeout(30000)
+  void testExcessReduceContainerAssign() throws Exception {
+    final Configuration conf = new Configuration();
     conf.setFloat(MRJobConfig.COMPLETED_MAPS_FOR_REDUCE_SLOWSTART, 0.0f);
     final MyResourceManager2 rm = new MyResourceManager2(conf);
     rm.start();
@@ -692,7 +699,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  public void testMapReduceAllocationWithNodeLabelExpression() throws Exception {
+  void testMapReduceAllocationWithNodeLabelExpression() throws Exception {
 
     LOG.info("Running testMapReduceAllocationWithNodeLabelExpression");
     Configuration conf = new Configuration();
@@ -742,7 +749,7 @@ public class TestRMContainerAllocator {
     allocator.schedule();
     // verify all of the host-specific asks were sent plus one for the
     // default rack and one for the ANY request
-    Assert.assertEquals(3, mockScheduler.lastAsk.size());
+    Assertions.assertEquals(3, mockScheduler.lastAsk.size());
     // verify ResourceRequest sent for MAP have appropriate node
     // label expression as per the configuration
     validateLabelsRequests(mockScheduler.lastAsk.get(0), false);
@@ -753,7 +760,7 @@ public class TestRMContainerAllocator {
     ContainerId cid0 = mockScheduler.assignContainer("map", false);
     allocator.schedule();
     // default rack and one for the ANY request
-    Assert.assertEquals(3, mockScheduler.lastAsk.size());
+    Assertions.assertEquals(3, mockScheduler.lastAsk.size());
     validateLabelsRequests(mockScheduler.lastAsk.get(0), true);
     validateLabelsRequests(mockScheduler.lastAsk.get(1), true);
     validateLabelsRequests(mockScheduler.lastAsk.get(2), true);
@@ -768,20 +775,20 @@ public class TestRMContainerAllocator {
     case "map":
     case "reduce":
     case NetworkTopology.DEFAULT_RACK:
-      Assert.assertNull(resourceRequest.getNodeLabelExpression());
+      Assertions.assertNull(resourceRequest.getNodeLabelExpression());
       break;
     case "*":
-      Assert.assertEquals(isReduce ? "ReduceNodes" : "MapNodes",
+      Assertions.assertEquals(isReduce ? "ReduceNodes" : "MapNodes",
           resourceRequest.getNodeLabelExpression());
       break;
     default:
-      Assert.fail("Invalid resource location "
+      Assertions.fail("Invalid resource location "
           + resourceRequest.getResourceName());
     }
   }
 
   @Test
-  public void testUpdateCollectorInfo() throws Exception {
+  void testUpdateCollectorInfo() throws Exception {
     LOG.info("Running testUpdateCollectorInfo");
     Configuration conf = new Configuration();
     conf.setBoolean(YarnConfiguration.TIMELINE_SERVICE_ENABLED, true);
@@ -871,7 +878,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  public void testMapReduceScheduling() throws Exception {
+  void testMapReduceScheduling() throws Exception {
 
     LOG.info("Running testMapReduceScheduling");
 
@@ -929,7 +936,7 @@ public class TestRMContainerAllocator {
     // as nodes are not added, no allocations
     List<TaskAttemptContainerAssignedEvent> assigned = allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(), "No of assignments must be 0");
 
     // update resources in scheduler
     nodeManager1.nodeHeartbeat(true); // Node heartbeat
@@ -944,8 +951,8 @@ public class TestRMContainerAllocator {
 
     // validate that no container is assigned to h1 as it doesn't have 2048
     for (TaskAttemptContainerAssignedEvent assig : assigned) {
-      Assert.assertFalse("Assigned count not correct", "h1".equals(assig
-          .getContainer().getNodeId().getHost()));
+      Assertions.assertFalse("h1".equals(assig.getContainer().getNodeId().getHost()),
+          "Assigned count not correct");
     }
   }
 
@@ -1001,7 +1008,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  public void testReportedAppProgress() throws Exception {
+  void testReportedAppProgress() throws Exception {
 
     LOG.info("Running testReportedAppProgress");
 
@@ -1036,7 +1043,7 @@ public class TestRMContainerAllocator {
       };
     };
 
-    Assert.assertEquals(0.0, rmApp.getProgress(), 0.0);
+    Assertions.assertEquals(0.0, rmApp.getProgress(), 0.0);
 
     mrApp.submit(conf);
     Job job = mrApp.getContext().getAllJobs().entrySet().iterator().next()
@@ -1075,23 +1082,23 @@ public class TestRMContainerAllocator {
 
     allocator.schedule(); // Send heartbeat
     rm.drainEvents();
-    Assert.assertEquals(0.05f, job.getProgress(), 0.001f);
-    Assert.assertEquals(0.05f, rmApp.getProgress(), 0.001f);
+    Assertions.assertEquals(0.05f, job.getProgress(), 0.001f);
+    Assertions.assertEquals(0.05f, rmApp.getProgress(), 0.001f);
 
     // Finish off 1 map.
     Iterator<Task> it = job.getTasks().values().iterator();
     finishNextNTasks(rmDispatcher, amNodeManager, mrApp, it, 1);
     allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals(0.095f, job.getProgress(), 0.001f);
-    Assert.assertEquals(0.095f, rmApp.getProgress(), 0.001f);
+    Assertions.assertEquals(0.095f, job.getProgress(), 0.001f);
+    Assertions.assertEquals(0.095f, rmApp.getProgress(), 0.001f);
 
     // Finish off 7 more so that map-progress is 80%
     finishNextNTasks(rmDispatcher, amNodeManager, mrApp, it, 7);
     allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals(0.41f, job.getProgress(), 0.001f);
-    Assert.assertEquals(0.41f, rmApp.getProgress(), 0.001f);
+    Assertions.assertEquals(0.41f, job.getProgress(), 0.001f);
+    Assertions.assertEquals(0.41f, rmApp.getProgress(), 0.001f);
 
     // Finish off the 2 remaining maps
     finishNextNTasks(rmDispatcher, amNodeManager, mrApp, it, 2);
@@ -1115,16 +1122,16 @@ public class TestRMContainerAllocator {
 
     allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals(0.59f, job.getProgress(), 0.001f);
-    Assert.assertEquals(0.59f, rmApp.getProgress(), 0.001f);
+    Assertions.assertEquals(0.59f, job.getProgress(), 0.001f);
+    Assertions.assertEquals(0.59f, rmApp.getProgress(), 0.001f);
 
     // Finish off the remaining 8 reduces.
     finishNextNTasks(rmDispatcher, amNodeManager, mrApp, it, 8);
     allocator.schedule();
     rm.drainEvents();
     // Remaining is JobCleanup
-    Assert.assertEquals(0.95f, job.getProgress(), 0.001f);
-    Assert.assertEquals(0.95f, rmApp.getProgress(), 0.001f);
+    Assertions.assertEquals(0.95f, job.getProgress(), 0.001f);
+    Assertions.assertEquals(0.95f, rmApp.getProgress(), 0.001f);
   }
 
   private void finishNextNTasks(DrainDispatcher rmDispatcher, MockNM node,
@@ -1153,7 +1160,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  public void testReportedAppProgressWithOnlyMaps() throws Exception {
+  void testReportedAppProgressWithOnlyMaps() throws Exception {
 
     LOG.info("Running testReportedAppProgressWithOnlyMaps");
 
@@ -1188,7 +1195,7 @@ public class TestRMContainerAllocator {
       };
     };
 
-    Assert.assertEquals(0.0, rmApp.getProgress(), 0.0);
+    Assertions.assertEquals(0.0, rmApp.getProgress(), 0.0);
 
     mrApp.submit(conf);
     Job job = mrApp.getContext().getAllJobs().entrySet().iterator().next()
@@ -1223,8 +1230,8 @@ public class TestRMContainerAllocator {
 
     allocator.schedule(); // Send heartbeat
     rm.drainEvents();
-    Assert.assertEquals(0.05f, job.getProgress(), 0.001f);
-    Assert.assertEquals(0.05f, rmApp.getProgress(), 0.001f);
+    Assertions.assertEquals(0.05f, job.getProgress(), 0.001f);
+    Assertions.assertEquals(0.05f, rmApp.getProgress(), 0.001f);
 
     Iterator<Task> it = job.getTasks().values().iterator();
 
@@ -1232,26 +1239,26 @@ public class TestRMContainerAllocator {
     finishNextNTasks(rmDispatcher, amNodeManager, mrApp, it, 1);
     allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals(0.14f, job.getProgress(), 0.001f);
-    Assert.assertEquals(0.14f, rmApp.getProgress(), 0.001f);
+    Assertions.assertEquals(0.14f, job.getProgress(), 0.001f);
+    Assertions.assertEquals(0.14f, rmApp.getProgress(), 0.001f);
 
     // Finish off 5 more map so that map-progress is 60%
     finishNextNTasks(rmDispatcher, amNodeManager, mrApp, it, 5);
     allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals(0.59f, job.getProgress(), 0.001f);
-    Assert.assertEquals(0.59f, rmApp.getProgress(), 0.001f);
+    Assertions.assertEquals(0.59f, job.getProgress(), 0.001f);
+    Assertions.assertEquals(0.59f, rmApp.getProgress(), 0.001f);
 
     // Finish off remaining map so that map-progress is 100%
     finishNextNTasks(rmDispatcher, amNodeManager, mrApp, it, 4);
     allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals(0.95f, job.getProgress(), 0.001f);
-    Assert.assertEquals(0.95f, rmApp.getProgress(), 0.001f);
+    Assertions.assertEquals(0.95f, job.getProgress(), 0.001f);
+    Assertions.assertEquals(0.95f, rmApp.getProgress(), 0.001f);
   }
 
   @Test
-  public void testUpdatedNodes() throws Exception {
+  void testUpdatedNodes() throws Exception {
     Configuration conf = new Configuration();
     MyResourceManager rm = new MyResourceManager(conf);
     rm.start();
@@ -1298,17 +1305,17 @@ public class TestRMContainerAllocator {
 
     nm1.nodeHeartbeat(true);
     rm.drainEvents();
-    Assert.assertEquals(1, allocator.getJobUpdatedNodeEvents().size());
-    Assert.assertEquals(3, allocator.getJobUpdatedNodeEvents().get(0).getUpdatedNodes().size());
+    Assertions.assertEquals(1, allocator.getJobUpdatedNodeEvents().size());
+    Assertions.assertEquals(3, allocator.getJobUpdatedNodeEvents().get(0).getUpdatedNodes().size());
     allocator.getJobUpdatedNodeEvents().clear();
     // get the assignment
     assigned = allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals(1, assigned.size());
-    Assert.assertEquals(nm1.getNodeId(), assigned.get(0).getContainer().getNodeId());
+    Assertions.assertEquals(1, assigned.size());
+    Assertions.assertEquals(nm1.getNodeId(), assigned.get(0).getContainer().getNodeId());
     // no updated nodes reported
-    Assert.assertTrue(allocator.getJobUpdatedNodeEvents().isEmpty());
-    Assert.assertTrue(allocator.getTaskAttemptKillEvents().isEmpty());
+    Assertions.assertTrue(allocator.getJobUpdatedNodeEvents().isEmpty());
+    Assertions.assertTrue(allocator.getTaskAttemptKillEvents().isEmpty());
 
     // mark nodes bad
     nm1.nodeHeartbeat(false);
@@ -1318,27 +1325,27 @@ public class TestRMContainerAllocator {
     // schedule response returns updated nodes
     assigned = allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals(0, assigned.size());
+    Assertions.assertEquals(0, assigned.size());
     // updated nodes are reported
-    Assert.assertEquals(1, allocator.getJobUpdatedNodeEvents().size());
-    Assert.assertEquals(1, allocator.getTaskAttemptKillEvents().size());
-    Assert.assertEquals(2,
+    Assertions.assertEquals(1, allocator.getJobUpdatedNodeEvents().size());
+    Assertions.assertEquals(1, allocator.getTaskAttemptKillEvents().size());
+    Assertions.assertEquals(2,
         allocator.getJobUpdatedNodeEvents().get(0).getUpdatedNodes().size());
-    Assert.assertEquals(attemptId,
+    Assertions.assertEquals(attemptId,
         allocator.getTaskAttemptKillEvents().get(0).getTaskAttemptID());
     allocator.getJobUpdatedNodeEvents().clear();
     allocator.getTaskAttemptKillEvents().clear();
 
     assigned = allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals(0, assigned.size());
+    Assertions.assertEquals(0, assigned.size());
     // no updated nodes reported
-    Assert.assertTrue(allocator.getJobUpdatedNodeEvents().isEmpty());
-    Assert.assertTrue(allocator.getTaskAttemptKillEvents().isEmpty());
+    Assertions.assertTrue(allocator.getJobUpdatedNodeEvents().isEmpty());
+    Assertions.assertTrue(allocator.getTaskAttemptKillEvents().isEmpty());
   }
 
   @Test
-  public void testBlackListedNodes() throws Exception {
+  void testBlackListedNodes() throws Exception {
 
     LOG.info("Running testBlackListedNodes");
 
@@ -1403,7 +1410,7 @@ public class TestRMContainerAllocator {
     // as nodes are not added, no allocations
     List<TaskAttemptContainerAssignedEvent> assigned = allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(), "No of assignments must be 0");
 
     // Send events to blacklist nodes h1 and h2
     ContainerFailedEvent f1 = createFailEvent(jobId, 1, "h1", false);
@@ -1417,9 +1424,9 @@ public class TestRMContainerAllocator {
     rm.drainEvents();
 
     assigned = allocator.schedule();
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(), "No of assignments must be 0");
     rm.drainEvents();
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(), "No of assignments must be 0");
     assertBlacklistAdditionsAndRemovals(2, 0, rm);
 
     // mark h1/h2 as bad nodes
@@ -1430,7 +1437,7 @@ public class TestRMContainerAllocator {
     assigned = allocator.schedule();
     rm.drainEvents();
     assertBlacklistAdditionsAndRemovals(0, 0, rm);
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(), "No of assignments must be 0");
 
     nodeManager3.nodeHeartbeat(true); // Node heartbeat
     rm.drainEvents();
@@ -1438,17 +1445,17 @@ public class TestRMContainerAllocator {
     rm.drainEvents();
     assertBlacklistAdditionsAndRemovals(0, 0, rm);
 
-    Assert.assertTrue("No of assignments must be 3", assigned.size() == 3);
+    Assertions.assertTrue(assigned.size() == 3, "No of assignments must be 3");
 
     // validate that all containers are assigned to h3
     for (TaskAttemptContainerAssignedEvent assig : assigned) {
-      Assert.assertTrue("Assigned container host not correct", "h3".equals(assig
-          .getContainer().getNodeId().getHost()));
+      Assertions.assertTrue("h3".equals(assig.getContainer().getNodeId().getHost()),
+          "Assigned container host not correct");
     }
   }
 
   @Test
-  public void testIgnoreBlacklisting() throws Exception {
+  void testIgnoreBlacklisting() throws Exception {
     LOG.info("Running testIgnoreBlacklisting");
 
     Configuration conf = new Configuration();
@@ -1488,7 +1495,8 @@ public class TestRMContainerAllocator {
     assigned =
         getContainerOnHost(jobId, 1, 1024, new String[] {"h1"},
             nodeManagers[0], allocator, 0, 0, 0, 0, rm);
-    Assert.assertEquals("No of assignments must be 1", 1, assigned.size());
+    Assertions.assertEquals(1, assigned.size(),
+        "No of assignments must be 1");
 
     LOG.info("Failing container _1 on H1 (Node should be blacklisted and"
         + " ignore blacklisting enabled");
@@ -1503,47 +1511,51 @@ public class TestRMContainerAllocator {
     assigned =
         getContainerOnHost(jobId, 2, 1024, new String[] {"h1"},
             nodeManagers[0], allocator, 1, 0, 0, 1, rm);
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(),
+            "No of assignments must be 0");
 
     // Known=1, blacklisted=1, ignore should be true - assign 1
     assigned =
         getContainerOnHost(jobId, 2, 1024, new String[] {"h1"},
             nodeManagers[0], allocator, 0, 0, 0, 0, rm);
-    Assert.assertEquals("No of assignments must be 1", 1, assigned.size());
+    Assertions.assertEquals(1, assigned.size(),
+        "No of assignments must be 1");
 
     nodeManagers[nmNum] = registerNodeManager(nmNum++, rm);
     // Known=2, blacklisted=1, ignore should be true - assign 1 anyway.
     assigned =
         getContainerOnHost(jobId, 3, 1024, new String[] {"h2"},
             nodeManagers[1], allocator, 0, 0, 0, 0, rm);
-    Assert.assertEquals("No of assignments must be 1", 1, assigned.size());
+    Assertions.assertEquals(1, assigned.size(),
+        "No of assignments must be 1");
 
     nodeManagers[nmNum] = registerNodeManager(nmNum++, rm);
     // Known=3, blacklisted=1, ignore should be true - assign 1 anyway.
     assigned =
         getContainerOnHost(jobId, 4, 1024, new String[] {"h3"},
             nodeManagers[2], allocator, 0, 0, 0, 0, rm);
-    Assert.assertEquals("No of assignments must be 1", 1, assigned.size());
+    Assertions.assertEquals(1, assigned.size(),
+        "No of assignments must be 1");
 
     // Known=3, blacklisted=1, ignore should be true - assign 1
     assigned =
         getContainerOnHost(jobId, 5, 1024, new String[] {"h1"},
             nodeManagers[0], allocator, 0, 0, 0, 0, rm);
-    Assert.assertEquals("No of assignments must be 1", 1, assigned.size());
+    Assertions.assertEquals(1, assigned.size(), "No of assignments must be 1");
 
     nodeManagers[nmNum] = registerNodeManager(nmNum++, rm);
     // Known=4, blacklisted=1, ignore should be false - assign 1 anyway
     assigned =
         getContainerOnHost(jobId, 6, 1024, new String[] {"h4"},
             nodeManagers[3], allocator, 0, 0, 1, 0, rm);
-    Assert.assertEquals("No of assignments must be 1", 1, assigned.size());
+    Assertions.assertEquals(1, assigned.size(), "No of assignments must be 1");
 
     // Test blacklisting re-enabled.
     // Known=4, blacklisted=1, ignore should be false - no assignment on h1
     assigned =
         getContainerOnHost(jobId, 7, 1024, new String[] {"h1"},
             nodeManagers[0], allocator, 0, 0, 0, 0, rm);
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(), "No of assignments must be 0");
     // RMContainerRequestor would have created a replacement request.
 
     // Blacklist h2
@@ -1556,20 +1568,20 @@ public class TestRMContainerAllocator {
     assigned =
         getContainerOnHost(jobId, 8, 1024, new String[] {"h1"},
             nodeManagers[0], allocator, 1, 0, 0, 2, rm);
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(), "No of assignments must be 0");
 
     // Known=4, blacklisted=2, ignore should be true. Should assign 2
     // containers.
     assigned =
         getContainerOnHost(jobId, 8, 1024, new String[] {"h1"},
             nodeManagers[0], allocator, 0, 0, 0, 0, rm);
-    Assert.assertEquals("No of assignments must be 2", 2, assigned.size());
+    Assertions.assertEquals(2, assigned.size(), "No of assignments must be 2");
 
     // Known=4, blacklisted=2, ignore should be true.
     assigned =
         getContainerOnHost(jobId, 9, 1024, new String[] {"h2"},
             nodeManagers[1], allocator, 0, 0, 0, 0, rm);
-    Assert.assertEquals("No of assignments must be 1", 1, assigned.size());
+    Assertions.assertEquals(1, assigned.size(), "No of assignments must be 1");
 
     // Test blacklist while ignore blacklisting enabled
     ContainerFailedEvent f3 = createFailEvent(jobId, 4, "h3", false);
@@ -1580,7 +1592,7 @@ public class TestRMContainerAllocator {
     assigned =
         getContainerOnHost(jobId, 10, 1024, new String[] {"h3"},
             nodeManagers[2], allocator, 0, 0, 0, 0, rm);
-    Assert.assertEquals("No of assignments must be 1", 1, assigned.size());
+    Assertions.assertEquals(1, assigned.size(), "No of assignments must be 1");
 
     // Assign on 5 more nodes - to re-enable blacklisting
     for (int i = 0; i < 5; i++) {
@@ -1589,14 +1601,15 @@ public class TestRMContainerAllocator {
           getContainerOnHost(jobId, 11 + i, 1024,
               new String[] {String.valueOf(5 + i)}, nodeManagers[4 + i],
               allocator, 0, 0, (i == 4 ? 3 : 0), 0, rm);
-      Assert.assertEquals("No of assignments must be 1", 1, assigned.size());
+      Assertions.assertEquals(1, assigned.size(), "No of assignments must be 1");
     }
 
     // Test h3 (blacklisted while ignoring blacklisting) is blacklisted.
     assigned =
         getContainerOnHost(jobId, 20, 1024, new String[] {"h3"},
             nodeManagers[2], allocator, 0, 0, 0, 0, rm);
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(),
+            "No of assignments must be 0");
   }
 
   private MockNM registerNodeManager(int i, MyResourceManager rm)
@@ -1623,7 +1636,8 @@ public class TestRMContainerAllocator {
     rm.drainEvents();
     assertBlacklistAdditionsAndRemovals(
         expectedAdditions1, expectedRemovals1, rm);
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(),
+        "No of assignments must be 0");
 
     // Heartbeat from the required nodeManager
     mockNM.nodeHeartbeat(true);
@@ -1637,7 +1651,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  public void testBlackListedNodesWithSchedulingToThatNode() throws Exception {
+  void testBlackListedNodesWithSchedulingToThatNode() throws Exception {
     LOG.info("Running testBlackListedNodesWithSchedulingToThatNode");
 
     Configuration conf = new Configuration();
@@ -1688,7 +1702,8 @@ public class TestRMContainerAllocator {
     // as nodes are not added, no allocations
     List<TaskAttemptContainerAssignedEvent> assigned = allocator.schedule();
     rm.drainEvents();
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(),
+        "No of assignments must be 0");
 
     LOG.info("h1 Heartbeat (To actually schedule the containers)");
     // update resources in scheduler
@@ -1699,7 +1714,8 @@ public class TestRMContainerAllocator {
     assigned = allocator.schedule();
     rm.drainEvents();
     assertBlacklistAdditionsAndRemovals(0, 0, rm);
-    Assert.assertEquals("No of assignments must be 1", 1, assigned.size());
+    Assertions.assertEquals(1, assigned.size(),
+        "No of assignments must be 1");
 
     LOG.info("Failing container _1 on H1 (should blacklist the node)");
     // Send events to blacklist nodes h1 and h2
@@ -1717,7 +1733,8 @@ public class TestRMContainerAllocator {
     assigned = allocator.schedule();
     rm.drainEvents();
     assertBlacklistAdditionsAndRemovals(1, 0, rm);
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(),
+        "No of assignments must be 0");
 
     // send another request with different resource and priority
     ContainerRequestEvent event3 =
@@ -1738,7 +1755,8 @@ public class TestRMContainerAllocator {
     assigned = allocator.schedule();
     rm.drainEvents();
     assertBlacklistAdditionsAndRemovals(0, 0, rm);
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(),
+        "No of assignments must be 0");
 
     //RMContainerAllocator gets assigned a p:5 on a blacklisted node.
 
@@ -1747,7 +1765,8 @@ public class TestRMContainerAllocator {
     assigned = allocator.schedule();
     rm.drainEvents();
     assertBlacklistAdditionsAndRemovals(0, 0, rm);
-    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+    Assertions.assertEquals(0, assigned.size(),
+        "No of assignments must be 0");
 
     //Hearbeat from H3 to schedule on this host.
     LOG.info("h3 Heartbeat (To re-schedule the containers)");
@@ -1766,27 +1785,29 @@ public class TestRMContainerAllocator {
           " with priority " + assig.getContainer().getPriority());
     }
 
-    Assert.assertEquals("No of assignments must be 2", 2, assigned.size());
+    Assertions.assertEquals(2, assigned.size(),
+        "No of assignments must be 2");
 
     // validate that all containers are assigned to h3
     for (TaskAttemptContainerAssignedEvent assig : assigned) {
-      Assert.assertEquals("Assigned container " + assig.getContainer().getId()
-          + " host not correct", "h3", assig.getContainer().getNodeId().getHost());
+      Assertions.assertEquals("h3", assig.getContainer().getNodeId().getHost(),
+          "Assigned container " + assig.getContainer().getId()
+              + " host not correct");
     }
   }
 
   private static void assertBlacklistAdditionsAndRemovals(
       int expectedAdditions, int expectedRemovals, MyResourceManager rm) {
-    Assert.assertEquals(expectedAdditions,
+    Assertions.assertEquals(expectedAdditions,
         rm.getMyFifoScheduler().lastBlacklistAdditions.size());
-    Assert.assertEquals(expectedRemovals,
+    Assertions.assertEquals(expectedRemovals,
         rm.getMyFifoScheduler().lastBlacklistRemovals.size());
   }
 
   private static void assertAsksAndReleases(int expectedAsk,
       int expectedRelease, MyResourceManager rm) {
-    Assert.assertEquals(expectedAsk, rm.getMyFifoScheduler().lastAsk.size());
-    Assert.assertEquals(expectedRelease,
+    Assertions.assertEquals(expectedAsk, rm.getMyFifoScheduler().lastAsk.size());
+    Assertions.assertEquals(expectedRelease,
         rm.getMyFifoScheduler().lastRelease.size());
   }
 
@@ -1929,17 +1950,17 @@ public class TestRMContainerAllocator {
   private void checkAssignments(ContainerRequestEvent[] requests,
       List<TaskAttemptContainerAssignedEvent> assignments,
       boolean checkHostMatch) {
-    Assert.assertNotNull("Container not assigned", assignments);
-    Assert.assertEquals("Assigned count not correct", requests.length,
-        assignments.size());
+    Assertions.assertNotNull(assignments, "Container not assigned");
+    Assertions.assertEquals(requests.length, assignments.size(),
+        "Assigned count not correct");
 
     // check for uniqueness of containerIDs
     Set<ContainerId> containerIds = new HashSet<ContainerId>();
     for (TaskAttemptContainerAssignedEvent assigned : assignments) {
       containerIds.add(assigned.getContainer().getId());
     }
-    Assert.assertEquals("Assigned containers must be different", assignments
-        .size(), containerIds.size());
+    Assertions.assertEquals(assignments.size(), containerIds.size(),
+        "Assigned containers must be different");
 
     // check for all assignment
     for (ContainerRequestEvent req : requests) {
@@ -1956,14 +1977,14 @@ public class TestRMContainerAllocator {
 
   private void checkAssignment(ContainerRequestEvent request,
       TaskAttemptContainerAssignedEvent assigned, boolean checkHostMatch) {
-    Assert.assertNotNull("Nothing assigned to attempt "
-        + request.getAttemptID(), assigned);
-    Assert.assertEquals("assigned to wrong attempt", request.getAttemptID(),
-        assigned.getTaskAttemptID());
+    Assertions.assertNotNull(assigned, "Nothing assigned to attempt "
+        + request.getAttemptID());
+    Assertions.assertEquals(request.getAttemptID(), assigned.getTaskAttemptID(),
+        "assigned to wrong attempt");
     if (checkHostMatch) {
-      Assert.assertTrue("Not assigned to requested host", Arrays.asList(
-          request.getHosts()).contains(
-          assigned.getContainer().getNodeId().getHost()));
+      Assertions.assertTrue(Arrays.asList(request.getHosts()).contains(
+          assigned.getContainer().getNodeId().getHost()),
+          "Not assigned to requested host");
     }
   }
 
@@ -2163,7 +2184,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  public void testIfApplicationPriorityIsNotSet() {
+  void testIfApplicationPriorityIsNotSet() {
     Job mockJob = mock(Job.class);
     RMCommunicator communicator = mock(RMCommunicator.class);
     ClientService service = mock(ClientService.class);
@@ -2177,7 +2198,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  public void testReduceScheduling() throws Exception {
+  void testReduceScheduling() throws Exception {
     int totalMaps = 10;
     int succeededMaps = 1;
     int scheduledMaps = 10;
@@ -2315,7 +2336,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  public void testCompletedTasksRecalculateSchedule() throws Exception {
+  void testCompletedTasksRecalculateSchedule() throws Exception {
     LOG.info("Running testCompletedTasksRecalculateSchedule");
 
     Configuration conf = new Configuration();
@@ -2350,17 +2371,17 @@ public class TestRMContainerAllocator {
 
     allocator.recalculatedReduceSchedule = false;
     allocator.schedule();
-    Assert.assertFalse("Unexpected recalculate of reduce schedule",
-        allocator.recalculatedReduceSchedule);
+    Assertions.assertFalse(allocator.recalculatedReduceSchedule,
+        "Unexpected recalculate of reduce schedule");
 
     doReturn(1).when(job).getCompletedMaps();
     allocator.schedule();
-    Assert.assertTrue("Expected recalculate of reduce schedule",
-        allocator.recalculatedReduceSchedule);
+    Assertions.assertTrue(allocator.recalculatedReduceSchedule,
+        "Expected recalculate of reduce schedule");
   }
 
   @Test
-  public void testHeartbeatHandler() throws Exception {
+  void testHeartbeatHandler() throws Exception {
     LOG.info("Running testHeartbeatHandler");
 
     Configuration conf = new Configuration();
@@ -2394,14 +2415,14 @@ public class TestRMContainerAllocator {
       Thread.sleep(10);
       timeToWaitMs -= 10;
     }
-    Assert.assertEquals(5, allocator.getLastHeartbeatTime());
+    Assertions.assertEquals(5, allocator.getLastHeartbeatTime());
     clock.setTime(7);
     timeToWaitMs = 5000;
     while (allocator.getLastHeartbeatTime() != 7 && timeToWaitMs > 0) {
       Thread.sleep(10);
       timeToWaitMs -= 10;
     }
-    Assert.assertEquals(7, allocator.getLastHeartbeatTime());
+    Assertions.assertEquals(7, allocator.getLastHeartbeatTime());
 
     final AtomicBoolean callbackCalled = new AtomicBoolean(false);
     allocator.runOnNextHeartbeat(new Runnable() {
@@ -2416,12 +2437,12 @@ public class TestRMContainerAllocator {
       Thread.sleep(10);
       timeToWaitMs -= 10;
     }
-    Assert.assertEquals(8, allocator.getLastHeartbeatTime());
-    Assert.assertTrue(callbackCalled.get());
+    Assertions.assertEquals(8, allocator.getLastHeartbeatTime());
+    Assertions.assertTrue(callbackCalled.get());
   }
 
   @Test
-  public void testCompletedContainerEvent() {
+  void testCompletedContainerEvent() {
     RMContainerAllocator allocator = new RMContainerAllocator(
         mock(ClientService.class), mock(AppContext.class),
         new NoopAMPreemptionPolicy());
@@ -2445,12 +2466,12 @@ public class TestRMContainerAllocator {
 
     TaskAttemptEvent event = allocator.createContainerFinishedEvent(status,
         attemptId);
-    Assert.assertEquals(TaskAttemptEventType.TA_CONTAINER_COMPLETED,
+    Assertions.assertEquals(TaskAttemptEventType.TA_CONTAINER_COMPLETED,
         event.getType());
 
     TaskAttemptEvent abortedEvent = allocator.createContainerFinishedEvent(
         abortedStatus, attemptId);
-    Assert.assertEquals(TaskAttemptEventType.TA_KILL, abortedEvent.getType());
+    Assertions.assertEquals(TaskAttemptEventType.TA_KILL, abortedEvent.getType());
 
     // PREEMPTED
     ContainerId containerId2 =
@@ -2463,12 +2484,12 @@ public class TestRMContainerAllocator {
 
     TaskAttemptEvent event2 = allocator.createContainerFinishedEvent(status2,
         attemptId);
-    Assert.assertEquals(TaskAttemptEventType.TA_CONTAINER_COMPLETED,
+    Assertions.assertEquals(TaskAttemptEventType.TA_CONTAINER_COMPLETED,
         event2.getType());
 
     TaskAttemptEvent abortedEvent2 = allocator.createContainerFinishedEvent(
         preemptedStatus, attemptId);
-    Assert.assertEquals(TaskAttemptEventType.TA_KILL, abortedEvent2.getType());
+    Assertions.assertEquals(TaskAttemptEventType.TA_KILL, abortedEvent2.getType());
 
     // KILLED_BY_CONTAINER_SCHEDULER
     ContainerId containerId3 =
@@ -2482,16 +2503,16 @@ public class TestRMContainerAllocator {
 
     TaskAttemptEvent event3 = allocator.createContainerFinishedEvent(status3,
         attemptId);
-    Assert.assertEquals(TaskAttemptEventType.TA_CONTAINER_COMPLETED,
+    Assertions.assertEquals(TaskAttemptEventType.TA_CONTAINER_COMPLETED,
         event3.getType());
 
     TaskAttemptEvent abortedEvent3 = allocator.createContainerFinishedEvent(
         killedByContainerSchedulerStatus, attemptId);
-    Assert.assertEquals(TaskAttemptEventType.TA_KILL, abortedEvent3.getType());
+    Assertions.assertEquals(TaskAttemptEventType.TA_KILL, abortedEvent3.getType());
   }
 
   @Test
-  public void testUnregistrationOnlyIfRegistered() throws Exception {
+  void testUnregistrationOnlyIfRegistered() throws Exception {
     Configuration conf = new Configuration();
     final MyResourceManager rm = new MyResourceManager(conf);
     rm.start();
@@ -2528,9 +2549,9 @@ public class TestRMContainerAllocator {
     MyContainerAllocator allocator =
         (MyContainerAllocator) mrApp.getContainerAllocator();
     amDispatcher.await();
-    Assert.assertTrue(allocator.isApplicationMasterRegistered());
+    Assertions.assertTrue(allocator.isApplicationMasterRegistered());
     mrApp.stop();
-    Assert.assertTrue(allocator.isUnregistered());
+    Assertions.assertTrue(allocator.isUnregistered());
   }
 
   // Step-1 : AM send allocate request for 2 ContainerRequests and 1
@@ -2546,7 +2567,7 @@ public class TestRMContainerAllocator {
   // and another containerRequest(event5)
   // Step-6 : RM allocates containers i.e event3,event4 and cRequest5
   @Test
-  public void testRMContainerAllocatorResendsRequestsOnRMRestart()
+  void testRMContainerAllocatorResendsRequestsOnRMRestart()
       throws Exception {
 
     Configuration conf = new Configuration();
@@ -2610,8 +2631,8 @@ public class TestRMContainerAllocator {
     List<TaskAttemptContainerAssignedEvent> assignedContainers =
         allocator.schedule();
     rm1.drainEvents();
-    Assert.assertEquals("No of assignments must be 0", 0,
-        assignedContainers.size());
+    Assertions.assertEquals(0, assignedContainers.size(),
+        "No of assignments must be 0");
     // Why ask is 3, not 4? --> ask from blacklisted node h2 is removed
     assertAsksAndReleases(3, 0, rm1);
     assertBlacklistAdditionsAndRemovals(1, 0, rm1);
@@ -2622,14 +2643,14 @@ public class TestRMContainerAllocator {
     // Step-2 : 2 containers are allocated by RM.
     assignedContainers = allocator.schedule();
     rm1.drainEvents();
-    Assert.assertEquals("No of assignments must be 2", 2,
-        assignedContainers.size());
+    Assertions.assertEquals(2, assignedContainers.size(),
+        "No of assignments must be 2");
     assertAsksAndReleases(0, 0, rm1);
     assertBlacklistAdditionsAndRemovals(0, 0, rm1);
 
     assignedContainers = allocator.schedule();
-    Assert.assertEquals("No of assignments must be 0", 0,
-        assignedContainers.size());
+    Assertions.assertEquals(0, assignedContainers.size(),
+        "No of assignments must be 0");
     assertAsksAndReleases(3, 0, rm1);
     assertBlacklistAdditionsAndRemovals(0, 0, rm1);
 
@@ -2648,8 +2669,8 @@ public class TestRMContainerAllocator {
     allocator.sendDeallocate(deallocate1);
 
     assignedContainers = allocator.schedule();
-    Assert.assertEquals("No of assignments must be 0", 0,
-        assignedContainers.size());
+    Assertions.assertEquals(0, assignedContainers.size(),
+        "No of assignments must be 0");
     assertAsksAndReleases(3, 1, rm1);
     assertBlacklistAdditionsAndRemovals(0, 0, rm1);
 
@@ -2661,7 +2682,7 @@ public class TestRMContainerAllocator {
 
     // NM should be rebooted on heartbeat, even first heartbeat for nm2
     NodeHeartbeatResponse hbResponse = nm1.nodeHeartbeat(true);
-    Assert.assertEquals(NodeAction.RESYNC, hbResponse.getNodeAction());
+    Assertions.assertEquals(NodeAction.RESYNC, hbResponse.getNodeAction());
 
     // new NM to represent NM re-register
     nm1 = new MockNM("h1:1234", 10240, rm2.getResourceTrackerService());
@@ -2714,12 +2735,12 @@ public class TestRMContainerAllocator {
     assignedContainers = allocator.schedule();
     rm2.drainEvents();
 
-    Assert.assertEquals("Number of container should be 3", 3,
-        assignedContainers.size());
+    Assertions.assertEquals(3, assignedContainers.size(),
+        "Number of container should be 3");
 
     for (TaskAttemptContainerAssignedEvent assig : assignedContainers) {
-      Assert.assertTrue("Assigned count not correct",
-          "h1".equals(assig.getContainer().getNodeId().getHost()));
+      Assertions.assertTrue("h1".equals(assig.getContainer().getNodeId().getHost()),
+          "Assigned count not correct");
     }
 
     rm1.stop();
@@ -2728,7 +2749,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  public void testUnsupportedMapContainerRequirement() throws Exception {
+  void testUnsupportedMapContainerRequirement() throws Exception {
     final Resource maxContainerSupported = Resource.newInstance(1, 1);
 
     final ApplicationId appId = ApplicationId.newInstance(1, 1);
@@ -2763,11 +2784,11 @@ public class TestRMContainerAllocator {
     allocator.sendRequests(Arrays.asList(mapRequestEvt));
     allocator.schedule();
 
-    Assert.assertEquals(0, mockScheduler.lastAnyAskMap);
+    Assertions.assertEquals(0, mockScheduler.lastAnyAskMap);
   }
 
   @Test
-  public void testUnsupportedReduceContainerRequirement() throws Exception {
+  void testUnsupportedReduceContainerRequirement() throws Exception {
     final Resource maxContainerSupported = Resource.newInstance(1, 1);
 
     final ApplicationId appId = ApplicationId.newInstance(1, 1);
@@ -2806,11 +2827,11 @@ public class TestRMContainerAllocator {
     allocator.scheduleAllReduces();
     allocator.schedule();
 
-    Assert.assertEquals(0, mockScheduler.lastAnyAskReduce);
+    Assertions.assertEquals(0, mockScheduler.lastAnyAskReduce);
   }
 
   @Test
-  public void testRMUnavailable()
+  void testRMUnavailable()
       throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(
@@ -2841,20 +2862,21 @@ public class TestRMContainerAllocator {
     allocator.jobEvents.clear();
     try {
       allocator.schedule();
-      Assert.fail("Should Have Exception");
+      Assertions.fail("Should Have Exception");
     } catch (RMContainerAllocationException e) {
-      Assert.assertTrue(e.getMessage().contains("Could not contact RM after"));
+      Assertions.assertTrue(e.getMessage().contains("Could not contact RM after"));
     }
     rm1.drainEvents();
-    Assert.assertEquals("Should Have 1 Job Event", 1,
-        allocator.jobEvents.size());
+    Assertions.assertEquals(1, allocator.jobEvents.size(),
+        "Should Have 1 Job Event");
     JobEvent event = allocator.jobEvents.get(0);
-    Assert.assertTrue("Should Reboot",
-        event.getType().equals(JobEventType.JOB_AM_REBOOT));
+    Assertions.assertTrue(event.getType().equals(JobEventType.JOB_AM_REBOOT),
+        "Should Reboot");
   }
 
-  @Test(timeout=60000)
-  public void testAMRMTokenUpdate() throws Exception {
+  @Test
+  @Timeout(60000)
+  void testAMRMTokenUpdate() throws Exception {
     LOG.info("Running testAMRMTokenUpdate");
 
     final String rmAddr = "somermaddress:1234";
@@ -2891,7 +2913,7 @@ public class TestRMContainerAllocator {
 
     final Token<AMRMTokenIdentifier> oldToken = rm.getRMContext().getRMApps()
         .get(appId).getRMAppAttempt(appAttemptId).getAMRMToken();
-    Assert.assertNotNull("app should have a token", oldToken);
+    Assertions.assertNotNull(oldToken, "app should have a token");
     UserGroupInformation testUgi = UserGroupInformation.createUserForTesting(
         "someuser", new String[0]);
     Token<AMRMTokenIdentifier> newToken = testUgi.doAs(
@@ -2906,7 +2928,7 @@ public class TestRMContainerAllocator {
             long startTime = Time.monotonicNow();
             while (currentToken == oldToken) {
               if (Time.monotonicNow() - startTime > 20000) {
-                Assert.fail("Took to long to see AMRM token change");
+                Assertions.fail("Took to long to see AMRM token change");
               }
               Thread.sleep(100);
               allocator.schedule();
@@ -2929,17 +2951,17 @@ public class TestRMContainerAllocator {
       }
     }
 
-    Assert.assertEquals("too many AMRM tokens", 1, tokenCount);
-    Assert.assertArrayEquals("token identifier not updated",
-        newToken.getIdentifier(), ugiToken.getIdentifier());
-    Assert.assertArrayEquals("token password not updated",
-        newToken.getPassword(), ugiToken.getPassword());
-    Assert.assertEquals("AMRM token service not updated",
-        new Text(rmAddr), ugiToken.getService());
+    Assertions.assertEquals(1, tokenCount, "too many AMRM tokens");
+    Assertions.assertArrayEquals(newToken.getIdentifier(), ugiToken.getIdentifier(),
+        "token identifier not updated");
+    Assertions.assertArrayEquals(newToken.getPassword(), ugiToken.getPassword(),
+        "token password not updated");
+    Assertions.assertEquals(new Text(rmAddr), ugiToken.getService(),
+        "AMRM token service not updated");
   }
 
   @Test
-  public void testConcurrentTaskLimitsDisabledIfSmaller() throws Exception {
+  void testConcurrentTaskLimitsDisabledIfSmaller() throws Exception {
     final int MAP_COUNT = 1;
     final int REDUCE_COUNT = 1;
     final int MAP_LIMIT = 1;
@@ -2975,7 +2997,7 @@ public class TestRMContainerAllocator {
           @Override
           protected void setRequestLimit(Priority priority,
               Resource capability, int limit) {
-            Assert.fail("setRequestLimit() should not be invoked");
+            Assertions.fail("setRequestLimit() should not be invoked");
           }
         };
 
@@ -3003,7 +3025,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  public void testConcurrentTaskLimits() throws Exception {
+  void testConcurrentTaskLimits() throws Exception {
     final int MAP_COUNT = 5;
     final int REDUCE_COUNT = 2;
     final int MAP_LIMIT = 3;
@@ -3057,22 +3079,22 @@ public class TestRMContainerAllocator {
 
     // verify all of the host-specific asks were sent plus one for the
     // default rack and one for the ANY request
-    Assert.assertEquals(reqMapEvents.length + 2, mockScheduler.lastAsk.size());
+    Assertions.assertEquals(reqMapEvents.length + 2, mockScheduler.lastAsk.size());
 
     // verify AM is only asking for the map limit overall
-    Assert.assertEquals(MAP_LIMIT, mockScheduler.lastAnyAskMap);
+    Assertions.assertEquals(MAP_LIMIT, mockScheduler.lastAnyAskMap);
 
     // assign a map task and verify we do not ask for any more maps
     ContainerId cid0 = mockScheduler.assignContainer("h0", false);
     allocator.schedule();
     allocator.schedule();
-    Assert.assertEquals(2, mockScheduler.lastAnyAskMap);
+    Assertions.assertEquals(2, mockScheduler.lastAnyAskMap);
 
     // complete the map task and verify that we ask for one more
     mockScheduler.completeContainer(cid0);
     allocator.schedule();
     allocator.schedule();
-    Assert.assertEquals(3, mockScheduler.lastAnyAskMap);
+    Assertions.assertEquals(3, mockScheduler.lastAnyAskMap);
 
     // assign three more maps and verify we ask for no more maps
     ContainerId cid1 = mockScheduler.assignContainer("h1", false);
@@ -3080,7 +3102,7 @@ public class TestRMContainerAllocator {
     ContainerId cid3 = mockScheduler.assignContainer("h3", false);
     allocator.schedule();
     allocator.schedule();
-    Assert.assertEquals(0, mockScheduler.lastAnyAskMap);
+    Assertions.assertEquals(0, mockScheduler.lastAnyAskMap);
 
     // complete two containers and verify we only asked for one more
     // since at that point all maps should be scheduled/completed
@@ -3088,7 +3110,7 @@ public class TestRMContainerAllocator {
     mockScheduler.completeContainer(cid3);
     allocator.schedule();
     allocator.schedule();
-    Assert.assertEquals(1, mockScheduler.lastAnyAskMap);
+    Assertions.assertEquals(1, mockScheduler.lastAnyAskMap);
 
     // allocate the last container and complete the first one
     // and verify there are no more map asks.
@@ -3096,80 +3118,81 @@ public class TestRMContainerAllocator {
     ContainerId cid4 = mockScheduler.assignContainer("h4", false);
     allocator.schedule();
     allocator.schedule();
-    Assert.assertEquals(0, mockScheduler.lastAnyAskMap);
+    Assertions.assertEquals(0, mockScheduler.lastAnyAskMap);
 
     // complete the last map
     mockScheduler.completeContainer(cid4);
     allocator.schedule();
     allocator.schedule();
-    Assert.assertEquals(0, mockScheduler.lastAnyAskMap);
+    Assertions.assertEquals(0, mockScheduler.lastAnyAskMap);
 
     // verify only reduce limit being requested
-    Assert.assertEquals(REDUCE_LIMIT, mockScheduler.lastAnyAskReduce);
+    Assertions.assertEquals(REDUCE_LIMIT, mockScheduler.lastAnyAskReduce);
 
     // assign a reducer and verify ask goes to zero
     cid0 = mockScheduler.assignContainer("h0", true);
     allocator.schedule();
     allocator.schedule();
-    Assert.assertEquals(0, mockScheduler.lastAnyAskReduce);
+    Assertions.assertEquals(0, mockScheduler.lastAnyAskReduce);
 
     // complete the reducer and verify we ask for another
     mockScheduler.completeContainer(cid0);
     allocator.schedule();
     allocator.schedule();
-    Assert.assertEquals(1, mockScheduler.lastAnyAskReduce);
+    Assertions.assertEquals(1, mockScheduler.lastAnyAskReduce);
 
     // assign a reducer and verify ask goes to zero
     cid0 = mockScheduler.assignContainer("h0", true);
     allocator.schedule();
     allocator.schedule();
-    Assert.assertEquals(0, mockScheduler.lastAnyAskReduce);
+    Assertions.assertEquals(0, mockScheduler.lastAnyAskReduce);
 
     // complete the reducer and verify no more reducers
     mockScheduler.completeContainer(cid0);
     allocator.schedule();
     allocator.schedule();
-    Assert.assertEquals(0, mockScheduler.lastAnyAskReduce);
+    Assertions.assertEquals(0, mockScheduler.lastAnyAskReduce);
     allocator.close();
   }
 
-  @Test(expected = RMContainerAllocationException.class)
-  public void testAttemptNotFoundCausesRMCommunicatorException()
+  @Test
+  void testAttemptNotFoundCausesRMCommunicatorException()
       throws Exception {
+    assertThrows(RMContainerAllocationException.class, () -> {
+      Configuration conf = new Configuration();
+      MyResourceManager rm = new MyResourceManager(conf);
+      rm.start();
 
-    Configuration conf = new Configuration();
-    MyResourceManager rm = new MyResourceManager(conf);
-    rm.start();
+      // Submit the application
+      RMApp app = MockRMAppSubmitter.submitWithMemory(1024, rm);
+      rm.drainEvents();
 
-    // Submit the application
-    RMApp app = MockRMAppSubmitter.submitWithMemory(1024, rm);
-    rm.drainEvents();
+      MockNM amNodeManager = rm.registerNode("amNM:1234", 2048);
+      amNodeManager.nodeHeartbeat(true);
+      rm.drainEvents();
 
-    MockNM amNodeManager = rm.registerNode("amNM:1234", 2048);
-    amNodeManager.nodeHeartbeat(true);
-    rm.drainEvents();
+      ApplicationAttemptId appAttemptId = app.getCurrentAppAttempt()
+          .getAppAttemptId();
+      rm.sendAMLaunched(appAttemptId);
+      rm.drainEvents();
 
-    ApplicationAttemptId appAttemptId = app.getCurrentAppAttempt()
-        .getAppAttemptId();
-    rm.sendAMLaunched(appAttemptId);
-    rm.drainEvents();
+      JobId jobId = MRBuilderUtils.newJobId(appAttemptId.getApplicationId(), 0);
+      Job mockJob = mock(Job.class);
+      when(mockJob.getReport()).thenReturn(
+          MRBuilderUtils.newJobReport(jobId, "job", "user", JobState.RUNNING, 0,
+              0, 0, 0, 0, 0, 0, "jobfile", null, false, ""));
+      MyContainerAllocator allocator = new MyContainerAllocator(rm, conf,
+          appAttemptId, mockJob);
 
-    JobId jobId = MRBuilderUtils.newJobId(appAttemptId.getApplicationId(), 0);
-    Job mockJob = mock(Job.class);
-    when(mockJob.getReport()).thenReturn(
-        MRBuilderUtils.newJobReport(jobId, "job", "user", JobState.RUNNING, 0,
-            0, 0, 0, 0, 0, 0, "jobfile", null, false, ""));
-    MyContainerAllocator allocator = new MyContainerAllocator(rm, conf,
-        appAttemptId, mockJob);
-
-    // Now kill the application
-    rm.killApp(app.getApplicationId());
-    rm.waitForState(app.getApplicationId(), RMAppState.KILLED);
-    allocator.schedule();
+      // Now kill the application
+      rm.killApp(app.getApplicationId());
+      rm.waitForState(app.getApplicationId(), RMAppState.KILLED);
+      allocator.schedule();
+    });
   }
 
   @Test
-  public void testUpdateAskOnRampDownAllReduces() throws Exception {
+  void testUpdateAskOnRampDownAllReduces() throws Exception {
     LOG.info("Running testUpdateAskOnRampDownAllReduces");
     Configuration conf = new Configuration();
     MyResourceManager rm = new MyResourceManager(conf);
@@ -3246,29 +3269,29 @@ public class TestRMContainerAllocator {
     rm.drainEvents();
 
     // One map is assigned.
-    Assert.assertEquals(1, allocator.getAssignedRequests().maps.size());
+    Assertions.assertEquals(1, allocator.getAssignedRequests().maps.size());
     // Send deallocate request for map so that no maps are assigned after this.
     ContainerAllocatorEvent deallocate = createDeallocateEvent(jobId, 1, false);
     allocator.sendDeallocate(deallocate);
     // Now one reducer should be scheduled and one should be pending.
-    Assert.assertEquals(1, allocator.getScheduledRequests().reduces.size());
-    Assert.assertEquals(1, allocator.getNumOfPendingReduces());
+    Assertions.assertEquals(1, allocator.getScheduledRequests().reduces.size());
+    Assertions.assertEquals(1, allocator.getNumOfPendingReduces());
     // No map should be assigned and one should be scheduled.
-    Assert.assertEquals(1, allocator.getScheduledRequests().maps.size());
-    Assert.assertEquals(0, allocator.getAssignedRequests().maps.size());
+    Assertions.assertEquals(1, allocator.getScheduledRequests().maps.size());
+    Assertions.assertEquals(0, allocator.getAssignedRequests().maps.size());
 
-    Assert.assertEquals(6, allocator.getAsk().size());
+    Assertions.assertEquals(6, allocator.getAsk().size());
     for (ResourceRequest req : allocator.getAsk()) {
       boolean isReduce =
           req.getPriority().equals(RMContainerAllocator.PRIORITY_REDUCE);
       if (isReduce) {
         // 1 reducer each asked on h2, * and default-rack
-        Assert.assertTrue((req.getResourceName().equals("*") ||
+        Assertions.assertTrue((req.getResourceName().equals("*") ||
             req.getResourceName().equals("/default-rack") ||
             req.getResourceName().equals("h2")) && req.getNumContainers() == 1);
       } else { //map
         // 0 mappers asked on h1 and 1 each on * and default-rack
-        Assert.assertTrue(((req.getResourceName().equals("*") ||
+        Assertions.assertTrue(((req.getResourceName().equals("*") ||
             req.getResourceName().equals("/default-rack")) &&
             req.getNumContainers() == 1) || (req.getResourceName().equals("h1")
             && req.getNumContainers() == 0));
@@ -3281,17 +3304,17 @@ public class TestRMContainerAllocator {
     // After allocate response from scheduler, all scheduled reduces are ramped
     // down and move to pending. 3 asks are also updated with 0 containers to
     // indicate ramping down of reduces to scheduler.
-    Assert.assertEquals(0, allocator.getScheduledRequests().reduces.size());
-    Assert.assertEquals(2, allocator.getNumOfPendingReduces());
-    Assert.assertEquals(3, allocator.getAsk().size());
+    Assertions.assertEquals(0, allocator.getScheduledRequests().reduces.size());
+    Assertions.assertEquals(2, allocator.getNumOfPendingReduces());
+    Assertions.assertEquals(3, allocator.getAsk().size());
     for (ResourceRequest req : allocator.getAsk()) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           RMContainerAllocator.PRIORITY_REDUCE, req.getPriority());
-      Assert.assertTrue(req.getResourceName().equals("*") ||
+      Assertions.assertTrue(req.getResourceName().equals("*") ||
           req.getResourceName().equals("/default-rack") ||
           req.getResourceName().equals("h2"));
-      Assert.assertEquals(Resource.newInstance(1024, 1), req.getCapability());
-      Assert.assertEquals(0, req.getNumContainers());
+      Assertions.assertEquals(Resource.newInstance(1024, 1), req.getCapability());
+      Assertions.assertEquals(0, req.getNumContainers());
     }
   }
 
@@ -3300,7 +3323,7 @@ public class TestRMContainerAllocator {
    * right order while processing finished containers.
    */
   @Test
-  public void testHandlingFinishedContainers() {
+  void testHandlingFinishedContainers() {
     EventHandler eventHandler = mock(EventHandler.class);
 
     AppContext context = mock(RunningAppContext.class);
@@ -3339,7 +3362,7 @@ public class TestRMContainerAllocator {
   }
 
   @Test
-  public void testAvoidAskMoreReducersWhenReducerPreemptionIsRequired()
+  void testAvoidAskMoreReducersWhenReducerPreemptionIsRequired()
       throws Exception {
     LOG.info("Running testAvoidAskMoreReducersWhenReducerPreemptionIsRequired");
     Configuration conf = new Configuration();
@@ -3416,29 +3439,29 @@ public class TestRMContainerAllocator {
     rm.drainEvents();
 
     // One map is assigned.
-    Assert.assertEquals(1, allocator.getAssignedRequests().maps.size());
+    Assertions.assertEquals(1, allocator.getAssignedRequests().maps.size());
     // Send deallocate request for map so that no maps are assigned after this.
     ContainerAllocatorEvent deallocate = createDeallocateEvent(jobId, 1, false);
     allocator.sendDeallocate(deallocate);
     // Now one reducer should be scheduled and one should be pending.
-    Assert.assertEquals(1, allocator.getScheduledRequests().reduces.size());
-    Assert.assertEquals(1, allocator.getNumOfPendingReduces());
+    Assertions.assertEquals(1, allocator.getScheduledRequests().reduces.size());
+    Assertions.assertEquals(1, allocator.getNumOfPendingReduces());
     // No map should be assigned and one should be scheduled.
-    Assert.assertEquals(1, allocator.getScheduledRequests().maps.size());
-    Assert.assertEquals(0, allocator.getAssignedRequests().maps.size());
+    Assertions.assertEquals(1, allocator.getScheduledRequests().maps.size());
+    Assertions.assertEquals(0, allocator.getAssignedRequests().maps.size());
 
-    Assert.assertEquals(6, allocator.getAsk().size());
+    Assertions.assertEquals(6, allocator.getAsk().size());
     for (ResourceRequest req : allocator.getAsk()) {
       boolean isReduce =
           req.getPriority().equals(RMContainerAllocator.PRIORITY_REDUCE);
       if (isReduce) {
         // 1 reducer each asked on h2, * and default-rack
-        Assert.assertTrue((req.getResourceName().equals("*") ||
+        Assertions.assertTrue((req.getResourceName().equals("*") ||
             req.getResourceName().equals("/default-rack") ||
             req.getResourceName().equals("h2")) && req.getNumContainers() == 1);
       } else { //map
         // 0 mappers asked on h1 and 1 each on * and default-rack
-        Assert.assertTrue(((req.getResourceName().equals("*") ||
+        Assertions.assertTrue(((req.getResourceName().equals("*") ||
             req.getResourceName().equals("/default-rack")) &&
             req.getNumContainers() == 1) || (req.getResourceName().equals("h1")
             && req.getNumContainers() == 0));
@@ -3454,17 +3477,17 @@ public class TestRMContainerAllocator {
     // After allocate response from scheduler, all scheduled reduces are ramped
     // down and move to pending. 3 asks are also updated with 0 containers to
     // indicate ramping down of reduces to scheduler.
-    Assert.assertEquals(0, allocator.getScheduledRequests().reduces.size());
-    Assert.assertEquals(2, allocator.getNumOfPendingReduces());
-    Assert.assertEquals(3, allocator.getAsk().size());
+    Assertions.assertEquals(0, allocator.getScheduledRequests().reduces.size());
+    Assertions.assertEquals(2, allocator.getNumOfPendingReduces());
+    Assertions.assertEquals(3, allocator.getAsk().size());
     for (ResourceRequest req : allocator.getAsk()) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           RMContainerAllocator.PRIORITY_REDUCE, req.getPriority());
-      Assert.assertTrue(req.getResourceName().equals("*") ||
+      Assertions.assertTrue(req.getResourceName().equals("*") ||
           req.getResourceName().equals("/default-rack") ||
           req.getResourceName().equals("h2"));
-      Assert.assertEquals(Resource.newInstance(1024, 1), req.getCapability());
-      Assert.assertEquals(0, req.getNumContainers());
+      Assertions.assertEquals(Resource.newInstance(1024, 1), req.getCapability());
+      Assertions.assertEquals(0, req.getNumContainers());
     }
   }
 
@@ -3473,7 +3496,7 @@ public class TestRMContainerAllocator {
    * calculating headroom.
    */
   @Test
-  public void testExcludeSchedReducesFromHeadroom() throws Exception {
+  void testExcludeSchedReducesFromHeadroom() throws Exception {
     LOG.info("Running testExcludeSchedReducesFromHeadroom");
     Configuration conf = new Configuration();
     conf.setInt(MRJobConfig.MR_JOB_REDUCER_UNCONDITIONAL_PREEMPT_DELAY_SEC, -1);
@@ -3552,14 +3575,14 @@ public class TestRMContainerAllocator {
     rm.drainEvents();
 
     // Two maps are assigned.
-    Assert.assertEquals(2, allocator.getAssignedRequests().maps.size());
+    Assertions.assertEquals(2, allocator.getAssignedRequests().maps.size());
     // Send deallocate request for map so that no maps are assigned after this.
     ContainerAllocatorEvent deallocate1 = createDeallocateEvent(jobId, 1, false);
     allocator.sendDeallocate(deallocate1);
     ContainerAllocatorEvent deallocate2 = createDeallocateEvent(jobId, 2, false);
     allocator.sendDeallocate(deallocate2);
     // No map should be assigned.
-    Assert.assertEquals(0, allocator.getAssignedRequests().maps.size());
+    Assertions.assertEquals(0, allocator.getAssignedRequests().maps.size());
 
     nodeManager.nodeHeartbeat(true);
     rm.drainEvents();
@@ -3583,18 +3606,18 @@ public class TestRMContainerAllocator {
     allocator.schedule();
     rm.drainEvents();
     // One reducer is assigned and one map is scheduled
-    Assert.assertEquals(1, allocator.getScheduledRequests().maps.size());
-    Assert.assertEquals(1, allocator.getAssignedRequests().reduces.size());
+    Assertions.assertEquals(1, allocator.getScheduledRequests().maps.size());
+    Assertions.assertEquals(1, allocator.getAssignedRequests().reduces.size());
     // Headroom enough to run a mapper if headroom is taken as it is but wont be
     // enough if scheduled reducers resources are deducted.
     rm.getMyFifoScheduler().forceResourceLimit(Resource.newInstance(1260, 2));
     allocator.schedule();
     rm.drainEvents();
     // After allocate response, the one assigned reducer is preempted and killed
-    Assert.assertEquals(1, MyContainerAllocator.getTaskAttemptKillEvents().size());
-    Assert.assertEquals(RMContainerAllocator.RAMPDOWN_DIAGNOSTIC,
+    Assertions.assertEquals(1, MyContainerAllocator.getTaskAttemptKillEvents().size());
+    Assertions.assertEquals(RMContainerAllocator.RAMPDOWN_DIAGNOSTIC,
         MyContainerAllocator.getTaskAttemptKillEvents().get(0).getMessage());
-    Assert.assertEquals(1, allocator.getNumOfPendingReduces());
+    Assertions.assertEquals(1, allocator.getNumOfPendingReduces());
   }
 
   private static class MockScheduler implements ApplicationMasterProtocol {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestResourceCalculatorUtils.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestResourceCalculatorUtils.java
@@ -28,7 +28,7 @@ import static org.apache.hadoop.yarn.proto.YarnServiceProtos.*;
 
 public class TestResourceCalculatorUtils {
   @Test
-  void testComputeAvailableContainers() throws Exception {
+  public void testComputeAvailableContainers() throws Exception {
     Resource clusterAvailableResources = Resource.newInstance(81920, 40);
 
     Resource nonZeroResource = Resource.newInstance(1024, 2);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestResourceCalculatorUtils.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestResourceCalculatorUtils.java
@@ -19,8 +19,8 @@
 package org.apache.hadoop.mapreduce.v2.app.rm;
 
 import org.apache.hadoop.yarn.api.records.Resource;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.EnumSet;
 
@@ -28,7 +28,7 @@ import static org.apache.hadoop.yarn.proto.YarnServiceProtos.*;
 
 public class TestResourceCalculatorUtils {
   @Test
-  public void testComputeAvailableContainers() throws Exception {
+  void testComputeAvailableContainers() throws Exception {
     Resource clusterAvailableResources = Resource.newInstance(81920, 40);
 
     Resource nonZeroResource = Resource.newInstance(1024, 2);
@@ -59,17 +59,17 @@ public class TestResourceCalculatorUtils {
       Resource nonZeroResource, int expectedNumberOfContainersForMemoryOnly,
       int expectedNumberOfContainersOverall) {
 
-    Assert.assertEquals("Incorrect number of available containers for Memory",
-        expectedNumberOfContainersForMemoryOnly,
+    Assertions.assertEquals(expectedNumberOfContainersForMemoryOnly,
         ResourceCalculatorUtils.computeAvailableContainers(
             clusterAvailableResources, nonZeroResource,
-            EnumSet.of(SchedulerResourceTypes.MEMORY)));
+            EnumSet.of(SchedulerResourceTypes.MEMORY)),
+        "Incorrect number of available containers for Memory");
 
-    Assert.assertEquals("Incorrect number of available containers overall",
-        expectedNumberOfContainersOverall,
+    Assertions.assertEquals(expectedNumberOfContainersOverall,
         ResourceCalculatorUtils.computeAvailableContainers(
             clusterAvailableResources, nonZeroResource,
             EnumSet.of(SchedulerResourceTypes.CPU,
-                SchedulerResourceTypes.MEMORY)));
+                SchedulerResourceTypes.MEMORY)),
+        "Incorrect number of available containers overall");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/TestDataStatistics.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/TestDataStatistics.java
@@ -18,56 +18,56 @@
 
 package org.apache.hadoop.mapreduce.v2.app.speculate;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestDataStatistics {
 
   private static final double TOL = 0.001;
 
   @Test
-  public void testEmptyDataStatistics() throws Exception {
+  void testEmptyDataStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics();
-    Assert.assertEquals(0, statistics.count(), TOL);
-    Assert.assertEquals(0, statistics.mean(), TOL);
-    Assert.assertEquals(0, statistics.var(), TOL);
-    Assert.assertEquals(0, statistics.std(), TOL);
-    Assert.assertEquals(0, statistics.outlier(1.0f), TOL);
+    Assertions.assertEquals(0, statistics.count(), TOL);
+    Assertions.assertEquals(0, statistics.mean(), TOL);
+    Assertions.assertEquals(0, statistics.var(), TOL);
+    Assertions.assertEquals(0, statistics.std(), TOL);
+    Assertions.assertEquals(0, statistics.outlier(1.0f), TOL);
   }
   
   @Test
-  public void testSingleEntryDataStatistics() throws Exception {
+  void testSingleEntryDataStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics(17.29);
-    Assert.assertEquals(1, statistics.count(), TOL);
-    Assert.assertEquals(17.29, statistics.mean(), TOL);
-    Assert.assertEquals(0, statistics.var(), TOL);
-    Assert.assertEquals(0, statistics.std(), TOL);
-    Assert.assertEquals(17.29, statistics.outlier(1.0f), TOL);
+    Assertions.assertEquals(1, statistics.count(), TOL);
+    Assertions.assertEquals(17.29, statistics.mean(), TOL);
+    Assertions.assertEquals(0, statistics.var(), TOL);
+    Assertions.assertEquals(0, statistics.std(), TOL);
+    Assertions.assertEquals(17.29, statistics.outlier(1.0f), TOL);
   }
   
   @Test
-  public void testMutiEntryDataStatistics() throws Exception {
+  void testMutiEntryDataStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics();
     statistics.add(17);
     statistics.add(29);
-    Assert.assertEquals(2, statistics.count(), TOL);
-    Assert.assertEquals(23.0, statistics.mean(), TOL);
-    Assert.assertEquals(36.0, statistics.var(), TOL);
-    Assert.assertEquals(6.0, statistics.std(), TOL);
-    Assert.assertEquals(29.0, statistics.outlier(1.0f), TOL);
+    Assertions.assertEquals(2, statistics.count(), TOL);
+    Assertions.assertEquals(23.0, statistics.mean(), TOL);
+    Assertions.assertEquals(36.0, statistics.var(), TOL);
+    Assertions.assertEquals(6.0, statistics.std(), TOL);
+    Assertions.assertEquals(29.0, statistics.outlier(1.0f), TOL);
  }
   
   @Test
-  public void testUpdateStatistics() throws Exception {
+  void testUpdateStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics(17);
     statistics.add(29);
-    Assert.assertEquals(2, statistics.count(), TOL);
-    Assert.assertEquals(23.0, statistics.mean(), TOL);
-    Assert.assertEquals(36.0, statistics.var(), TOL);
+    Assertions.assertEquals(2, statistics.count(), TOL);
+    Assertions.assertEquals(23.0, statistics.mean(), TOL);
+    Assertions.assertEquals(36.0, statistics.var(), TOL);
 
     statistics.updateStatistics(17, 29);
-    Assert.assertEquals(2, statistics.count(), TOL);
-    Assert.assertEquals(29.0, statistics.mean(), TOL);
-    Assert.assertEquals(0.0, statistics.var(), TOL);
+    Assertions.assertEquals(2, statistics.count(), TOL);
+    Assertions.assertEquals(29.0, statistics.mean(), TOL);
+    Assertions.assertEquals(0.0, statistics.var(), TOL);
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/TestDataStatistics.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/TestDataStatistics.java
@@ -26,7 +26,7 @@ public class TestDataStatistics {
   private static final double TOL = 0.001;
 
   @Test
-  void testEmptyDataStatistics() throws Exception {
+  public void testEmptyDataStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics();
     Assertions.assertEquals(0, statistics.count(), TOL);
     Assertions.assertEquals(0, statistics.mean(), TOL);
@@ -36,7 +36,7 @@ public class TestDataStatistics {
   }
   
   @Test
-  void testSingleEntryDataStatistics() throws Exception {
+  public void testSingleEntryDataStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics(17.29);
     Assertions.assertEquals(1, statistics.count(), TOL);
     Assertions.assertEquals(17.29, statistics.mean(), TOL);
@@ -46,7 +46,7 @@ public class TestDataStatistics {
   }
   
   @Test
-  void testMutiEntryDataStatistics() throws Exception {
+  public void testMutiEntryDataStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics();
     statistics.add(17);
     statistics.add(29);
@@ -58,7 +58,7 @@ public class TestDataStatistics {
  }
   
   @Test
-  void testUpdateStatistics() throws Exception {
+  public void testUpdateStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics(17);
     statistics.add(29);
     Assertions.assertEquals(2, statistics.count(), TOL);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/forecast/TestSimpleExponentialForecast.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/forecast/TestSimpleExponentialForecast.java
@@ -98,21 +98,21 @@ public class TestSimpleExponentialForecast {
   }
 
   @Test
-  void testSimpleExponentialForecastLinearInc() throws Exception {
+  public void testSimpleExponentialForecastLinearInc() throws Exception {
     int res = incTestSimpleExponentialForecast();
     Assertions.assertEquals(res, 0,
         "We got the wrong estimate from simple exponential.");
   }
 
   @Test
-  void testSimpleExponentialForecastLinearDec() throws Exception {
+  public void testSimpleExponentialForecastLinearDec() throws Exception {
     int res = decTestSimpleExponentialForecast();
     Assertions.assertEquals(res, 0,
         "We got the wrong estimate from simple exponential.");
   }
 
   @Test
-  void testSimpleExponentialForecastZeros() throws Exception {
+  public void testSimpleExponentialForecastZeros() throws Exception {
     int res = zeroTestSimpleExponentialForecast();
     Assertions.assertEquals(res, 0,
         "We got the wrong estimate from simple exponential.");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/forecast/TestSimpleExponentialForecast.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/forecast/TestSimpleExponentialForecast.java
@@ -21,8 +21,8 @@ package org.apache.hadoop.mapreduce.v2.app.speculate.forecast;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.yarn.util.ControlledClock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Testing the statistical model of simple exponential estimator.
@@ -98,23 +98,23 @@ public class TestSimpleExponentialForecast {
   }
 
   @Test
-  public void testSimpleExponentialForecastLinearInc() throws Exception {
+  void testSimpleExponentialForecastLinearInc() throws Exception {
     int res = incTestSimpleExponentialForecast();
-    Assert.assertEquals("We got the wrong estimate from simple exponential.",
-        res, 0);
+    Assertions.assertEquals(res, 0,
+        "We got the wrong estimate from simple exponential.");
   }
 
   @Test
-  public void testSimpleExponentialForecastLinearDec() throws Exception {
+  void testSimpleExponentialForecastLinearDec() throws Exception {
     int res = decTestSimpleExponentialForecast();
-    Assert.assertEquals("We got the wrong estimate from simple exponential.",
-        res, 0);
+    Assertions.assertEquals(res, 0,
+        "We got the wrong estimate from simple exponential.");
   }
 
   @Test
-  public void testSimpleExponentialForecastZeros() throws Exception {
+  void testSimpleExponentialForecastZeros() throws Exception {
     int res = zeroTestSimpleExponentialForecast();
-    Assert.assertEquals("We got the wrong estimate from simple exponential.",
-        res, 0);
+    Assertions.assertEquals(res, 0,
+        "We got the wrong estimate from simple exponential.");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebApp.java
@@ -89,7 +89,7 @@ public class TestAMWebApp {
   }
 
   @Test
-  void testAppControllerIndex() {
+  public void testAppControllerIndex() {
     AppContext ctx = new MockAppContext(0, 1, 1, 1);
     Injector injector = WebAppTests.createMockInjector(AppContext.class, ctx);
     AppController controller = injector.getInstance(AppController.class);
@@ -98,28 +98,28 @@ public class TestAMWebApp {
   }
 
   @Test
-  void testAppView() {
+  public void testAppView() {
     WebAppTests.testPage(AppView.class, AppContext.class, new MockAppContext(0, 1, 1, 1));
   }
 
 
   
   @Test
-  void testJobView() {
+  public void testJobView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Map<String, String> params = getJobParams(appContext);
     WebAppTests.testPage(JobPage.class, AppContext.class, appContext, params);
   }
 
   @Test
-  void testTasksView() {
+  public void testTasksView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Map<String, String> params = getTaskParams(appContext);
     WebAppTests.testPage(TasksPage.class, AppContext.class, appContext, params);
   }
 
   @Test
-  void testTaskView() {
+  public void testTaskView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Map<String, String> params = getTaskParams(appContext);
     App app = new App(appContext);
@@ -147,13 +147,13 @@ public class TestAMWebApp {
   }
 
   @Test
-  void testConfView() {
+  public void testConfView() {
     WebAppTests.testPage(JobConfPage.class, AppContext.class,
                          new MockAppContext(0, 1, 1, 1));
   }
 
   @Test
-  void testCountersView() {
+  public void testCountersView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Map<String, String> params = getJobParams(appContext);
     WebAppTests.testPage(CountersPage.class, AppContext.class,
@@ -161,7 +161,7 @@ public class TestAMWebApp {
   }
   
   @Test
-  void testSingleCounterView() {
+  public void testSingleCounterView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Job job = appContext.getAllJobs().values().iterator().next();
     // add a failed task to the job without any counters
@@ -177,7 +177,7 @@ public class TestAMWebApp {
   }
 
   @Test
-  void testTaskCountersView() {
+  public void testTaskCountersView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Map<String, String> params = getTaskParams(appContext);
     WebAppTests.testPage(CountersPage.class, AppContext.class,
@@ -185,7 +185,7 @@ public class TestAMWebApp {
   }
 
   @Test
-  void testSingleTaskCounterView() {
+  public void testSingleTaskCounterView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 2);
     Map<String, String> params = getTaskParams(appContext);
     params.put(AMParams.COUNTER_GROUP, 
@@ -205,7 +205,7 @@ public class TestAMWebApp {
   }
 
   @Test
-  void testMRWebAppSSLDisabled() throws Exception {
+  public void testMRWebAppSSLDisabled() throws Exception {
     MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true) {
       @Override
       protected ClientService createClientService(AppContext context) {
@@ -247,7 +247,7 @@ public class TestAMWebApp {
   public EnvironmentVariables environmentVariables;
 
   @Test
-  void testMRWebAppSSLEnabled() throws Exception {
+  public void testMRWebAppSSLEnabled() throws Exception {
     MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true) {
       @Override
       protected ClientService createClientService(AppContext context) {
@@ -302,7 +302,7 @@ public class TestAMWebApp {
   }
 
   @Test
-  void testMRWebAppSSLEnabledWithClientAuth() throws Exception {
+  public void testMRWebAppSSLEnabledWithClientAuth() throws Exception {
     MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true) {
       @Override
       protected ClientService createClientService(AppContext context) {
@@ -383,7 +383,7 @@ public class TestAMWebApp {
   }
 
   @Test
-  void testMRWebAppRedirection() throws Exception {
+  public void testMRWebAppRedirection() throws Exception {
 
     String[] schemePrefix =
         { WebAppUtils.HTTP_PREFIX, WebAppUtils.HTTPS_PREFIX };

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebApp.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.mapreduce.v2.app.webapp;
 
 import static org.apache.hadoop.mapreduce.v2.app.webapp.AMParams.APP_ID;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -39,7 +39,7 @@ import javax.net.ssl.SSLException;
 
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.HttpConfig.Policy;
@@ -65,14 +65,17 @@ import org.apache.hadoop.yarn.webapp.WebApps;
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
 import org.apache.http.HttpStatus;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.net.HttpHeaders;
 import com.google.inject.Injector;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
+@ExtendWith(SystemStubsExtension.class)
 public class TestAMWebApp {
 
   private static final File TEST_DIR = new File(
@@ -80,12 +83,13 @@ public class TestAMWebApp {
           System.getProperty("java.io.tmpdir")),
       TestAMWebApp.class.getName());
 
-  @After
+  @AfterEach
   public void tearDown() {
     TEST_DIR.delete();
   }
 
-  @Test public void testAppControllerIndex() {
+  @Test
+  void testAppControllerIndex() {
     AppContext ctx = new MockAppContext(0, 1, 1, 1);
     Injector injector = WebAppTests.createMockInjector(AppContext.class, ctx);
     AppController controller = injector.getInstance(AppController.class);
@@ -93,25 +97,29 @@ public class TestAMWebApp {
     assertEquals(ctx.getApplicationID().toString(), controller.get(APP_ID,""));
   }
 
-  @Test public void testAppView() {
+  @Test
+  void testAppView() {
     WebAppTests.testPage(AppView.class, AppContext.class, new MockAppContext(0, 1, 1, 1));
   }
 
 
   
-  @Test public void testJobView() {
+  @Test
+  void testJobView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Map<String, String> params = getJobParams(appContext);
     WebAppTests.testPage(JobPage.class, AppContext.class, appContext, params);
   }
 
-  @Test public void testTasksView() {
+  @Test
+  void testTasksView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Map<String, String> params = getTaskParams(appContext);
     WebAppTests.testPage(TasksPage.class, AppContext.class, appContext, params);
   }
 
-  @Test public void testTaskView() {
+  @Test
+  void testTaskView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Map<String, String> params = getTaskParams(appContext);
     App app = new App(appContext);
@@ -138,19 +146,22 @@ public class TestAMWebApp {
     return params;
   }
 
-  @Test public void testConfView() {
+  @Test
+  void testConfView() {
     WebAppTests.testPage(JobConfPage.class, AppContext.class,
                          new MockAppContext(0, 1, 1, 1));
   }
 
-  @Test public void testCountersView() {
+  @Test
+  void testCountersView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Map<String, String> params = getJobParams(appContext);
     WebAppTests.testPage(CountersPage.class, AppContext.class,
                          appContext, params);
   }
   
-  @Test public void testSingleCounterView() {
+  @Test
+  void testSingleCounterView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Job job = appContext.getAllJobs().values().iterator().next();
     // add a failed task to the job without any counters
@@ -165,14 +176,16 @@ public class TestAMWebApp {
                          appContext, params);
   }
 
-  @Test public void testTaskCountersView() {
+  @Test
+  void testTaskCountersView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Map<String, String> params = getTaskParams(appContext);
     WebAppTests.testPage(CountersPage.class, AppContext.class,
                          appContext, params);
   }
 
-  @Test public void testSingleTaskCounterView() {
+  @Test
+  void testSingleTaskCounterView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 2);
     Map<String, String> params = getTaskParams(appContext);
     params.put(AMParams.COUNTER_GROUP, 
@@ -192,7 +205,7 @@ public class TestAMWebApp {
   }
 
   @Test
-  public void testMRWebAppSSLDisabled() throws Exception {
+  void testMRWebAppSSLDisabled() throws Exception {
     MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true) {
       @Override
       protected ClientService createClientService(AppContext context) {
@@ -213,7 +226,7 @@ public class TestAMWebApp {
     InputStream in = conn.getInputStream();
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     IOUtils.copyBytes(in, out, 1024);
-    Assert.assertTrue(out.toString().contains("MapReduce Application"));
+    Assertions.assertTrue(out.toString().contains("MapReduce Application"));
 
     // https:// is not accessible.
     URL httpsUrl = new URL("https://" + hostPort);
@@ -221,7 +234,7 @@ public class TestAMWebApp {
       HttpURLConnection httpsConn =
           (HttpURLConnection) httpsUrl.openConnection();
       httpsConn.getInputStream();
-      Assert.fail("https:// is not accessible, expected to fail");
+      Assertions.fail("https:// is not accessible, expected to fail");
     } catch (SSLException e) {
       // expected
     }
@@ -230,12 +243,11 @@ public class TestAMWebApp {
     app.verifyCompleted();
   }
 
-  @Rule
-  public final EnvironmentVariables environmentVariables
-      = new EnvironmentVariables();
+  @SystemStub
+  public EnvironmentVariables environmentVariables;
 
   @Test
-  public void testMRWebAppSSLEnabled() throws Exception {
+  void testMRWebAppSSLEnabled() throws Exception {
     MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true) {
       @Override
       protected ClientService createClientService(AppContext context) {
@@ -270,7 +282,7 @@ public class TestAMWebApp {
     InputStream in = httpsConn.getInputStream();
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     IOUtils.copyBytes(in, out, 1024);
-    Assert.assertTrue(out.toString().contains("MapReduce Application"));
+    Assertions.assertTrue(out.toString().contains("MapReduce Application"));
 
     // http:// is not accessible.
     URL httpUrl = new URL("http://" + hostPort);
@@ -278,7 +290,7 @@ public class TestAMWebApp {
       HttpURLConnection httpConn =
           (HttpURLConnection) httpUrl.openConnection();
       httpConn.getResponseCode();
-      Assert.fail("http:// is not accessible, expected to fail");
+      Assertions.fail("http:// is not accessible, expected to fail");
     } catch (SocketException e) {
       // expected
     }
@@ -290,7 +302,7 @@ public class TestAMWebApp {
   }
 
   @Test
-  public void testMRWebAppSSLEnabledWithClientAuth() throws Exception {
+  void testMRWebAppSSLEnabledWithClientAuth() throws Exception {
     MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true) {
       @Override
       protected ClientService createClientService(AppContext context) {
@@ -337,7 +349,7 @@ public class TestAMWebApp {
     InputStream in = httpsConn.getInputStream();
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     IOUtils.copyBytes(in, out, 1024);
-    Assert.assertTrue(out.toString().contains("MapReduce Application"));
+    Assertions.assertTrue(out.toString().contains("MapReduce Application"));
 
     // Try with wrong client cert
     KeyPair otherClientKeyPair = KeyStoreTestUtil.generateKeyPair("RSA");
@@ -349,7 +361,7 @@ public class TestAMWebApp {
       HttpURLConnection httpConn =
           (HttpURLConnection) httpsUrl.openConnection();
       httpConn.getResponseCode();
-      Assert.fail("Wrong client certificate, expected to fail");
+      Assertions.fail("Wrong client certificate, expected to fail");
     } catch (SSLException e) {
       // expected
     }
@@ -371,7 +383,7 @@ public class TestAMWebApp {
   }
 
   @Test
-  public void testMRWebAppRedirection() throws Exception {
+  void testMRWebAppRedirection() throws Exception {
 
     String[] schemePrefix =
         { WebAppUtils.HTTP_PREFIX, WebAppUtils.HTTPS_PREFIX };
@@ -404,9 +416,9 @@ public class TestAMWebApp {
       String expectedURL = scheme + conf.get(YarnConfiguration.PROXY_ADDRESS)
           + ProxyUriUtils.getPath(app.getAppID(), "/mapreduce", true);
 
-      Assert.assertEquals(expectedURL,
+      Assertions.assertEquals(expectedURL,
         conn.getHeaderField(HttpHeaders.LOCATION));
-      Assert.assertEquals(HttpStatus.SC_MOVED_TEMPORARILY,
+      Assertions.assertEquals(HttpStatus.SC_MOVED_TEMPORARILY,
         conn.getResponseCode());
       app.waitForState(job, JobState.SUCCEEDED);
       app.verifyCompleted();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServices.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServices.java
@@ -110,7 +110,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  void testAM() throws JSONException, Exception {
+  public void testAM() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
@@ -122,7 +122,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  void testAMSlash() throws JSONException, Exception {
+  public void testAMSlash() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce/")
         .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
@@ -134,7 +134,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  void testAMDefault() throws JSONException, Exception {
+  public void testAMDefault() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce/")
         .get(ClientResponse.class);
@@ -146,7 +146,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  void testAMXML() throws JSONException, Exception {
+  public void testAMXML() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .accept(MediaType.APPLICATION_XML).get(ClientResponse.class);
@@ -157,7 +157,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  void testInfo() throws JSONException, Exception {
+  public void testInfo() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("info").accept(MediaType.APPLICATION_JSON)
@@ -170,7 +170,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  void testInfoSlash() throws JSONException, Exception {
+  public void testInfoSlash() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("info/").accept(MediaType.APPLICATION_JSON)
@@ -183,7 +183,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  void testInfoDefault() throws JSONException, Exception {
+  public void testInfoDefault() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("info/").get(ClientResponse.class);
@@ -195,7 +195,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  void testInfoXML() throws JSONException, Exception {
+  public void testInfoXML() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("info/").accept(MediaType.APPLICATION_XML)
@@ -207,7 +207,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  void testInvalidUri() throws JSONException, Exception {
+  public void testInvalidUri() throws JSONException, Exception {
     WebResource r = resource();
     String responseStr = "";
     try {
@@ -223,7 +223,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  void testInvalidUri2() throws JSONException, Exception {
+  public void testInvalidUri2() throws JSONException, Exception {
     WebResource r = resource();
     String responseStr = "";
     try {
@@ -239,7 +239,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  void testInvalidAccept() throws JSONException, Exception {
+  public void testInvalidAccept() throws JSONException, Exception {
     WebResource r = resource();
     String responseStr = "";
     try {
@@ -256,7 +256,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
   
   @Test
-  void testBlacklistedNodes() throws JSONException, Exception {
+  public void testBlacklistedNodes() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("blacklistednodes").accept(MediaType.APPLICATION_JSON)
@@ -269,7 +269,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
   
   @Test
-  void testBlacklistedNodesXML() throws Exception {
+  public void testBlacklistedNodesXML() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("blacklistednodes").accept(MediaType.APPLICATION_XML)

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServices.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServices.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.mapreduce.v2.app.webapp;
 
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.StringReader;
 import java.util.Set;
@@ -43,8 +43,8 @@ import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -93,7 +93,7 @@ public class TestAMWebServices extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -110,43 +110,43 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testAM() throws JSONException, Exception {
+  void testAM() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     verifyAMInfo(json.getJSONObject("info"), appContext);
   }
 
   @Test
-  public void testAMSlash() throws JSONException, Exception {
+  void testAMSlash() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce/")
         .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     verifyAMInfo(json.getJSONObject("info"), appContext);
   }
 
   @Test
-  public void testAMDefault() throws JSONException, Exception {
+  void testAMDefault() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce/")
         .get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     verifyAMInfo(json.getJSONObject("info"), appContext);
   }
 
   @Test
-  public void testAMXML() throws JSONException, Exception {
+  void testAMXML() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .accept(MediaType.APPLICATION_XML).get(ClientResponse.class);
@@ -157,7 +157,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testInfo() throws JSONException, Exception {
+  void testInfo() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("info").accept(MediaType.APPLICATION_JSON)
@@ -165,12 +165,12 @@ public class TestAMWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     verifyAMInfo(json.getJSONObject("info"), appContext);
   }
 
   @Test
-  public void testInfoSlash() throws JSONException, Exception {
+  void testInfoSlash() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("info/").accept(MediaType.APPLICATION_JSON)
@@ -178,24 +178,24 @@ public class TestAMWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     verifyAMInfo(json.getJSONObject("info"), appContext);
   }
 
   @Test
-  public void testInfoDefault() throws JSONException, Exception {
+  void testInfoDefault() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("info/").get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     verifyAMInfo(json.getJSONObject("info"), appContext);
   }
 
   @Test
-  public void testInfoXML() throws JSONException, Exception {
+  void testInfoXML() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("info/").accept(MediaType.APPLICATION_XML)
@@ -207,7 +207,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testInvalidUri() throws JSONException, Exception {
+  void testInvalidUri() throws JSONException, Exception {
     WebResource r = resource();
     String responseStr = "";
     try {
@@ -223,7 +223,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testInvalidUri2() throws JSONException, Exception {
+  void testInvalidUri2() throws JSONException, Exception {
     WebResource r = resource();
     String responseStr = "";
     try {
@@ -239,7 +239,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testInvalidAccept() throws JSONException, Exception {
+  void testInvalidAccept() throws JSONException, Exception {
     WebResource r = resource();
     String responseStr = "";
     try {
@@ -256,7 +256,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
   
   @Test
-  public void testBlacklistedNodes() throws JSONException, Exception {
+  void testBlacklistedNodes() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("blacklistednodes").accept(MediaType.APPLICATION_JSON)
@@ -264,12 +264,12 @@ public class TestAMWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     verifyBlacklistedNodesInfo(json, appContext);
   }
   
   @Test
-  public void testBlacklistedNodesXML() throws Exception {
+  void testBlacklistedNodesXML() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("blacklistednodes").accept(MediaType.APPLICATION_XML)
@@ -282,7 +282,7 @@ public class TestAMWebServices extends JerseyTestBase {
 
   public void verifyAMInfo(JSONObject info, AppContext ctx)
       throws JSONException {
-    assertEquals("incorrect number of elements", 5, info.length());
+    assertEquals(5, info.length(), "incorrect number of elements");
 
     verifyAMInfoGeneric(ctx, info.getString("appId"), info.getString("user"),
         info.getString("name"), info.getLong("startedOn"),
@@ -297,7 +297,7 @@ public class TestAMWebServices extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodes = dom.getElementsByTagName("info");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
 
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
@@ -320,8 +320,8 @@ public class TestAMWebServices extends JerseyTestBase {
     WebServicesTestUtils.checkStringMatch("name", ctx.getApplicationName(),
         name);
 
-    assertEquals("startedOn incorrect", ctx.getStartTime(), startedOn);
-    assertTrue("elapsedTime not greater then 0", (elapsedTime > 0));
+    assertEquals(ctx.getStartTime(), startedOn, "startedOn incorrect");
+    assertTrue((elapsedTime > 0), "elapsedTime not greater then 0");
 
   }
   
@@ -342,11 +342,11 @@ public class TestAMWebServices extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList infonodes = dom.getElementsByTagName("blacklistednodesinfo");
-    assertEquals("incorrect number of elements", 1, infonodes.getLength());
+    assertEquals(1, infonodes.getLength(), "incorrect number of elements");
     NodeList nodes = dom.getElementsByTagName("blacklistedNodes");
     Set<String> blacklistedNodes = ctx.getBlacklistedNodes();
-    assertEquals("incorrect number of elements", blacklistedNodes.size(),
-        nodes.getLength());
+    assertEquals(blacklistedNodes.size(),
+        nodes.getLength(), "incorrect number of elements");
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
       assertTrue(

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempt.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempt.java
@@ -135,7 +135,7 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
   }
 
   @Test
-  void testGetTaskAttemptIdState() throws Exception {
+  public void testGetTaskAttemptIdState() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -165,7 +165,7 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
   }
 
   @Test
-  void testGetTaskAttemptIdXMLState() throws Exception {
+  public void testGetTaskAttemptIdXMLState() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -202,7 +202,7 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
   }
 
   @Test
-  void testPutTaskAttemptIdState() throws Exception {
+  public void testPutTaskAttemptIdState() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -235,7 +235,7 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
   }
 
   @Test
-  void testPutTaskAttemptIdXMLState() throws Exception {
+  public void testPutTaskAttemptIdXMLState() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempt.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempt.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.mapreduce.v2.app.webapp;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.StringReader;
 import java.util.Enumeration;
@@ -50,8 +50,8 @@ import org.apache.hadoop.yarn.webapp.GuiceServletConfig;
 import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -118,7 +118,7 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -135,7 +135,7 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
   }
 
   @Test
-  public void testGetTaskAttemptIdState() throws Exception {
+  void testGetTaskAttemptIdState() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -157,7 +157,7 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
           assertEquals(MediaType.APPLICATION_JSON_TYPE + "; "
                   + JettyUtils.UTF_8, response.getType().toString());
           JSONObject json = response.getEntity(JSONObject.class);
-          assertEquals("incorrect number of elements", 1, json.length());
+          assertEquals(1, json.length(), "incorrect number of elements");
           assertEquals(att.getState().toString(), json.get("state"));
         }
       }
@@ -165,7 +165,7 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
   }
 
   @Test
-  public void testGetTaskAttemptIdXMLState() throws Exception {
+  void testGetTaskAttemptIdXMLState() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -202,7 +202,7 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
   }
 
   @Test
-  public void testPutTaskAttemptIdState() throws Exception {
+  void testPutTaskAttemptIdState() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -226,7 +226,8 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
           assertEquals(MediaType.APPLICATION_JSON_TYPE + "; "
                   + JettyUtils.UTF_8, response.getType().toString());
           JSONObject json = response.getEntity(JSONObject.class);
-          assertEquals("incorrect number of elements", 1, json.length());
+          assertEquals(1, json.length(),
+              "incorrect number of elements");
           assertEquals(TaskAttemptState.KILLED.toString(), json.get("state"));
         }
       }
@@ -234,7 +235,7 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
   }
 
   @Test
-  public void testPutTaskAttemptIdXMLState() throws Exception {
+  void testPutTaskAttemptIdXMLState() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempts.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempts.java
@@ -118,7 +118,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  void testTaskAttempts() throws JSONException, Exception {
+  public void testTaskAttempts() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -138,7 +138,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  void testTaskAttemptsSlash() throws JSONException, Exception {
+  public void testTaskAttemptsSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -158,7 +158,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  void testTaskAttemptsDefault() throws JSONException, Exception {
+  public void testTaskAttemptsDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -178,7 +178,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  void testTaskAttemptsXML() throws JSONException, Exception {
+  public void testTaskAttemptsXML() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -208,7 +208,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  void testTaskAttemptId() throws JSONException, Exception {
+  public void testTaskAttemptId() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -238,7 +238,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  void testTaskAttemptIdSlash() throws JSONException, Exception {
+  public void testTaskAttemptIdSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -268,7 +268,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  void testTaskAttemptIdDefault() throws JSONException, Exception {
+  public void testTaskAttemptIdDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -297,7 +297,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  void testTaskAttemptIdXML() throws JSONException, Exception {
+  public void testTaskAttemptIdXML() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -333,14 +333,14 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  void testTaskAttemptIdBogus() throws JSONException, Exception {
+  public void testTaskAttemptIdBogus() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("bogusid",
         "java.lang.Exception: TaskAttemptId string : bogusid is not properly formed");
   }
 
   @Test
-  void testTaskAttemptIdNonExist() throws JSONException, Exception {
+  public void testTaskAttemptIdNonExist() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric(
         "attempt_0_12345_m_000000_0",
@@ -348,21 +348,21 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  void testTaskAttemptIdInvalid() throws JSONException, Exception {
+  public void testTaskAttemptIdInvalid() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("attempt_0_12345_d_000000_0",
         "java.lang.Exception: Bad TaskType identifier. TaskAttemptId string : attempt_0_12345_d_000000_0 is not properly formed.");
   }
 
   @Test
-  void testTaskAttemptIdInvalid2() throws JSONException, Exception {
+  public void testTaskAttemptIdInvalid2() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("attempt_12345_m_000000_0",
         "java.lang.Exception: TaskAttemptId string : attempt_12345_m_000000_0 is not properly formed");
   }
 
   @Test
-  void testTaskAttemptIdInvalid3() throws JSONException, Exception {
+  public void testTaskAttemptIdInvalid3() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("attempt_0_12345_m_000000",
         "java.lang.Exception: TaskAttemptId string : attempt_0_12345_m_000000 is not properly formed");
@@ -550,7 +550,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  void testTaskAttemptIdCounters() throws JSONException, Exception {
+  public void testTaskAttemptIdCounters() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -580,7 +580,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  void testTaskAttemptIdXMLCounters() throws JSONException, Exception {
+  public void testTaskAttemptIdXMLCounters() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempts.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempts.java
@@ -19,11 +19,11 @@
 package org.apache.hadoop.mapreduce.v2.app.webapp;
 
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.StringReader;
 import java.util.List;
@@ -52,8 +52,8 @@ import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -101,7 +101,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -118,7 +118,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttempts() throws JSONException, Exception {
+  void testTaskAttempts() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -138,7 +138,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptsSlash() throws JSONException, Exception {
+  void testTaskAttemptsSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -158,7 +158,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptsDefault() throws JSONException, Exception {
+  void testTaskAttemptsDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -178,7 +178,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptsXML() throws JSONException, Exception {
+  void testTaskAttemptsXML() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -199,7 +199,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
         is.setCharacterStream(new StringReader(xml));
         Document dom = db.parse(is);
         NodeList attempts = dom.getElementsByTagName("taskAttempts");
-        assertEquals("incorrect number of elements", 1, attempts.getLength());
+        assertEquals(1, attempts.getLength(), "incorrect number of elements");
 
         NodeList nodes = dom.getElementsByTagName("taskAttempt");
         verifyAMTaskAttemptsXML(nodes, task);
@@ -208,7 +208,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptId() throws JSONException, Exception {
+  void testTaskAttemptId() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -229,7 +229,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
           assertEquals(MediaType.APPLICATION_JSON_TYPE + "; "
                   + JettyUtils.UTF_8, response.getType().toString());
           JSONObject json = response.getEntity(JSONObject.class);
-          assertEquals("incorrect number of elements", 1, json.length());
+          assertEquals(1, json.length(), "incorrect number of elements");
           JSONObject info = json.getJSONObject("taskAttempt");
           verifyAMTaskAttempt(info, att, task.getType());
         }
@@ -238,7 +238,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptIdSlash() throws JSONException, Exception {
+  void testTaskAttemptIdSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -259,7 +259,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
           assertEquals(MediaType.APPLICATION_JSON_TYPE + "; "
                   + JettyUtils.UTF_8, response.getType().toString());
           JSONObject json = response.getEntity(JSONObject.class);
-          assertEquals("incorrect number of elements", 1, json.length());
+          assertEquals(1, json.length(), "incorrect number of elements");
           JSONObject info = json.getJSONObject("taskAttempt");
           verifyAMTaskAttempt(info, att, task.getType());
         }
@@ -268,7 +268,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptIdDefault() throws JSONException, Exception {
+  void testTaskAttemptIdDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -288,7 +288,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
           assertEquals(MediaType.APPLICATION_JSON_TYPE + "; "
                   + JettyUtils.UTF_8, response.getType().toString());
           JSONObject json = response.getEntity(JSONObject.class);
-          assertEquals("incorrect number of elements", 1, json.length());
+          assertEquals(1, json.length(), "incorrect number of elements");
           JSONObject info = json.getJSONObject("taskAttempt");
           verifyAMTaskAttempt(info, att, task.getType());
         }
@@ -297,7 +297,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptIdXML() throws JSONException, Exception {
+  void testTaskAttemptIdXML() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -333,14 +333,14 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptIdBogus() throws JSONException, Exception {
+  void testTaskAttemptIdBogus() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("bogusid",
         "java.lang.Exception: TaskAttemptId string : bogusid is not properly formed");
   }
 
   @Test
-  public void testTaskAttemptIdNonExist() throws JSONException, Exception {
+  void testTaskAttemptIdNonExist() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric(
         "attempt_0_12345_m_000000_0",
@@ -348,21 +348,21 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptIdInvalid() throws JSONException, Exception {
+  void testTaskAttemptIdInvalid() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("attempt_0_12345_d_000000_0",
         "java.lang.Exception: Bad TaskType identifier. TaskAttemptId string : attempt_0_12345_d_000000_0 is not properly formed.");
   }
 
   @Test
-  public void testTaskAttemptIdInvalid2() throws JSONException, Exception {
+  void testTaskAttemptIdInvalid2() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("attempt_12345_m_000000_0",
         "java.lang.Exception: TaskAttemptId string : attempt_12345_m_000000_0 is not properly formed");
   }
 
   @Test
-  public void testTaskAttemptIdInvalid3() throws JSONException, Exception {
+  void testTaskAttemptIdInvalid3() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("attempt_0_12345_m_000000",
         "java.lang.Exception: TaskAttemptId string : attempt_0_12345_m_000000 is not properly formed");
@@ -391,7 +391,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
                   + JettyUtils.UTF_8, response.getType().toString());
           JSONObject msg = response.getEntity(JSONObject.class);
           JSONObject exception = msg.getJSONObject("RemoteException");
-          assertEquals("incorrect number of elements", 3, exception.length());
+          assertEquals(3, exception.length(), "incorrect number of elements");
           String message = exception.getString("message");
           String type = exception.getString("exception");
           String classname = exception.getString("javaClassName");
@@ -434,9 +434,9 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   public void verifyAMTaskAttempt(JSONObject info, TaskAttempt att,
       TaskType ttype) throws JSONException {
     if (ttype == TaskType.REDUCE) {
-      assertEquals("incorrect number of elements", 17, info.length());
+      assertEquals(17, info.length(), "incorrect number of elements");
     } else {
-      assertEquals("incorrect number of elements", 12, info.length());
+      assertEquals(12, info.length(), "incorrect number of elements");
     }
 
     verifyTaskAttemptGeneric(att, ttype, info.getString("id"),
@@ -455,9 +455,9 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
 
   public void verifyAMTaskAttempts(JSONObject json, Task task)
       throws JSONException {
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject attempts = json.getJSONObject("taskAttempts");
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONArray arr = attempts.getJSONArray("taskAttempt");
     for (TaskAttempt att : task.getAttempts().values()) {
       TaskAttemptId id = att.getID();
@@ -471,13 +471,13 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
           verifyAMTaskAttempt(info, att, task.getType());
         }
       }
-      assertTrue("task attempt with id: " + attid
-          + " not in web service output", found);
+      assertTrue(found, "task attempt with id: " + attid
+              + " not in web service output");
     }
   }
 
   public void verifyAMTaskAttemptsXML(NodeList nodes, Task task) {
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
 
     for (TaskAttempt att : task.getAttempts().values()) {
       TaskAttemptId id = att.getID();
@@ -485,15 +485,14 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
       Boolean found = false;
       for (int i = 0; i < nodes.getLength(); i++) {
         Element element = (Element) nodes.item(i);
-        assertFalse("task attempt should not contain any attributes, it can lead to incorrect JSON marshaling",
-            element.hasAttributes());
+        assertFalse(element.hasAttributes(), "task attempt should not contain any attributes, it can lead to incorrect JSON marshaling");
 
         if (attid.matches(WebServicesTestUtils.getXmlString(element, "id"))) {
           found = true;
           verifyAMTaskAttemptXML(element, att, task.getType());
         }
       }
-      assertTrue("task with id: " + attid + " not in web service output", found);
+      assertTrue(found, "task with id: " + attid + " not in web service output");
     }
   }
 
@@ -528,30 +527,30 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
         ta.getAssignedContainerID().toString(),
         assignedContainerId);
 
-    assertEquals("startTime wrong", ta.getLaunchTime(), startTime);
-    assertEquals("finishTime wrong", ta.getFinishTime(), finishTime);
-    assertEquals("elapsedTime wrong", finishTime - startTime, elapsedTime);
-    assertEquals("progress wrong", ta.getProgress() * 100, progress, 1e-3f);
+    assertEquals(ta.getLaunchTime(), startTime, "startTime wrong");
+    assertEquals(ta.getFinishTime(), finishTime, "finishTime wrong");
+    assertEquals(finishTime - startTime, elapsedTime, "elapsedTime wrong");
+    assertEquals(ta.getProgress() * 100, progress, 1e-3f, "progress wrong");
   }
 
   public void verifyReduceTaskAttemptGeneric(TaskAttempt ta,
       long shuffleFinishTime, long mergeFinishTime, long elapsedShuffleTime,
       long elapsedMergeTime, long elapsedReduceTime) {
 
-    assertEquals("shuffleFinishTime wrong", ta.getShuffleFinishTime(),
-        shuffleFinishTime);
-    assertEquals("mergeFinishTime wrong", ta.getSortFinishTime(),
-        mergeFinishTime);
-    assertEquals("elapsedShuffleTime wrong",
-        ta.getShuffleFinishTime() - ta.getLaunchTime(), elapsedShuffleTime);
-    assertEquals("elapsedMergeTime wrong",
-        ta.getSortFinishTime() - ta.getShuffleFinishTime(), elapsedMergeTime);
-    assertEquals("elapsedReduceTime wrong",
-        ta.getFinishTime() - ta.getSortFinishTime(), elapsedReduceTime);
+    assertEquals(ta.getShuffleFinishTime(),
+        shuffleFinishTime, "shuffleFinishTime wrong");
+    assertEquals(ta.getSortFinishTime(),
+        mergeFinishTime, "mergeFinishTime wrong");
+    assertEquals(ta.getShuffleFinishTime() - ta.getLaunchTime(), elapsedShuffleTime,
+            "elapsedShuffleTime wrong");
+    assertEquals(ta.getSortFinishTime() - ta.getShuffleFinishTime(), elapsedMergeTime,
+            "elapsedMergeTime wrong");
+    assertEquals(ta.getFinishTime() - ta.getSortFinishTime(), elapsedReduceTime,
+            "elapsedReduceTime wrong");
   }
 
   @Test
-  public void testTaskAttemptIdCounters() throws JSONException, Exception {
+  void testTaskAttemptIdCounters() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -572,7 +571,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
           assertEquals(MediaType.APPLICATION_JSON_TYPE + "; "
                   + JettyUtils.UTF_8, response.getType().toString());
           JSONObject json = response.getEntity(JSONObject.class);
-          assertEquals("incorrect number of elements", 1, json.length());
+          assertEquals(1, json.length(), "incorrect number of elements");
           JSONObject info = json.getJSONObject("jobTaskAttemptCounters");
           verifyAMJobTaskAttemptCounters(info, att);
         }
@@ -581,7 +580,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptIdXMLCounters() throws JSONException, Exception {
+  void testTaskAttemptIdXMLCounters() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -617,7 +616,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   public void verifyAMJobTaskAttemptCounters(JSONObject info, TaskAttempt att)
       throws JSONException {
 
-    assertEquals("incorrect number of elements", 2, info.length());
+    assertEquals(2, info.length(), "incorrect number of elements");
 
     WebServicesTestUtils.checkStringMatch("id", MRApps.toString(att.getID()),
         info.getString("id"));
@@ -628,15 +627,15 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
     for (int i = 0; i < counterGroups.length(); i++) {
       JSONObject counterGroup = counterGroups.getJSONObject(i);
       String name = counterGroup.getString("counterGroupName");
-      assertTrue("name not set", (name != null && !name.isEmpty()));
+      assertTrue((name != null && !name.isEmpty()), "name not set");
       JSONArray counters = counterGroup.getJSONArray("counter");
       for (int j = 0; j < counters.length(); j++) {
         JSONObject counter = counters.getJSONObject(j);
         String counterName = counter.getString("name");
-        assertTrue("name not set",
-            (counterName != null && !counterName.isEmpty()));
+        assertTrue((counterName != null && !counterName.isEmpty()),
+                "name not set");
         long value = counter.getLong("value");
-        assertTrue("value  >= 0", value >= 0);
+        assertTrue(value >= 0, "value  >= 0");
       }
     }
   }
@@ -654,20 +653,19 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
 
       for (int j = 0; j < groups.getLength(); j++) {
         Element counters = (Element) groups.item(j);
-        assertNotNull("should have counters in the web service info", counters);
+        assertNotNull(counters, "should have counters in the web service info");
         String name = WebServicesTestUtils.getXmlString(counters,
             "counterGroupName");
-        assertTrue("name not set", (name != null && !name.isEmpty()));
+        assertTrue((name != null && !name.isEmpty()), "name not set");
         NodeList counterArr = counters.getElementsByTagName("counter");
         for (int z = 0; z < counterArr.getLength(); z++) {
           Element counter = (Element) counterArr.item(z);
           String counterName = WebServicesTestUtils.getXmlString(counter,
               "name");
-          assertTrue("counter name not set",
-              (counterName != null && !counterName.isEmpty()));
+          assertTrue((counterName != null && !counterName.isEmpty()), "counter name not set");
 
           long value = WebServicesTestUtils.getXmlLong(counter, "value");
-          assertTrue("value not >= 0", value >= 0);
+          assertTrue(value >= 0, "value not >= 0");
 
         }
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobConf.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobConf.java
@@ -149,7 +149,7 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
   }
 
   @Test
-  void testJobConf() throws JSONException, Exception {
+  public void testJobConf() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -168,7 +168,7 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
   }
 
   @Test
-  void testJobConfSlash() throws JSONException, Exception {
+  public void testJobConfSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -187,7 +187,7 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
   }
 
   @Test
-  void testJobConfDefault() throws JSONException, Exception {
+  public void testJobConfDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -205,7 +205,7 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
   }
 
   @Test
-  void testJobConfXML() throws JSONException, Exception {
+  public void testJobConfXML() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobConf.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobConf.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.mapreduce.v2.app.webapp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -52,9 +52,9 @@ import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -126,7 +126,7 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -135,7 +135,7 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @AfterClass
+  @AfterAll
   static public void stop() {
     FileUtil.fullyDelete(testConfDir);
   }
@@ -149,7 +149,7 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
   }
 
   @Test
-  public void testJobConf() throws JSONException, Exception {
+  void testJobConf() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -161,14 +161,14 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("conf");
       verifyAMJobConf(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobConfSlash() throws JSONException, Exception {
+  void testJobConfSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -180,14 +180,14 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("conf");
       verifyAMJobConf(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobConfDefault() throws JSONException, Exception {
+  void testJobConfDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -198,14 +198,14 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("conf");
       verifyAMJobConf(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobConfXML() throws JSONException, Exception {
+  void testJobConfXML() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -229,7 +229,7 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
 
   public void verifyAMJobConf(JSONObject info, Job job) throws JSONException {
 
-    assertEquals("incorrect number of elements", 2, info.length());
+    assertEquals(2, info.length(), "incorrect number of elements");
 
     WebServicesTestUtils.checkStringMatch("path", job.getConfFile().toString(),
         info.getString("path"));
@@ -240,14 +240,14 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
       JSONObject prop = properties.getJSONObject(i);
       String name = prop.getString("name");
       String value = prop.getString("value");
-      assertTrue("name not set", (name != null && !name.isEmpty()));
-      assertTrue("value not set", (value != null && !value.isEmpty()));
+      assertTrue((name != null && !name.isEmpty()), "name not set");
+      assertTrue((value != null && !value.isEmpty()), "value not set");
     }
   }
 
   public void verifyAMJobConfXML(NodeList nodes, Job job) {
 
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
 
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
@@ -260,11 +260,11 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
 
       for (int j = 0; j < properties.getLength(); j++) {
         Element property = (Element) properties.item(j);
-        assertNotNull("should have counters in the web service info", property);
+        assertNotNull(property, "should have counters in the web service info");
         String name = WebServicesTestUtils.getXmlString(property, "name");
         String value = WebServicesTestUtils.getXmlString(property, "value");
-        assertTrue("name not set", (name != null && !name.isEmpty()));
-        assertTrue("name not set", (value != null && !value.isEmpty()));
+        assertTrue((name != null && !name.isEmpty()), "name not set");
+        assertTrue((value != null && !value.isEmpty()), "name not set");
       }
     }
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java
@@ -120,7 +120,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobs() throws JSONException, Exception {
+  public void testJobs() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("jobs").accept(MediaType.APPLICATION_JSON)
@@ -138,7 +138,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobsSlash() throws JSONException, Exception {
+  public void testJobsSlash() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("jobs/").accept(MediaType.APPLICATION_JSON)
@@ -156,7 +156,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobsDefault() throws JSONException, Exception {
+  public void testJobsDefault() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("jobs").get(ClientResponse.class);
@@ -173,7 +173,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobsXML() throws Exception {
+  public void testJobsXML() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("jobs").accept(MediaType.APPLICATION_XML)
@@ -195,7 +195,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobId() throws JSONException, Exception {
+  public void testJobId() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -215,7 +215,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobIdSlash() throws JSONException, Exception {
+  public void testJobIdSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -234,7 +234,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobIdDefault() throws JSONException, Exception {
+  public void testJobIdDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -253,7 +253,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobIdNonExist() throws JSONException, Exception {
+  public void testJobIdNonExist() throws JSONException, Exception {
     WebResource r = resource();
 
     try {
@@ -281,7 +281,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobIdInvalid() throws JSONException, Exception {
+  public void testJobIdInvalid() throws JSONException, Exception {
     WebResource r = resource();
 
     try {
@@ -305,7 +305,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
   // verify the exception output default is JSON
   @Test
-  void testJobIdInvalidDefault() throws JSONException, Exception {
+  public void testJobIdInvalidDefault() throws JSONException, Exception {
     WebResource r = resource();
 
     try {
@@ -329,7 +329,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
   // test that the exception output works in XML
   @Test
-  void testJobIdInvalidXML() throws JSONException, Exception {
+  public void testJobIdInvalidXML() throws JSONException, Exception {
     WebResource r = resource();
 
     try {
@@ -369,7 +369,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobIdInvalidBogus() throws JSONException, Exception {
+  public void testJobIdInvalidBogus() throws JSONException, Exception {
     WebResource r = resource();
 
     try {
@@ -400,7 +400,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobIdXML() throws Exception {
+  public void testJobIdXML() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -634,7 +634,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobCounters() throws JSONException, Exception {
+  public void testJobCounters() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -654,7 +654,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobCountersSlash() throws JSONException, Exception {
+  public void testJobCountersSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -674,7 +674,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobCountersDefault() throws JSONException, Exception {
+  public void testJobCountersDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -693,7 +693,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobCountersXML() throws Exception {
+  public void testJobCountersXML() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -795,7 +795,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobAttempts() throws JSONException, Exception {
+  public void testJobAttempts() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -814,7 +814,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobAttemptsSlash() throws JSONException, Exception {
+  public void testJobAttemptsSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -833,7 +833,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobAttemptsDefault() throws JSONException, Exception {
+  public void testJobAttemptsDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -852,7 +852,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  void testJobAttemptsXML() throws Exception {
+  public void testJobAttemptsXML() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java
@@ -20,10 +20,10 @@ package org.apache.hadoop.mapreduce.v2.app.webapp;
 
 import static org.apache.hadoop.yarn.util.StringHelper.ujoin;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.StringReader;
 import java.util.List;
@@ -54,8 +54,8 @@ import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -103,7 +103,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -120,7 +120,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobs() throws JSONException, Exception {
+  void testJobs() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("jobs").accept(MediaType.APPLICATION_JSON)
@@ -128,7 +128,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject jobs = json.getJSONObject("jobs");
     JSONArray arr = jobs.getJSONArray("job");
     JSONObject info = arr.getJSONObject(0);
@@ -138,7 +138,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobsSlash() throws JSONException, Exception {
+  void testJobsSlash() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("jobs/").accept(MediaType.APPLICATION_JSON)
@@ -146,7 +146,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject jobs = json.getJSONObject("jobs");
     JSONArray arr = jobs.getJSONArray("job");
     JSONObject info = arr.getJSONObject(0);
@@ -156,14 +156,14 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobsDefault() throws JSONException, Exception {
+  void testJobsDefault() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("jobs").get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject jobs = json.getJSONObject("jobs");
     JSONArray arr = jobs.getJSONArray("job");
     JSONObject info = arr.getJSONObject(0);
@@ -173,7 +173,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobsXML() throws Exception {
+  void testJobsXML() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("jobs").accept(MediaType.APPLICATION_XML)
@@ -187,15 +187,15 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList jobs = dom.getElementsByTagName("jobs");
-    assertEquals("incorrect number of elements", 1, jobs.getLength());
+    assertEquals(1, jobs.getLength(), "incorrect number of elements");
     NodeList job = dom.getElementsByTagName("job");
-    assertEquals("incorrect number of elements", 1, job.getLength());
+    assertEquals(1, job.getLength(), "incorrect number of elements");
     verifyAMJobXML(job, appContext);
 
   }
 
   @Test
-  public void testJobId() throws JSONException, Exception {
+  void testJobId() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -207,7 +207,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("job");
       verifyAMJob(info, jobsMap.get(id));
     }
@@ -215,7 +215,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobIdSlash() throws JSONException, Exception {
+  void testJobIdSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -227,14 +227,14 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("job");
       verifyAMJob(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobIdDefault() throws JSONException, Exception {
+  void testJobIdDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -245,7 +245,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("job");
       verifyAMJob(info, jobsMap.get(id));
     }
@@ -253,7 +253,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobIdNonExist() throws JSONException, Exception {
+  void testJobIdNonExist() throws JSONException, Exception {
     WebResource r = resource();
 
     try {
@@ -267,7 +267,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
           response.getType().toString());
       JSONObject msg = response.getEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -281,7 +281,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobIdInvalid() throws JSONException, Exception {
+  void testJobIdInvalid() throws JSONException, Exception {
     WebResource r = resource();
 
     try {
@@ -295,7 +295,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
           response.getType().toString());
       JSONObject msg = response.getEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -305,7 +305,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
   // verify the exception output default is JSON
   @Test
-  public void testJobIdInvalidDefault() throws JSONException, Exception {
+  void testJobIdInvalidDefault() throws JSONException, Exception {
     WebResource r = resource();
 
     try {
@@ -319,7 +319,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
           response.getType().toString());
       JSONObject msg = response.getEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -329,7 +329,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
   // test that the exception output works in XML
   @Test
-  public void testJobIdInvalidXML() throws JSONException, Exception {
+  void testJobIdInvalidXML() throws JSONException, Exception {
     WebResource r = resource();
 
     try {
@@ -369,7 +369,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobIdInvalidBogus() throws JSONException, Exception {
+  void testJobIdInvalidBogus() throws JSONException, Exception {
     WebResource r = resource();
 
     try {
@@ -383,7 +383,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
           response.getType().toString());
       JSONObject msg = response.getEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -400,7 +400,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobIdXML() throws Exception {
+  void testJobIdXML() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -425,7 +425,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
   public void verifyAMJob(JSONObject info, Job job) throws JSONException {
 
-    assertEquals("incorrect number of elements", 31, info.length());
+    assertEquals(31, info.length(), "incorrect number of elements");
 
     // everyone access fields
     verifyAMJobGeneric(job, info.getString("id"), info.getString("user"),
@@ -476,8 +476,8 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
         } else {
           fail("should have acls in the web service info");
         }
-        assertTrue("acl: " + expectName + " not found in webservice output",
-            found);
+        assertTrue(found,
+                "acl: " + expectName + " not found in webservice output");
       }
     }
 
@@ -485,14 +485,14 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
   public void verifyAMJobXML(NodeList nodes, AppContext appContext) {
 
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
 
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
 
       Job job = appContext.getJob(MRApps.toJobID(WebServicesTestUtils
           .getXmlString(element, "id")));
-      assertNotNull("Job not found - output incorrect", job);
+      assertNotNull(job, "Job not found - output incorrect");
 
       verifyAMJobGeneric(job, WebServicesTestUtils.getXmlString(element, "id"),
           WebServicesTestUtils.getXmlString(element, "user"),
@@ -551,8 +551,8 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
           } else {
             fail("should have acls in the web service info");
           }
-          assertTrue("acl: " + expectName + " not found in webservice output",
-              found);
+          assertTrue(found,
+                  "acl: " + expectName + " not found in webservice output");
         }
       }
     }
@@ -572,21 +572,21 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
     WebServicesTestUtils.checkStringMatch("state", job.getState().toString(),
         state);
 
-    assertEquals("startTime incorrect", report.getStartTime(), startTime);
-    assertEquals("finishTime incorrect", report.getFinishTime(), finishTime);
-    assertEquals("elapsedTime incorrect",
-        Times.elapsed(report.getStartTime(), report.getFinishTime()),
-        elapsedTime);
-    assertEquals("mapsTotal incorrect", job.getTotalMaps(), mapsTotal);
-    assertEquals("mapsCompleted incorrect", job.getCompletedMaps(),
-        mapsCompleted);
-    assertEquals("reducesTotal incorrect", job.getTotalReduces(), reducesTotal);
-    assertEquals("reducesCompleted incorrect", job.getCompletedReduces(),
-        reducesCompleted);
-    assertEquals("mapProgress incorrect", report.getMapProgress() * 100,
-        mapProgress, 0);
-    assertEquals("reduceProgress incorrect", report.getReduceProgress() * 100,
-        reduceProgress, 0);
+    assertEquals(report.getStartTime(), startTime, "startTime incorrect");
+    assertEquals(report.getFinishTime(), finishTime, "finishTime incorrect");
+    assertEquals(Times.elapsed(report.getStartTime(), report.getFinishTime()),
+        elapsedTime, "elapsedTime incorrect");
+    assertEquals(job.getTotalMaps(), mapsTotal, "mapsTotal incorrect");
+    assertEquals(job.getCompletedMaps(), mapsCompleted,
+            "mapsCompleted incorrect");
+    assertEquals(job.getTotalReduces(), reducesTotal,
+            "reducesTotal incorrect");
+    assertEquals(job.getCompletedReduces(), reducesCompleted,
+            "reducesCompleted incorrect");
+    assertEquals(report.getMapProgress() * 100, mapProgress, 0,
+            "mapProgress incorrect");
+    assertEquals(report.getReduceProgress() * 100, reduceProgress, 0,
+            "reduceProgress incorrect");
   }
 
   public void verifyAMJobGenericSecure(Job job, int mapsPending,
@@ -609,33 +609,32 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
     WebServicesTestUtils.checkStringMatch("diagnostics", diagString,
         diagnostics);
 
-    assertEquals("isUber incorrect", job.isUber(), uberized);
+    assertEquals(job.isUber(), uberized, "isUber incorrect");
 
     // unfortunately the following fields are all calculated in JobInfo
     // so not easily accessible without doing all the calculations again.
     // For now just make sure they are present.
-    assertTrue("mapsPending not >= 0", mapsPending >= 0);
-    assertTrue("mapsRunning not >= 0", mapsRunning >= 0);
-    assertTrue("reducesPending not >= 0", reducesPending >= 0);
-    assertTrue("reducesRunning not >= 0", reducesRunning >= 0);
+    assertTrue(mapsPending >= 0, "mapsPending not >= 0");
+    assertTrue(mapsRunning >= 0, "mapsRunning not >= 0");
+    assertTrue(reducesPending >= 0, "reducesPending not >= 0");
+    assertTrue(reducesRunning >= 0, "reducesRunning not >= 0");
 
-    assertTrue("newReduceAttempts not >= 0", newReduceAttempts >= 0);
-    assertTrue("runningReduceAttempts not >= 0", runningReduceAttempts >= 0);
-    assertTrue("failedReduceAttempts not >= 0", failedReduceAttempts >= 0);
-    assertTrue("killedReduceAttempts not >= 0", killedReduceAttempts >= 0);
-    assertTrue("successfulReduceAttempts not >= 0",
-        successfulReduceAttempts >= 0);
+    assertTrue(newReduceAttempts >= 0, "newReduceAttempts not >= 0");
+    assertTrue(runningReduceAttempts >= 0, "runningReduceAttempts not >= 0");
+    assertTrue(failedReduceAttempts >= 0, "failedReduceAttempts not >= 0");
+    assertTrue(killedReduceAttempts >= 0, "killedReduceAttempts not >= 0");
+    assertTrue(successfulReduceAttempts >= 0, "successfulReduceAttempts not >= 0");
 
-    assertTrue("newMapAttempts not >= 0", newMapAttempts >= 0);
-    assertTrue("runningMapAttempts not >= 0", runningMapAttempts >= 0);
-    assertTrue("failedMapAttempts not >= 0", failedMapAttempts >= 0);
-    assertTrue("killedMapAttempts not >= 0", killedMapAttempts >= 0);
-    assertTrue("successfulMapAttempts not >= 0", successfulMapAttempts >= 0);
+    assertTrue(newMapAttempts >= 0, "newMapAttempts not >= 0");
+    assertTrue(runningMapAttempts >= 0, "runningMapAttempts not >= 0");
+    assertTrue(failedMapAttempts >= 0, "failedMapAttempts not >= 0");
+    assertTrue(killedMapAttempts >= 0, "killedMapAttempts not >= 0");
+    assertTrue(successfulMapAttempts >= 0, "successfulMapAttempts not >= 0");
 
   }
 
   @Test
-  public void testJobCounters() throws JSONException, Exception {
+  void testJobCounters() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -647,14 +646,15 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(),
+              "incorrect number of elements");
       JSONObject info = json.getJSONObject("jobCounters");
       verifyAMJobCounters(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobCountersSlash() throws JSONException, Exception {
+  void testJobCountersSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -666,14 +666,15 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(),
+              "incorrect number of elements");
       JSONObject info = json.getJSONObject("jobCounters");
       verifyAMJobCounters(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobCountersDefault() throws JSONException, Exception {
+  void testJobCountersDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -684,14 +685,15 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(),
+              "incorrect number of elements");
       JSONObject info = json.getJSONObject("jobCounters");
       verifyAMJobCounters(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobCountersXML() throws Exception {
+  void testJobCountersXML() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -716,7 +718,8 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   public void verifyAMJobCounters(JSONObject info, Job job)
       throws JSONException {
 
-    assertEquals("incorrect number of elements", 2, info.length());
+    assertEquals(2, info.length(),
+            "incorrect number of elements");
 
     WebServicesTestUtils.checkStringMatch("id", MRApps.toString(job.getID()),
         info.getString("id"));
@@ -726,22 +729,22 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
     for (int i = 0; i < counterGroups.length(); i++) {
       JSONObject counterGroup = counterGroups.getJSONObject(i);
       String name = counterGroup.getString("counterGroupName");
-      assertTrue("name not set", (name != null && !name.isEmpty()));
+      assertTrue((name != null && !name.isEmpty()), "name not set");
       JSONArray counters = counterGroup.getJSONArray("counter");
       for (int j = 0; j < counters.length(); j++) {
         JSONObject counter = counters.getJSONObject(j);
         String counterName = counter.getString("name");
-        assertTrue("counter name not set",
-            (counterName != null && !counterName.isEmpty()));
+        assertTrue((counterName != null && !counterName.isEmpty()),
+                "counter name not set");
 
         long mapValue = counter.getLong("mapCounterValue");
-        assertTrue("mapCounterValue  >= 0", mapValue >= 0);
+        assertTrue(mapValue >= 0, "mapCounterValue  >= 0");
 
         long reduceValue = counter.getLong("reduceCounterValue");
-        assertTrue("reduceCounterValue  >= 0", reduceValue >= 0);
+        assertTrue(reduceValue >= 0, "reduceCounterValue  >= 0");
 
         long totalValue = counter.getLong("totalCounterValue");
-        assertTrue("totalCounterValue  >= 0", totalValue >= 0);
+        assertTrue(totalValue >= 0, "totalCounterValue  >= 0");
 
       }
     }
@@ -752,7 +755,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
 
-      assertNotNull("Job not found - output incorrect", job);
+      assertNotNull(job, "Job not found - output incorrect");
 
       WebServicesTestUtils.checkStringMatch("id", MRApps.toString(job.getID()),
           WebServicesTestUtils.getXmlString(element, "id"));
@@ -762,36 +765,37 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
       for (int j = 0; j < groups.getLength(); j++) {
         Element counters = (Element) groups.item(j);
-        assertNotNull("should have counters in the web service info", counters);
+        assertNotNull(counters,
+                "should have counters in the web service info");
         String name = WebServicesTestUtils.getXmlString(counters,
             "counterGroupName");
-        assertTrue("name not set", (name != null && !name.isEmpty()));
+        assertTrue((name != null && !name.isEmpty()), "name not set");
         NodeList counterArr = counters.getElementsByTagName("counter");
         for (int z = 0; z < counterArr.getLength(); z++) {
           Element counter = (Element) counterArr.item(z);
           String counterName = WebServicesTestUtils.getXmlString(counter,
               "name");
-          assertTrue("counter name not set",
-              (counterName != null && !counterName.isEmpty()));
+          assertTrue((counterName != null && !counterName.isEmpty()),
+                  "counter name not set");
 
           long mapValue = WebServicesTestUtils.getXmlLong(counter,
               "mapCounterValue");
-          assertTrue("mapCounterValue not >= 0", mapValue >= 0);
+          assertTrue(mapValue >= 0, "mapCounterValue not >= 0");
 
           long reduceValue = WebServicesTestUtils.getXmlLong(counter,
               "reduceCounterValue");
-          assertTrue("reduceCounterValue  >= 0", reduceValue >= 0);
+          assertTrue(reduceValue >= 0, "reduceCounterValue  >= 0");
 
           long totalValue = WebServicesTestUtils.getXmlLong(counter,
               "totalCounterValue");
-          assertTrue("totalCounterValue  >= 0", totalValue >= 0);
+          assertTrue(totalValue >= 0, "totalCounterValue  >= 0");
         }
       }
     }
   }
 
   @Test
-  public void testJobAttempts() throws JSONException, Exception {
+  void testJobAttempts() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -803,14 +807,14 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("jobAttempts");
       verifyJobAttempts(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobAttemptsSlash() throws JSONException, Exception {
+  void testJobAttemptsSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -822,14 +826,14 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("jobAttempts");
       verifyJobAttempts(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobAttemptsDefault() throws JSONException, Exception {
+  void testJobAttemptsDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -841,14 +845,14 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("jobAttempts");
       verifyJobAttempts(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobAttemptsXML() throws Exception {
+  void testJobAttemptsXML() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -866,7 +870,8 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       is.setCharacterStream(new StringReader(xml));
       Document dom = db.parse(is);
       NodeList attempts = dom.getElementsByTagName("jobAttempts");
-      assertEquals("incorrect number of elements", 1, attempts.getLength());
+      assertEquals(1, attempts.getLength(),
+              "incorrect number of elements");
       NodeList info = dom.getElementsByTagName("jobAttempt");
       verifyJobAttemptsXML(info, jobsMap.get(id));
     }
@@ -876,7 +881,8 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       throws JSONException {
 
     JSONArray attempts = info.getJSONArray("jobAttempt");
-    assertEquals("incorrect number of elements", 2, attempts.length());
+    assertEquals(2, attempts.length(),
+            "incorrect number of elements");
     for (int i = 0; i < attempts.length(); i++) {
       JSONObject attempt = attempts.getJSONObject(i);
       verifyJobAttemptsGeneric(job, attempt.getString("nodeHttpAddress"),
@@ -888,7 +894,8 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
   public void verifyJobAttemptsXML(NodeList nodes, Job job) {
 
-    assertEquals("incorrect number of elements", 2, nodes.getLength());
+    assertEquals(2, nodes.getLength(),
+            "incorrect number of elements");
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
       verifyJobAttemptsGeneric(job,
@@ -914,17 +921,17 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
             + nmHttpPort, nodeHttpAddress);
         WebServicesTestUtils.checkStringMatch("nodeId",
             NodeId.newInstance(nmHost, nmPort).toString(), nodeId);
-        assertTrue("startime not greater than 0", startTime > 0);
+        assertTrue(startTime > 0, "startime not greater than 0");
         WebServicesTestUtils.checkStringMatch("containerId", amInfo
             .getContainerId().toString(), containerId);
 
         String localLogsLink =ujoin("node", "containerlogs", containerId,
             job.getUserName());
 
-        assertTrue("logsLink", logsLink.contains(localLogsLink));
+        assertTrue(logsLink.contains(localLogsLink), "logsLink");
       }
     }
-    assertTrue("attempt: " + id + " was not found", attemptFound);
+    assertTrue(attemptFound, "attempt: " + id + " was not found");
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesTasks.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesTasks.java
@@ -19,10 +19,10 @@
 package org.apache.hadoop.mapreduce.v2.app.webapp;
 
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.StringReader;
 import java.util.Map;
@@ -50,8 +50,8 @@ import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -99,7 +99,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -116,7 +116,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTasks() throws JSONException, Exception {
+  void testTasks() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -127,17 +127,17 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject tasks = json.getJSONObject("tasks");
       JSONArray arr = tasks.getJSONArray("task");
-      assertEquals("incorrect number of elements", 2, arr.length());
+      assertEquals(2, arr.length(), "incorrect number of elements");
 
       verifyAMTask(arr, jobsMap.get(id), null);
     }
   }
 
   @Test
-  public void testTasksDefault() throws JSONException, Exception {
+  void testTasksDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -147,17 +147,17 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject tasks = json.getJSONObject("tasks");
       JSONArray arr = tasks.getJSONArray("task");
-      assertEquals("incorrect number of elements", 2, arr.length());
+      assertEquals(2, arr.length(), "incorrect number of elements");
 
       verifyAMTask(arr, jobsMap.get(id), null);
     }
   }
 
   @Test
-  public void testTasksSlash() throws JSONException, Exception {
+  void testTasksSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -168,17 +168,17 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject tasks = json.getJSONObject("tasks");
       JSONArray arr = tasks.getJSONArray("task");
-      assertEquals("incorrect number of elements", 2, arr.length());
+      assertEquals(2, arr.length(), "incorrect number of elements");
 
       verifyAMTask(arr, jobsMap.get(id), null);
     }
   }
 
   @Test
-  public void testTasksXML() throws JSONException, Exception {
+  void testTasksXML() throws JSONException, Exception {
 
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
@@ -196,14 +196,14 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
       is.setCharacterStream(new StringReader(xml));
       Document dom = db.parse(is);
       NodeList tasks = dom.getElementsByTagName("tasks");
-      assertEquals("incorrect number of elements", 1, tasks.getLength());
+      assertEquals(1, tasks.getLength(), "incorrect number of elements");
       NodeList task = dom.getElementsByTagName("task");
       verifyAMTaskXML(task, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testTasksQueryMap() throws JSONException, Exception {
+  void testTasksQueryMap() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -215,16 +215,16 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject tasks = json.getJSONObject("tasks");
       JSONArray arr = tasks.getJSONArray("task");
-      assertEquals("incorrect number of elements", 1, arr.length());
+      assertEquals(1, arr.length(), "incorrect number of elements");
       verifyAMTask(arr, jobsMap.get(id), type);
     }
   }
 
   @Test
-  public void testTasksQueryReduce() throws JSONException, Exception {
+  void testTasksQueryReduce() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -236,16 +236,16 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject tasks = json.getJSONObject("tasks");
       JSONArray arr = tasks.getJSONArray("task");
-      assertEquals("incorrect number of elements", 1, arr.length());
+      assertEquals(1, arr.length(), "incorrect number of elements");
       verifyAMTask(arr, jobsMap.get(id), type);
     }
   }
 
   @Test
-  public void testTasksQueryInvalid() throws JSONException, Exception {
+  void testTasksQueryInvalid() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -265,7 +265,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
             response.getType().toString());
         JSONObject msg = response.getEntity(JSONObject.class);
         JSONObject exception = msg.getJSONObject("RemoteException");
-        assertEquals("incorrect number of elements", 3, exception.length());
+        assertEquals(3, exception.length(), "incorrect number of elements");
         String message = exception.getString("message");
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
@@ -280,7 +280,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskId() throws JSONException, Exception {
+  void testTaskId() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -294,7 +294,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
             response.getType().toString());
         JSONObject json = response.getEntity(JSONObject.class);
-        assertEquals("incorrect number of elements", 1, json.length());
+        assertEquals(1, json.length(), "incorrect number of elements");
         JSONObject info = json.getJSONObject("task");
         verifyAMSingleTask(info, task);
       }
@@ -302,7 +302,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdSlash() throws JSONException, Exception {
+  void testTaskIdSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -316,7 +316,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
             response.getType().toString());
         JSONObject json = response.getEntity(JSONObject.class);
-        assertEquals("incorrect number of elements", 1, json.length());
+        assertEquals(1, json.length(), "incorrect number of elements");
         JSONObject info = json.getJSONObject("task");
         verifyAMSingleTask(info, task);
       }
@@ -324,7 +324,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdDefault() throws JSONException, Exception {
+  void testTaskIdDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -338,7 +338,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
             response.getType().toString());
         JSONObject json = response.getEntity(JSONObject.class);
-        assertEquals("incorrect number of elements", 1, json.length());
+        assertEquals(1, json.length(), "incorrect number of elements");
         JSONObject info = json.getJSONObject("task");
         verifyAMSingleTask(info, task);
       }
@@ -346,7 +346,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdBogus() throws JSONException, Exception {
+  void testTaskIdBogus() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -363,7 +363,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
             response.getType().toString());
         JSONObject msg = response.getEntity(JSONObject.class);
         JSONObject exception = msg.getJSONObject("RemoteException");
-        assertEquals("incorrect number of elements", 3, exception.length());
+        assertEquals(3, exception.length(), "incorrect number of elements");
         String message = exception.getString("message");
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
@@ -381,7 +381,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdNonExist() throws JSONException, Exception {
+  void testTaskIdNonExist() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -398,7 +398,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
             response.getType().toString());
         JSONObject msg = response.getEntity(JSONObject.class);
         JSONObject exception = msg.getJSONObject("RemoteException");
-        assertEquals("incorrect number of elements", 3, exception.length());
+        assertEquals(3, exception.length(), "incorrect number of elements");
         String message = exception.getString("message");
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
@@ -414,7 +414,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdInvalid() throws JSONException, Exception {
+  void testTaskIdInvalid() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -431,7 +431,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
             response.getType().toString());
         JSONObject msg = response.getEntity(JSONObject.class);
         JSONObject exception = msg.getJSONObject("RemoteException");
-        assertEquals("incorrect number of elements", 3, exception.length());
+        assertEquals(3, exception.length(), "incorrect number of elements");
         String message = exception.getString("message");
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
@@ -449,7 +449,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdInvalid2() throws JSONException, Exception {
+  void testTaskIdInvalid2() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -466,7 +466,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
             response.getType().toString());
         JSONObject msg = response.getEntity(JSONObject.class);
         JSONObject exception = msg.getJSONObject("RemoteException");
-        assertEquals("incorrect number of elements", 3, exception.length());
+        assertEquals(3, exception.length(), "incorrect number of elements");
         String message = exception.getString("message");
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
@@ -484,7 +484,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdInvalid3() throws JSONException, Exception {
+  void testTaskIdInvalid3() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -501,7 +501,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
             response.getType().toString());
         JSONObject msg = response.getEntity(JSONObject.class);
         JSONObject exception = msg.getJSONObject("RemoteException");
-        assertEquals("incorrect number of elements", 3, exception.length());
+        assertEquals(3, exception.length(), "incorrect number of elements");
         String message = exception.getString("message");
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
@@ -519,7 +519,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdXML() throws JSONException, Exception {
+  void testTaskIdXML() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -550,7 +550,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
 
   public void verifyAMSingleTask(JSONObject info, Task task)
       throws JSONException {
-    assertEquals("incorrect number of elements", 9, info.length());
+    assertEquals(9, info.length(), "incorrect number of elements");
 
     verifyTaskGeneric(task, info.getString("id"), info.getString("state"),
         info.getString("type"), info.getString("successfulAttempt"),
@@ -574,7 +574,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
             verifyAMSingleTask(info, task);
           }
         }
-        assertTrue("task with id: " + tid + " not in web service output", found);
+        assertTrue(found, "task with id: " + tid + " not in web service output");
       }
     }
   }
@@ -593,12 +593,12 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
     WebServicesTestUtils.checkStringMatch("state", report.getTaskState()
         .toString(), state);
     // not easily checked without duplicating logic, just make sure its here
-    assertNotNull("successfulAttempt null", successfulAttempt);
-    assertEquals("startTime wrong", report.getStartTime(), startTime);
-    assertEquals("finishTime wrong", report.getFinishTime(), finishTime);
-    assertEquals("elapsedTime wrong", finishTime - startTime, elapsedTime);
-    assertEquals("progress wrong", report.getProgress() * 100, progress, 1e-3f);
-    assertEquals("status wrong", report.getStatus(), status);
+    assertNotNull(successfulAttempt, "successfulAttempt null");
+    assertEquals(report.getStartTime(), startTime, "startTime wrong");
+    assertEquals(report.getFinishTime(), finishTime, "finishTime wrong");
+    assertEquals(finishTime - startTime, elapsedTime, "elapsedTime wrong");
+    assertEquals(report.getProgress() * 100, progress, 1e-3f, "progress wrong");
+    assertEquals(report.getStatus(), status, "status wrong");
   }
 
   public void verifyAMSingleTaskXML(Element element, Task task) {
@@ -615,7 +615,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
 
   public void verifyAMTaskXML(NodeList nodes, Job job) {
 
-    assertEquals("incorrect number of elements", 2, nodes.getLength());
+    assertEquals(2, nodes.getLength(), "incorrect number of elements");
 
     for (Task task : job.getTasks().values()) {
       TaskId id = task.getID();
@@ -629,12 +629,12 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
           verifyAMSingleTaskXML(element, task);
         }
       }
-      assertTrue("task with id: " + tid + " not in web service output", found);
+      assertTrue(found, "task with id: " + tid + " not in web service output");
     }
   }
 
   @Test
-  public void testTaskIdCounters() throws JSONException, Exception {
+  void testTaskIdCounters() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -648,7 +648,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
             response.getType().toString());
         JSONObject json = response.getEntity(JSONObject.class);
-        assertEquals("incorrect number of elements", 1, json.length());
+        assertEquals(1, json.length(), "incorrect number of elements");
         JSONObject info = json.getJSONObject("jobTaskCounters");
         verifyAMJobTaskCounters(info, task);
       }
@@ -656,7 +656,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdCountersSlash() throws JSONException, Exception {
+  void testTaskIdCountersSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -670,7 +670,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
             response.getType().toString());
         JSONObject json = response.getEntity(JSONObject.class);
-        assertEquals("incorrect number of elements", 1, json.length());
+        assertEquals(1, json.length(), "incorrect number of elements");
         JSONObject info = json.getJSONObject("jobTaskCounters");
         verifyAMJobTaskCounters(info, task);
       }
@@ -678,7 +678,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdCountersDefault() throws JSONException, Exception {
+  void testTaskIdCountersDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -692,7 +692,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
             response.getType().toString());
         JSONObject json = response.getEntity(JSONObject.class);
-        assertEquals("incorrect number of elements", 1, json.length());
+        assertEquals(1, json.length(), "incorrect number of elements");
         JSONObject info = json.getJSONObject("jobTaskCounters");
         verifyAMJobTaskCounters(info, task);
       }
@@ -700,7 +700,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testJobTaskCountersXML() throws Exception {
+  void testJobTaskCountersXML() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -728,7 +728,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   public void verifyAMJobTaskCounters(JSONObject info, Task task)
       throws JSONException {
 
-    assertEquals("incorrect number of elements", 2, info.length());
+    assertEquals(2, info.length(), "incorrect number of elements");
 
     WebServicesTestUtils.checkStringMatch("id", MRApps.toString(task.getID()),
         info.getString("id"));
@@ -738,15 +738,14 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
     for (int i = 0; i < counterGroups.length(); i++) {
       JSONObject counterGroup = counterGroups.getJSONObject(i);
       String name = counterGroup.getString("counterGroupName");
-      assertTrue("name not set", (name != null && !name.isEmpty()));
+      assertTrue((name != null && !name.isEmpty()), "name not set");
       JSONArray counters = counterGroup.getJSONArray("counter");
       for (int j = 0; j < counters.length(); j++) {
         JSONObject counter = counters.getJSONObject(j);
         String counterName = counter.getString("name");
-        assertTrue("name not set",
-            (counterName != null && !counterName.isEmpty()));
+        assertTrue((counterName != null && !counterName.isEmpty()), "name not set");
         long value = counter.getLong("value");
-        assertTrue("value  >= 0", value >= 0);
+        assertTrue(value >= 0, "value  >= 0");
       }
     }
   }
@@ -765,20 +764,20 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
 
       for (int j = 0; j < groups.getLength(); j++) {
         Element counters = (Element) groups.item(j);
-        assertNotNull("should have counters in the web service info", counters);
+        assertNotNull(counters, "should have counters in the web service info");
         String name = WebServicesTestUtils.getXmlString(counters,
             "counterGroupName");
-        assertTrue("name not set", (name != null && !name.isEmpty()));
+        assertTrue((name != null && !name.isEmpty()), "name not set");
         NodeList counterArr = counters.getElementsByTagName("counter");
         for (int z = 0; z < counterArr.getLength(); z++) {
           Element counter = (Element) counterArr.item(z);
           String counterName = WebServicesTestUtils.getXmlString(counter,
               "name");
-          assertTrue("counter name not set",
-              (counterName != null && !counterName.isEmpty()));
+          assertTrue((counterName != null && !counterName.isEmpty()),
+                  "counter name not set");
 
           long value = WebServicesTestUtils.getXmlLong(counter, "value");
-          assertTrue("value not >= 0", value >= 0);
+          assertTrue(value >= 0, "value not >= 0");
 
         }
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesTasks.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesTasks.java
@@ -116,7 +116,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTasks() throws JSONException, Exception {
+  public void testTasks() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -137,7 +137,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTasksDefault() throws JSONException, Exception {
+  public void testTasksDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -157,7 +157,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTasksSlash() throws JSONException, Exception {
+  public void testTasksSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -178,7 +178,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTasksXML() throws JSONException, Exception {
+  public void testTasksXML() throws JSONException, Exception {
 
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
@@ -203,7 +203,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTasksQueryMap() throws JSONException, Exception {
+  public void testTasksQueryMap() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -224,7 +224,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTasksQueryReduce() throws JSONException, Exception {
+  public void testTasksQueryReduce() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -245,7 +245,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTasksQueryInvalid() throws JSONException, Exception {
+  public void testTasksQueryInvalid() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -280,7 +280,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTaskId() throws JSONException, Exception {
+  public void testTaskId() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -302,7 +302,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTaskIdSlash() throws JSONException, Exception {
+  public void testTaskIdSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -324,7 +324,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTaskIdDefault() throws JSONException, Exception {
+  public void testTaskIdDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -346,7 +346,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTaskIdBogus() throws JSONException, Exception {
+  public void testTaskIdBogus() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -381,7 +381,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTaskIdNonExist() throws JSONException, Exception {
+  public void testTaskIdNonExist() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -414,7 +414,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTaskIdInvalid() throws JSONException, Exception {
+  public void testTaskIdInvalid() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -449,7 +449,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTaskIdInvalid2() throws JSONException, Exception {
+  public void testTaskIdInvalid2() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -484,7 +484,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTaskIdInvalid3() throws JSONException, Exception {
+  public void testTaskIdInvalid3() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -519,7 +519,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTaskIdXML() throws JSONException, Exception {
+  public void testTaskIdXML() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -634,7 +634,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTaskIdCounters() throws JSONException, Exception {
+  public void testTaskIdCounters() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -656,7 +656,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTaskIdCountersSlash() throws JSONException, Exception {
+  public void testTaskIdCountersSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -678,7 +678,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testTaskIdCountersDefault() throws JSONException, Exception {
+  public void testTaskIdCountersDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -700,7 +700,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  void testJobTaskCountersXML() throws Exception {
+  public void testJobTaskCountersXML() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAppController.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAppController.java
@@ -37,8 +37,8 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.webapp.Controller.RequestContext;
 import org.apache.hadoop.yarn.webapp.MimeType;
 import org.apache.hadoop.yarn.webapp.ResponseInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import static org.junit.Assert.*;
 
 public class TestAppController {
@@ -48,7 +48,7 @@ public class TestAppController {
   private Job job;
   private static final String taskId = "task_01_01_m_01";
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     AppContext context = mock(AppContext.class);
     when(context.getApplicationID()).thenReturn(
@@ -82,14 +82,14 @@ public class TestAppController {
    * test bad request should be status 400...
    */
   @Test
-  public void testBadRequest() {
+  void testBadRequest() {
     String message = "test string";
     appController.badRequest(message);
     verifyExpectations(message);
   }
 
   @Test
-  public void testBadRequestWithNullMessage() {
+  void testBadRequestWithNullMessage() {
     // It should not throw NullPointerException
     appController.badRequest(null);
     verifyExpectations(StringUtils.EMPTY);
@@ -108,7 +108,7 @@ public class TestAppController {
    * Test the method 'info'.
    */
   @Test
-  public void testInfo() {
+  void testInfo() {
 
     appController.info();
     Iterator<ResponseInfo.Item> iterator = appController.getResponseInfo()
@@ -134,7 +134,7 @@ public class TestAppController {
    *  Test method 'job'. Should print message about error or set JobPage class for rendering
    */
   @Test
-  public void testGetJob() {
+  void testGetJob() {
     when(job.checkAccess(any(UserGroupInformation.class), any(JobACL.class)))
         .thenReturn(false);
 
@@ -161,7 +161,7 @@ public class TestAppController {
    *  Test method 'jobCounters'. Should print message about error or set CountersPage class for rendering
    */
   @Test
-  public void testGetJobCounters() {
+  void testGetJobCounters() {
 
     when(job.checkAccess(any(UserGroupInformation.class), any(JobACL.class)))
         .thenReturn(false);
@@ -189,7 +189,7 @@ public class TestAppController {
    *  Test method 'taskCounters'. Should print message about error or set CountersPage class for rendering
    */
   @Test
-  public void testGetTaskCounters() {
+  void testGetTaskCounters() {
 
     when(job.checkAccess(any(UserGroupInformation.class), any(JobACL.class)))
         .thenReturn(false);
@@ -218,7 +218,7 @@ public class TestAppController {
    */
 
   @Test
-  public void testGetSingleJobCounter() throws IOException {
+  void testGetSingleJobCounter() throws IOException {
     appController.singleJobCounter();
     assertEquals(SingleCounterPage.class, appController.getClazz());
   }
@@ -238,7 +238,7 @@ public class TestAppController {
    */
 
   @Test
-  public void testTasks() {
+  void testTasks() {
  
     appController.tasks();
  
@@ -248,7 +248,7 @@ public class TestAppController {
    *  Test method 'task'. Should set TaskPage class for rendering and information for title
    */
   @Test
-  public void testTask() {
+  void testTask() {
  
     appController.task();
     assertEquals("Attempts for " + taskId ,
@@ -261,7 +261,7 @@ public class TestAppController {
    *   Test method 'conf'. Should set JobConfPage class for rendering
    */
   @Test
-  public void testConfiguration() {
+  void testConfiguration() {
  
     appController.conf();
 
@@ -272,7 +272,7 @@ public class TestAppController {
    * Test downloadConf request handling.
    */
   @Test
-  public void testDownloadConfiguration() {
+  void testDownloadConfiguration() {
     appController.downloadConf();
     String jobConfXml = appController.getData();
     assertTrue("Error downloading the job configuration file.",
@@ -283,7 +283,7 @@ public class TestAppController {
    *   Test method 'conf'. Should set AttemptsPage class for rendering or print information about error
    */
   @Test
-  public void testAttempts() {
+  void testAttempts() {
 
     appController.getProperty().remove(AMParams.TASK_TYPE);
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAppController.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAppController.java
@@ -82,14 +82,14 @@ public class TestAppController {
    * test bad request should be status 400...
    */
   @Test
-  void testBadRequest() {
+  public void testBadRequest() {
     String message = "test string";
     appController.badRequest(message);
     verifyExpectations(message);
   }
 
   @Test
-  void testBadRequestWithNullMessage() {
+  public void testBadRequestWithNullMessage() {
     // It should not throw NullPointerException
     appController.badRequest(null);
     verifyExpectations(StringUtils.EMPTY);
@@ -108,7 +108,7 @@ public class TestAppController {
    * Test the method 'info'.
    */
   @Test
-  void testInfo() {
+  public void testInfo() {
 
     appController.info();
     Iterator<ResponseInfo.Item> iterator = appController.getResponseInfo()
@@ -134,7 +134,7 @@ public class TestAppController {
    *  Test method 'job'. Should print message about error or set JobPage class for rendering
    */
   @Test
-  void testGetJob() {
+  public void testGetJob() {
     when(job.checkAccess(any(UserGroupInformation.class), any(JobACL.class)))
         .thenReturn(false);
 
@@ -161,7 +161,7 @@ public class TestAppController {
    *  Test method 'jobCounters'. Should print message about error or set CountersPage class for rendering
    */
   @Test
-  void testGetJobCounters() {
+  public void testGetJobCounters() {
 
     when(job.checkAccess(any(UserGroupInformation.class), any(JobACL.class)))
         .thenReturn(false);
@@ -189,7 +189,7 @@ public class TestAppController {
    *  Test method 'taskCounters'. Should print message about error or set CountersPage class for rendering
    */
   @Test
-  void testGetTaskCounters() {
+  public void testGetTaskCounters() {
 
     when(job.checkAccess(any(UserGroupInformation.class), any(JobACL.class)))
         .thenReturn(false);
@@ -218,7 +218,7 @@ public class TestAppController {
    */
 
   @Test
-  void testGetSingleJobCounter() throws IOException {
+  public void testGetSingleJobCounter() throws IOException {
     appController.singleJobCounter();
     assertEquals(SingleCounterPage.class, appController.getClazz());
   }
@@ -238,7 +238,7 @@ public class TestAppController {
    */
 
   @Test
-  void testTasks() {
+  public void testTasks() {
  
     appController.tasks();
  
@@ -248,7 +248,7 @@ public class TestAppController {
    *  Test method 'task'. Should set TaskPage class for rendering and information for title
    */
   @Test
-  void testTask() {
+  public void testTask() {
  
     appController.task();
     assertEquals("Attempts for " + taskId ,
@@ -261,7 +261,7 @@ public class TestAppController {
    *   Test method 'conf'. Should set JobConfPage class for rendering
    */
   @Test
-  void testConfiguration() {
+  public void testConfiguration() {
  
     appController.conf();
 
@@ -272,7 +272,7 @@ public class TestAppController {
    * Test downloadConf request handling.
    */
   @Test
-  void testDownloadConfiguration() {
+  public void testDownloadConfiguration() {
     appController.downloadConf();
     String jobConfXml = appController.getData();
     assertTrue("Error downloading the job configuration file.",
@@ -283,7 +283,7 @@ public class TestAppController {
    *   Test method 'conf'. Should set AttemptsPage class for rendering or print information about error
    */
   @Test
-  void testAttempts() {
+  public void testAttempts() {
 
     appController.getProperty().remove(AMParams.TASK_TYPE);
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestBlocks.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestBlocks.java
@@ -61,7 +61,7 @@ public class TestBlocks {
    * Test rendering for ConfBlock
    */
   @Test
-  void testConfigurationBlock() throws Exception {
+  public void testConfigurationBlock() throws Exception {
     AppContext ctx = mock(AppContext.class);
     Job job = mock(Job.class);
     Path path = new Path("conf");
@@ -100,7 +100,7 @@ public class TestBlocks {
    * Test rendering for TasksBlock
    */
   @Test
-  void testTasksBlock() throws Exception {
+  public void testTasksBlock() throws Exception {
 
     ApplicationId appId = ApplicationIdPBImpl.newInstance(0, 1);
     JobId jobId = new JobIdPBImpl();
@@ -155,7 +155,7 @@ public class TestBlocks {
    * test AttemptsBlock's rendering.
    */
   @Test
-  void testAttemptsBlock() {
+  public void testAttemptsBlock() {
     AppContext ctx = mock(AppContext.class);
     AppForTest app = new AppForTest(ctx);
 
@@ -214,7 +214,7 @@ public class TestBlocks {
   }
 
   @Test
-  void testSingleCounterBlock() {
+  public void testSingleCounterBlock() {
     AppContext appCtx = mock(AppContext.class);
     View.ViewContext ctx = mock(View.ViewContext.class);
     JobId jobId = new JobIdPBImpl();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestBlocks.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestBlocks.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.util.MRJobConfUtil;
 import org.apache.hadoop.yarn.webapp.View;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.v2.api.records.JobId;
@@ -52,7 +52,7 @@ import org.apache.hadoop.yarn.webapp.view.HtmlBlock;
 import org.apache.hadoop.yarn.webapp.view.HtmlBlock.Block;
 
 import static org.mockito.Mockito.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestBlocks {
   private ByteArrayOutputStream data = new ByteArrayOutputStream();
@@ -61,7 +61,7 @@ public class TestBlocks {
    * Test rendering for ConfBlock
    */
   @Test
-  public void testConfigurationBlock() throws Exception {
+  void testConfigurationBlock() throws Exception {
     AppContext ctx = mock(AppContext.class);
     Job job = mock(Job.class);
     Path path = new Path("conf");
@@ -100,7 +100,7 @@ public class TestBlocks {
    * Test rendering for TasksBlock
    */
   @Test
-  public void testTasksBlock() throws Exception {
+  void testTasksBlock() throws Exception {
 
     ApplicationId appId = ApplicationIdPBImpl.newInstance(0, 1);
     JobId jobId = new JobIdPBImpl();
@@ -155,7 +155,7 @@ public class TestBlocks {
    * test AttemptsBlock's rendering.
    */
   @Test
-  public void testAttemptsBlock() {
+  void testAttemptsBlock() {
     AppContext ctx = mock(AppContext.class);
     AppForTest app = new AppForTest(ctx);
 
@@ -214,7 +214,7 @@ public class TestBlocks {
   }
 
   @Test
-  public void testSingleCounterBlock() {
+  void testSingleCounterBlock() {
     AppContext appCtx = mock(AppContext.class);
     View.ViewContext ctx = mock(View.ViewContext.class);
     JobId jobId = new JobIdPBImpl();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

