### PR TITLE
HADOOP-18596. Distcp -update to use modification time while checking for file skip.

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
@@ -142,6 +142,13 @@ public final class DistCpConstants {
       "distcp.blocks.per.chunk";
 
   public static final String CONF_LABEL_USE_ITERATOR = "distcp.use.iterator";
+
+  /** Distcp -update to use modification time of source and target file to
+   * check while skipping.
+   */
+  public static final String CONF_LABEL_UPDATE_MOD_TIME =
+      "distcp.update.modification.time";
+
   /**
    * Constants for DistCp return code to shell / consumer of ToolRunner's run
    */

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
@@ -144,8 +144,9 @@ public final class DistCpConstants {
   public static final String CONF_LABEL_USE_ITERATOR = "distcp.use.iterator";
 
   /**
-   * Enabling distcp -update to use modification time of source and target
-   * file to check while copying same file with same size but different content.
+   * Enabling {@code distcp -update} to use modification time of source and
+   * target file to check while copying same file with same size but
+   * different content.
    *
    * The check would verify if the target file is perceived as older than the
    * source then it indicates that the source has been recently updated and it
@@ -154,6 +155,12 @@ public final class DistCpConstants {
    */
   public static final String CONF_LABEL_UPDATE_MOD_TIME =
       "distcp.update.modification.time";
+
+  /**
+   * Default value for 'distcp.update.modification.time' configuration.
+   */
+  public static final boolean CONF_LABEL_UPDATE_MOD_TIME_DEFAULT =
+      true;
 
   /**
    * Constants for DistCp return code to shell / consumer of ToolRunner's run

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
@@ -150,6 +150,7 @@ public final class DistCpConstants {
    * The check would verify if the target file is perceived as older than the
    * source then it indicates that the source has been recently updated and it
    * is a newer version than what was synced, so we should not skip the copy.
+   * {@value}
    */
   public static final String CONF_LABEL_UPDATE_MOD_TIME =
       "distcp.update.modification.time";

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
@@ -143,8 +143,13 @@ public final class DistCpConstants {
 
   public static final String CONF_LABEL_USE_ITERATOR = "distcp.use.iterator";
 
-  /** Distcp -update to use modification time of source and target file to
-   * check while skipping.
+  /**
+   * Enabling distcp -update to use modification time of source and target
+   * file to check while copying same file with same size but different content.
+   *
+   * The check would verify if the target file is perceived as older than the
+   * source then it indicates that the source has been recently updated and it
+   * is a newer version than what was synced, so we should not skip the copy.
    */
   public static final String CONF_LABEL_UPDATE_MOD_TIME =
       "distcp.update.modification.time";

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyMapper.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyMapper.java
@@ -354,7 +354,14 @@ public class CopyMapper extends Mapper<Text, CopyListingFileStatus, Text, Text> 
     boolean sameLength = target.getLen() == source.getLen();
     boolean sameBlockSize = source.getBlockSize() == target.getBlockSize()
         || !preserve.contains(FileAttribute.BLOCKSIZE);
-    if (sameLength && sameBlockSize) {
+    // checksum check to be done if same file len(greater than 0), same block
+    // size and the target file has been updated more recently than the source
+    // file.
+    // Note: For Different cloud stores with different checksum algorithms,
+    // checksum comparisons are not performed so we would be depending on the
+    // file size and modification time.
+    if (sameLength && (source.getLen() > 0) && sameBlockSize &&
+        source.getModificationTime() < target.getModificationTime()) {
       return skipCrc ||
           DistCpUtils.checksumsAreEqual(sourceFS, source.getPath(), null,
               targetFS, target.getPath(), source.getLen());

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyMapper.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyMapper.java
@@ -80,9 +80,9 @@ public class CopyMapper extends Mapper<Text, CopyListingFileStatus, Text, Text> 
    * Indicates the checksum comparison result.
    */
   public enum ChecksumComparison {
-    COMPATIBLE_AND_TRUE, // checksum compariosn is compatible and true.
-    COMPATIBLE_AND_FALSE, // checksum compariosn is compatible and false.
-    INCOMPATIBLE, // checksum compariosn is not compatible.
+    TRUE,           // checksum comparison is compatible and true.
+    FALSE,          // checksum comparison is compatible and false.
+    INCOMPATIBLE,   // checksum comparison is not compatible.
   }
 
   private static Logger LOG = LoggerFactory.getLogger(CopyMapper.class);
@@ -403,8 +403,7 @@ public class CopyMapper extends Mapper<Text, CopyListingFileStatus, Text, Text> 
         }
         // if skipCrc is disabled and checksumComparison is compatible we
         // need not check the mod time.
-        return checksumComparison
-            .equals(ChecksumComparison.COMPATIBLE_AND_TRUE);
+        return checksumComparison.equals(ChecksumComparison.TRUE);
       }
     }
     return false;

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyMapper.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyMapper.java
@@ -412,10 +412,11 @@ public class CopyMapper extends Mapper<Text, CopyListingFileStatus, Text, Text> 
   /**
    * If the mod time comparison is enabled, check the mod time else return
    * false.
-   * Comparison: If the target file perceives to have greater mod time(older)
-   * than the source file, we can assume that there has been no new changes
-   * that occurred in the source file, hence we should return true to skip the
-   * copy of the file.
+   * Comparison: If the target file perceives to have greater or equal mod time
+   * (older) than the source file, we can assume that there has been no new
+   * changes that occurred in the source file, hence we should return true to
+   * skip the copy of the file.
+   *
    * @param source Source fileStatus.
    * @param target Target fileStatus.
    * @return boolean representing result of modTime check.
@@ -423,7 +424,7 @@ public class CopyMapper extends Mapper<Text, CopyListingFileStatus, Text, Text> 
   private boolean maybeUseModTimeToCompare(
       CopyListingFileStatus source, FileStatus target) {
     if (useModTimeToUpdate) {
-      return source.getModificationTime() < target.getModificationTime();
+      return source.getModificationTime() <= target.getModificationTime();
     }
     // if we cannot check mod time, return true (skip the copy).
     return true;

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyMapper.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyMapper.java
@@ -357,8 +357,9 @@ public class CopyMapper extends Mapper<Text, CopyListingFileStatus, Text, Text> 
     boolean sameLength = target.getLen() == source.getLen();
     boolean sameBlockSize = source.getBlockSize() == target.getBlockSize()
         || !preserve.contains(FileAttribute.BLOCKSIZE);
-    if (source.getLen() == 0) {
-      return false;
+    // Skip the copy if a 0 size file is being copied.
+    if (sameLength && source.getLen() == 0) {
+      return true;
     }
     // if both the source and target have the same length, then check if the
     // config to use modification time is set to true, then use the

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.tools.CopyListing.XAttrsNotSupportedException;
 import org.apache.hadoop.tools.CopyListingFileStatus;
 import org.apache.hadoop.tools.DistCpContext;
 import org.apache.hadoop.tools.DistCpOptions.FileAttribute;
+import org.apache.hadoop.tools.mapred.CopyMapper;
 import org.apache.hadoop.tools.mapred.UniformSizeInputFormat;
 import org.apache.hadoop.util.StringUtils;
 
@@ -568,10 +569,12 @@ public class DistCpUtils {
    * and false otherwise.
    * @throws IOException if there's an exception while retrieving checksums.
    */
-  public static boolean checksumsAreEqual(FileSystem sourceFS, Path source,
-                                          FileChecksum sourceChecksum,
-                                          FileSystem targetFS,
-                                          Path target, long sourceLen)
+  public static CopyMapper.ChecksumComparison checksumsAreEqual(
+      FileSystem sourceFS,
+      Path source,
+      FileChecksum sourceChecksum,
+      FileSystem targetFS,
+      Path target, long sourceLen)
       throws IOException {
     FileChecksum targetChecksum = null;
     try {
@@ -585,8 +588,15 @@ public class DistCpUtils {
     } catch (IOException e) {
       LOG.error("Unable to retrieve checksum for " + source + " or " + target, e);
     }
-    return (sourceChecksum == null || targetChecksum == null ||
-            sourceChecksum.equals(targetChecksum));
+    // If the source or target checksum is null, that means there is no
+    // comparison that took place and return not compatible.
+    // else if matched, return compatible with the matched result.
+    if (sourceChecksum == null || targetChecksum == null) {
+      return CopyMapper.ChecksumComparison.INCOMPATIBLE;
+    } else if (sourceChecksum.equals(targetChecksum)) {
+      return CopyMapper.ChecksumComparison.COMPATIBLE_AND_TRUE;
+    }
+    return CopyMapper.ChecksumComparison.COMPATIBLE_AND_FALSE;
   }
 
   /**
@@ -613,8 +623,13 @@ public class DistCpUtils {
 
     //At this point, src & dest lengths are same. if length==0, we skip checksum
     if ((srcLen != 0) && (!skipCrc)) {
-      if (!checksumsAreEqual(sourceFS, source, sourceChecksum,
-          targetFS, target, srcLen)) {
+      CopyMapper.ChecksumComparison
+          checksumComparison = checksumsAreEqual(sourceFS, source, sourceChecksum,
+              targetFS, target, srcLen);
+      // If Checksum comparison is false set it to false, else set to true.
+      boolean checksumResult = !checksumComparison.equals(
+          CopyMapper.ChecksumComparison.COMPATIBLE_AND_FALSE);
+      if (!checksumResult) {
         StringBuilder errorMessage =
             new StringBuilder(DistCpConstants.CHECKSUM_MISMATCH_ERROR_MSG)
                 .append(source).append(" and ").append(target).append(".");

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
@@ -594,9 +594,9 @@ public class DistCpUtils {
     if (sourceChecksum == null || targetChecksum == null) {
       return CopyMapper.ChecksumComparison.INCOMPATIBLE;
     } else if (sourceChecksum.equals(targetChecksum)) {
-      return CopyMapper.ChecksumComparison.COMPATIBLE_AND_TRUE;
+      return CopyMapper.ChecksumComparison.TRUE;
     }
-    return CopyMapper.ChecksumComparison.COMPATIBLE_AND_FALSE;
+    return CopyMapper.ChecksumComparison.FALSE;
   }
 
   /**
@@ -627,8 +627,7 @@ public class DistCpUtils {
           checksumComparison = checksumsAreEqual(sourceFS, source, sourceChecksum,
               targetFS, target, srcLen);
       // If Checksum comparison is false set it to false, else set to true.
-      boolean checksumResult = !checksumComparison.equals(
-          CopyMapper.ChecksumComparison.COMPATIBLE_AND_FALSE);
+      boolean checksumResult = !checksumComparison.equals(CopyMapper.ChecksumComparison.FALSE);
       if (!checksumResult) {
         StringBuilder errorMessage =
             new StringBuilder(DistCpConstants.CHECKSUM_MISMATCH_ERROR_MSG)

--- a/hadoop-tools/hadoop-distcp/src/site/markdown/DistCp.md.vm
+++ b/hadoop-tools/hadoop-distcp/src/site/markdown/DistCp.md.vm
@@ -631,14 +631,39 @@ hadoop distcp -update -numListstatusThreads 20  \
 Because object stores are slow to list files, consider setting the `-numListstatusThreads` option when performing a `-update` operation
 on a large directory tree (the limit is 40 threads).
 
-When `DistCp -update` is used with object stores,
-generally only the modification time and length of the individual files are compared,
-not any checksums. The fact that most object stores do have valid timestamps
-for directories is irrelevant; only the file timestamps are compared.
-However, it is important to have the clock of the client computers close
-to that of the infrastructure, so that timestamps are consistent between
-the client/HDFS cluster and that of the object store. Otherwise, changed files may be
-missed/copied too often.
+When `DistCp -update` is used with object stores, generally only the
+modification time and length of the individual files are compared, not any
+checksums if the checksum algorithm between the two stores is different.
+
+* The `distcp -update` between two object stores with different checksum
+  algorithm compares the modification times of source and target files along
+  with the file size to determine whether to skip the file copy. The behavior
+  is controlled by the property `distcp.update.modification.time`, which is
+  set to true by default. If the source file is more recently modified than
+  the target file, it is assumed that the content has changed, and the file
+  should be updated.
+  We need to ensure that there is no clock skew between the machines.
+  The fact that most object stores do have valid timestamps for directories
+  is irrelevant; only the file timestamps are compared. However, it is
+  important to have the clock of the client computers close to that of the
+  infrastructure, so that timestamps are consistent between the client/HDFS
+  cluster and that of the object store. Otherwise, changed files may be
+  missed/copied too often.
+
+* `distcp.update.modification.time` can be used alongside the checksum check
+  in stores with same checksum algorithm as well. if set to true we check
+  both modification time and checksum between the files, but if this property
+  is set to false we only compare the checksum between the files to determine
+  if we should skip the copy or not.
+
+  To turn off, set this in your core-site.xml
+
+```xml
+<property>
+        <name>distcp.update.modification.time</name>
+        <value>true</value>
+</property>
+```
 
 **Notes**
 

--- a/hadoop-tools/hadoop-distcp/src/site/markdown/DistCp.md.vm
+++ b/hadoop-tools/hadoop-distcp/src/site/markdown/DistCp.md.vm
@@ -650,18 +650,16 @@ checksums if the checksum algorithm between the two stores is different.
   cluster and that of the object store. Otherwise, changed files may be
   missed/copied too often.
 
-* `distcp.update.modification.time` can be used alongside the checksum check
-  in stores with same checksum algorithm as well. if set to true we check
-  both modification time and checksum between the files, but if this property
-  is set to false we only compare the checksum between the files to determine
-  if we should skip the copy or not.
+* `distcp.update.modification.time` would only be used if either of the two
+  stores don't have checksum validation resulting in incompatible checksum
+  comparison between the two. Even if the property is set to true, it won't
+  be used if their is valid checksum comparison between the two stores.
 
-  To turn off, set this in your core-site.xml
-
+To turn off the modification time check, set this in your core-site.xml
 ```xml
 <property>
         <name>distcp.update.modification.time</name>
-        <value>true</value>
+        <value>false</value>
 </property>
 ```
 

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/contract/AbstractContractDistCpTest.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/contract/AbstractContractDistCpTest.java
@@ -24,10 +24,6 @@ import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.logIOStatistic
 import static org.apache.hadoop.tools.DistCpConstants.CONF_LABEL_DISTCP_JOB_ID;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/contract/AbstractContractDistCpTest.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/contract/AbstractContractDistCpTest.java
@@ -376,7 +376,7 @@ public abstract class AbstractContractDistCpTest
             Collections.singletonList(srcDir), destDir)
             .withDeleteMissing(true)
             .withSyncFolder(true)
-            .withSkipCRC(true)
+            .withSkipCRC(false)
             .withDirectWrite(shouldUseDirectWrite())
             .withOverwrite(false)));
   }

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/contract/AbstractContractDistCpTest.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/contract/AbstractContractDistCpTest.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
@@ -50,7 +49,6 @@ import org.apache.hadoop.tools.SimpleCopyListing;
 import org.apache.hadoop.tools.mapred.CopyMapper;
 import org.apache.hadoop.tools.util.DistCpTestUtils;
 import org.apache.hadoop.util.functional.RemoteIterators;
-import org.apache.http.annotation.Contract;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
@@ -893,10 +891,10 @@ public abstract class AbstractContractDistCpTest
     Path source = new Path(remoteDir, "file");
     Path dest = new Path(localDir, "file");
 
-    Path source_0byte = new Path(remoteDir, "file_0byte");
-    Path dest_0byte = new Path(localDir, "file_0byte");
+    Path source0byte = new Path(remoteDir, "file_0byte");
+    Path dest0byte = new Path(localDir, "file_0byte");
     dest = localFS.makeQualified(dest);
-    dest_0byte = localFS.makeQualified(dest_0byte);
+    dest0byte = localFS.makeQualified(dest0byte);
 
     // Creating a source file with certain dataset.
     byte[] sourceBlock = dataset(10, 'a', 'z');
@@ -908,16 +906,16 @@ public abstract class AbstractContractDistCpTest
             1024, true);
 
     // Create 0 byte source and target files.
-    ContractTestUtils.createFile(remoteFS, source_0byte, true, new byte[0]);
-    ContractTestUtils.createFile(localFS, dest_0byte, true, new byte[0]);
+    ContractTestUtils.createFile(remoteFS, source0byte, true, new byte[0]);
+    ContractTestUtils.createFile(localFS, dest0byte, true, new byte[0]);
 
     // Execute the distcp -update job.
     Job job = distCpUpdateWithFs(remoteDir, localDir, remoteFS, localFS);
 
     // First distcp -update would normally copy the source to dest.
     verifyFileContents(localFS, dest, sourceBlock);
-    // Verify 1 file was skipped in the distcp -update(They 0 byte files).
-    // Verify 1 file was copied in the distcp -update(The new source file).
+    // Verify 1 file was skipped in the distcp -update (The 0 byte file).
+    // Verify 1 file was copied in the distcp -update (The new source file).
     verifySkipAndCopyCounter(job, 1, 1);
 
     // Remove the source file and replace with a file with same name and size
@@ -952,7 +950,7 @@ public abstract class AbstractContractDistCpTest
     // newer than the updatedSource which indicates that the sync happened
     // more recently and there is no update.
     verifyFileContents(localFS, dest, sourceBlock);
-    // Skipped both 0 byte file and sourceFile(since mod time of target is
+    // Skipped both 0 byte file and sourceFile (since mod time of target is
     // older than the source it is perceived that source is of older version
     // and we can skip it's copy).
     verifySkipAndCopyCounter(updatedSourceJobOldSrc, 2, 0);

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
@@ -562,9 +562,11 @@ public class TestCopyCommitter {
         Path sourcePath = new Path(sourceBase + srcFilename);
         CopyListingFileStatus sourceCurrStatus =
                 new CopyListingFileStatus(fs.getFileStatus(sourcePath));
-        Assert.assertFalse(DistCpUtils.checksumsAreEqual(
+        Assert.assertFalse(!DistCpUtils.checksumsAreEqual(
             fs, new Path(sourceBase + srcFilename), null,
-            fs, new Path(targetBase + srcFilename), sourceCurrStatus.getLen()));
+            fs, new Path(targetBase + srcFilename),
+            sourceCurrStatus.getLen())
+            .equals(CopyMapper.ChecksumComparison.COMPATIBLE_AND_FALSE));
       } catch(IOException exception) {
         if (skipCrc) {
           LOG.error("Unexpected exception is found", exception);

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
@@ -562,11 +562,12 @@ public class TestCopyCommitter {
         Path sourcePath = new Path(sourceBase + srcFilename);
         CopyListingFileStatus sourceCurrStatus =
                 new CopyListingFileStatus(fs.getFileStatus(sourcePath));
-        Assert.assertFalse(!DistCpUtils.checksumsAreEqual(
-            fs, new Path(sourceBase + srcFilename), null,
-            fs, new Path(targetBase + srcFilename),
-            sourceCurrStatus.getLen())
-            .equals(CopyMapper.ChecksumComparison.FALSE));
+        Assert.assertEquals("Checksum should not be equal",
+            DistCpUtils.checksumsAreEqual(
+                fs, new Path(sourceBase + srcFilename), null,
+                fs, new Path(targetBase + srcFilename),
+                sourceCurrStatus.getLen()),
+            CopyMapper.ChecksumComparison.FALSE);
       } catch(IOException exception) {
         if (skipCrc) {
           LOG.error("Unexpected exception is found", exception);

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
@@ -563,11 +563,11 @@ public class TestCopyCommitter {
         CopyListingFileStatus sourceCurrStatus =
                 new CopyListingFileStatus(fs.getFileStatus(sourcePath));
         Assert.assertEquals("Checksum should not be equal",
+            CopyMapper.ChecksumComparison.FALSE,
             DistCpUtils.checksumsAreEqual(
                 fs, new Path(sourceBase + srcFilename), null,
                 fs, new Path(targetBase + srcFilename),
-                sourceCurrStatus.getLen()),
-            CopyMapper.ChecksumComparison.FALSE);
+                sourceCurrStatus.getLen()));
       } catch(IOException exception) {
         if (skipCrc) {
           LOG.error("Unexpected exception is found", exception);

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
@@ -566,7 +566,7 @@ public class TestCopyCommitter {
             fs, new Path(sourceBase + srcFilename), null,
             fs, new Path(targetBase + srcFilename),
             sourceCurrStatus.getLen())
-            .equals(CopyMapper.ChecksumComparison.COMPATIBLE_AND_FALSE));
+            .equals(CopyMapper.ChecksumComparison.FALSE));
       } catch(IOException exception) {
         if (skipCrc) {
           LOG.error("Unexpected exception is found", exception);


### PR DESCRIPTION
### Description of PR
Using modification time as a way to add more checks to determine if distcp -update should skip a file or not. 
In specific cases like the same file name, and size but different content we used to incorrectly skip files in update since there is no checksum comparison between object stores with different algorithm for it, to mitigate this we introduce comparing modification time between the target file and the source.

### How was this patch tested?
Manually tested on an environment after reproducing the scenario where we might incorrectly skip a file.
Added a test in `AbstractContractDistCpTest.java` to test by changing the target file's modification time to emulate the scenario.

Tested on S3A(ap-south-1), ABFS(us-west-2), and LocalFS, and the test was successful. 

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

