### PR TITLE
Yarn 11420

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestNMClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestNMClient.java
@@ -23,10 +23,10 @@ import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.service.Service.STATE;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.SubmitApplicationRequest;
-import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
@@ -36,14 +36,12 @@ import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.api.records.ContainerState;
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
-import org.apache.hadoop.yarn.api.records.ExecutionType;
 import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.NMToken;
 import org.apache.hadoop.yarn.api.records.NodeReport;
 import org.apache.hadoop.yarn.api.records.NodeState;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
-import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.client.api.AMRMClient;
 import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest;
@@ -60,46 +58,48 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.RMAppAttempt;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.RMAppAttemptState;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class TestNMClient {
-  Configuration conf = null;
-  MiniYARNCluster yarnCluster = null;
-  YarnClientImpl yarnClient = null;
-  AMRMClientImpl<ContainerRequest> rmClient = null;
-  NMClientImpl nmClient = null;
-  List<NodeReport> nodeReports = null;
-  ApplicationAttemptId attemptId = null;
-  int nodeCount = 3;
-  NMTokenCache nmTokenCache = null;
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestNMClient.class);
+  private static final int MAX_EARLY_FINISH = 3;
+  private Configuration conf;
+  private MiniYARNCluster yarnCluster;
+  private YarnClientImpl yarnClient;
+  private AMRMClientImpl<ContainerRequest> rmClient;
+  private NMClientImpl nmClient;
+  private List<NodeReport> nodeReports;
+  private NMTokenCache nmTokenCache;
+  private RMAppAttempt appAttempt;
 
   /**
    * Container State transition listener to track the number of times
    * a container has transitioned into a state.
    */
-  public static class DebugSumContainerStateListener
-      implements ContainerStateTransitionListener {
+  public static class DebugSumContainerStateListener implements ContainerStateTransitionListener {
 
     private static final Logger LOG =
         LoggerFactory.getLogger(DebugSumContainerStateListener.class);
@@ -128,15 +128,13 @@ public class TestNMClient {
       synchronized (TRANSITION_COUNTER) {
         if (beforeState != afterState) {
           ContainerId id = op.getContainerId();
-          TRANSITION_COUNTER
-              .putIfAbsent(id, new HashMap<>());
+          TRANSITION_COUNTER.putIfAbsent(id, new HashMap<>());
           long sum = TRANSITION_COUNTER.get(id)
-              .compute(afterState,
-                  (state, count) -> count == null ? 1 : count + 1);
+              .compute(afterState, (state, count) -> count == null ? 1 : count + 1);
           LOG.info("***** " + id +
               " Transition from " + beforeState +
               " to " + afterState +
-              "sum:" + sum);
+              " sum:" + sum);
         }
       }
     }
@@ -145,424 +143,356 @@ public class TestNMClient {
      * Get the current number of state transitions.
      * This is useful to check, if an event has occurred in unit tests.
      * @param id Container id to check
-     * @param state Return the overall number of transitions to this state
      * @return Number of transitions to the state specified
      */
-    static long getTransitionCounter(ContainerId id,
-                                     org.apache.hadoop.yarn.server.nodemanager
-                                         .containermanager.container
-                                         .ContainerState state) {
-      Long ret = TRANSITION_COUNTER.getOrDefault(id, new HashMap<>())
-          .get(state);
-      return ret != null ? ret : 0;
+    static long getTransitionCounter(ContainerId id) {
+      return TRANSITION_COUNTER
+          .getOrDefault(id, new HashMap<>())
+          .getOrDefault(org.apache.hadoop.yarn.server.nodemanager
+              .containermanager.container
+              .ContainerState.RUNNING, 0L);
     }
   }
 
-  @Before
-  public void setup() throws YarnException, IOException {
-    // start minicluster
+  public void setup() throws YarnException, IOException, InterruptedException, TimeoutException {
     conf = new YarnConfiguration();
-    // Turn on state tracking
     conf.set(YarnConfiguration.NM_CONTAINER_STATE_TRANSITION_LISTENERS,
         DebugSumContainerStateListener.class.getName());
-    yarnCluster =
-        new MiniYARNCluster(TestAMRMClient.class.getName(), nodeCount, 1, 1);
-    yarnCluster.init(conf);
-    yarnCluster.start();
-    assertNotNull(yarnCluster);
-    assertEquals(STATE.STARTED, yarnCluster.getServiceState());
-
-    // start rm client
-    yarnClient = (YarnClientImpl) YarnClient.createYarnClient();
-    yarnClient.init(conf);
-    yarnClient.start();
-    assertNotNull(yarnClient);
-    assertEquals(STATE.STARTED, yarnClient.getServiceState());
-
-    // get node info
-    nodeReports = yarnClient.getNodeReports(NodeState.RUNNING);
-
-    // submit new app
-    ApplicationSubmissionContext appContext = 
-        yarnClient.createApplication().getApplicationSubmissionContext();
-    ApplicationId appId = appContext.getApplicationId();
-    // set the application name
-    appContext.setApplicationName("Test");
-    // Set the priority for the application master
-    Priority pri = Priority.newInstance(0);
-    appContext.setPriority(pri);
-    // Set the queue to which this application is to be submitted in the RM
-    appContext.setQueue("default");
-    // Set up the container launch context for the application master
-    ContainerLaunchContext amContainer = Records
-        .newRecord(ContainerLaunchContext.class);
-    appContext.setAMContainerSpec(amContainer);
-    // unmanaged AM
-    appContext.setUnmanagedAM(true);
-    // Create the request to send to the applications manager
-    SubmitApplicationRequest appRequest = Records
-        .newRecord(SubmitApplicationRequest.class);
-    appRequest.setApplicationSubmissionContext(appContext);
-    // Submit the application to the applications manager
-    yarnClient.submitApplication(appContext);
-
-    // wait for app to start
-    int iterationsLeft = 30;
-    RMAppAttempt appAttempt = null;
-    while (iterationsLeft > 0) {
-      ApplicationReport appReport = yarnClient.getApplicationReport(appId);
-      if (appReport.getYarnApplicationState() ==
-          YarnApplicationState.ACCEPTED) {
-        attemptId = appReport.getCurrentApplicationAttemptId();
-        appAttempt =
-            yarnCluster.getResourceManager().getRMContext().getRMApps()
-              .get(attemptId.getApplicationId()).getCurrentAppAttempt();
-        while (true) {
-          if (appAttempt.getAppAttemptState() == RMAppAttemptState.LAUNCHED) {
-            break;
-          }
-        }
-        break;
-      }
-      sleep(1000);
-      --iterationsLeft;
-    }
-    if (iterationsLeft == 0) {
-      fail("Application hasn't bee started");
-    }
-
-    // Just dig into the ResourceManager and get the AMRMToken just for the sake
-    // of testing.
+    startYarnCluster();
+    startYarnClient();
     UserGroupInformation.setLoginUser(UserGroupInformation
       .createRemoteUser(UserGroupInformation.getCurrentUser().getUserName()));
     UserGroupInformation.getCurrentUser().addToken(appAttempt.getAMRMToken());
-
-    //creating an instance NMTokenCase
     nmTokenCache = new NMTokenCache();
-    
-    // start am rm client
-    rmClient =
-        (AMRMClientImpl<ContainerRequest>) AMRMClient
-          .<ContainerRequest> createAMRMClient();
+    startRMClient();
+    startNMClient();
+  }
 
-    //setting an instance NMTokenCase
+
+  private void startYarnCluster() {
+    yarnCluster = new MiniYARNCluster(TestNMClient.class.getName(), 3, 1, 1);
+    yarnCluster.init(conf);
+    yarnCluster.start();
+    assertEquals(STATE.STARTED, yarnCluster.getServiceState());
+  }
+
+  private void startYarnClient()
+      throws IOException, YarnException, InterruptedException, TimeoutException {
+    yarnClient = (YarnClientImpl) YarnClient.createYarnClient();
+    yarnClient.init(conf);
+    yarnClient.start();
+    assertEquals(STATE.STARTED, yarnClient.getServiceState());
+    nodeReports = yarnClient.getNodeReports(NodeState.RUNNING);
+    ApplicationSubmissionContext appContext =
+        yarnClient.createApplication().getApplicationSubmissionContext();
+    ApplicationId appId = appContext.getApplicationId();
+    appContext.setApplicationName("Test");
+    Priority pri = Priority.newInstance(0);
+    appContext.setPriority(pri);
+    appContext.setQueue("default");
+    ContainerLaunchContext amContainer = Records.newRecord(ContainerLaunchContext.class);
+    appContext.setAMContainerSpec(amContainer);
+    appContext.setUnmanagedAM(true);
+    SubmitApplicationRequest appRequest = Records.newRecord(SubmitApplicationRequest.class);
+    appRequest.setApplicationSubmissionContext(appContext);
+    yarnClient.submitApplication(appContext);
+    GenericTestUtils.waitFor(() -> yarnCluster.getResourceManager().getRMContext().getRMApps()
+        .get(appId).getCurrentAppAttempt().getAppAttemptState() == RMAppAttemptState.LAUNCHED,
+        100, 30_000, "Failed to start app");
+    appAttempt = yarnCluster.getResourceManager().getRMContext().getRMApps()
+        .get(appId).getCurrentAppAttempt();
+  }
+
+  private void startRMClient() {
+    rmClient = (AMRMClientImpl<ContainerRequest>) AMRMClient.createAMRMClient();
     rmClient.setNMTokenCache(nmTokenCache);
     rmClient.init(conf);
     rmClient.start();
-    assertNotNull(rmClient);
     assertEquals(STATE.STARTED, rmClient.getServiceState());
+  }
 
-    // start am nm client
+  private void startNMClient() {
     nmClient = (NMClientImpl) NMClient.createNMClient();
-    
-    //propagating the AMRMClient NMTokenCache instance
     nmClient.setNMTokenCache(rmClient.getNMTokenCache());
     nmClient.init(conf);
     nmClient.start();
-    assertNotNull(nmClient);
     assertEquals(STATE.STARTED, nmClient.getServiceState());
   }
 
-  @After
-  public void tearDown() {
+  public void tearDown() throws InterruptedException {
     rmClient.stop();
     yarnClient.stop();
     yarnCluster.stop();
   }
 
-  private void stopNmClient(boolean stopContainers) {
+  @Test (timeout = 180_000 * MAX_EARLY_FINISH)
+  public void testNMClientNoCleanupOnStop()
+      throws YarnException, IOException, InterruptedException, TimeoutException {
+    int earlyFinishCounter = MAX_EARLY_FINISH;
+    while (0 < earlyFinishCounter) {
+      try {
+        setup();
+        rmClient.registerApplicationMaster("Host", 10_000, "");
+        testContainerManagement(nmClient, allocateContainers(rmClient, 5));
+        rmClient.unregisterApplicationMaster(FinalApplicationStatus.SUCCEEDED, null, null);
+        stopNmClient();
+        assertFalse(nmClient.startedContainers.isEmpty());
+        nmClient.cleanupRunningContainers();
+        assertEquals(0, nmClient.startedContainers.size());
+        return;
+      } catch (EarlyFinishException e) {
+        --earlyFinishCounter;
+      } finally {
+        tearDown();
+      }
+    }
+    if (earlyFinishCounter == 0) {
+      fail("Too many early finish exception happened");
+    }
+  }
+
+  @Test (timeout = 200_000 * MAX_EARLY_FINISH)
+  public void testNMClient()
+      throws YarnException, IOException, InterruptedException, TimeoutException {
+    int earlyFinishCounter = MAX_EARLY_FINISH;
+    while (0 < earlyFinishCounter) {
+      try {
+        setup();
+        rmClient.registerApplicationMaster("Host", 10_000, "");
+        testContainerManagement(nmClient, allocateContainers(rmClient, 5));
+        rmClient.unregisterApplicationMaster(FinalApplicationStatus.SUCCEEDED, null, null);
+        // stop the running containers on close
+        assertFalse(nmClient.startedContainers.isEmpty());
+        nmClient.cleanupRunningContainersOnStop(true);
+        assertTrue(nmClient.getCleanupRunningContainers().get());
+        nmClient.stop();
+        return;
+      } catch (EarlyFinishException e) {
+        --earlyFinishCounter;
+      } finally {
+        tearDown();
+      }
+    }
+    if (earlyFinishCounter == 0) {
+      fail("Too many early finish exception happened");
+    }
+  }
+
+  private void stopNmClient() {
     assertNotNull("Null nmClient", nmClient);
     // leave one unclosed
     assertEquals(1, nmClient.startedContainers.size());
     // default true
     assertTrue(nmClient.getCleanupRunningContainers().get());
-    nmClient.cleanupRunningContainersOnStop(stopContainers);
-    assertEquals(stopContainers, nmClient.getCleanupRunningContainers().get());
-    nmClient.stop();
-  }
-
-  @Test (timeout = 180000)
-  public void testNMClientNoCleanupOnStop()
-      throws YarnException, IOException {
-
-    rmClient.registerApplicationMaster("Host", 10000, "");
-
-    testContainerManagement(nmClient, allocateContainers(rmClient, 5));
-
-    rmClient.unregisterApplicationMaster(FinalApplicationStatus.SUCCEEDED,
-        null, null);
-    // don't stop the running containers
-    stopNmClient(false);
-    assertFalse(nmClient.startedContainers.isEmpty());
-    //now cleanup
-    nmClient.cleanupRunningContainers();
-    assertEquals(0, nmClient.startedContainers.size());
-  }
-
-  @Test (timeout = 200000)
-  public void testNMClient()
-      throws YarnException, IOException {
-    rmClient.registerApplicationMaster("Host", 10000, "");
-
-    testContainerManagement(nmClient, allocateContainers(rmClient, 5));
-    
-    rmClient.unregisterApplicationMaster(FinalApplicationStatus.SUCCEEDED,
-        null, null);
-    // stop the running containers on close
-    assertFalse(nmClient.startedContainers.isEmpty());
-    nmClient.cleanupRunningContainersOnStop(true);
-    assertTrue(nmClient.getCleanupRunningContainers().get());
+    nmClient.cleanupRunningContainersOnStop(false);
+    assertFalse(nmClient.getCleanupRunningContainers().get());
     nmClient.stop();
   }
 
   private Set<Container> allocateContainers(
-      AMRMClientImpl<ContainerRequest> rmClient, int num)
-      throws YarnException, IOException {
-    // setup container request
-    Resource capability = Resource.newInstance(1024, 0);
-    Priority priority = Priority.newInstance(0);
-    String node = nodeReports.get(0).getNodeId().getHost();
-    String rack = nodeReports.get(0).getRackName();
-    String[] nodes = new String[] {node};
-    String[] racks = new String[] {rack};
-
+      AMRMClientImpl<ContainerRequest> rmClient, int num
+  ) throws YarnException, IOException {
     for (int i = 0; i < num; ++i) {
-      rmClient.addContainerRequest(new ContainerRequest(capability, nodes,
-          racks, priority));
+      rmClient.addContainerRequest(new ContainerRequest(
+          Resource.newInstance(256, 0),
+          new String[] {nodeReports.get(0).getNodeId().getHost()},
+          new String[] {nodeReports.get(0).getRackName()},
+          Priority.newInstance(0)
+      ));
     }
-
-    int containersRequestedAny = rmClient.getTable(0)
-        .get(priority, ResourceRequest.ANY, ExecutionType.GUARANTEED,
-            capability).remoteRequest.getNumContainers();
-
-    // RM should allocate container within 2 calls to allocate()
-    int allocatedContainerCount = 0;
-    int iterationsLeft = 2;
-    Set<Container> containers = new TreeSet<Container>();
-    while (allocatedContainerCount < containersRequestedAny
-        && iterationsLeft > 0) {
+    Set<Container> allocateContainers = new TreeSet<>();
+    while (allocateContainers.size() < num) {
       AllocateResponse allocResponse = rmClient.allocate(0.1f);
-
-      allocatedContainerCount += allocResponse.getAllocatedContainers().size();
-      for(Container container : allocResponse.getAllocatedContainers()) {
-        containers.add(container);
+      allocateContainers.addAll(allocResponse.getAllocatedContainers());
+      for (NMToken token : allocResponse.getNMTokens()) {
+        rmClient.getNMTokenCache().setToken(token.getNodeId().toString(), token.getToken());
       }
-      if (!allocResponse.getNMTokens().isEmpty()) {
-        for (NMToken token : allocResponse.getNMTokens()) {
-          rmClient.getNMTokenCache().setToken(token.getNodeId().toString(),
-              token.getToken());
-        }
+      if (allocateContainers.size() < num) {
+        sleep(100);
       }
-      if(allocatedContainerCount < containersRequestedAny) {
-        // sleep to let NM's heartbeat to RM and trigger allocations
-        sleep(1000);
-      }
-
-      --iterationsLeft;
     }
-    return containers;
+    return allocateContainers;
   }
 
-  private void testContainerManagement(NMClientImpl client,
-      Set<Container> containers) throws YarnException, IOException {
+  private void testContainerManagement(
+      NMClientImpl client, Set<Container> containers
+  ) throws YarnException, IOException, EarlyFinishException {
     int size = containers.size();
     int i = 0;
     for (Container container : containers) {
       // getContainerStatus shouldn't be called before startContainer,
       // otherwise, NodeManager cannot find the container
-      try {
-        client.getContainerStatus(container.getId(), container.getNodeId());
-        fail("Exception is expected");
-      } catch (YarnException e) {
-        assertTrue("The thrown exception is not expected",
-            e.getMessage().contains("is not handled by this NodeManager"));
-      }
+      assertYarnException(
+          () -> client.getContainerStatus(container.getId(), container.getNodeId()),
+          "is not handled by this NodeManager");
       // upadateContainerResource shouldn't be called before startContainer,
       // otherwise, NodeManager cannot find the container
-      try {
-        client.updateContainerResource(container);
-        fail("Exception is expected");
-      } catch (YarnException e) {
-        assertTrue("The thrown exception is not expected",
-            e.getMessage().contains("is not handled by this NodeManager"));
-      }
-
+      assertYarnException(
+          () -> client.updateContainerResource(container),
+          "is not handled by this NodeManager");
       // restart shouldn't be called before startContainer,
       // otherwise, NodeManager cannot find the container
-      try {
-        client.restartContainer(container.getId());
-        fail("Exception is expected");
-      } catch (YarnException e) {
-        assertTrue("The thrown exception is not expected",
-            e.getMessage().contains("Unknown container"));
-      }
-
+      assertYarnException(
+          () -> client.restartContainer(container.getId()),
+          "Unknown container");
       // rollback shouldn't be called before startContainer,
       // otherwise, NodeManager cannot find the container
-      try {
-        client.rollbackLastReInitialization(container.getId());
-        fail("Exception is expected");
-      } catch (YarnException e) {
-        assertTrue("The thrown exception is not expected",
-            e.getMessage().contains("Unknown container"));
-      }
-
+      assertYarnException(
+          () -> client.rollbackLastReInitialization(container.getId()),
+          "Unknown container");
       // commit shouldn't be called before startContainer,
       // otherwise, NodeManager cannot find the container
-      try {
-        client.commitLastReInitialization(container.getId());
-        fail("Exception is expected");
-      } catch (YarnException e) {
-        assertTrue("The thrown exception is not expected",
-            e.getMessage().contains("Unknown container"));
-      }
-
+      assertYarnException(
+          () -> client.commitLastReInitialization(container.getId()),
+          "Unknown container");
       // stopContainer shouldn't be called before startContainer,
       // otherwise, an exception will be thrown
-      try {
-        client.stopContainer(container.getId(), container.getNodeId());
-        fail("Exception is expected");
-      } catch (YarnException e) {
-        if (!e.getMessage()
-              .contains("is not handled by this NodeManager")) {
-          throw new AssertionError("Exception is not expected: ", e);
-        }
-      }
+      assertYarnException(
+          () -> client.stopContainer(container.getId(), container.getNodeId()),
+          "is not handled by this NodeManager");
 
       Credentials ts = new Credentials();
       DataOutputBuffer dob = new DataOutputBuffer();
       ts.writeTokenStorageToStream(dob);
-      ByteBuffer securityTokens =
-          ByteBuffer.wrap(dob.getData(), 0, dob.getLength());
-      ContainerLaunchContext clc =
-          Records.newRecord(ContainerLaunchContext.class);
-      if (Shell.WINDOWS) {
-        clc.setCommands(
-            Arrays.asList("ping", "-n", "10000000", "127.0.0.1", ">nul"));
-      } else {
-        clc.setCommands(Arrays.asList("sleep", "1000000"));
-      }
+      ByteBuffer securityTokens = ByteBuffer.wrap(dob.getData(), 0, dob.getLength());
+      ContainerLaunchContext clc = Records.newRecord(ContainerLaunchContext.class);
+      clc.setCommands(Shell.WINDOWS
+          ? Arrays.asList("ping", "-n", "10000000", "127.0.0.1", ">nul")
+          : Arrays.asList("sleep", "1000000")
+      );
       clc.setTokens(securityTokens);
-      try {
-        client.startContainer(container, clc);
-      } catch (YarnException e) {
-        throw new AssertionError("Exception is not expected ", e);
-      }
-      List<Integer> exitStatuses = Collections.singletonList(-1000);
-
+      client.startContainer(container, clc);
       // leave one container unclosed
       if (++i < size) {
-        testContainer(client, i, container, clc, exitStatuses);
-
+        testContainer(client, i, container, clc);
       }
     }
   }
 
-  private void testContainer(NMClientImpl client, int i, Container container,
-                             ContainerLaunchContext clc, List<Integer> exitCode)
-      throws YarnException, IOException {
-    // NodeManager may still need some time to make the container started
-    testGetContainerStatus(container, i, ContainerState.RUNNING, "",
-        exitCode);
-    waitForContainerTransitionCount(container,
-        org.apache.hadoop.yarn.server.nodemanager.
-            containermanager.container.ContainerState.RUNNING, 1);
-    // Test increase container API and make sure requests can reach NM
+  private void testContainer(
+      NMClientImpl client, int i, Container container, ContainerLaunchContext clc
+  ) throws YarnException, IOException, EarlyFinishException {
+    testContainerStatusRunning(container);
+    waitForContainerTransitionCount(container, 1);
     testIncreaseContainerResource(container);
-
-    testRestartContainer(container.getId());
-    testGetContainerStatus(container, i, ContainerState.RUNNING,
-        "will be Restarted", exitCode);
-    waitForContainerTransitionCount(container,
-        org.apache.hadoop.yarn.server.nodemanager.
-            containermanager.container.ContainerState.RUNNING, 2);
-
+    testRestartContainer(container);
+    testContainerStatusRunning(container, "will be Restarted");
+    waitForContainerTransitionCount(container, 2);
     if (i % 2 == 0) {
-      testReInitializeContainer(container.getId(), clc, false);
-      testGetContainerStatus(container, i, ContainerState.RUNNING,
-          "will be Re-initialized", exitCode);
-      waitForContainerTransitionCount(container,
-          org.apache.hadoop.yarn.server.nodemanager.
-              containermanager.container.ContainerState.RUNNING, 3);
-
-      testRollbackContainer(container.getId(), false);
-      testGetContainerStatus(container, i, ContainerState.RUNNING,
-          "will be Rolled-back", exitCode);
-      waitForContainerTransitionCount(container,
-          org.apache.hadoop.yarn.server.nodemanager.
-              containermanager.container.ContainerState.RUNNING, 4);
-
-      testCommitContainer(container.getId(), true);
-      testReInitializeContainer(container.getId(), clc, false);
-      testGetContainerStatus(container, i, ContainerState.RUNNING,
-          "will be Re-initialized", exitCode);
-      waitForContainerTransitionCount(container,
-          org.apache.hadoop.yarn.server.nodemanager.
-              containermanager.container.ContainerState.RUNNING, 5);
-      testCommitContainer(container.getId(), false);
+      testReInitializeContainer(container, clc, false);
+      testContainerStatusRunning(container,  "will be Re-initialized");
+      waitForContainerTransitionCount(container, 3);
+      testContainerRollback(container, true);
+      testContainerStatusRunning(container, "will be Rolled-back");
+      waitForContainerTransitionCount(container, 4);
+      testContainerCommit(container, false);
+      testReInitializeContainer(container, clc, false);
+      testContainerStatusRunning(container, "will be Re-initialized");
+      waitForContainerTransitionCount(container, 5);
+      testContainerCommit(container, true);
     } else {
-      testReInitializeContainer(container.getId(), clc, true);
-      testGetContainerStatus(container, i, ContainerState.RUNNING,
-          "will be Re-initialized", exitCode);
-      waitForContainerTransitionCount(container,
-          org.apache.hadoop.yarn.server.nodemanager.
-              containermanager.container.ContainerState.RUNNING, 3);
-      testRollbackContainer(container.getId(), true);
-      testCommitContainer(container.getId(), true);
+      testReInitializeContainer(container, clc, true);
+      testContainerStatusRunning(container, "will be Re-initialized");
+      waitForContainerTransitionCount(container, 3);
+      testContainerRollback(container, false);
+      testContainerCommit(container, false);
     }
-
-    try {
-      client.stopContainer(container.getId(), container.getNodeId());
-    } catch (YarnException e) {
-      throw (AssertionError)
-        (new AssertionError("Exception is not expected: " + e, e));
-    }
-
-    // getContainerStatus can be called after stopContainer
-    try {
-      // O is possible if CLEANUP_CONTAINER is executed too late
-      // -105 is possible if the container is not terminated but killed
-      testGetContainerStatus(container, i, ContainerState.COMPLETE,
-          "Container killed by the ApplicationMaster.",
-          Arrays.asList(
-              ContainerExitStatus.KILLED_BY_APPMASTER,
-              ContainerExitStatus.SUCCESS));
-    } catch (YarnException e) {
-      // The exception is possible because, after the container is stopped,
-      // it may be removed from NM's context.
-      if (!e.getMessage()
-            .contains("was recently stopped on node manager")) {
-        throw (AssertionError)
-          (new AssertionError("Exception is not expected: ", e));
-      }
-    }
+    client.stopContainer(container.getId(), container.getNodeId());
+    testContainerStatusCompleted(container, "killed by the ApplicationMaster");
   }
 
   /**
    * Wait until the container reaches a state N times.
    * @param container container to watch
-   * @param state state to test
    * @param transitions the number N above
-   * @throws YarnException This happens if the test times out while waiting
    */
-  private void waitForContainerTransitionCount(
-      Container container,
-      org.apache.hadoop.yarn.server.nodemanager.
-          containermanager.container.ContainerState state, long transitions)
-      throws YarnException {
-    long transitionCount = -1;
-    do {
-      if (transitionCount != -1) {
-        try {
-          Thread.sleep(10);
-        } catch (InterruptedException e) {
-          throw new YarnException(
-              "Timeout at transition count:" + transitionCount, e);
-        }
-      }
-      transitionCount = DebugSumContainerStateListener
-          .getTransitionCounter(container.getId(), state);
-    } while (transitionCount != transitions);
+  private void waitForContainerTransitionCount(Container container, long transitions) {
+    while (DebugSumContainerStateListener.getTransitionCounter(container.getId()) != transitions) {
+      sleep(1000);
+    }
+  }
+
+  private void testContainerStatusRunning(
+      Container container, String... diagnostics
+  ) throws YarnException, IOException, EarlyFinishException {
+    ContainerStatus actualStatus = nmClient.getContainerStatus(container.getId(), container.getNodeId());
+    while (ContainerState.NEW == actualStatus.getState()) {
+      sleep(100);
+      actualStatus = nmClient.getContainerStatus(container.getId(), container.getNodeId());
+    }
+    if (ContainerState.COMPLETE == actualStatus.getState()) {
+      LOG.warn("The container finished earlier than expected, EXIT_CODE[{}], DIAGNOSTIC[{}]",
+          actualStatus.getExitStatus(), actualStatus.getDiagnostics());
+      throw new EarlyFinishException();
+    }
+    assertEquals(container.getId(), actualStatus.getContainerId());
+    assertEquals(actualStatus.getExitStatus(), ContainerExitStatus.INVALID);
+    for (String diagnostic : diagnostics) {
+      assertTrue(actualStatus.getDiagnostics().contains(diagnostic));
+    }
+  }
+
+  private void testContainerStatusCompleted(
+      Container container, String... diagnostics
+  ) throws YarnException, IOException {
+    ContainerStatus actualStatus = nmClient.getContainerStatus(container.getId(), container.getNodeId());
+    while (ContainerState.COMPLETE != actualStatus.getState()) {
+      sleep(100);
+      actualStatus = nmClient.getContainerStatus(container.getId(), container.getNodeId());
+    }
+    assertEquals(container.getId(), actualStatus.getContainerId());
+    assertTrue(Arrays.asList(
+        ContainerExitStatus.KILLED_BY_APPMASTER,
+        ContainerExitStatus.SUCCESS
+    ).contains(actualStatus.getExitStatus()));
+    for (String diagnostic : diagnostics) {
+      assertTrue(actualStatus.getDiagnostics().contains(diagnostic));
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  private void testIncreaseContainerResource(Container container) {
+    assertYarnException(
+        () -> nmClient.increaseContainerResource(container),
+        container.getId() + " has update version ");
+  }
+
+  private void testRestartContainer(Container container) throws IOException, YarnException {
+    nmClient.restartContainer(container.getId());
+  }
+
+  private void testContainerRollback(Container container, boolean enabled)
+      throws IOException, YarnException {
+    if (enabled) {
+      nmClient.rollbackLastReInitialization(container.getId());
+    } else {
+      assertYarnException(
+          () -> nmClient.rollbackLastReInitialization(container.getId()),
+          "Nothing to rollback to");
+    }
+  }
+
+  private void testContainerCommit(Container container, boolean enabled)
+      throws IOException, YarnException {
+    if (enabled) {
+      nmClient.commitLastReInitialization(container.getId());
+    } else {
+      assertYarnException(
+          () -> nmClient.commitLastReInitialization(container.getId()),
+          "Nothing to Commit");
+    }
+  }
+
+  private void testReInitializeContainer(
+      Container container, ContainerLaunchContext clc, boolean autoCommit
+  ) throws IOException, YarnException {
+    nmClient.reInitializeContainer(container.getId(), clc, autoCommit);
+  }
+
+  private void assertYarnException(ThrowingRunnable runnable, String text) {
+    YarnException e = assertThrows(YarnException.class, runnable);
+    assertTrue(String.format("The thrown exception is not expected cause it has text [%s]"
+        + ", what not contains text [%s]", e.getMessage(), text), e.getMessage().contains(text));
   }
 
   private void sleep(int sleepTime) {
@@ -570,131 +500,8 @@ public class TestNMClient {
       Thread.sleep(sleepTime);
     } catch (InterruptedException e) {
       e.printStackTrace();
+      throw new RuntimeException(e);
     }
   }
-
-  private void testGetContainerStatus(Container container, int index,
-      ContainerState state, String diagnostics, List<Integer> exitStatuses)
-          throws YarnException, IOException {
-    while (true) {
-      sleep(250);
-      ContainerStatus status = nmClient.getContainerStatus(
-          container.getId(), container.getNodeId());
-      // NodeManager may still need some time to get the stable
-      // container status
-      if (status.getState() == state) {
-        assertEquals(container.getId(), status.getContainerId());
-        assertTrue("" + index + ": " + status.getDiagnostics(),
-            status.getDiagnostics().contains(diagnostics));
-
-        assertTrue("Exit Statuses are supposed to be in: " + exitStatuses +
-                ", but the actual exit status code is: " +
-                status.getExitStatus(),
-            exitStatuses.contains(status.getExitStatus()));
-        break;
-      }
-    }
-  }
-
-  @SuppressWarnings("deprecation")
-  private void testIncreaseContainerResource(Container container)
-    throws YarnException, IOException {
-    try {
-      nmClient.increaseContainerResource(container);
-    } catch (YarnException e) {
-      // NM container increase container resource should fail without a version
-      // increase action to fail.
-      if (!e.getMessage().contains(
-          container.getId() + " has update version ")) {
-        throw (AssertionError)
-            (new AssertionError("Exception is not expected: " + e)
-                .initCause(e));
-      }
-    }
-  }
-
-  private void testRestartContainer(ContainerId containerId)
-      throws YarnException, IOException {
-    try {
-      sleep(250);
-      nmClient.restartContainer(containerId);
-      sleep(250);
-    } catch (YarnException e) {
-      // NM container will only be in SCHEDULED state, so expect the increase
-      // action to fail.
-      if (!e.getMessage().contains(
-          "can only be changed when a container is in RUNNING state")) {
-        throw (AssertionError)
-            (new AssertionError("Exception is not expected: " + e)
-                .initCause(e));
-      }
-    }
-  }
-
-  private void testRollbackContainer(ContainerId containerId,
-      boolean notRollbackable) throws YarnException, IOException {
-    try {
-      sleep(250);
-      nmClient.rollbackLastReInitialization(containerId);
-      if (notRollbackable) {
-        fail("Should not be able to rollback..");
-      }
-      sleep(250);
-    } catch (YarnException e) {
-      // NM container will only be in SCHEDULED state, so expect the increase
-      // action to fail.
-      if (notRollbackable) {
-        Assert.assertTrue(e.getMessage().contains(
-            "Nothing to rollback to"));
-      } else {
-        if (!e.getMessage().contains(
-            "can only be changed when a container is in RUNNING state")) {
-          throw (AssertionError)
-              (new AssertionError("Exception is not expected: " + e)
-                  .initCause(e));
-        }
-      }
-    }
-  }
-
-  private void testCommitContainer(ContainerId containerId,
-      boolean notCommittable) throws YarnException, IOException {
-    try {
-      nmClient.commitLastReInitialization(containerId);
-      if (notCommittable) {
-        fail("Should not be able to commit..");
-      }
-    } catch (YarnException e) {
-      // NM container will only be in SCHEDULED state, so expect the increase
-      // action to fail.
-      if (notCommittable) {
-        Assert.assertTrue(e.getMessage().contains(
-            "Nothing to Commit"));
-      } else {
-        if (!e.getMessage().contains(
-            "can only be changed when a container is in RUNNING state")) {
-          throw (AssertionError)
-              (new AssertionError("Exception is not expected: " + e)
-                  .initCause(e));
-        }
-      }
-    }
-  }
-
-  private void testReInitializeContainer(ContainerId containerId,
-      ContainerLaunchContext clc, boolean autoCommit)
-      throws YarnException, IOException {
-    try {
-      nmClient.reInitializeContainer(containerId, clc, autoCommit);
-    } catch (YarnException e) {
-      // NM container will only be in SCHEDULED state, so expect the increase
-      // action to fail.
-      if (!e.getMessage().contains(
-          "can only be changed when a container is in RUNNING state")) {
-        throw (AssertionError)
-            (new AssertionError("Exception is not expected: " + e)
-                .initCause(e));
-      }
-    }
-  }
+  private static class EarlyFinishException extends Exception {}
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/state/StateMachine.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/state/StateMachine.java
@@ -26,8 +26,31 @@ import org.apache.hadoop.classification.InterfaceStability.Evolving;
 public interface StateMachine
                  <STATE extends Enum<STATE>,
                   EVENTTYPE extends Enum<EVENTTYPE>, EVENT> {
-  public STATE getCurrentState();
-  public STATE getPreviousState();
-  public STATE doTransition(EVENTTYPE eventType, EVENT event)
-        throws InvalidStateTransitionException;
+  /**
+   * Return the current state
+   * @return the current state, default null
+   */
+  default public STATE getCurrentState() {
+    return null;
+  }
+
+  /**
+   * Return the previous state
+   * @return the previous state, default null
+   */
+  default public STATE getPreviousState() {
+    return null;
+  }
+
+  /**
+   * Do transition to another state.
+   * @param eventType type of the event
+   * @param event the event what was triggered
+   * @return the new state of the machine, default null
+   * @throws InvalidStateTransitionException if the state transition is invalid
+   */
+  default public STATE doTransition(EVENTTYPE eventType, EVENT event)
+        throws InvalidStateTransitionException {
+    return null;
+  }
 }


### PR DESCRIPTION
### Description of PR

The TestNMClient test methods can stuck if the test container fails, while the test is expecting it running state. This can happen for example if the container fails due low memory. To fix this the test should tolerate some failure like this.

### How was this patch tested?

I run the test ~400 times in a row with zero failer

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

