### PR TITLE
HADOOP-18597 Simplify the single node setup instructions

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/SingleCluster.md.vm
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/SingleCluster.md.vm
@@ -155,8 +155,7 @@ The following instructions are to run a MapReduce job locally. If you want to ex
 
 4.  Make the HDFS directories required to execute MapReduce jobs:
 
-          $ bin/hdfs dfs -mkdir /user
-          $ bin/hdfs dfs -mkdir /user/<username>
+          $ bin/hdfs dfs -mkdir -p /user/<username>
 
 5.  Copy the input files into the distributed filesystem:
 


### PR DESCRIPTION
The `mkdir` command supports the `-p` option which instructs `hdfs` to create all the parent directories if needed. This option is used to simplify the single node setup instructions.

Signed-off-by: Nikita Eshkeev <neshkeev@yandex.ru>

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->