### PR TITLE
HADOOP-18621. Resource leak in CryptoOutputStream.close()

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/CryptoOutputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/CryptoOutputStream.java
@@ -241,12 +241,15 @@ public class CryptoOutputStream extends FilterOutputStream implements
       return;
     }
     try {
-      flush();
-      if (closeOutputStream) {
-        super.close();
-        codec.close();
+      try {
+        flush();
+      } finally {
+        if (closeOutputStream) {
+          super.close();
+          codec.close();
+        }
+        freeBuffers();
       }
-      freeBuffers();
     } finally {
       closed = true;
     }


### PR DESCRIPTION
Fix a bug in the close() method of CryptoOutputStream.

### Description of PR

When closing we need to wrap the flush() in a try .. finally, otherwise when flush throws it will prevent us completing the remainder of the close activities and in particular the close of the underlying wrapped stream object resulting in a resource leak.

### How was this patch tested?

Unit test added

