### PR TITLE
HADOOP-18601. Fix build failure with docs profile.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/pom.xml
@@ -152,6 +152,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           <groupId>xml-apis</groupId>
           <artifactId>xml-apis</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>xerces</groupId>
+          <artifactId>xercesImpl</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/pom.xml
@@ -122,6 +122,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-handler-proxy</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-18601

build with `-Pdocs` fails due to dependency conversion errors.

```
[WARNING]
Dependency convergence error for xerces:xercesImpl:jar:2.12.2:provided paths to dependency are:
+-org.apache.hadoop:hadoop-hdfs:jar:3.4.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-common:jar:3.4.0-SNAPSHOT:provided
    +-xerces:xercesImpl:jar:2.12.2:provided
and
+-org.apache.hadoop:hadoop-hdfs:jar:3.4.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-common:test-jar:tests:3.4.0-SNAPSHOT:test
    +-xerces:xercesImpl:jar:2.12.2:test
and
+-org.apache.hadoop:hadoop-hdfs:jar:3.4.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-hdfs-client:jar:3.4.0-SNAPSHOT:provided
    +-xerces:xercesImpl:jar:2.12.2:provided
and
+-org.apache.hadoop:hadoop-hdfs:jar:3.4.0-SNAPSHOT
  +-com.google.code.findbugs:findbugs:jar:3.0.1:provided
    +-jaxen:jaxen:jar:1.1.6:provided
      +-xerces:xercesImpl:jar:2.6.2:provided
and
+-org.apache.hadoop:hadoop-hdfs:jar:3.4.0-SNAPSHOT
  +-xerces:xercesImpl:jar:2.12.2:compile
```

```
[WARNING]
Dependency convergence error for xml-apis:xml-apis:jar:1.0.b2:provided paths to dependency are:
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-documentstore:jar:3.4.0-SNAPSHOT
  +-com.microsoft.azure:azure-cosmosdb:jar:2.4.5:compile
    +-com.microsoft.azure:azure-cosmosdb-commons:jar:2.4.5:compile
      +-commons-validator:commons-validator:jar:1.6:compile
        +-commons-digester:commons-digester:jar:1.8.1:compile
          +-xml-apis:xml-apis:jar:1.0.b2:provided
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-documentstore:jar:3.4.0-SNAPSHOT
  +-xerces:xercesImpl:jar:2.12.2:compile
    +-xml-apis:xml-apis:jar:1.4.01:compile
```