### PR TITLE
HDFS-16909. Improve ReplicaMap#mergeAll method.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaMap.java
@@ -178,13 +178,13 @@ class ReplicaMap {
         for (ReplicaInfo replicaInfo : replicaInfos) {
           replicaSet.add(replicaInfo);
         }
+        if (curSet == null && !replicaSet.isEmpty()) {
+          // Add an entry for block pool if it does not exist already
+          curSet = new LightWeightResizableGSet<>();
+          map.put(bp, curSet);
+        }
         for (ReplicaInfo replicaInfo : replicaSet) {
           checkBlock(replicaInfo);
-          if (curSet == null) {
-            // Add an entry for block pool if it does not exist already
-            curSet = new LightWeightResizableGSet<>();
-            map.put(bp, curSet);
-          }
           curSet.put(replicaInfo);
         }
       }


### PR DESCRIPTION
Currently, the code is as below:

```java
for (ReplicaInfo replicaInfo : replicaSet) {
  checkBlock(replicaInfo);
  if (curSet == null) {
    // Add an entry for block pool if it does not exist already
    curSet = new LightWeightResizableGSet<>();
    map.put(bp, curSet);
  }
  curSet.put(replicaInfo);
} 
```

the statment :

```java
if(curSet == null)
```

should be moved to outside from the for loop.