### PR TITLE
HADOOP-18594 ProxyUserAuthenticationFilter add properties for custom ImpersonationProvider 

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/authentication/server/ProxyUserAuthenticationFilter.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/authentication/server/ProxyUserAuthenticationFilter.java
@@ -14,6 +14,7 @@
 package org.apache.hadoop.security.authentication.server;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.security.authorize.AuthorizationException;
 import org.apache.hadoop.security.authorize.ProxyUsers;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -111,6 +112,12 @@ public class ProxyUserAuthenticationFilter extends AuthenticationFilter {
     while (names.hasMoreElements()) {
       String name = (String) names.nextElement();
       if (name.startsWith(PROXYUSER_PREFIX + ".")) {
+        String value = filterConfig.getInitParameter(name);
+        conf.set(name, value);
+      }
+
+      //add impersonation provider class config
+      if (name.equals(CommonConfigurationKeysPublic.HADOOP_SECURITY_IMPERSONATION_PROVIDER_CLASS)) {
         String value = filterConfig.getInitParameter(name);
         conf.set(name, value);
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/authentication/server/ProxyUserAuthenticationFilterInitializer.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/authentication/server/ProxyUserAuthenticationFilterInitializer.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.security.authentication.server;
 
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.http.FilterContainer;
 import org.apache.hadoop.http.FilterInitializer;
 import org.apache.hadoop.security.AuthenticationFilterInitializer;
@@ -46,6 +47,15 @@ public class ProxyUserAuthenticationFilterInitializer
     for (Map.Entry<String, String> entry : conf.getPropsWithPrefix(
         ProxyUsers.CONF_HADOOP_PROXYUSER).entrySet()) {
       filterConfig.put("proxyuser" + entry.getKey(), entry.getValue());
+    }
+
+    //add impersonation provider class config
+    String valueImpersonationProvider = conf.
+        get(CommonConfigurationKeysPublic.HADOOP_SECURITY_IMPERSONATION_PROVIDER_CLASS);
+    if (valueImpersonationProvider != null) {
+      filterConfig.
+          put(CommonConfigurationKeysPublic.HADOOP_SECURITY_IMPERSONATION_PROVIDER_CLASS,
+              valueImpersonationProvider);
     }
     return filterConfig;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/AuthFilterInitializer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/AuthFilterInitializer.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdfs.web;
 
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.http.FilterContainer;
 import org.apache.hadoop.http.FilterInitializer;
 import org.apache.hadoop.security.AuthenticationFilterInitializer;
@@ -46,6 +47,15 @@ public class AuthFilterInitializer extends FilterInitializer {
     for (Map.Entry<String, String> entry : conf.getPropsWithPrefix(
         ProxyUsers.CONF_HADOOP_PROXYUSER).entrySet()) {
       filterConfig.put("proxyuser" + entry.getKey(), entry.getValue());
+    }
+
+    //add impersonation provider class config
+    String valueImpersonationProvider = conf.
+        get(CommonConfigurationKeysPublic.HADOOP_SECURITY_IMPERSONATION_PROVIDER_CLASS);
+    if (valueImpersonationProvider != null) {
+      filterConfig.
+          put(CommonConfigurationKeysPublic.HADOOP_SECURITY_IMPERSONATION_PROVIDER_CLASS,
+              valueImpersonationProvider);
     }
 
     if (filterConfig.get("type") == null) {


### PR DESCRIPTION


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: https://issues.apache.org/jira/browse/HADOOP-18594

ProxyUserAuthenticationFilter add properties 'hadoop.security.impersonation.provider.class' to enable load custom ImpersonationProvider class when start namenode

### How was this patch tested?
by local test


