### PR TITLE
HADOOP-18618 : Support custom property for credential provider.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -2406,6 +2406,30 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
   }
 
   /**
+   * Get the value for a known password configuration element.
+   * In order to enable the elimination of clear text passwords in config,
+   * this method attempts to resolve the property name as an alias through
+   * the CredentialProvider API and conditionally fallsback to config. This
+   * method accept external provider property name.
+   * @param name property name
+   * @param providerKey provider property name
+   * @return password
+   * @throws IOException when error in fetching password
+   */
+  public char[] getPassword(String name, String providerKey)
+      throws IOException {
+    char[] pass = null;
+
+    pass = getPasswordFromCredentialProviders(name, providerKey);
+
+    if (pass == null) {
+      pass = getPasswordFromConfig(name);
+    }
+
+    return pass;
+  }
+
+  /**
    * Get the credential entry by name from a credential provider.
    *
    * Handle key deprecation.
@@ -2455,10 +2479,23 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
    */
   public char[] getPasswordFromCredentialProviders(String name)
       throws IOException {
+      return getPasswordFromCredentialProviders(name, null);
+  }
+ 
+  /**
+   * Try and resolve the provided element name as a credential provider
+   * alias from given provider.
+   * @param name alias of the provisioned credential
+   * @param providerKey external credential provider
+   * @return password or null if not found
+   * @throws IOException
+   */
+  public char[] getPasswordFromCredentialProviders(String name,
+      String providerKey) throws IOException {
     char[] pass = null;
     try {
       List<CredentialProvider> providers =
-          CredentialProviderFactory.getProviders(this);
+          CredentialProviderFactory.getProviders(this, providerKey);
 
       if (providers != null) {
         for (CredentialProvider provider : providers) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -2487,15 +2487,15 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
    * Try and resolve the provided element name as a credential provider
    * alias from the given provider path.
    * @param name alias of the provisioned credential
-   * @param credProviderPath path for credential provider
+   * @param providerURI The URI of the provider path
    * @return password or null if not found
    * @throws IOException when error in fetching password
    */
-  public char[] getPasswordFromCredentialProvider(String name, String credProviderPath)
+  public char[] getPasswordFromCredentialProvider(String name, URI providerUri)
       throws IOException {
     try {
       CredentialProvider provider = CredentialProviderFactory.getProvider(this,
-          credProviderPath);
+          providerUri);
       if (provider != null) {
         try {
           CredentialEntry entry = getCredentialEntry(provider, name);
@@ -2503,8 +2503,10 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
             return entry.getCredential();
           }
         } catch (IOException ioe) {
-          throw new IOException("Can't get key " + name + " from key provider"
-              + "of type: " + provider.getClass().getName() + ".", ioe);
+          String msg = String.format(
+              "Can't get key %s from key provider of type: %s.", name,
+              provider.getClass().getName());
+          throw NetUtils.wrapWithMessage(ioe, msg);
         }
       }
     } catch (IOException ioe) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -2487,7 +2487,7 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
    * Try and resolve the provided element name as a credential provider
    * alias from the given provider path.
    * @param name alias of the provisioned credential
-   * @param name credProviderPath path for credential provider
+   * @param credProviderPath path for credential provider
    * @return password or null if not found
    * @throws IOException when error in fetching password
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
@@ -940,7 +940,7 @@ public class NetUtils {
   }
   
   @SuppressWarnings("unchecked")
-  private static <T extends IOException> T wrapWithMessage(
+  public static <T extends IOException> T wrapWithMessage(
       T exception, String msg) throws T {
     Class<? extends Throwable> clazz = exception.getClass();
     try {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/CredentialProviderFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/CredentialProviderFactory.java
@@ -72,8 +72,16 @@ public abstract class CredentialProviderFactory {
 
   public static List<CredentialProvider> getProviders(Configuration conf
                                                ) throws IOException {
+    return getProviders(conf, CREDENTIAL_PROVIDER_PATH);
+  }
+
+  public static List<CredentialProvider> getProviders(Configuration conf,
+      String providerKey) throws IOException {
     List<CredentialProvider> result = new ArrayList<>();
-    for(String path: conf.getStringCollection(CREDENTIAL_PROVIDER_PATH)) {
+    if (providerKey == null || conf.getStringCollection(providerKey) == null) {
+      providerKey = CREDENTIAL_PROVIDER_PATH;
+    }
+    for(String path: conf.getStringCollection(providerKey)) {
       try {
         URI uri = new URI(path);
         boolean found = false;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/CredentialProviderFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/CredentialProviderFactory.java
@@ -112,30 +112,24 @@ public abstract class CredentialProviderFactory {
   }
 
   /**
-   * Get CredentialProvider for hive provider path.
+   * Get the CredentialProvider for a given provider URI.
    *
-   * @param conf configuration
-   * @param credProviderPath provider path
-   * @return CredentialProvider
-   * @throws IOException
+   * @param conf The configuration object
+   * @param providerURI The URI of the provider path
+   * @return The CredentialProvider
+   * @throws IOException If an I/O error occurs
    */
   public static CredentialProvider getProvider(Configuration conf,
-      String credProviderPath) throws IOException {
-    try {
-      URI uri = new URI(credProviderPath);
-      synchronized (serviceLoader) {
-        for (CredentialProviderFactory factory : serviceLoader) {
-          CredentialProvider kp = factory.createProvider(uri, conf);
-          if (kp != null) {
-            return kp;
-          }
+      URI providerUri) throws IOException {
+    synchronized (serviceLoader) {
+      for (CredentialProviderFactory factory : serviceLoader) {
+        CredentialProvider kp = factory.createProvider(providerUri, conf);
+        if (kp != null) {
+          return kp;
         }
       }
-    } catch (URISyntaxException error) {
-      throw new IOException(
-          "Failed to get provider for path : " + credProviderPath, error);
     }
     throw new IOException(
-        "No CredentialProviderFactory for path " + credProviderPath);
+        "No CredentialProviderFactory for " + providerUri);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/CredentialProviderFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/CredentialProviderFactory.java
@@ -114,9 +114,10 @@ public abstract class CredentialProviderFactory {
   /**
    * Get CredentialProvider for hive provider path.
    *
-   * @param conf configuration object
+   * @param conf configuration
    * @param credProviderPath provider path
-   * @return credProviderPath object
+   * @return CredentialProvider
+   * @throws IOException
    */
   public static CredentialProvider getProvider(Configuration conf,
       String credProviderPath) throws IOException {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredentialProviderFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredentialProviderFactory.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.security.alias;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
@@ -263,15 +262,15 @@ public class TestCredentialProviderFactory {
   @Test
   public void testCustomKeyProviderProperty() throws Exception {
     Configuration conf = new Configuration();
-    final String DEFAULT_CREDENTIAL_KEY = "default.credential.key";
-    final char[] DEFAULT_CREDENTIAL_PASSWORD = { 'p', 'a', 's', 's', 'w', 'o',
-        'r', 'd', '1', '2', '3' };
+    final String defaultCredentialKey = "default.credential.key";
+    final char[] defaultCredentialPassword = {'p', 'a', 's', 's', 'w', 'o',
+        'r', 'd', '1', '2', '3'};
 
-    final String CUSTOM_CREDENTIAL_PROVIDER_KEY =
+    final String customCredentialProviderKey =
         "fs.cloud.storage.account.key.provider.path";
-    final String CUSTOM_CREDENTIAL_KEY = "custom.credential.key";
-    final char[] CUSTOM_CREDENTIAL_PASSWORD = { 'c', 'u', 's', 't', 'o', 'm', '.',
-        'p', 'a', 's', 's', 'w', 'o', 'r', 'd' };
+    final String customCredentialKey = "custom.credential.key";
+    final char[] customCredentialPassword = {'c', 'u', 's', 't', 'o', 'm', '.',
+        'p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
 
     String defaultJksName = "default.jks";
     String customJksName = "custom.jks";
@@ -279,9 +278,9 @@ public class TestCredentialProviderFactory {
       // Set provider in default credential path property
       createCredentialProviderPath(conf, defaultJksName,
           CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH,
-          DEFAULT_CREDENTIAL_KEY, DEFAULT_CREDENTIAL_PASSWORD);
-      assertThat(conf.getPassword(DEFAULT_CREDENTIAL_KEY))
-          .isEqualTo(DEFAULT_CREDENTIAL_PASSWORD);
+          defaultCredentialKey, defaultCredentialPassword);
+      assertThat(conf.getPassword(defaultCredentialKey))
+          .isEqualTo(defaultCredentialPassword);
     } finally {
       // Clean jks files
       File defaultJks = new File(tmpDir, defaultJksName);
@@ -293,12 +292,12 @@ public class TestCredentialProviderFactory {
     try {
       // Set provider in custom credential path property
       createCredentialProviderPath(conf, customJksName,
-          CUSTOM_CREDENTIAL_PROVIDER_KEY, CUSTOM_CREDENTIAL_KEY,
-          CUSTOM_CREDENTIAL_PASSWORD);
+          customCredentialProviderKey, customCredentialKey,
+          customCredentialPassword);
 
-      assertThat(conf.getPasswordFromCredentialProvider(CUSTOM_CREDENTIAL_KEY,
-          conf.get(CUSTOM_CREDENTIAL_PROVIDER_KEY)))
-              .isEqualTo(CUSTOM_CREDENTIAL_PASSWORD);
+      assertThat(conf.getPasswordFromCredentialProvider(customCredentialKey,
+          conf.get(customCredentialProviderKey)))
+              .isEqualTo(customCredentialPassword);
     } finally {
       // Clean jks files
       File defaultJks = new File(tmpDir, customJksName);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredentialProviderFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredentialProviderFactory.java
@@ -273,19 +273,39 @@ public class TestCredentialProviderFactory {
     final char[] CUSTOM_CREDENTIAL_PASSWORD = { 'c', 'u', 's', 't', 'o', 'm', '.',
         'p', 'a', 's', 's', 'w', 'o', 'r', 'd' };
 
-    // Set provider in default credential path property
-    createCredentialProviderPath(conf, "default.jks",
-        CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH,
-        DEFAULT_CREDENTIAL_KEY, DEFAULT_CREDENTIAL_PASSWORD);
-    // Set provider in custom credential path property
-    createCredentialProviderPath(conf, "custom.jks",
-        CUSTOM_CREDENTIAL_PROVIDER_KEY, CUSTOM_CREDENTIAL_KEY,
-        CUSTOM_CREDENTIAL_PASSWORD);
-    assertThat(conf.getPassword(DEFAULT_CREDENTIAL_KEY))
-        .isEqualTo(DEFAULT_CREDENTIAL_PASSWORD);
-    assertThat(conf.getPasswordFromCredentialProvider(CUSTOM_CREDENTIAL_KEY,
-        conf.get(CUSTOM_CREDENTIAL_PROVIDER_KEY)))
-            .isEqualTo(CUSTOM_CREDENTIAL_PASSWORD);
+    String defaultJksName = "default.jks";
+    String customJksName = "custom.jks";
+    try {
+      // Set provider in default credential path property
+      createCredentialProviderPath(conf, defaultJksName,
+          CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH,
+          DEFAULT_CREDENTIAL_KEY, DEFAULT_CREDENTIAL_PASSWORD);
+      assertThat(conf.getPassword(DEFAULT_CREDENTIAL_KEY))
+          .isEqualTo(DEFAULT_CREDENTIAL_PASSWORD);
+    } finally {
+      // Clean jks files
+      File defaultJks = new File(tmpDir, defaultJksName);
+      if (defaultJks.exists()) {
+        defaultJks.delete();
+      }
+    }
+
+    try {
+      // Set provider in custom credential path property
+      createCredentialProviderPath(conf, customJksName,
+          CUSTOM_CREDENTIAL_PROVIDER_KEY, CUSTOM_CREDENTIAL_KEY,
+          CUSTOM_CREDENTIAL_PASSWORD);
+
+      assertThat(conf.getPasswordFromCredentialProvider(CUSTOM_CREDENTIAL_KEY,
+          conf.get(CUSTOM_CREDENTIAL_PROVIDER_KEY)))
+              .isEqualTo(CUSTOM_CREDENTIAL_PASSWORD);
+    } finally {
+      // Clean jks files
+      File defaultJks = new File(tmpDir, customJksName);
+      if (defaultJks.exists()) {
+        defaultJks.delete();
+      }
+    }
   }
 
   private void createCredentialProviderPath(Configuration conf, String jksName,
@@ -294,8 +314,6 @@ public class TestCredentialProviderFactory {
     final String ourUrl = LocalJavaKeyStoreProvider.SCHEME_NAME + "://file"
         + jksPath.toUri();
 
-    File file = new File(tmpDir, jksName);
-    file.delete();
     conf.set(credentialProvider, ourUrl);
     CredentialProvider provider = CredentialProviderFactory
         .getProvider(conf, ourUrl);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredentialProviderFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredentialProviderFactory.java
@@ -296,7 +296,7 @@ public class TestCredentialProviderFactory {
           customCredentialPassword);
 
       assertThat(conf.getPasswordFromCredentialProvider(customCredentialKey,
-          conf.get(customCredentialProviderKey)))
+          new URI(conf.get(customCredentialProviderKey))))
               .isEqualTo(customCredentialPassword);
     } finally {
       // Clean jks files
@@ -308,14 +308,14 @@ public class TestCredentialProviderFactory {
   }
 
   private void createCredentialProviderPath(Configuration conf, String jksName,
-      String credentialProvider, String key, char[] value) throws IOException {
+      String credentialProvider, String key, char[] value) throws Exception {
     final Path jksPath = new Path(tmpDir.toString(), jksName);
     final String ourUrl = LocalJavaKeyStoreProvider.SCHEME_NAME + "://file"
         + jksPath.toUri();
 
     conf.set(credentialProvider, ourUrl);
     CredentialProvider provider = CredentialProviderFactory
-        .getProvider(conf, ourUrl);
+        .getProvider(conf, new URI(ourUrl));
     provider.createCredentialEntry(key, value);
     provider.flush();
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredentialProviderFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredentialProviderFactory.java
@@ -41,6 +41,7 @@ import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -280,13 +281,11 @@ public class TestCredentialProviderFactory {
     createCredentialProviderPath(conf, "custom.jks",
         CUSTOM_CREDENTIAL_PROVIDER_KEY, CUSTOM_CREDENTIAL_KEY,
         CUSTOM_CREDENTIAL_PASSWORD);
-
-    assertTrue("Password should match for default provider path", Arrays.equals(
-        conf.getPassword(DEFAULT_CREDENTIAL_KEY), DEFAULT_CREDENTIAL_PASSWORD));
-
-    assertTrue("Password should match for custom provider path", Arrays.equals(
-        conf.getPassword(CUSTOM_CREDENTIAL_KEY, CUSTOM_CREDENTIAL_PROVIDER_KEY),
-        CUSTOM_CREDENTIAL_PASSWORD));
+    assertThat(conf.getPassword(DEFAULT_CREDENTIAL_KEY))
+        .isEqualTo(DEFAULT_CREDENTIAL_PASSWORD);
+    assertThat(conf.getPasswordFromCredentialProvider(CUSTOM_CREDENTIAL_KEY,
+        conf.get(CUSTOM_CREDENTIAL_PROVIDER_KEY)))
+            .isEqualTo(CUSTOM_CREDENTIAL_PASSWORD);
   }
 
   private void createCredentialProviderPath(Configuration conf, String jksName,
@@ -299,7 +298,7 @@ public class TestCredentialProviderFactory {
     file.delete();
     conf.set(credentialProvider, ourUrl);
     CredentialProvider provider = CredentialProviderFactory
-        .getProviders(conf, credentialProvider).get(0);
+        .getProvider(conf, ourUrl);
     provider.createCredentialEntry(key, value);
     provider.flush();
   }


### PR DESCRIPTION
Hadoop allows the configuration of a credential provider path through the property "hadoop.security.credential.provider.path", and the Configuration#getPassword() method retrieves the credentials from this provider.

However, using common credential provider properties for components like Hive, HDFS, and MapReduce can cause issues when they want to configure separate JCEKS files for credentials. For example, the value in the core-site.xml property file can be overridden by the hive-site.xml property file. To resolve this, all components should share a common credential provider path and add all their credentials.

Azure storage supports account-specific credentials, and thus the credential provider should permit the configuration of separate JCEKS files for each account, such as the property "fs.azure.account.credential.provider.path.<account>.blob.core.windows.net".

To accommodate this, the Configuration#getPassword() method should accept a custom property for the credential provider path and retrieve its value. The current default property can be overridden to achieve this.

public char[] getPassword(String name) throws IOException {
    ......
    ......
}


public char[] getPassword(String name, String providerKey) throws IOException {                  
    ......
    ......
 }