### PR TITLE
HADOOP-18598. maven site generation doesn't include javadocs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
 
     <!-- maven plugin versions -->
     <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
-    <maven-site-plugin.version>3.11.0</maven-site-plugin.version>
+    <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
     <maven-stylus-skin.version>1.5</maven-stylus-skin.version>
     <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>2.4</maven-assembly-plugin.version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-18598

maven-site-plugin-3.11.0 is incompatible with maven-javadoc-plugin-3.0.1. Downgrading maven-site-plugin to 3.9.1 fixes missing javadocs in aggregated site documentation.
