### PR TITLE
HDFS-16895. NamenodeHeartbeatService should use credentials of logged…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.security.PrivilegedExceptionAction;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -45,6 +46,7 @@ import org.apache.hadoop.hdfs.tools.DFSHAAdmin;
 import org.apache.hadoop.hdfs.tools.NNHAServiceTarget;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.security.SecurityUtil;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -339,8 +341,11 @@ public class NamenodeHeartbeatService extends PeriodicService {
       // should be required at some point for QoS
       updateSafeModeParameters(serviceURI, report);
 
-      // Read the stats from JMX (optional)
-      updateJMXParameters(webAddress, report);
+      // Read the stats from JMX (optional) using the login user credentials
+      SecurityUtil.doAsLoginUser((PrivilegedExceptionAction<Void>) () -> {
+        updateJMXParameters(webAddress, report);
+        return null;
+      });
 
       // Try to get the HA status
       updateHAStatusParameters(report);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
@@ -330,7 +330,7 @@ public class TestRouterNamenodeHeartbeat {
       // Start Namenodes and routers
       testCluster.startCluster(conf);
       testCluster.startRouters();
-      
+
       // Register Namenodes to generate a NamenodeStatusReport
       testCluster.registerNamenodes();
       testCluster.waitNamenodeRegistration();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.NamenodeCon
 import org.apache.hadoop.hdfs.server.federation.resolver.ActiveNamenodeResolver;
 import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeContext;
 import org.apache.hadoop.net.MockDomainNameResolver;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.service.Service.STATE;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -345,6 +346,8 @@ public class TestRouterNamenodeHeartbeat {
       if (testCluster != null) {
         testCluster.shutdown();
       }
+      UserGroupInformation.reset();
+      SecurityConfUtil.destroy();   
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
@@ -347,7 +347,7 @@ public class TestRouterNamenodeHeartbeat {
         testCluster.shutdown();
       }
       UserGroupInformation.reset();
-      SecurityConfUtil.destroy();   
+      SecurityConfUtil.destroy();
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
@@ -322,7 +322,7 @@ public class TestRouterNamenodeHeartbeat {
   }
 
   @Test
-  public void testNamendodeHeartbeatWithSecurity() throws Exception {
+  public void testNamenodeHeartbeatWithSecurity() throws Exception {
     Configuration conf = SecurityConfUtil.initSecurity();
     MiniRouterDFSCluster testCluster = null;
     try {


### PR DESCRIPTION
… in user

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Ensuring that the NamenodeHeartbeatService uses the credentials of the logged in user before calling the JMX API. Without this fix, requests to secured JMX APIs will log the following error:
"Cannot parse JMX output for Hadoop:service=NameNode,name=FSNamesystem* from server"

### How was this patch tested?
Deployed to a test cluster, in which the JMX API is secured.
Ran kdestroy on the router to ensure no credentials are taken from kinit'ed users.
Validated that NamenodeHeartbeatService is able to complete the JMX request with no errors.
Added unit test to validate report is generated when using a secured cluster

### For code changes:

- [Y] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [Y] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

