### PR TITLE
YARN-11418. Add a new metric that reflects the number of applications whose FinalStatus is FAILED

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
@@ -1522,7 +1522,7 @@ public class RMAppImpl implements RMApp, Recoverable {
       // need to remove them from scheduler.
       if (app.recoveredFinalState == null) {
         app.handler.handle(new AppRemovedSchedulerEvent(app.applicationId,
-            finalState));
+            finalState, app.getFinalApplicationStatus()));
       }
 
       app.handler.handle(new RMAppManagerEvent(app.applicationId,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerApplication.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerApplication.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.classification.InterfaceStability.Unstable;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppState;
 
@@ -67,8 +68,8 @@ public class SchedulerApplication<T extends SchedulerApplicationAttempt> {
     this.currentAttempt = currentAttempt;
   }
 
-  public void stop(RMAppState rmAppFinalState) {
-    queue.getMetrics().finishApp(user, rmAppFinalState, isUnmanagedAM());
+  public void stop(RMAppState rmAppFinalState, FinalApplicationStatus finalApplicationStatus) {
+    queue.getMetrics().finishApp(user, rmAppFinalState, finalApplicationStatus, isUnmanagedAM());
   }
 
   public Priority getPriority() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractLeafQueue.java
@@ -803,7 +803,7 @@ public class AbstractLeafQueue extends AbstractCSQueue {
           resourceCalculator, queuePartitionUsableResource, amResourcePercent,
           queueAllocationSettings.getMinimumAllocation());
 
-      usageTracker.getMetrics().setAMResouceLimit(nodePartition, amResouceLimit);
+      usageTracker.getMetrics().setAMResourceLimit(nodePartition, amResouceLimit);
       usageTracker.getQueueUsage().setAMLimit(nodePartition, amResouceLimit);
       LOG.debug("Queue: {}, node label : {}, queue partition resource : {},"
           + " queue current limit : {}, queue partition usable resource : {},"
@@ -920,7 +920,7 @@ public class AbstractLeafQueue extends AbstractCSQueue {
         user.getResourceUsage().setAMLimit(partitionName, userAMLimit);
         usageTracker.getMetrics().incAMUsed(partitionName, application.getUser(),
             application.getAMResource(partitionName));
-        usageTracker.getMetrics().setAMResouceLimitForUser(partitionName,
+        usageTracker.getMetrics().setAMResourceLimitForUser(partitionName,
             application.getUser(), userAMLimit);
         fsApp.remove();
         LOG.info("Application " + applicationId + " from user: " + application

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CSQueueMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CSQueueMetrics.java
@@ -120,18 +120,18 @@ public class CSQueueMetrics extends QueueMetrics {
     return usedAMResourceVCores.value();
   }
 
-  public void setAMResouceLimit(String partition, Resource res) {
+  public void setAMResourceLimit(String partition, Resource res) {
     if(partition == null || partition.equals(RMNodeLabelsManager.NO_LABEL)) {
       AMResourceLimitMB.set(res.getMemorySize());
       AMResourceLimitVCores.set(res.getVirtualCores());
     }
   }
 
-  public void setAMResouceLimitForUser(String partition,
+  public void setAMResourceLimitForUser(String partition,
       String user, Resource res) {
     CSQueueMetrics userMetrics = (CSQueueMetrics) getUserMetrics(user);
     if (userMetrics != null) {
-      userMetrics.setAMResouceLimit(partition, res);
+      userMetrics.setAMResourceLimit(partition, res);
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
@@ -2014,7 +2014,7 @@ public class CapacityScheduler extends
     {
       AppRemovedSchedulerEvent appRemovedEvent = (AppRemovedSchedulerEvent)event;
       doneApplication(appRemovedEvent.getApplicationID(),
-        appRemovedEvent.getFinalState(), appRemovedEvent.getFinalApplicationStatus());
+          appRemovedEvent.getFinalState(), appRemovedEvent.getFinalApplicationStatus());
     }
     break;
     case APP_ATTEMPT_ADDED:

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.ExecutionType;
 import org.apache.hadoop.yarn.api.records.NodeAttribute;
 import org.apache.hadoop.yarn.api.records.NodeId;
@@ -1198,7 +1199,7 @@ public class CapacityScheduler extends
   }
 
   private void doneApplication(ApplicationId applicationId,
-      RMAppState finalState) {
+      RMAppState finalState, FinalApplicationStatus finalApplicationStatus) {
     writeLock.lock();
     try {
       SchedulerApplication<FiCaSchedulerApp> application = applications.get(
@@ -1216,7 +1217,7 @@ public class CapacityScheduler extends
       } else{
         queue.finishApplication(applicationId, application.getUser());
       }
-      application.stop(finalState);
+      application.stop(finalState, finalApplicationStatus);
       applications.remove(applicationId);
     } finally {
       writeLock.unlock();
@@ -2013,7 +2014,7 @@ public class CapacityScheduler extends
     {
       AppRemovedSchedulerEvent appRemovedEvent = (AppRemovedSchedulerEvent)event;
       doneApplication(appRemovedEvent.getApplicationID(),
-        appRemovedEvent.getFinalState());
+        appRemovedEvent.getFinalState(), appRemovedEvent.getFinalApplicationStatus());
     }
     break;
     case APP_ATTEMPT_ADDED:

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/event/AppRemovedSchedulerEvent.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/event/AppRemovedSchedulerEvent.java
@@ -19,18 +19,21 @@
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.event;
 
 import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppState;
 
 public class AppRemovedSchedulerEvent extends SchedulerEvent {
 
   private final ApplicationId applicationId;
   private final RMAppState finalState;
+  private final FinalApplicationStatus finalApplicationStatus;
 
   public AppRemovedSchedulerEvent(ApplicationId applicationId,
-      RMAppState finalState) {
+      RMAppState finalState, FinalApplicationStatus finalApplicationStatus) {
     super(SchedulerEventType.APP_REMOVED);
     this.applicationId = applicationId;
     this.finalState = finalState;
+    this.finalApplicationStatus = finalApplicationStatus;
   }
 
   public ApplicationId getApplicationID() {
@@ -39,5 +42,9 @@ public class AppRemovedSchedulerEvent extends SchedulerEvent {
 
   public RMAppState getFinalState() {
     return this.finalState;
+  }
+
+  public FinalApplicationStatus getFinalApplicationStatus() {
+    return finalApplicationStatus;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairScheduler.java
@@ -1263,7 +1263,7 @@ public class FairScheduler extends
       }
       AppRemovedSchedulerEvent appRemovedEvent = (AppRemovedSchedulerEvent)event;
       removeApplication(appRemovedEvent.getApplicationID(),
-        appRemovedEvent.getFinalState(), appRemovedEvent.getFinalApplicationStatus());
+          appRemovedEvent.getFinalState(), appRemovedEvent.getFinalApplicationStatus());
       break;
     case NODE_RESOURCE_UPDATE:
       if (!(event instanceof NodeResourceUpdateSchedulerEvent)) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairScheduler.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.NMToken;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.QueueACL;
@@ -635,13 +636,13 @@ public class FairScheduler extends
   }
 
   private void removeApplication(ApplicationId applicationId,
-      RMAppState finalState) {
+      RMAppState finalState, FinalApplicationStatus finalApplicationStatus) {
     SchedulerApplication<FSAppAttempt> application = applications.remove(
         applicationId);
     if (application == null) {
       LOG.warn("Couldn't find application " + applicationId);
     } else{
-      application.stop(finalState);
+      application.stop(finalState, finalApplicationStatus);
     }
   }
 
@@ -1262,7 +1263,7 @@ public class FairScheduler extends
       }
       AppRemovedSchedulerEvent appRemovedEvent = (AppRemovedSchedulerEvent)event;
       removeApplication(appRemovedEvent.getApplicationID(),
-        appRemovedEvent.getFinalState());
+        appRemovedEvent.getFinalState(), appRemovedEvent.getFinalApplicationStatus());
       break;
     case NODE_RESOURCE_UPDATE:
       if (!(event instanceof NodeResourceUpdateSchedulerEvent)) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fifo/FifoScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fifo/FifoScheduler.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.QueueACL;
@@ -441,7 +442,7 @@ public class FifoScheduler extends
   }
 
   private synchronized void doneApplication(ApplicationId applicationId,
-      RMAppState finalState) {
+      RMAppState finalState, FinalApplicationStatus finalApplicationStatus) {
     SchedulerApplication<FifoAppAttempt> application =
         applications.get(applicationId);
     if (application == null){
@@ -452,7 +453,7 @@ public class FifoScheduler extends
     // Inform the activeUsersManager
     activeUsersManager.deactivateApplication(application.getUser(),
       applicationId);
-    application.stop(finalState);
+    application.stop(finalState, finalApplicationStatus);
     applications.remove(applicationId);
   }
 
@@ -779,7 +780,7 @@ public class FifoScheduler extends
     {
       AppRemovedSchedulerEvent appRemovedEvent = (AppRemovedSchedulerEvent)event;
       doneApplication(appRemovedEvent.getApplicationID(),
-        appRemovedEvent.getFinalState());
+        appRemovedEvent.getFinalState(), appRemovedEvent.getFinalApplicationStatus());
     }
     break;
     case APP_ATTEMPT_ADDED:

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fifo/FifoScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fifo/FifoScheduler.java
@@ -780,7 +780,7 @@ public class FifoScheduler extends
     {
       AppRemovedSchedulerEvent appRemovedEvent = (AppRemovedSchedulerEvent)event;
       doneApplication(appRemovedEvent.getApplicationID(),
-        appRemovedEvent.getFinalState(), appRemovedEvent.getFinalApplicationStatus());
+          appRemovedEvent.getFinalState(), appRemovedEvent.getFinalApplicationStatus());
     }
     break;
     case APP_ATTEMPT_ADDED:

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/MetricsOverviewTable.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/MetricsOverviewTable.java
@@ -100,6 +100,7 @@ public class MetricsOverviewTable extends HtmlBlock {
         th().$class("ui-state-default").__("Apps Submitted").__().
         th().$class("ui-state-default").__("Apps Pending").__().
         th().$class("ui-state-default").__("Apps Running").__().
+        th().$class("ui-state-default").__("Apps FinalFailed").__().
         th().$class("ui-state-default").__("Apps Completed").__().
         th().$class("ui-state-default").__("Containers Running").__().
         th().$class("ui-state-default").__("Used Resources").__().
@@ -114,6 +115,7 @@ public class MetricsOverviewTable extends HtmlBlock {
         td(String.valueOf(clusterMetrics.getAppsSubmitted())).
         td(String.valueOf(clusterMetrics.getAppsPending())).
         td(String.valueOf(clusterMetrics.getAppsRunning())).
+        td(String.valueOf(clusterMetrics.getAppsFinalFailed())).
         td(
             String.valueOf(
                 clusterMetrics.getAppsCompleted() + 
@@ -165,6 +167,7 @@ public class MetricsOverviewTable extends HtmlBlock {
             th().$class("ui-state-default").__("Apps Submitted").__().
             th().$class("ui-state-default").__("Apps Pending").__().
             th().$class("ui-state-default").__("Apps Running").__().
+            th().$class("ui-state-default").__("Apps FinalFailed").__().
             th().$class("ui-state-default").__("Apps Completed").__().
             th().$class("ui-state-default").__("Containers Running").__().
             th().$class("ui-state-default").__("Containers Pending").__().
@@ -182,6 +185,7 @@ public class MetricsOverviewTable extends HtmlBlock {
             td(String.valueOf(userMetrics.getAppsSubmitted())).
             td(String.valueOf(userMetrics.getAppsPending())).
             td(String.valueOf(userMetrics.getAppsRunning())).
+            td(String.valueOf(userMetrics.getAppsFinalFailed())).
             td(
                 String.valueOf(
                     (userMetrics.getAppsCompleted() + 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ClusterMetricsInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ClusterMetricsInfo.java
@@ -38,6 +38,7 @@ public class ClusterMetricsInfo {
   private int appsRunning;
   private int appsFailed;
   private int appsKilled;
+  private int appsFinalFailed;
 
   private long reservedMB;
   private long availableMB;
@@ -103,6 +104,7 @@ public class ClusterMetricsInfo {
     this.appsRunning = metrics.getAppsRunning();
     this.appsFailed = metrics.getAppsFailed();
     this.appsKilled = metrics.getAppsKilled();
+    this.appsFinalFailed = metrics.getAppsFinalFailed();
 
     this.reservedMB = metrics.getReservedMB();
     this.availableMB = metrics.getAvailableMB();
@@ -191,6 +193,10 @@ public class ClusterMetricsInfo {
 
   public int getAppsKilled() {
     return appsKilled;
+  }
+
+  public int getAppsFinalFailed() {
+    return appsFinalFailed;
   }
 
   public long getReservedMB() {
@@ -319,6 +325,10 @@ public class ClusterMetricsInfo {
 
   public void setAppsKilled(int appsKilled) {
     this.appsKilled = appsKilled;
+  }
+
+  public void setAppsFinalFailed(int appsFinalFailed) {
+    this.appsFinalFailed = appsFinalFailed;
   }
 
   public void setReservedMB(long reservedMB) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/UserMetricsInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/UserMetricsInfo.java
@@ -36,6 +36,7 @@ public class UserMetricsInfo {
   protected int appsRunning;
   protected int appsFailed;
   protected int appsKilled;
+  protected int appsFinalFailed;
   protected int runningContainers;
   protected int pendingContainers;
   protected int reservedContainers;
@@ -67,6 +68,7 @@ public class UserMetricsInfo {
       this.appsRunning = userMetrics.getAppsRunning();
       this.appsFailed = userMetrics.getAppsFailed();
       this.appsKilled = userMetrics.getAppsKilled();
+      this.appsFinalFailed = userMetrics.getAppsFinalFailed();
 
       this.runningContainers = userMetrics.getAllocatedContainers();
       this.pendingContainers = userMetrics.getPendingContainers();
@@ -108,6 +110,10 @@ public class UserMetricsInfo {
 
   public int getAppsKilled() {
     return appsKilled;
+  }
+
+  public int getAppsFinalFailed() {
+    return appsFinalFailed;
   }
 
   public long getReservedMB() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AppMetricsChecker.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AppMetricsChecker.java
@@ -30,6 +30,7 @@ import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.AppMetricsChecker.AppMetricsKey.APPS_COMPLETED;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.AppMetricsChecker.AppMetricsKey.APPS_FAILED;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.AppMetricsChecker.AppMetricsKey.APPS_KILLED;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.AppMetricsChecker.AppMetricsKey.APPS_FINAL_FAILED;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.AppMetricsChecker.AppMetricsKey.APPS_PENDING;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.AppMetricsChecker.AppMetricsKey.APPS_RUNNING;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.AppMetricsChecker.AppMetricsKey.APPS_SUBMITTED;
@@ -52,6 +53,7 @@ final class AppMetricsChecker {
         .counter(APPS_COMPLETED, 0)
         .counter(APPS_FAILED, 0)
         .counter(APPS_KILLED, 0)
+        .counter(APPS_FINAL_FAILED, 0)
         .counter(UNMANAGED_APPS_SUBMITTED, 0)
         .gaugeInt(UNMANAGED_APPS_PENDING, 0)
         .gaugeInt(UNMANAGED_APPS_RUNNING, 0)
@@ -66,6 +68,7 @@ final class AppMetricsChecker {
     APPS_COMPLETED("AppsCompleted"),
     APPS_FAILED("AppsFailed"),
     APPS_KILLED("AppsKilled"),
+    APPS_FINAL_FAILED("AppsFinalFailed"),
     UNMANAGED_APPS_SUBMITTED("UnmanagedAppsSubmitted"),
     UNMANAGED_APPS_PENDING("UnmanagedAppsPending"),
     UNMANAGED_APPS_RUNNING("UnmanagedAppsRunning"),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestPartitionQueueMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestPartitionQueueMetrics.java
@@ -502,7 +502,7 @@ public class TestPartitionQueueMetrics {
     metrics.finishAppAttempt(app.getApplicationId(), app.isPending(),
         app.getUser(), false);
 
-    metrics.finishApp(user, RMAppState.FINISHED, FinalApplicationStatus.SUCCEEDED,false);
+    metrics.finishApp(user, RMAppState.FINISHED, FinalApplicationStatus.SUCCEEDED, false);
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestPartitionQueueMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestPartitionQueueMetrics.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.impl.MetricsSystemImpl;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppState;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CSQueueMetrics;
@@ -501,7 +502,7 @@ public class TestPartitionQueueMetrics {
     metrics.finishAppAttempt(app.getApplicationId(), app.isPending(),
         app.getUser(), false);
 
-    metrics.finishApp(user, RMAppState.FINISHED, false);
+    metrics.finishApp(user, RMAppState.FINISHED, FinalApplicationStatus.SUCCEEDED,false);
   }
 
   @Test
@@ -625,7 +626,7 @@ public class TestPartitionQueueMetrics {
     metrics1.finishAppAttempt(app.getApplicationId(), app.isPending(),
         app.getUser(), false);
 
-    metrics1.finishApp(user, RMAppState.FINISHED, false);
+    metrics1.finishApp(user, RMAppState.FINISHED, FinalApplicationStatus.SUCCEEDED, false);
   }
 
   /**
@@ -690,7 +691,7 @@ public class TestPartitionQueueMetrics {
 
     q1.finishAppAttempt(app.getApplicationId(), app.isPending(), app.getUser(),
         false);
-    q1.finishApp(user, RMAppState.FINISHED, false);
+    q1.finishApp(user, RMAppState.FINISHED, FinalApplicationStatus.FAILED, false);
   }
 
   public static MetricsSource partitionSource(MetricsSystem ms,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestQueueMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestQueueMetrics.java
@@ -240,7 +240,7 @@ public class TestQueueMetrics {
         .gaugeInt(APPS_RUNNING, 0)
         .checkAgainst(queueSource, true);
 
-    metrics.finishApp(USER, RMAppState.FAILED, FinalApplicationStatus.FAILED,false);
+    metrics.finishApp(USER, RMAppState.FAILED, FinalApplicationStatus.FAILED, false);
     AppMetricsChecker.createFromChecker(appMetricsChecker)
         .gaugeInt(APPS_RUNNING, 0)
         .counter(APPS_FAILED, 1)
@@ -322,7 +322,7 @@ public class TestQueueMetrics {
         .gaugeInt(UNMANAGED_APPS_RUNNING, 0).gaugeInt(APPS_RUNNING, 0)
         .checkAgainst(queueSource, true);
 
-    metrics.finishApp(USER, RMAppState.FAILED, FinalApplicationStatus.FAILED,true);
+    metrics.finishApp(USER, RMAppState.FAILED, FinalApplicationStatus.FAILED, true);
     AppMetricsChecker.createFromChecker(appMetricsChecker)
         .gaugeInt(UNMANAGED_APPS_RUNNING, 0).gaugeInt(APPS_RUNNING, 0)
         .counter(UNMANAGED_APPS_FAILED, 1).counter(APPS_FAILED, 1).counter(APPS_FINAL_FAILED, 1)
@@ -715,7 +715,7 @@ public class TestQueueMetrics {
             .gaugeInt(APPS_RUNNING, 0)
             .checkAgainst(root.userSource, true);
 
-    leaf.queueMetrics.finishApp(USER, RMAppState.FINISHED, FinalApplicationStatus.FAILED,false);
+    leaf.queueMetrics.finishApp(USER, RMAppState.FINISHED, FinalApplicationStatus.FAILED, false);
     AppMetricsChecker.createFromChecker(appMetricsQueueSourceChecker)
         .counter(APPS_COMPLETED, 1)
         .checkAgainst(leaf.queueSource, true);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestQueueMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestQueueMetrics.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.metrics2.impl.MetricsSystemImpl;
 import org.apache.hadoop.test.MetricsAsserts;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.MockRM;
 import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsManager;
@@ -41,6 +42,7 @@ import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.AppMetricsChecker.AppMetricsKey.APPS_COMPLETED;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.AppMetricsChecker.AppMetricsKey.APPS_FAILED;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.AppMetricsChecker.AppMetricsKey.APPS_FINAL_FAILED;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.AppMetricsChecker.AppMetricsKey.APPS_PENDING;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.AppMetricsChecker.AppMetricsKey.APPS_RUNNING;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.AppMetricsChecker.AppMetricsKey.APPS_SUBMITTED;
@@ -160,7 +162,7 @@ public class TestQueueMetrics {
         .counter(APPS_SUBMITTED, 1)
         .gaugeInt(APPS_RUNNING, 0)
         .checkAgainst(queueSource, true);
-    metrics.finishApp(USER, RMAppState.FINISHED, false);
+    metrics.finishApp(USER, RMAppState.FINISHED, FinalApplicationStatus.FAILED, false);
     AppMetricsChecker.createFromChecker(appMetricsChecker)
         .counter(APPS_COMPLETED, 1)
         .checkAgainst(queueSource, true);
@@ -238,10 +240,11 @@ public class TestQueueMetrics {
         .gaugeInt(APPS_RUNNING, 0)
         .checkAgainst(queueSource, true);
 
-    metrics.finishApp(USER, RMAppState.FAILED, false);
+    metrics.finishApp(USER, RMAppState.FAILED, FinalApplicationStatus.FAILED,false);
     AppMetricsChecker.createFromChecker(appMetricsChecker)
         .gaugeInt(APPS_RUNNING, 0)
         .counter(APPS_FAILED, 1)
+        .counter(APPS_FINAL_FAILED, 1)
         .checkAgainst(queueSource, true);
 
     assertNull(userSource);
@@ -319,10 +322,10 @@ public class TestQueueMetrics {
         .gaugeInt(UNMANAGED_APPS_RUNNING, 0).gaugeInt(APPS_RUNNING, 0)
         .checkAgainst(queueSource, true);
 
-    metrics.finishApp(USER, RMAppState.FAILED, true);
+    metrics.finishApp(USER, RMAppState.FAILED, FinalApplicationStatus.FAILED,true);
     AppMetricsChecker.createFromChecker(appMetricsChecker)
         .gaugeInt(UNMANAGED_APPS_RUNNING, 0).gaugeInt(APPS_RUNNING, 0)
-        .counter(UNMANAGED_APPS_FAILED, 1).counter(APPS_FAILED, 1)
+        .counter(UNMANAGED_APPS_FAILED, 1).counter(APPS_FAILED, 1).counter(APPS_FINAL_FAILED, 1)
         .checkAgainst(queueSource, true);
 
     assertNull(userSource);
@@ -443,7 +446,7 @@ public class TestQueueMetrics {
         AppMetricsChecker.createFromChecker(appMetricsUserSourceChecker)
             .gaugeInt(APPS_RUNNING, 0)
             .checkAgainst(userSource, true);
-    metrics.finishApp(USER_2, RMAppState.FINISHED, false);
+    metrics.finishApp(USER_2, RMAppState.FINISHED, FinalApplicationStatus.FAILED, false);
     AppMetricsChecker.createFromChecker(appMetricsQueueSourceChecker)
         .counter(APPS_COMPLETED, 1)
         .checkAgainst(queueSource, true);
@@ -712,7 +715,7 @@ public class TestQueueMetrics {
             .gaugeInt(APPS_RUNNING, 0)
             .checkAgainst(root.userSource, true);
 
-    leaf.queueMetrics.finishApp(USER, RMAppState.FINISHED, false);
+    leaf.queueMetrics.finishApp(USER, RMAppState.FINISHED, FinalApplicationStatus.FAILED,false);
     AppMetricsChecker.createFromChecker(appMetricsQueueSourceChecker)
         .counter(APPS_COMPLETED, 1)
         .checkAgainst(leaf.queueSource, true);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestQueueMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestQueueMetrics.java
@@ -162,7 +162,7 @@ public class TestQueueMetrics {
         .counter(APPS_SUBMITTED, 1)
         .gaugeInt(APPS_RUNNING, 0)
         .checkAgainst(queueSource, true);
-    metrics.finishApp(USER, RMAppState.FINISHED, FinalApplicationStatus.FAILED, false);
+    metrics.finishApp(USER, RMAppState.FINISHED, FinalApplicationStatus.SUCCEEDED, false);
     AppMetricsChecker.createFromChecker(appMetricsChecker)
         .counter(APPS_COMPLETED, 1)
         .checkAgainst(queueSource, true);
@@ -446,7 +446,7 @@ public class TestQueueMetrics {
         AppMetricsChecker.createFromChecker(appMetricsUserSourceChecker)
             .gaugeInt(APPS_RUNNING, 0)
             .checkAgainst(userSource, true);
-    metrics.finishApp(USER_2, RMAppState.FINISHED, FinalApplicationStatus.FAILED, false);
+    metrics.finishApp(USER_2, RMAppState.FINISHED, FinalApplicationStatus.SUCCEEDED, false);
     AppMetricsChecker.createFromChecker(appMetricsQueueSourceChecker)
         .counter(APPS_COMPLETED, 1)
         .checkAgainst(queueSource, true);
@@ -715,7 +715,7 @@ public class TestQueueMetrics {
             .gaugeInt(APPS_RUNNING, 0)
             .checkAgainst(root.userSource, true);
 
-    leaf.queueMetrics.finishApp(USER, RMAppState.FINISHED, FinalApplicationStatus.FAILED, false);
+    leaf.queueMetrics.finishApp(USER, RMAppState.FINISHED, FinalApplicationStatus.SUCCEEDED, false);
     AppMetricsChecker.createFromChecker(appMetricsQueueSourceChecker)
         .counter(APPS_COMPLETED, 1)
         .checkAgainst(leaf.queueSource, true);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestSchedulerUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestSchedulerUtils.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ContainerExitStatus;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.NodeLabel;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.QueueInfo;
@@ -1148,7 +1149,7 @@ public class TestSchedulerUtils {
     Assert.assertEquals("user", app.getUser());
 
     AppRemovedSchedulerEvent appRemoveEvent =
-            new AppRemovedSchedulerEvent(appId, RMAppState.FINISHED);
+            new AppRemovedSchedulerEvent(appId, RMAppState.FINISHED, FinalApplicationStatus.SUCCEEDED);
     handler.handle(appRemoveEvent);
     Assert.assertNull(applications.get(appId));
     return app;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestSchedulerUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestSchedulerUtils.java
@@ -1149,7 +1149,8 @@ public class TestSchedulerUtils {
     Assert.assertEquals("user", app.getUser());
 
     AppRemovedSchedulerEvent appRemoveEvent =
-            new AppRemovedSchedulerEvent(appId, RMAppState.FINISHED, FinalApplicationStatus.SUCCEEDED);
+            new AppRemovedSchedulerEvent(appId, RMAppState.FINISHED,
+                FinalApplicationStatus.SUCCEEDED);
     handler.handle(appRemoveEvent);
     Assert.assertNull(applications.get(appId));
     return app;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestAutoCreatedQueueDeletionPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestAutoCreatedQueueDeletionPolicy.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppState;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.RMAppAttemptState;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.AppAttemptRemovedSchedulerEvent;
@@ -81,7 +82,7 @@ public class TestAutoCreatedQueueDeletionPolicy
             RMAppAttemptState.FINISHED, false);
     cs.handle(event);
     AppRemovedSchedulerEvent rEvent = new AppRemovedSchedulerEvent(
-        user0AppAttemptId.getApplicationId(), RMAppState.FINISHED);
+        user0AppAttemptId.getApplicationId(), RMAppState.FINISHED, FinalApplicationStatus.FAILED);
     cs.handle(rEvent);
 
     // There are no apps in user0

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerNewQueueAutoCreation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerNewQueueAutoCreation.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.QueueState;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
@@ -903,7 +904,7 @@ public class TestCapacitySchedulerNewQueueAutoCreation
             RMAppAttemptState.FINISHED, false);
     cs.handle(event);
     AppRemovedSchedulerEvent rEvent = new AppRemovedSchedulerEvent(
-        a2App.getApplicationId(), RMAppState.FINISHED);
+        a2App.getApplicationId(), RMAppState.FINISHED, FinalApplicationStatus.FAILED);
     cs.handle(rEvent);
 
     // Now there are no apps in a2 queue.
@@ -985,7 +986,7 @@ public class TestCapacitySchedulerNewQueueAutoCreation
             RMAppAttemptState.FINISHED, false);
     cs.handle(event);
     AppRemovedSchedulerEvent rEvent = new AppRemovedSchedulerEvent(
-        a2App.getApplicationId(), RMAppState.FINISHED);
+        a2App.getApplicationId(), RMAppState.FINISHED, FinalApplicationStatus.FAILED);
     cs.handle(rEvent);
 
     // Now there are no apps in a2 queue.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestLeafQueue.java
@@ -68,6 +68,7 @@ import org.apache.hadoop.yarn.api.records.ContainerExitStatus;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.api.records.ContainerState;
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.QueueACL;
@@ -541,7 +542,7 @@ public class TestLeafQueue {
         RMAppAttemptState.FINISHED, false);
     cs.handle(event);
     AppRemovedSchedulerEvent rEvent = new AppRemovedSchedulerEvent(
-        appAttemptId_0.getApplicationId(), RMAppState.FINISHED);
+        appAttemptId_0.getApplicationId(), RMAppState.FINISHED, FinalApplicationStatus.FAILED);
     cs.handle(rEvent);
     
     assertEquals(1, a.getMetrics().getAppsSubmitted());
@@ -609,7 +610,7 @@ public class TestLeafQueue {
         RMAppAttemptState.FINISHED, false);
     cs.handle(event);
     AppRemovedSchedulerEvent rEvent = new AppRemovedSchedulerEvent(
-        appAttemptId0.getApplicationId(), RMAppState.FINISHED);
+        appAttemptId0.getApplicationId(), RMAppState.FINISHED, FinalApplicationStatus.FAILED);
     cs.handle(rEvent);
 
     assertEquals(1, a.getMetrics().getUnmanagedAppsSubmitted());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
@@ -476,7 +476,7 @@ public class TestRMWebServices extends JerseyTestBase {
       Exception {
     assertEquals("incorrect number of elements", 1, json.length());
     JSONObject clusterinfo = json.getJSONObject("clusterMetrics");
-    assertEquals("incorrect number of elements", 35, clusterinfo.length());
+    assertEquals("incorrect number of elements", 36, clusterinfo.length());
     verifyClusterMetrics(
         clusterinfo.getInt("appsSubmitted"), clusterinfo.getInt("appsCompleted"),
         clusterinfo.getInt("reservedMB"), clusterinfo.getInt("availableMB"),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/RouterWebServiceUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/RouterWebServiceUtil.java
@@ -463,6 +463,8 @@ public final class RouterWebServiceUtil {
         metrics.getAppsFailed() + metricsResponse.getAppsFailed());
     metrics.setAppsKilled(
         metrics.getAppsKilled() + metricsResponse.getAppsKilled());
+    metrics.setAppsFinalFailed(
+        metrics.getAppsFinalFailed() + metricsResponse.getAppsFinalFailed());
 
     metrics.setReservedMB(
         metrics.getReservedMB() + metricsResponse.getReservedMB());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/MockDefaultRequestInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/MockDefaultRequestInterceptorREST.java
@@ -337,6 +337,7 @@ public class MockDefaultRequestInterceptorREST
     metrics.setAppsRunning(Integer.valueOf(getSubClusterId().getId()));
     metrics.setAppsFailed(Integer.valueOf(getSubClusterId().getId()));
     metrics.setAppsKilled(Integer.valueOf(getSubClusterId().getId()));
+    metrics.setAppsFinalFailed(Integer.valueOf(getSubClusterId().getId()));
 
     return metrics;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorRESTRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorRESTRetry.java
@@ -491,6 +491,8 @@ public class TestFederationInterceptorRESTRetry
         response.getAppsFailed());
     Assert.assertEquals(Integer.parseInt(good.getId()),
         response.getAppsKilled());
+    Assert.assertEquals(Integer.parseInt(good.getId()),
+        response.getAppsFinalFailed());
   }
 
   private void checkEmptyMetrics(ClusterMetricsInfo response) {
@@ -500,6 +502,7 @@ public class TestFederationInterceptorRESTRetry
     Assert.assertEquals(0, response.getAppsRunning());
     Assert.assertEquals(0, response.getAppsFailed());
     Assert.assertEquals(0, response.getAppsKilled());
+    Assert.assertEquals(0, response.getAppsFinalFailed());
 
     Assert.assertEquals(0, response.getReservedMB());
     Assert.assertEquals(0, response.getAvailableMB());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServiceUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServiceUtil.java
@@ -444,6 +444,9 @@ public class TestRouterWebServiceUtil {
     Assert.assertEquals(
         metricsResponse.getAppsKilled() + metricsClone.getAppsKilled(),
         metrics.getAppsKilled());
+    Assert.assertEquals(
+        metricsResponse.getAppsFinalFailed() + metricsClone.getAppsFinalFailed(),
+        metrics.getAppsFinalFailed());
 
     Assert.assertEquals(
         metricsResponse.getReservedMB() + metricsClone.getReservedMB(),
@@ -525,6 +528,7 @@ public class TestRouterWebServiceUtil {
     metricsClone.setAppsRunning(metrics.getAppsRunning());
     metricsClone.setAppsFailed(metrics.getAppsFailed());
     metricsClone.setAppsKilled(metrics.getAppsKilled());
+    metricsClone.setAppsFinalFailed(metrics.getAppsFinalFailed());
 
     metricsClone.setReservedMB(metrics.getReservedMB());
     metricsClone.setAvailableMB(metrics.getAvailableMB());
@@ -561,6 +565,7 @@ public class TestRouterWebServiceUtil {
     metrics.setAppsRunning(rand.nextInt(1000));
     metrics.setAppsFailed(rand.nextInt(1000));
     metrics.setAppsKilled(rand.nextInt(1000));
+    metrics.setAppsFinalFailed(rand.nextInt(1000));
 
     metrics.setReservedMB(rand.nextInt(1000));
     metrics.setAvailableMB(rand.nextInt(1000));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/ResourceManagerRest.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/ResourceManagerRest.md
@@ -162,6 +162,7 @@ The cluster metrics resource provides some overall metrics about the cluster. Mo
 | appsPending | int | The number of applications pending |
 | appsRunning | int | The number of applications running |
 | appsFailed | int | The number of applications failed |
+| appsFinalFailed | int | The number of applications finally failed |
 | appsKilled | int | The number of applications killed |
 | reservedMB | long | The amount of memory reserved in MB |
 | availableMB | long | The amount of memory available in MB |


### PR DESCRIPTION
YARN-11418: Add a new metric that reflects the number of applications whose FinalStatus is FAILED

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
We are faced with a scenario where the **State** of the application is **FINISHED**, but the **FinalStatus** is **FAILED**. When the **FinalStatus** of the application is **FAILED**, we want to show that through metrics.

### How was this patch tested?
create an Application whose FinalStatus is  FAILED, and verify that metrics in JMX are as expected. By the way, the metric is also added to the YARN WebUI.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

