### PR TITLE
 MAPREDUCE-7416. Upgrade Junit 4 to 5 in hadoop-mapreduce-client-shuffle

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/pom.xml
@@ -48,6 +48,21 @@
       <artifactId>hadoop-yarn-server-nodemanager</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-common</artifactId>
     </dependency>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/test/java/org/apache/hadoop/mapred/TestFadvisedChunkedFile.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/test/java/org/apache/hadoop/mapred/TestFadvisedChunkedFile.java
@@ -17,13 +17,13 @@
  */
 package org.apache.hadoop.mapred;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.RandomAccessFile;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit test for FadvisedChunkedFile.
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertTrue;
 public class TestFadvisedChunkedFile {
 
   @Test
-  public void testDoubleClose() throws Exception {
+  void testDoubleClose() throws Exception {
     File absoluteFile = new File("target",
         TestFadvisedChunkedFile.class.getSimpleName()).getAbsoluteFile();
     absoluteFile.deleteOnExit();
@@ -42,11 +42,11 @@ public class TestFadvisedChunkedFile {
             f, 0, 5, 2, true,
             10, null, "foo");
 
-        assertTrue("fd not valid", f.getFD().valid());
+        assertTrue(f.getFD().valid(), "fd not valid");
         af.close();
-        assertFalse("fd still valid", f.getFD().valid());
+        assertFalse(f.getFD().valid(), "fd still valid");
         af.close();
-        assertFalse("fd still valid", f.getFD().valid());
+        assertFalse(f.getFD().valid(), "fd still valid");
       }
     } finally {
       absoluteFile.delete();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/test/java/org/apache/hadoop/mapred/TestFadvisedFileRegion.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/test/java/org/apache/hadoop/mapred/TestFadvisedFileRegion.java
@@ -28,80 +28,84 @@ import java.util.Random;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestFadvisedFileRegion {
   private final int FILE_SIZE = 16*1024*1024;
   private static final Logger LOG =
       LoggerFactory.getLogger(TestFadvisedFileRegion.class);
-  
-  @Test(timeout = 100000)
-  public void testCustomShuffleTransfer() throws IOException {
-    File absLogDir = new File("target", 
-        TestFadvisedFileRegion.class.getSimpleName() + 
-        "LocDir").getAbsoluteFile();
-    
+
+  @Test
+  @Timeout(100000)
+  void testCustomShuffleTransfer() throws IOException {
+    File absLogDir = new File("target",
+        TestFadvisedFileRegion.class.getSimpleName() +
+            "LocDir").getAbsoluteFile();
+
     String testDirPath =
         StringUtils.join(Path.SEPARATOR,
-            new String[] { absLogDir.getAbsolutePath(),
+            new String[]{absLogDir.getAbsolutePath(),
                 "testCustomShuffleTransfer"});
     File testDir = new File(testDirPath);
     testDir.mkdirs();
-    
+
     System.out.println(testDir.getAbsolutePath());
-    
+
     File inFile = new File(testDir, "fileIn.out");
     File outFile = new File(testDir, "fileOut.out");
-    
-    
+
+
     //Initialize input file
     byte [] initBuff = new byte[FILE_SIZE];
     Random rand = new Random();
     rand.nextBytes(initBuff);
-    
+
     FileOutputStream out = new FileOutputStream(inFile);
-    try{
-      out.write(initBuff);  
+    try {
+      out.write(initBuff);
     } finally {
       IOUtils.cleanupWithLogger(LOG, out);
     }
-    
-    
+
+
     //define position and count to read from a file region.
-    int position = 2*1024*1024;
-    int count = 4*1024*1024 - 1;
-    
+    int position = 2 * 1024 * 1024;
+    int count = 4 * 1024 * 1024 - 1;
+
     RandomAccessFile inputFile = null;
     RandomAccessFile targetFile = null;
     WritableByteChannel target = null;
     FadvisedFileRegion fileRegion = null;
-    
+
     try {
       inputFile = new RandomAccessFile(inFile.getAbsolutePath(), "r");
       targetFile = new RandomAccessFile(outFile.getAbsolutePath(), "rw");
       target = targetFile.getChannel();
-      
-      Assert.assertEquals(FILE_SIZE, inputFile.length());
-      
+
+      assertEquals(FILE_SIZE, inputFile.length());
+
       //create FadvisedFileRegion
       fileRegion = new FadvisedFileRegion(
           inputFile, position, count, false, 0, null, null, 1024, false);
-      
+
       //test corner cases
       customShuffleTransferCornerCases(fileRegion, target, count);
-            
+
       long pos = 0;
       long size;
-      while((size = fileRegion.customShuffleTransfer(target, pos)) > 0) {
-        pos += size; 
+      while ((size = fileRegion.customShuffleTransfer(target, pos)) > 0) {
+        pos += size;
       }
-    
+
       //assert size
-      Assert.assertEquals(count, (int)pos);
-      Assert.assertEquals(count, targetFile.length());
+      assertEquals(count, (int) pos);
+      assertEquals(count, targetFile.length());
     } finally {
       if (fileRegion != null) {
         fileRegion.deallocate();
@@ -110,22 +114,22 @@ public class TestFadvisedFileRegion {
       IOUtils.cleanupWithLogger(LOG, targetFile);
       IOUtils.cleanupWithLogger(LOG, inputFile);
     }
-    
+
     //Read the target file and verify that copy is done correctly
     byte [] buff = new byte[FILE_SIZE];
     FileInputStream in = new FileInputStream(outFile);
     try {
       int total = in.read(buff, 0, count);
-    
-      Assert.assertEquals(count, total);
-    
-      for(int i = 0; i < count; i++) {
-        Assert.assertEquals(initBuff[position+i], buff[i]);
+
+      assertEquals(count, total);
+
+      for (int i = 0; i < count; i++) {
+        assertEquals(initBuff[position + i], buff[i]);
       }
     } finally {
       IOUtils.cleanupWithLogger(LOG, in);
     }
-    
+
     //delete files and folders
     inFile.delete();
     outFile.delete();
@@ -137,21 +141,21 @@ public class TestFadvisedFileRegion {
       FadvisedFileRegion fileRegion, WritableByteChannel target, int count) {
     try {
       fileRegion.customShuffleTransfer(target, -1);
-      Assert.fail("Expected a IllegalArgumentException");
+      fail("Expected a IllegalArgumentException");
     } catch (IllegalArgumentException ie) {
       LOG.info("Expected - illegal argument is passed.");
     } catch (Exception e) {
-      Assert.fail("Expected a IllegalArgumentException");
+      fail("Expected a IllegalArgumentException");
     }
 
     //test corner cases
     try {
       fileRegion.customShuffleTransfer(target, count + 1);
-      Assert.fail("Expected a IllegalArgumentException");
+      fail("Expected a IllegalArgumentException");
     } catch (IllegalArgumentException ie) {
       LOG.info("Expected - illegal argument is passed.");
     } catch (Exception e) {
-      Assert.fail("Expected a IllegalArgumentException");
+      fail("Expected a IllegalArgumentException");
     }
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/test/java/org/apache/hadoop/mapred/TestShuffleHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/test/java/org/apache/hadoop/mapred/TestShuffleHandler.java
@@ -40,11 +40,13 @@ import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.assertGauge;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -57,6 +59,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -73,6 +76,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -112,12 +116,11 @@ import org.apache.hadoop.yarn.server.api.AuxiliaryLocalPathHandler;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ContainerLocalizer;
 import org.apache.hadoop.yarn.server.records.Version;
 import org.hamcrest.CoreMatchers;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.eclipse.jetty.http.HttpHeader;
 import org.slf4j.Logger;
@@ -529,17 +532,17 @@ public class TestShuffleHandler {
 
     public static void assertKeepAliveConnectionsAreSame(
         HttpConnectionHelper httpConnectionHelper) {
-      assertTrue("At least two connection data " +
-          "is required to perform this assertion",
-          httpConnectionHelper.connectionData.size() >= 2);
+      assertTrue(httpConnectionHelper.connectionData.size() >= 2,
+          "At least two connection data " +
+          "is required to perform this assertion");
       SocketAddress firstAddress = httpConnectionHelper.getConnectionData(0).socket;
       SocketAddress secondAddress = httpConnectionHelper.getConnectionData(1).socket;
-      Assert.assertNotNull("Initial shuffle address should not be null",
-          firstAddress);
-      Assert.assertNotNull("Keep-Alive shuffle address should not be null",
-          secondAddress);
-      assertEquals("Initial shuffle address and keep-alive shuffle "
-          + "address should be the same", firstAddress, secondAddress);
+      assertNotNull(firstAddress,
+          "Initial shuffle address should not be null");
+      assertNotNull(secondAddress,
+          "Keep-Alive shuffle address should not be null");
+      assertEquals(firstAddress, secondAddress, "Initial shuffle address and keep-alive shuffle "
+          + "address should be the same");
     }
 
     public HttpConnectionAssert expectKeepAliveWithTimeout(long timeout) {
@@ -563,10 +566,11 @@ public class TestShuffleHandler {
 
     private void assertHeaderValue(HttpHeader header, String expectedValue) {
       List<String> headerList = connData.headers.get(header.asString());
-      Assert.assertNotNull("Got null header value for header: " + header, headerList);
-      Assert.assertFalse("Got empty header value for header: " + header, headerList.isEmpty());
-      assertEquals("Unexpected size of header list for header: " + header, 1,
-          headerList.size());
+      assertNotNull(headerList, "Got null header value for header: " + header);
+      assertFalse(headerList.isEmpty(), "Got empty header value for header: " + header);
+      assertEquals(1,
+          headerList.size(),
+          "Unexpected size of header list for header: " + header);
       assertEquals(expectedValue, headerList.get(0));
     }
   }
@@ -824,21 +828,25 @@ public class TestShuffleHandler {
     }
   }
 
-  @Rule
-  public TestName name = new TestName();
+  
+  public String name;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  public void setup(TestInfo testInfo) {
+    Optional<Method> testMethod = testInfo.getTestMethod();
+    if (testMethod.isPresent()) {
+      this.name = testMethod.get().getName();
+    }
     TEST_EXECUTION = new TestExecution(DEBUG_MODE, USE_PROXY);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     int port = TEST_EXECUTION.shuffleHandlerPort();
     if (isPortUsed(port)) {
       String msg = String.format("Port is being used: %d. " +
           "Current testcase name: %s",
-          port, name.getMethodName());
+          port, name);
       throw new IllegalStateException(msg);
     }
   }
@@ -862,8 +870,9 @@ public class TestShuffleHandler {
    *
    * @throws Exception exception
    */
-  @Test (timeout = 10000)
-  public void testSerializeMeta()  throws Exception {
+  @Test
+  @Timeout(10000)
+  void testSerializeMeta()  throws Exception {
     assertEquals(1, ShuffleHandler.deserializeMetaData(
         ShuffleHandler.serializeMetaData(1)));
     assertEquals(-1, ShuffleHandler.deserializeMetaData(
@@ -877,8 +886,9 @@ public class TestShuffleHandler {
    *
    * @throws Exception exception
    */
-  @Test (timeout = 10000)
-  public void testShuffleMetrics() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testShuffleMetrics() throws Exception {
     MetricsSystem ms = new MetricsSystemImpl();
     ShuffleHandler sh = new ShuffleHandlerForTests(ms);
     ChannelFuture cf = mock(ChannelFuture.class);
@@ -887,14 +897,14 @@ public class TestShuffleHandler {
     sh.metrics.shuffleConnections.incr();
     sh.metrics.shuffleOutputBytes.incr(MiB);
     sh.metrics.shuffleConnections.incr();
-    sh.metrics.shuffleOutputBytes.incr(2*MiB);
+    sh.metrics.shuffleOutputBytes.incr(2 * MiB);
 
-    checkShuffleMetrics(ms, 3*MiB, 0, 0, 2);
+    checkShuffleMetrics(ms, 3 * MiB, 0, 0, 2);
 
     sh.metrics.operationComplete(cf);
     sh.metrics.operationComplete(cf);
 
-    checkShuffleMetrics(ms, 3*MiB, 1, 1, 0);
+    checkShuffleMetrics(ms, 3 * MiB, 1, 1, 0);
 
     sh.stop();
   }
@@ -914,8 +924,9 @@ public class TestShuffleHandler {
    *
    * @throws Exception exception.
    */
-  @Test (timeout = 10000)
-  public void testClientClosesConnection() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testClientClosesConnection() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY, TEST_EXECUTION.shuffleHandlerPort());
     ShuffleHandlerForTests shuffleHandler = new ShuffleHandlerForTests() {
@@ -946,7 +957,7 @@ public class TestShuffleHandler {
           protected ChannelFuture sendMapOutput(ChannelHandlerContext ctx,
               Channel ch, String user, String mapId, int reduce,
               MapOutputInfo info)
-                  throws IOException {
+              throws IOException {
             ShuffleHeader header =
                 new ShuffleHeader("attempt_12345_1_m_1_0", 5678, 5678, 1);
             DataOutputBuffer dob = new DataOutputBuffer();
@@ -999,10 +1010,12 @@ public class TestShuffleHandler {
     header.readFields(input);
     input.close();
 
-    assertEquals("sendError called when client closed connection", 0,
-        shuffleHandler.failures.size());
-    assertEquals("Should have no caught exceptions", Collections.emptyList(),
-        shuffleHandler.failures);
+    assertEquals(0,
+        shuffleHandler.failures.size(),
+        "sendError called when client closed connection");
+    assertEquals(Collections.emptyList(),
+        shuffleHandler.failures,
+        "Should have no caught exceptions");
 
     shuffleHandler.stop();
   }
@@ -1017,8 +1030,9 @@ public class TestShuffleHandler {
     }
   }
 
-  @Test(timeout = 10000)
-  public void testKeepAliveInitiallyEnabled() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testKeepAliveInitiallyEnabled() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY, TEST_EXECUTION.shuffleHandlerPort());
     conf.setBoolean(ShuffleHandler.SHUFFLE_CONNECTION_KEEP_ALIVE_ENABLED, true);
@@ -1031,8 +1045,9 @@ public class TestShuffleHandler {
         ShuffleUrlType.WITH_KEEPALIVE);
   }
 
-  @Test(timeout = 1000000)
-  public void testKeepAliveInitiallyEnabledTwoKeepAliveUrls() throws Exception {
+  @Test
+  @Timeout(1000000)
+  void testKeepAliveInitiallyEnabledTwoKeepAliveUrls() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY, TEST_EXECUTION.shuffleHandlerPort());
     conf.setBoolean(ShuffleHandler.SHUFFLE_CONNECTION_KEEP_ALIVE_ENABLED, true);
@@ -1046,8 +1061,9 @@ public class TestShuffleHandler {
   }
 
   //TODO snemeth implement keepalive test that used properly mocked ShuffleHandler
-  @Test(timeout = 10000)
-  public void testKeepAliveInitiallyDisabled() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testKeepAliveInitiallyDisabled() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY, TEST_EXECUTION.shuffleHandlerPort());
     conf.setBoolean(ShuffleHandler.SHUFFLE_CONNECTION_KEEP_ALIVE_ENABLED, false);
@@ -1060,8 +1076,9 @@ public class TestShuffleHandler {
         ShuffleUrlType.WITH_KEEPALIVE);
   }
 
-  @Test(timeout = 10000)
-  public void testKeepAliveMultipleMapAttemptIds() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testKeepAliveMultipleMapAttemptIds() throws Exception {
     final int mapOutputContentLength = 11;
     final int mapOutputCount = 2;
 
@@ -1096,8 +1113,9 @@ public class TestShuffleHandler {
         ShuffleUrlType.WITH_KEEPALIVE_MULTIPLE_MAP_IDS);
   }
 
-  @Test(timeout = 10000)
-  public void testKeepAliveWithoutMapAttemptIds() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testKeepAliveWithoutMapAttemptIds() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY, TEST_EXECUTION.shuffleHandlerPort());
     conf.setBoolean(ShuffleHandler.SHUFFLE_CONNECTION_KEEP_ALIVE_ENABLED, true);
@@ -1135,8 +1153,8 @@ public class TestShuffleHandler {
       ShuffleUrlType[] shuffleUrlTypes,
       int expectedHttpStatus) throws IOException {
     if (expectedHttpStatus != HttpURLConnection.HTTP_BAD_REQUEST) {
-      assertTrue("Expected at least two shuffle URL types ",
-          shuffleUrlTypes.length >= 2);
+      assertTrue(shuffleUrlTypes.length >= 2,
+          "Expected at least two shuffle URL types ");
     }
     shuffleHandler.init(conf);
     shuffleHandler.start();
@@ -1179,13 +1197,15 @@ public class TestShuffleHandler {
     });
     if (expectedHttpStatus == HttpURLConnection.HTTP_OK) {
       HttpConnectionAssert.assertKeepAliveConnectionsAreSame(connHelper);
-      assertEquals("Unexpected ShuffleHandler failure", Collections.emptyList(),
-          shuffleHandler.failures);
+      assertEquals(Collections.emptyList(),
+          shuffleHandler.failures,
+          "Unexpected ShuffleHandler failure");
     }
   }
 
-  @Test(timeout = 10000)
-  public void testSocketKeepAlive() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testSocketKeepAlive() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY, TEST_EXECUTION.shuffleHandlerPort());
     conf.setBoolean(ShuffleHandler.SHUFFLE_CONNECTION_KEEP_ALIVE_ENABLED, true);
@@ -1204,8 +1224,8 @@ public class TestShuffleHandler {
       shuffleHandler.start();
 
       String shuffleBaseURL = "http://127.0.0.1:"
-              + shuffleHandler.getConfig().get(
-                ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY);
+          + shuffleHandler.getConfig().get(
+          ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY);
       URL url =
           new URL(shuffleBaseURL + "/mapOutput?job=job_12345_1&reduce=1&"
               + "map=attempt_12345_1_m_1_0");
@@ -1218,16 +1238,15 @@ public class TestShuffleHandler {
       int rc = conn.getResponseCode();
       conn.getInputStream();
       assertEquals(HttpURLConnection.HTTP_OK, rc);
-      assertTrue("socket should be set KEEP_ALIVE",
-          shuffleHandler.isSocketKeepAlive());
+      assertTrue(shuffleHandler.isSocketKeepAlive(),
+          "socket should be set KEEP_ALIVE");
     } finally {
       if (conn != null) {
         conn.disconnect();
       }
       shuffleHandler.stop();
     }
-    assertEquals("Should have no caught exceptions",
-        Collections.emptyList(), shuffleHandler.failures);
+    assertEquals(Collections.emptyList(), shuffleHandler.failures, "Should have no caught exceptions");
   }
 
   /**
@@ -1236,8 +1255,9 @@ public class TestShuffleHandler {
    * 
    * @throws Exception exception
    */
-  @Test (timeout = 10000)
-  public void testIncompatibleShuffleVersion() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testIncompatibleShuffleVersion() throws Exception {
     final int failureNum = 3;
     Configuration conf = new Configuration();
     conf.setInt(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY, TEST_EXECUTION.shuffleHandlerPort());
@@ -1270,13 +1290,14 @@ public class TestShuffleHandler {
    * 
    * @throws Exception exception
    */
-  @Test (timeout = 10000)
-  public void testMaxConnections() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testMaxConnections() throws Exception {
     final ArrayList<Throwable> failures = new ArrayList<>();
     final int maxAllowedConnections = 3;
     final int notAcceptedConnections = 1;
     final int connAttempts = maxAllowedConnections + notAcceptedConnections;
-    
+
     Configuration conf = new Configuration();
     conf.setInt(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY, TEST_EXECUTION.shuffleHandlerPort());
     conf.setInt(ShuffleHandler.MAX_SHUFFLE_CONNECTIONS, maxAllowedConnections);
@@ -1307,7 +1328,7 @@ public class TestShuffleHandler {
           protected ChannelFuture sendMapOutput(ChannelHandlerContext ctx,
               Channel ch, String user, String mapId, int reduce,
               MapOutputInfo info)
-                  throws IOException {
+              throws IOException {
             // send a shuffle header and a lot of data down the channel
             // to trigger a broken pipe
             ShuffleHeader header =
@@ -1316,7 +1337,7 @@ public class TestShuffleHandler {
             header.write(dob);
             ch.writeAndFlush(wrappedBuffer(dob.getData(), 0, dob.getLength()));
             dob = new DataOutputBuffer();
-            for (int i=0; i<100000; ++i) {
+            for (int i = 0; i < 100000; ++i) {
               header.write(dob);
             }
             return ch.writeAndFlush(wrappedBuffer(dob.getData(), 0, dob.getLength()));
@@ -1340,10 +1361,10 @@ public class TestShuffleHandler {
     HttpURLConnection[] conns = new HttpURLConnection[connAttempts];
 
     for (int i = 0; i < connAttempts; i++) {
-      String urlString = "http://127.0.0.1:" 
-           + shuffleHandler.getConfig().get(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
-           + "/mapOutput?job=job_12345_1&reduce=1&map=attempt_12345_1_m_"
-           + i + "_0";
+      String urlString = "http://127.0.0.1:"
+          + shuffleHandler.getConfig().get(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
+          + "/mapOutput?job=job_12345_1&reduce=1&map=attempt_12345_1_m_"
+          + i + "_0";
       URL url = new URL(urlString);
       conns[i] = TEST_EXECUTION.openConnection(url);
       conns[i].setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
@@ -1375,43 +1396,39 @@ public class TestShuffleHandler {
       connectionList.add(conn);
     }
 
-    assertEquals(String.format("Expected only %s and %s response",
-            OK_STATUS, ShuffleHandler.TOO_MANY_REQ_STATUS),
-        Sets.newHashSet(
+    assertEquals(Sets.newHashSet(
             HttpURLConnection.HTTP_OK,
             ShuffleHandler.TOO_MANY_REQ_STATUS.code()),
-        mapOfConnections.keySet());
-    
+        mapOfConnections.keySet(),
+        String.format("Expected only %s and %s response",
+            OK_STATUS, ShuffleHandler.TOO_MANY_REQ_STATUS));
+
     List<HttpURLConnection> successfulConnections =
         mapOfConnections.get(HttpURLConnection.HTTP_OK);
-    assertEquals(String.format("Expected exactly %d requests " +
-            "with %s response", maxAllowedConnections, OK_STATUS),
-        maxAllowedConnections, successfulConnections.size());
+    assertEquals(maxAllowedConnections, successfulConnections.size(), String.format("Expected exactly %d requests " +
+        "with %s response", maxAllowedConnections, OK_STATUS));
 
     //Ensure exactly one connection is HTTP 429 (TOO MANY REQUESTS)
     List<HttpURLConnection> closedConnections =
         mapOfConnections.get(ShuffleHandler.TOO_MANY_REQ_STATUS.code());
-    assertEquals(String.format("Expected exactly %d %s response",
-            notAcceptedConnections, ShuffleHandler.TOO_MANY_REQ_STATUS),
-        notAcceptedConnections, closedConnections.size());
+    assertEquals(notAcceptedConnections, closedConnections.size(), String.format("Expected exactly %d %s response",
+        notAcceptedConnections, ShuffleHandler.TOO_MANY_REQ_STATUS));
 
     // This connection should be closed because it is above the maximum limit
     HttpURLConnection conn = closedConnections.get(0);
-    assertEquals(String.format("Expected a %s response",
-            ShuffleHandler.TOO_MANY_REQ_STATUS),
-        ShuffleHandler.TOO_MANY_REQ_STATUS.code(), conn.getResponseCode());
+    assertEquals(ShuffleHandler.TOO_MANY_REQ_STATUS.code(), conn.getResponseCode(), String.format("Expected a %s response",
+        ShuffleHandler.TOO_MANY_REQ_STATUS));
     long backoff = Long.parseLong(
         conn.getHeaderField(ShuffleHandler.RETRY_AFTER_HEADER));
-    assertTrue("The backoff value cannot be negative.", backoff > 0);
+    assertTrue(backoff > 0, "The backoff value cannot be negative.");
 
     shuffleHandler.stop();
 
     //It's okay to get a ClosedChannelException.
     //All other kinds of exceptions means something went wrong
-    assertEquals("Should have no caught exceptions",
-        Collections.emptyList(), failures.stream()
-            .filter(f -> !(f instanceof ClosedChannelException))
-            .collect(toList()));
+    assertEquals(Collections.emptyList(), failures.stream()
+        .filter(f -> !(f instanceof ClosedChannelException))
+        .collect(toList()), "Should have no caught exceptions");
   }
 
   /**
@@ -1420,8 +1437,9 @@ public class TestShuffleHandler {
    *
    * @throws Exception exception
    */
-  @Test(timeout = 100000)
-  public void testMapFileAccess() throws IOException {
+  @Test
+  @Timeout(100000)
+  void testMapFileAccess() throws IOException {
     final ArrayList<Throwable> failures = new ArrayList<>();
     // This will run only in NativeIO is enabled as SecureIOUtils need it
     assumeTrue(NativeIO.isAvailable());
@@ -1486,12 +1504,12 @@ public class TestShuffleHandler {
       shuffleHandler
           .initializeApplication(new ApplicationInitializationContext(user,
               appId, ByteBuffer.wrap(outputBuffer.getData(), 0,
-              outputBuffer.getLength())));
+                  outputBuffer.getLength())));
       URL url =
           new URL(
               "http://127.0.0.1:"
                   + shuffleHandler.getConfig().get(
-                      ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
+                  ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
                   + "/mapOutput?job=job_12345_0001&reduce=" + reducerId
                   + "&map=attempt_12345_1_m_1_0");
       HttpURLConnection conn = TEST_EXECUTION.openConnection(url);
@@ -1512,9 +1530,9 @@ public class TestShuffleHandler {
       String message =
           "Owner '" + owner + "' for path " + fileMap.get(0).getAbsolutePath()
               + " did not match expected owner '" + user + "'";
-      assertTrue(String.format("Received string '%s' should contain " +
-          "message '%s'", receivedString, message),
-          receivedString.contains(message));
+      assertTrue(receivedString.contains(message),
+          String.format("Received string '%s' should contain " +
+              "message '%s'", receivedString, message));
       assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
       LOG.info("received: " + receivedString);
       assertNotEquals("", receivedString);
@@ -1523,8 +1541,7 @@ public class TestShuffleHandler {
       FileUtil.fullyDelete(ABS_LOG_DIR);
     }
 
-    assertEquals("Should have no caught exceptions",
-        Collections.emptyList(), failures);
+    assertEquals(Collections.emptyList(), failures, "Should have no caught exceptions");
   }
 
   private static void createShuffleHandlerFiles(File logDir, String user,
@@ -1576,12 +1593,12 @@ public class TestShuffleHandler {
   }
 
   @Test
-  public void testRecovery() throws IOException {
+  void testRecovery() throws IOException {
     final String user = "someuser";
     final ApplicationId appId = ApplicationId.newInstance(12345, 1);
     final JobID jobId = JobID.downgrade(TypeConverter.fromYarn(appId));
     final File tmpDir = new File(System.getProperty("test.build.data",
-        System.getProperty("java.io.tmpdir")),
+            System.getProperty("java.io.tmpdir")),
         TestShuffleHandler.class.getName());
     ShuffleHandler shuffle = new ShuffleHandlerForTests();
     AuxiliaryLocalPathHandler pathHandler = new TestAuxiliaryLocalPathHandler();
@@ -1607,7 +1624,7 @@ public class TestShuffleHandler {
       jt.write(outputBuffer);
       shuffle.initializeApplication(new ApplicationInitializationContext(user,
           appId, ByteBuffer.wrap(outputBuffer.getData(), 0,
-            outputBuffer.getLength())));
+              outputBuffer.getLength())));
 
       // verify we are authorized to shuffle
       int rc = getShuffleResponseCode(shuffle, jt);
@@ -1647,13 +1664,13 @@ public class TestShuffleHandler {
       FileUtil.fullyDelete(tmpDir);
     }
   }
-  
+
   @Test
-  public void testRecoveryFromOtherVersions() throws IOException {
+  void testRecoveryFromOtherVersions() throws IOException {
     final String user = "someuser";
     final ApplicationId appId = ApplicationId.newInstance(12345, 1);
     final File tmpDir = new File(System.getProperty("test.build.data",
-        System.getProperty("java.io.tmpdir")),
+            System.getProperty("java.io.tmpdir")),
         TestShuffleHandler.class.getName());
     Configuration conf = new Configuration();
     conf.setInt(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY, TEST_EXECUTION.shuffleHandlerPort());
@@ -1697,7 +1714,7 @@ public class TestShuffleHandler {
       assertEquals(HttpURLConnection.HTTP_OK, rc);
       Version version = Version.newInstance(1, 0);
       assertEquals(version, shuffle.getCurrentVersion());
-    
+
       // emulate shuffle handler restart with compatible version
       Version version11 = Version.newInstance(1, 1);
       // update version info before close shuffle
@@ -1715,7 +1732,7 @@ public class TestShuffleHandler {
       // verify we are still authorized to shuffle to the old application
       rc = getShuffleResponseCode(shuffle, jt);
       assertEquals(HttpURLConnection.HTTP_OK, rc);
-    
+
       // emulate shuffle handler restart with incompatible version
       Version version21 = Version.newInstance(2, 1);
       shuffle.storeVersion(version21);
@@ -1725,15 +1742,15 @@ public class TestShuffleHandler {
       shuffle.setAuxiliaryLocalPathHandler(pathHandler);
       shuffle.setRecoveryPath(new Path(tmpDir.toString()));
       shuffle.init(conf);
-    
+
       try {
         shuffle.start();
         fail("Incompatible version, should expect fail here.");
       } catch (ServiceStateException e) {
-        assertTrue("Exception message mismatch",
-            e.getMessage().contains("Incompatible version for state DB schema:"));
-      } 
-    
+        assertTrue(e.getMessage().contains("Incompatible version for state DB schema:"),
+            "Exception message mismatch");
+      }
+
     } finally {
       if (shuffle != null) {
         shuffle.close();
@@ -1763,8 +1780,9 @@ public class TestShuffleHandler {
     return rc;
   }
 
-  @Test(timeout = 100000)
-  public void testGetMapOutputInfo() throws Exception {
+  @Test
+  @Timeout(100000)
+  void testGetMapOutputInfo() throws Exception {
     final ArrayList<Throwable> failures = new ArrayList<>(1);
     Configuration conf = new Configuration();
     conf.setInt(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY, TEST_EXECUTION.shuffleHandlerPort());
@@ -1837,13 +1855,13 @@ public class TestShuffleHandler {
       jt.write(outputBuffer);
       shuffleHandler
           .initializeApplication(new ApplicationInitializationContext(user,
-          appId, ByteBuffer.wrap(outputBuffer.getData(), 0,
-          outputBuffer.getLength())));
+              appId, ByteBuffer.wrap(outputBuffer.getData(), 0,
+                  outputBuffer.getLength())));
       URL url =
           new URL(
               "http://127.0.0.1:"
                   + shuffleHandler.getConfig().get(
-                      ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
+                  ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
                   + "/mapOutput?job=job_12345_0001&reduce=" + reducerId
                   + "&map=attempt_12345_1_m_1_0");
       HttpURLConnection conn = TEST_EXECUTION.openConnection(url);
@@ -1860,16 +1878,16 @@ public class TestShuffleHandler {
       } catch (EOFException e) {
         // ignore
       }
-      assertEquals("sendError called due to shuffle error",
-          0, failures.size());
+      assertEquals(0, failures.size(), "sendError called due to shuffle error");
     } finally {
       shuffleHandler.stop();
       FileUtil.fullyDelete(ABS_LOG_DIR);
     }
   }
 
-  @Test(timeout = 4000)
-  public void testSendMapCount() throws Exception {
+  @Test
+  @Timeout(4000)
+  void testSendMapCount() throws Exception {
     final List<ShuffleHandler.ReduceMapFileCount> listenerList =
         new ArrayList<>();
     int connectionKeepAliveTimeOut = 5; //arbitrary value
@@ -1897,34 +1915,35 @@ public class TestShuffleHandler {
     Configuration conf = new Configuration();
     sh.init(conf);
     sh.start();
-    int maxOpenFiles =conf.getInt(ShuffleHandler.SHUFFLE_MAX_SESSION_OPEN_FILES,
+    int maxOpenFiles = conf.getInt(ShuffleHandler.SHUFFLE_MAX_SESSION_OPEN_FILES,
         ShuffleHandler.DEFAULT_SHUFFLE_MAX_SESSION_OPEN_FILES);
     sh.getShuffle(conf).channelRead(mockCtx, mockHttpRequest);
-    assertTrue("Number of Open files should not exceed the configured " +
-            "value!-Not Expected",
-        listenerList.size() <= maxOpenFiles);
-    while(!listenerList.isEmpty()) {
+    assertTrue(listenerList.size() <= maxOpenFiles,
+        "Number of Open files should not exceed the configured " +
+            "value!-Not Expected");
+    while (!listenerList.isEmpty()) {
       listenerList.remove(0).operationComplete(mockFuture);
-      assertTrue("Number of Open files should not exceed the configured " +
-              "value!-Not Expected",
-          listenerList.size() <= maxOpenFiles);
+      assertTrue(listenerList.size() <= maxOpenFiles,
+          "Number of Open files should not exceed the configured " +
+              "value!-Not Expected");
     }
     sh.close();
     sh.stop();
 
-    assertEquals("Should have no caught exceptions",
-        Collections.emptyList(), sh.failures);
+    assertEquals(Collections.emptyList(), sh.failures, "Should have no caught exceptions");
   }
 
-  @Test(timeout = 10000)
-  public void testIdleStateHandlingSpecifiedTimeout() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testIdleStateHandlingSpecifiedTimeout() throws Exception {
     int timeoutSeconds = 4;
     int expectedTimeoutSeconds = timeoutSeconds;
     testHandlingIdleState(timeoutSeconds, expectedTimeoutSeconds);
   }
 
-  @Test(timeout = 10000)
-  public void testIdleStateHandlingNegativeTimeoutDefaultsTo1Second() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testIdleStateHandlingNegativeTimeoutDefaultsTo1Second() throws Exception {
     int expectedTimeoutSeconds = 1; //expected by production code
     testHandlingIdleState(ARBITRARY_NEGATIVE_TIMEOUT_SECONDS, expectedTimeoutSeconds);
   }
@@ -1983,9 +2002,9 @@ public class TestShuffleHandler {
     long secondsPassed =
         TimeUnit.SECONDS.convert(channelClosedTimestamp - beforeConnectionTimestamp,
             TimeUnit.MILLISECONDS);
-    assertTrue(String.format("Expected at least %s seconds of timeout. " +
-            "Actual timeout seconds: %s", expectedTimeoutSeconds, secondsPassed),
-        secondsPassed >= expectedTimeoutSeconds);
+    assertTrue(secondsPassed >= expectedTimeoutSeconds,
+        String.format("Expected at least %s seconds of timeout. " +
+            "Actual timeout seconds: %s", expectedTimeoutSeconds, secondsPassed));
     shuffleHandler.stop();
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/test/java/org/apache/hadoop/mapred/TestShuffleHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/test/java/org/apache/hadoop/mapred/TestShuffleHandler.java
@@ -1246,7 +1246,8 @@ public class TestShuffleHandler {
       }
       shuffleHandler.stop();
     }
-    assertEquals(Collections.emptyList(), shuffleHandler.failures, "Should have no caught exceptions");
+    assertEquals(Collections.emptyList(), shuffleHandler.failures,
+        "Should have no caught exceptions");
   }
 
   /**
@@ -1403,21 +1404,22 @@ public class TestShuffleHandler {
         String.format("Expected only %s and %s response",
             OK_STATUS, ShuffleHandler.TOO_MANY_REQ_STATUS));
 
-    List<HttpURLConnection> successfulConnections =
-        mapOfConnections.get(HttpURLConnection.HTTP_OK);
-    assertEquals(maxAllowedConnections, successfulConnections.size(), String.format("Expected exactly %d requests " +
-        "with %s response", maxAllowedConnections, OK_STATUS));
+    List<HttpURLConnection> successfulConnections = mapOfConnections.get(HttpURLConnection.HTTP_OK);
+    assertEquals(maxAllowedConnections, successfulConnections.size(),
+        String.format("Expected exactly %d requests " + "with %s response", maxAllowedConnections,
+            OK_STATUS));
 
     //Ensure exactly one connection is HTTP 429 (TOO MANY REQUESTS)
     List<HttpURLConnection> closedConnections =
         mapOfConnections.get(ShuffleHandler.TOO_MANY_REQ_STATUS.code());
-    assertEquals(notAcceptedConnections, closedConnections.size(), String.format("Expected exactly %d %s response",
-        notAcceptedConnections, ShuffleHandler.TOO_MANY_REQ_STATUS));
+    assertEquals(notAcceptedConnections, closedConnections.size(),
+        String.format("Expected exactly %d %s response", notAcceptedConnections,
+            ShuffleHandler.TOO_MANY_REQ_STATUS));
 
     // This connection should be closed because it is above the maximum limit
     HttpURLConnection conn = closedConnections.get(0);
-    assertEquals(ShuffleHandler.TOO_MANY_REQ_STATUS.code(), conn.getResponseCode(), String.format("Expected a %s response",
-        ShuffleHandler.TOO_MANY_REQ_STATUS));
+    assertEquals(ShuffleHandler.TOO_MANY_REQ_STATUS.code(), conn.getResponseCode(),
+        String.format("Expected a %s response", ShuffleHandler.TOO_MANY_REQ_STATUS));
     long backoff = Long.parseLong(
         conn.getHeaderField(ShuffleHandler.RETRY_AFTER_HEADER));
     assertTrue(backoff > 0, "The backoff value cannot be negative.");


### PR DESCRIPTION
### Description of PR

Upgrade Junit 4 to 5 in hadoop-mapreduce-client-shuffle

JIRA - MAPREDUCE-7416

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?