### PR TITLE
HDFS-16897. fix abundant Broken pipe exception in BlockSender

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
@@ -655,8 +655,9 @@ class BlockSender implements java.io.Closeable {
           if (ioem.startsWith(EIO_ERROR)) {
             throw new DiskFileCorruptException("A disk IO error occurred", e);
           }
-          if (!ioem.contains("Broken pipe")
-              && !ioem.startsWith("Connection reset")) {
+          String causeMessage = e.getCause() != null ? e.getCause().getMessage() : "";
+          if (!ioem.startsWith("Broken pipe") && !ioem.startsWith("Connection reset") &&
+              !causeMessage.startsWith("Broken pipe") && !causeMessage.startsWith("Connection reset")) {
             LOG.error("BlockSender.sendChunks() exception: ", e);
             datanode.getBlockScanner().markSuspectBlock(
                 ris.getVolumeRef().getVolume().getStorageID(), block);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
@@ -655,7 +655,7 @@ class BlockSender implements java.io.Closeable {
           if (ioem.startsWith(EIO_ERROR)) {
             throw new DiskFileCorruptException("A disk IO error occurred", e);
           }
-          if (!ioem.startsWith("Broken pipe")
+          if (!ioem.contains("Broken pipe")
               && !ioem.startsWith("Connection reset")) {
             LOG.error("BlockSender.sendChunks() exception: ", e);
             datanode.getBlockScanner().markSuspectBlock(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
@@ -656,8 +656,10 @@ class BlockSender implements java.io.Closeable {
             throw new DiskFileCorruptException("A disk IO error occurred", e);
           }
           String causeMessage = e.getCause() != null ? e.getCause().getMessage() : "";
-          if (!ioem.startsWith("Broken pipe") && !ioem.startsWith("Connection reset") &&
-              !causeMessage.startsWith("Broken pipe") && !causeMessage.startsWith("Connection reset")) {
+          if (!ioem.startsWith("Broken pipe")
+              && !ioem.startsWith("Connection reset")
+              && !causeMessage.startsWith("Broken pipe")
+              && !causeMessage.startsWith("Connection reset")) {
             LOG.error("BlockSender.sendChunks() exception: ", e);
             datanode.getBlockScanner().markSuspectBlock(
                 ris.getVolumeRef().getVolume().getStorageID(), block);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
@@ -656,6 +656,7 @@ class BlockSender implements java.io.Closeable {
             throw new DiskFileCorruptException("A disk IO error occurred", e);
           }
           String causeMessage = e.getCause() != null ? e.getCause().getMessage() : "";
+          causeMessage = causeMessage != null ? causeMessage : "";
           if (!ioem.startsWith("Broken pipe")
               && !ioem.startsWith("Connection reset")
               && !causeMessage.startsWith("Broken pipe")


### PR DESCRIPTION
### Description of PR
in our production cluster env , we found some exception in datanode logs，its frequently print below error
in HDFS-2054 we only ignored message starting with `Broken pipe`  which may not enough for the following case:
![image](https://user-images.githubusercontent.com/20748856/215264829-5f16dbc3-fea2-4883-a3d6-ded367564b8c.png)
this situation look like related to short-circuit read. in HDFS-4354 the error has been wrapped, so that our previous judgment conditions are invalid.
![image](https://user-images.githubusercontent.com/20748856/215314257-2064637b-ea46-42f5-b53f-a29e68bb50ea.png)
maybe we can improve it. 
### How was this patch tested?
No test is added since it only changes the log message.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

