### PR TITLE
HDFS-16908. fix javadoc of field IncrementalBlockReportManager#readyToSend.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/IncrementalBlockReportManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/IncrementalBlockReportManager.java
@@ -128,8 +128,8 @@ class IncrementalBlockReportManager {
       = Maps.newHashMap();
 
   /**
-   * If this flag is set then an IBR will be sent immediately by the actor
-   * thread without waiting for the IBR timer to elapse.
+   * If this flag is set then an IBR will be sent by the actor
+   * thread after waiting for the IBR timer to elapse.
    */
   private volatile boolean readyToSend = false;
 


### PR DESCRIPTION
fix javadoc of field IncrementalBlockReportManager#readyToSend.
in sendImmediately(), readyToSend will be used with `monotonicNow() - ibrInterval >= lastIBR` condition. So, we should update the javadoc of it.