### PR TITLE
HDFS-16905. Provide default hadoop.log.dir for tests

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/test/resources/log4j.properties
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/test/resources/log4j.properties
@@ -16,6 +16,8 @@
 #
 # log4j configuration used during build and unit tests
 
+hadoop.log.dir=.
+
 log4j.rootLogger=info,stdout
 log4j.threshold=ALL
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/test/resources/log4j.properties
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/test/resources/log4j.properties
@@ -16,7 +16,7 @@
 #
 # log4j configuration used during build and unit tests
 
-hadoop.log.dir=.
+hadoop.log.dir=target/log
 
 log4j.rootLogger=info,stdout
 log4j.threshold=ALL

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/resources/log4j.properties
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/resources/log4j.properties
@@ -16,6 +16,8 @@
 #
 # log4j configuration used during build and unit tests
 
+hadoop.log.dir=.
+
 log4j.rootLogger=info,stdout
 log4j.threshold=ALL
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/resources/log4j.properties
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/resources/log4j.properties
@@ -16,7 +16,7 @@
 #
 # log4j configuration used during build and unit tests
 
-hadoop.log.dir=.
+hadoop.log.dir=target/log
 
 log4j.rootLogger=info,stdout
 log4j.threshold=ALL


### PR DESCRIPTION
### Description of PR

Allow testing in other environments by providing a default setting for hadoop.log.dir.  The same default is provided in other modules.

### How was this patch tested?

Tested using the Hadoop development environment Docker image and an IDE on Mac

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

