### PR TITLE
YARN-11391. Support using DNS to resolve yarn services to IP addresses.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/MockDomainNameResolver.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/MockDomainNameResolver.java
@@ -95,4 +95,9 @@ public class MockDomainNameResolver implements DomainNameResolver {
   public void setAddressMap(Map<String, InetAddress[]> addresses) {
     this.addrs = addresses;
   }
+
+  @VisibleForTesting
+  public void setPtrMap(Map<InetAddress, String> ptrMap) {
+    this.ptrMap = ptrMap;
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/HAUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/HAUtil.java
@@ -267,7 +267,7 @@ public class HAUtil {
 
   /**
    * Instead of returning RM_HA_IDS in current configurations, it
-   * would return the originally preset one in case of DNS resolving
+   * would return the originally preset one in case of DNS resolving.
    * @param conf Configuration.
    * @return RM Ids from original xml file
    */
@@ -343,7 +343,8 @@ public class HAUtil {
     // this function would only return value which is corresponded to YarnConfiguration.RM_ADDRESS
     Map<String, InetSocketAddress> ret = null;
     for (List<String> configKeys : addressesConfigKeysMap.values()) {
-      Map<String, InetSocketAddress> res = getResolvedIdPairs(conf, resolveNeeded, requireFQDN, getOriginalRMHAIds(conf),
+      Map<String, InetSocketAddress> res = getResolvedIdPairs(
+          conf, resolveNeeded, requireFQDN, getOriginalRMHAIds(conf),
           configKeys.get(0), YarnConfiguration.RM_HA_IDS, configKeys);
       if (configKeys.contains(YarnConfiguration.RM_ADDRESS)) {
         ret = res;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/HAUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/HAUtil.java
@@ -371,22 +371,19 @@ public class HAUtil {
         }
         // If the address needs to be resolved, get all of the IP addresses
         // from this address and pass them into the map
-        LOG.info("Multi-A domain name " + addr +
-            " will be resolved by " + dnr.getClass().getName());
+        LOG.info("Multi-A domain name {} will be resolved by {}" + addr, dnr.getClass().getName());
         int port = address.getPort();
         String[] resolvedHostNames;
         try {
           resolvedHostNames = dnr.getAllResolvedHostnameByDomainName(
               address.getHostName(), requireFQDN);
         } catch (UnknownHostException e) {
-          LOG.warn("Exception in resolving socket address "
-              + address.getHostName(), e);
+          LOG.warn("Exception in resolving socket address {}", address.getHostName(), e);
           continue;
         }
-        LOG.info("Resolved addresses for " + addr +
-            " is " + Arrays.toString(resolvedHostNames));
+        LOG.info("Resolved addresses for {} is {}", addr, Arrays.toString(resolvedHostNames));
         if (resolvedHostNames == null || resolvedHostNames.length < 1) {
-          LOG.warn("Cannot resolve from address " + address.getHostName());
+          LOG.warn("Cannot resolve from address {}", address.getHostName());
         } else {
           // If multiple address resolved, corresponding id needs to be created
           for (int i = 0; i < resolvedHostNames.length; i++) {
@@ -444,7 +441,7 @@ public class HAUtil {
           InetSocketAddress originalAddress = getInetSocketAddressFromString(
               conf.get(keyToRead));
           if (originalAddress == null) {
-            LOG.warn("Missing configuration for key " + keyToRead);
+            LOG.warn("Missing configuration for key {}", keyToRead);
             continue;
           }
           int port = originalAddress.getPort();
@@ -469,7 +466,7 @@ public class HAUtil {
     try {
       address = NetUtils.createSocketAddr(addr);
     } catch (Exception e) {
-      LOG.warn("Exception in creating socket address " + addr, e);
+      LOG.warn("Exception in creating socket address {}", addr, e);
       return null;
     }
     return address;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -895,7 +895,7 @@ public class YarnConfiguration extends Configuration {
   public static final String RM_HA_IDS = RM_HA_PREFIX + "rm-ids";
   public static final String RM_HA_ID = RM_HA_PREFIX + "id";
 
-  /** YARN DNS resolving related configs */
+  /** YARN DNS resolving related configs. */
   public static final String  RESOLVE_RM_ADDRESS_NEEDED_KEY = RM_HA_PREFIX + "resolve-needed";
   public static final boolean RESOLVE_RM_ADDRESS_NEEDED_DEFAULT = false;
   public static final String RESOLVE_RM_ADDRESS_KEY = RM_HA_PREFIX + "resolver.impl";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -895,6 +895,15 @@ public class YarnConfiguration extends Configuration {
   public static final String RM_HA_IDS = RM_HA_PREFIX + "rm-ids";
   public static final String RM_HA_ID = RM_HA_PREFIX + "id";
 
+  /** YARN DNS resolving related configs */
+  public static final String  RESOLVE_RM_ADDRESS_NEEDED_KEY = RM_HA_PREFIX + "resolve-needed";
+  public static final boolean RESOLVE_RM_ADDRESS_NEEDED_DEFAULT = false;
+  public static final String RESOLVE_RM_ADDRESS_KEY = RM_HA_PREFIX + "resolver.impl";
+  public static final String  RESOLVE_RM_ADDRESS_TO_FQDN = RM_HA_PREFIX + "resolver.useFQDN";
+  public static final boolean RESOLVE_RM_ADDRESS_TO_FQDN_DEFAULT = true;
+  public static final String RM_ID_REFRESH_INTERVAL = RM_HA_PREFIX + "refresh-period-ms";
+  public static final long RM_ID_REFRESH_INTERVAL_DEFAULT = -1;
+
   /** Store the related configuration files in File System */
   public static final String FS_BASED_RM_CONF_STORE = RM_PREFIX
       + "configuration.file-system-based-store";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/ClientRMProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/ClientRMProxy.java
@@ -148,7 +148,13 @@ public class ClientRMProxy<T> extends RMProxy<T>  {
       // Build a list of service addresses to form the service name
       ArrayList<String> services = new ArrayList<String>();
       YarnConfiguration yarnConf = new YarnConfiguration(conf);
-      for (String rmId : HAUtil.getRMHAIds(conf)) {
+      boolean resolveNeeded = yarnConf.getBoolean(
+          YarnConfiguration.RESOLVE_RM_ADDRESS_NEEDED_KEY,
+          YarnConfiguration.RESOLVE_RM_ADDRESS_NEEDED_DEFAULT);
+      if (resolveNeeded) {
+        HAUtil.getResolvedRMIdPairs(yarnConf);
+      }
+      for (String rmId : HAUtil.getRMHAIds(yarnConf)) {
         // Set RM_ID to get the corresponding RM_ADDRESS
         yarnConf.set(YarnConfiguration.RM_HA_ID, rmId);
         services.add(SecurityUtil.buildTokenService(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/ConfiguredRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/ConfiguredRMFailoverProxyProvider.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.yarn.client;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -669,6 +669,15 @@
   </property>
 
   <property>
+    <description>
+      Determines what class to use to resolve resourcemanager address to specific machine
+      address(es).
+    </description>
+    <name>yarn.resourcemanager.ha.resolver.impl</name>
+    <value>org.apache.hadoop.net.DNSDomainNameResolver</value>
+  </property>
+
+  <property>
     <description>Enable automatic failover.
       By default, it is enabled only when HA is enabled</description>
     <name>yarn.resourcemanager.ha.automatic-failover.enabled</name>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -678,6 +678,40 @@
   </property>
 
   <property>
+    <description>
+      Determines if the given resourcemanager address is a domain name which needs to
+      be resolved (using the resolver configured by yarn.resourcemanager.ha.resolver.impl).
+      This adds a transparency layer in the client so physical server address
+      can change without changing the client.
+    </description>
+    <name>yarn.resourcemanager.ha.resolve-needed</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <description>
+      The amount of milliseconds between DNS address re-resolving.
+      By default, this parameter is set to -1 which disabled the DNS auto-refresh functionality.
+      Enabling the auto-refresh would help long running sessions (including node managers) able to
+      find the replaced resource managers (e.g. during node replacement/migration) without downtime.
+    </description>
+    <name>yarn.resourcemanager.ha.refresh-period-ms</name>
+    <value>-1</value>
+  </property>
+
+  <property>
+    <description>
+      Determines whether the resolved result is fully qualified domain name instead
+      of pure IP address(es).
+      In secure environment, this has to be enabled since Kerberos is using fqdn
+      in machine's principal therefore accessing servers by IP won't be recognized
+      by the KDC.
+    </description>
+    <name>yarn.resourcemanager.ha.resolver.useFQDN</name>
+    <value>true</value>
+  </property>
+
+  <property>
     <description>Enable automatic failover.
       By default, it is enabled only when HA is enabled</description>
     <name>yarn.resourcemanager.ha.automatic-failover.enabled</name>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/client/TestConfiguredRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/client/TestConfiguredRMFailoverProxyProvider.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.hadoop.conf.Configuration;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/client/TestConfiguredRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/client/TestConfiguredRMFailoverProxyProvider.java
@@ -1,0 +1,232 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.client;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.retry.FailoverProxyProvider;
+import org.apache.hadoop.net.MockDomainNameResolver;
+import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
+import org.apache.hadoop.yarn.conf.HAUtil;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+
+public class TestConfiguredRMFailoverProxyProvider {
+  private Configuration conf;
+  private final static List<String> HOST_LIST = Arrays.asList(
+      "host01",
+      "host02",
+      "host03",
+      "host04"
+  );
+  private final static String SCHEDULER_HOST_ADDRESS = "host11";
+  private final static List<byte[]> IP_LIST = Arrays.asList(
+      new byte[] {10, 0, 0, 1},
+      new byte[] {10, 0, 0, 2},
+      new byte[] {10, 0, 0, 3},
+      new byte[] {10, 0, 0, 4}
+  );
+  private final static String MULTI_A_RM_ID = "rm";
+  private final static String MULTI_A_RM_ADDRESS = "rm.com";
+  private final static String MULTI_A_RM_SCHEDULER_ADDRESS = "rmscheduler.com";
+  private final static long REFRESH_TIME_INTERVAL = 1000; // unit ms
+
+  ConfiguredRMFailoverProxyProvider<ApplicationClientProtocol> proxyProvider;
+
+  @Before
+  public void testInit() {
+    conf = new Configuration();
+    conf.set(YarnConfiguration.RM_HA_IDS, "rm1,rm2");
+    RMProxy rm1Mock = mock(RMProxy.class);
+    doNothing().when(rm1Mock).checkAllowedProtocols(ApplicationClientProtocol.class);
+    proxyProvider = new ConfiguredRMFailoverProxyProvider<ApplicationClientProtocol>();
+    proxyProvider.init(conf, rm1Mock, ApplicationClientProtocol.class);
+  }
+
+  public Configuration getDNSConfig() {
+    Configuration dnsConf = new Configuration();
+    dnsConf.set(YarnConfiguration.RESOLVE_RM_ADDRESS_KEY, MockDomainNameResolver.class.getName());
+    dnsConf.set(YarnConfiguration.RM_HA_IDS, MULTI_A_RM_ID);
+    dnsConf.set(HAUtil.addSuffix(YarnConfiguration.RM_ADDRESS, MULTI_A_RM_ID), MULTI_A_RM_ADDRESS +
+        ":" + YarnConfiguration.DEFAULT_RM_PORT);
+    dnsConf.set(HAUtil.addSuffix(YarnConfiguration.RM_ADMIN_ADDRESS, MULTI_A_RM_ID), MULTI_A_RM_ADDRESS +
+        ":" + YarnConfiguration.DEFAULT_RM_ADMIN_PORT);
+    dnsConf.set(HAUtil.addSuffix(YarnConfiguration.RM_SCHEDULER_ADDRESS, MULTI_A_RM_ID), MULTI_A_RM_SCHEDULER_ADDRESS +
+        ":" + YarnConfiguration.DEFAULT_RM_SCHEDULER_PORT);
+    dnsConf.setBoolean(YarnConfiguration.RESOLVE_RM_ADDRESS_NEEDED_KEY, true);
+    dnsConf.setBoolean(YarnConfiguration.RESOLVE_RM_ADDRESS_TO_FQDN, true);
+    return dnsConf;
+  }
+
+  /*
+   * Override the MockDomainNameResolver address mapping in HAUtil
+   * Source of mapping is from HOST_LIST and IP_LIST except for the exludeIdx one
+   */
+  private void overrideDNSMapping(int excludeIdx) throws UnknownHostException {
+    // Mapping of domain names and IP addresses
+    Map<String, InetAddress[]> addressMap = new HashMap<>();
+    // Mapping from IP addresses to fqdns
+    Map<InetAddress, String> ptrMap = new HashMap<>();
+    int idx = 0;
+    InetAddress[] addresses = new InetAddress[HOST_LIST.size() - 1];
+    InetAddress[] schedulerAddresses = new InetAddress[1];
+    addressMap.put(MULTI_A_RM_ADDRESS, addresses);
+    addressMap.put(MULTI_A_RM_SCHEDULER_ADDRESS, schedulerAddresses);
+    // for addresses
+    for (int i = 0; i < HOST_LIST.size(); i++) {
+      if (i == excludeIdx) {
+        continue;
+      }
+      InetAddress address = InetAddress.getByAddress(IP_LIST.get(i));
+      String host = HOST_LIST.get(i);
+      addresses[idx++] = address;
+      ptrMap.put(address, host);
+    }
+    // for schedulerAddress
+    InetAddress schedulerAddress = InetAddress.getByAddress(new byte[] {10, 1, 1, 1});
+    schedulerAddresses[0] = schedulerAddress;
+    ptrMap.put(schedulerAddress, SCHEDULER_HOST_ADDRESS);
+    ((MockDomainNameResolver)HAUtil.getDnr()).setAddressMap(addressMap);
+    ((MockDomainNameResolver)HAUtil.getDnr()).setPtrMap(ptrMap);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testInitWithNoInstances() {
+    Configuration conf = new Configuration();;
+    RMProxy rm1Mock = mock(RMProxy.class);
+    doNothing().when(rm1Mock).checkAllowedProtocols(ApplicationClientProtocol.class);
+    ConfiguredRMFailoverProxyProvider<ApplicationClientProtocol> proxyProviderWithNoInstances = new ConfiguredRMFailoverProxyProvider<ApplicationClientProtocol>();
+    proxyProviderWithNoInstances.init(conf, rm1Mock, ApplicationClientProtocol.class);
+  }
+
+  @Test
+  public void testGetProxy() {
+    FailoverProxyProvider.ProxyInfo<ApplicationClientProtocol> proxy = proxyProvider.getProxy();
+    Configuration conf = new Configuration();
+    conf.set(YarnConfiguration.RM_HA_IDS, "rm1,rm2,rm3,rm4");
+    RMProxy rm1Mock = mock(RMProxy.class);
+    doNothing().when(rm1Mock).checkAllowedProtocols(ApplicationClientProtocol.class);
+    ConfiguredRMFailoverProxyProvider<ApplicationClientProtocol> proxyProviderWithNoInstances = new ConfiguredRMFailoverProxyProvider<ApplicationClientProtocol>();
+    proxyProviderWithNoInstances.init(conf, rm1Mock, ApplicationClientProtocol.class);
+    assertEquals(proxyProviderWithNoInstances.rmServiceIds[0], "rm1");
+    FailoverProxyProvider.ProxyInfo<ApplicationClientProtocol> current = proxyProviderWithNoInstances.getProxy();
+    assertEquals(current.proxyInfo, "rm1");
+  }
+
+  @Test
+  public void testInitWithMultiARecordRM() throws UnknownHostException {
+    Configuration conf = getDNSConfig();
+    RMProxy rm1Mock = mock(RMProxy.class);
+    doNothing().when(rm1Mock).checkAllowedProtocols(ApplicationClientProtocol.class);
+    ConfiguredRMFailoverProxyProvider<ApplicationClientProtocol> proxyProviderWithmultiA =
+        new ConfiguredRMFailoverProxyProvider<ApplicationClientProtocol>();
+    HAUtil.setDnrByConfiguration(conf);
+    overrideDNSMapping(1);
+    proxyProviderWithmultiA.init(conf, rm1Mock, ApplicationClientProtocol.class);
+    assertEquals(HOST_LIST.size() - 1, proxyProviderWithmultiA.rmServiceIds.length);
+    for (String rmId : proxyProviderWithmultiA.rmServiceIds) {
+      assertTrue(rmId.startsWith("rm_resolved_"));
+    }
+  }
+
+  @Test
+  public void testResolveDifferentMultiARecordRM() throws UnknownHostException {
+    Configuration conf = getDNSConfig();
+    RMProxy rm1Mock = mock(RMProxy.class);
+    doNothing().when(rm1Mock).checkAllowedProtocols(ApplicationClientProtocol.class);
+    ConfiguredRMFailoverProxyProvider<ApplicationClientProtocol> proxyProviderWithmultiA =
+        new ConfiguredRMFailoverProxyProvider<ApplicationClientProtocol>();
+    HAUtil.setDnrByConfiguration(conf);
+    overrideDNSMapping(1);
+    proxyProviderWithmultiA.init(conf, rm1Mock, ApplicationClientProtocol.class);
+    List<String> rmAddresses = getRMAddresses(proxyProviderWithmultiA.conf,
+        proxyProviderWithmultiA.rmServiceIds,
+        YarnConfiguration.RM_ADDRESS);
+    List<String> rmAdminAddresses = getRMAddresses(proxyProviderWithmultiA.conf, proxyProviderWithmultiA.rmServiceIds,
+        YarnConfiguration.RM_ADMIN_ADDRESS);
+    List<String> rmSchedulerAddresses = getRMAddresses(proxyProviderWithmultiA.conf, proxyProviderWithmultiA.rmServiceIds,
+        YarnConfiguration.RM_SCHEDULER_ADDRESS);
+    assertEquals(HOST_LIST.size() - 1, rmAddresses.size());
+    assertEquals(HOST_LIST.size() - 1, rmAdminAddresses.size());
+    assertEquals(1, rmSchedulerAddresses.size());
+    assertEquals(SCHEDULER_HOST_ADDRESS + ":8030", rmSchedulerAddresses.get(0));
+  }
+
+  @Test
+  public void testRefreshWithMultiARecordRM() throws UnknownHostException, InterruptedException {
+    Configuration conf = getDNSConfig();
+    conf.setLong(YarnConfiguration.RM_ID_REFRESH_INTERVAL, REFRESH_TIME_INTERVAL);
+    RMProxy rm1Mock = mock(RMProxy.class);
+    doNothing().when(rm1Mock).checkAllowedProtocols(ApplicationClientProtocol.class);
+    ConfiguredRMFailoverProxyProvider<ApplicationClientProtocol> proxyProviderWithmultiA =
+        new ConfiguredRMFailoverProxyProvider<ApplicationClientProtocol>();
+    HAUtil.setDnrByConfiguration(conf);
+    overrideDNSMapping(0);
+    proxyProviderWithmultiA.init(conf, rm1Mock, ApplicationClientProtocol.class);
+    InetSocketAddress oldActiveRMAddress =
+        conf.getSocketAddr(HAUtil.addSuffix(YarnConfiguration.RM_ADDRESS, HAUtil.getRMHAId(conf)),
+            YarnConfiguration.DEFAULT_RM_ADDRESS,
+            YarnConfiguration.DEFAULT_RM_PORT);
+    List<String> oldRMAddresses = getRMAddresses(conf, proxyProviderWithmultiA.rmServiceIds, YarnConfiguration.RM_ADDRESS);
+    for (String address : oldRMAddresses) {
+      assertTrue(!address.equals(HOST_LIST.get(0)));
+    }
+    // refresh
+    overrideDNSMapping(2);
+    Thread.sleep(REFRESH_TIME_INTERVAL * 2);
+    InetSocketAddress newActiveRMAddress =
+        conf.getSocketAddr(HAUtil.addSuffix(YarnConfiguration.RM_ADDRESS, HAUtil.getRMHAId(conf)),
+            YarnConfiguration.DEFAULT_RM_ADDRESS,
+            YarnConfiguration.DEFAULT_RM_PORT);
+    List<String> newRMAddresses = getRMAddresses(conf, proxyProviderWithmultiA.rmServiceIds, YarnConfiguration.RM_ADDRESS);
+    assertEquals(HOST_LIST.size() - 1, newRMAddresses.size());
+    // active RM should remain same, even without failover
+    assertEquals(oldActiveRMAddress, newActiveRMAddress);
+    for (String address : newRMAddresses) {
+      assertTrue(!address.equals(HOST_LIST.get(2)));
+    }
+  }
+
+  private List<String> getRMAddresses(Configuration conf, String[] rmServiceIds,
+      String configKey) {
+    List<String> addresses = new ArrayList<>();
+    for (String rmId : rmServiceIds) {
+      String address = conf.get(HAUtil.addSuffix(configKey, rmId));
+      if (address != null) {
+        addresses.add(address);
+      }
+    }
+    return addresses;
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The patch reuses the resolver introduced from the HDFS side and apply similar logic to YARN RM service addresses resolving.
To utilize the YARN DNS support and use DNS as endpoint, simply upgrade the hadoop binary and revise configs from, for example:

 ```
<property>
   <name>yarn.resourcemanager.address.rm1</name>
   <value>rm1_address:8032</value>
 </property>
 <property>
   <name>yarn.resourcemanager.scheduler.address.rm1</name>
   <value>rm1_address:8030</value>
 </property>
 <property>
   <name>yarn.resourcemanager.resource-tracker.address.rm1</name>
   <value>rm1_address:8031</value>
 </property>
 <property>
   <name>yarn.resourcemanager.admin.address.rm1</name>
   <value>rm1_address:8033</value>
 </property>
 <property>
   <name>yarn.resourcemanager.webapp.address.rm1</name>
   <value>rm1_address:8088</value>
 </property>
 <property>
   <name>yarn.resourcemanager.webapp.https.address.rm1</name>
   <value>rm1_address:8090</value>
 </property>
 <property>
   <name>yarn.resourcemanager.address.rm2</name>
   <value>rm2_address:8032</value>
 </property>
 <property>
   <name>yarn.resourcemanager.scheduler.address.rm2</name>
   <value>rm2_address:8030</value>
 </property>
 <property>
   <name>yarn.resourcemanager.resource-tracker.address.rm2</name>
   <value>rm2_address:8031</value>
 </property>
 <property>
   <name>yarn.resourcemanager.admin.address.rm2</name>
   <value>rm2_address:8033</value>
 </property>
 <property>
   <name>yarn.resourcemanager.webapp.address.rm2</name>
   <value>rm2_address:8088</value>
 </property>
 <property>
   <name>yarn.resourcemanager.webapp.https.address.rm2</name>
   <value>rm2_address:8090</value>
 </property>
 <property>
   <name>yarn.resourcemanager.ha.rm-ids</name>
   <value>rm1,rm2</value>
 </property>
```
to:

```
<property>
  <name>yarn.resourcemanager.address.rm1</name>
  <value>rm_multi_a_dns:8032</value>
</property>
<property>
  <name>yarn.resourcemanager.scheduler.address.rm1</name>
  <value>rm_multi_a_dns:8030</value>
</property>
<property>
  <name>yarn.resourcemanager.resource-tracker.address.rm1</name>
  <value>rm_multi_a_dns:8031</value>
</property>
<property>
  <name>yarn.resourcemanager.admin.address.rm1</name>
  <value>rm_multi_a_dns:8033</value>
</property>
<property>
  <name>yarn.resourcemanager.webapp.address.rm1</name>
  <value>rm_multi_a_dns:8088</value>
</property>
<property>
  <name>yarn.resourcemanager.webapp.https.address.rm1</name>
  <value>rm_multi_a_dns:8090</value>
</property>
<property>
  <name>yarn.resourcemanager.ha.rm-ids</name>
  <value>rm1</value>
</property>
<property>
  <name>yarn.resourcemanager.ha.resolve-needed</name>
  <value>true</value>
</property>
<property>
  <name>yarn.resourcemanager.ha.resolver.useFQDN</name>
  <value>true</value> # required in secure mode
</property>
<property>
  <name>yarn.resourcemanager.ha.refresh-period-ms</name>
  <value>180000</value> # 3 min
</property>
```
where rm_multi_a_dns is a multi-A DNS record for rm1_address and rm2_address. This means the following output on the terminal.

```
$ dig +short <rm_multi_a_dns> | xargs -n +1 dig +short -x | sort
<rm1_address>
<rm2_address>
```
For the newly introduced flags, please refer to yarn-default.xml.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

