### PR TITLE
HADOOP-17717. Update wildfly openssl to 1.1.3.Final

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -363,7 +363,7 @@ org.lz4:lz4-java:1.7.1
 org.objenesis:objenesis:2.6
 org.xerial.snappy:snappy-java:1.0.5
 org.yaml:snakeyaml:1.33
-org.wildfly.openssl:wildfly-openssl:1.0.7.Final
+org.wildfly.openssl:wildfly-openssl:1.1.3.Final
 
 
 --------------------------------------------------------------------------------

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -208,7 +208,7 @@
     <jline.version>3.9.0</jline.version>
     <powermock.version>1.5.6</powermock.version>
     <solr.version>8.8.2</solr.version>
-    <openssl-wildfly.version>1.0.7.Final</openssl-wildfly.version>
+    <openssl-wildfly.version>1.1.3.Final</openssl-wildfly.version>
     <jsonschema2pojo.version>1.0.2</jsonschema2pojo.version>
     <woodstox.version>5.4.0</woodstox.version>
     <json-smart.version>2.4.7</json-smart.version>


### PR DESCRIPTION
Contributed by Wei-Chiu Chuang

### Description of PR

pr #3029 rebased; tests in progress


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

