### PR TITLE
YARN-11419. Remove redundant exception capture in NMClientAsyncImpl and improve readability in ContainerShellWebSocket, etc

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/ContainerShellWebSocket.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/ContainerShellWebSocket.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.yarn.client.api;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -62,7 +62,7 @@ public class ContainerShellWebSocket {
       session.getRemote().flush();
       sttySet = true;
     }
-    terminal.output().write(message.getBytes(Charset.forName("UTF-8")));
+    terminal.output().write(message.getBytes(StandardCharsets.UTF_8));
     terminal.output().flush();
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/async/impl/NMClientAsyncImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/async/impl/NMClientAsyncImpl.java
@@ -636,12 +636,8 @@ public class NMClientAsyncImpl extends NMClientAsync {
                 + "Container " + containerId, thr);
           }
           return ContainerState.RUNNING;
-        } catch (YarnException e) {
+        } catch (Throwable e) {
           return onExceptionRaised(container, event, e);
-        } catch (IOException e) {
-          return onExceptionRaised(container, event, e);
-        } catch (Throwable t) {
-          return onExceptionRaised(container, event, t);
         }
       }
 
@@ -854,12 +850,8 @@ public class NMClientAsyncImpl extends NMClientAsync {
                 + "Container " + event.getContainerId(), thr);
           }
           return ContainerState.DONE;
-        } catch (YarnException e) {
+        } catch (Throwable e) {
           return onExceptionRaised(container, event, e);
-        } catch (IOException e) {
-          return onExceptionRaised(container, event, e);
-        } catch (Throwable t) {
-          return onExceptionRaised(container, event, t);
         }
       }
 
@@ -966,12 +958,8 @@ public class NMClientAsyncImpl extends NMClientAsync {
                 "Unchecked exception is thrown from onContainerStatusReceived" +
                     " for Container " + event.getContainerId(), thr);
           }
-        } catch (YarnException e) {
+        } catch (Throwable e) {
           onExceptionRaised(containerId, e);
-        } catch (IOException e) {
-          onExceptionRaised(containerId, e);
-        } catch (Throwable t) {
-          onExceptionRaised(containerId, t);
         }
       } else {
         StatefulContainer container = containers.get(containerId);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/async/impl/NMClientAsyncImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/async/impl/NMClientAsyncImpl.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.yarn.client.api.async.impl;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -51,7 +50,6 @@ import org.apache.hadoop.yarn.client.api.impl.NMClientImpl;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.event.AbstractEvent;
 import org.apache.hadoop.yarn.event.EventHandler;
-import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.ipc.RPCUtil;
 import org.apache.hadoop.yarn.state.InvalidStateTransitionException;
 import org.apache.hadoop.yarn.state.MultipleArcTransition;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/SharedCacheClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/SharedCacheClientImpl.java
@@ -158,14 +158,8 @@ public class SharedCacheClientImpl extends SharedCacheClient {
   public String getFileChecksum(Path sourceFile)
       throws IOException {
     FileSystem fs = sourceFile.getFileSystem(this.conf);
-    FSDataInputStream in = null;
-    try {
-      in = fs.open(sourceFile);
+    try (FSDataInputStream in = fs.open(sourceFile)) {
       return this.checksum.computeChecksum(in);
-    } finally {
-      if (in != null) {
-        in.close();
-      }
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/util/YarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/util/YarnClientUtils.java
@@ -145,7 +145,7 @@ public abstract class YarnClientUtils {
 
             // Now we only support one property, which is exclusive, so check if
             // key = exclusive and value = {true/false}
-            if (key.equals("exclusive")
+            if ("exclusive".equals(key)
                 && ImmutableSet.of("true", "false").contains(value)) {
               exclusive = Boolean.parseBoolean(value);
             } else {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->
[YARN-11419](https://issues.apache.org/jira/browse/YARN-11419) Remove redundant exception capture in NMClientAsyncImpl and improve readability in ContainerShellWebSocket, etc 
### Description of PR
1. Remove `YarnException` and `IOException`, because they are all subclasses of `Throwable`.
2. Use `try-resource`.
3. A non-empty string should be on the left side of the `equal`.

### How was this patch tested?
Origin uts.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

