### PR TITLE
Add bswap support for LoongArch

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/lib/primitives.h
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/lib/primitives.h
@@ -99,7 +99,7 @@ inline void simple_memcpy(void * dest, const void * src, size_t len) {
 inline uint32_t bswap(uint32_t val) {
 #ifdef __aarch64__
   __asm__("rev %w[dst], %w[src]" : [dst]"=r"(val) : [src]"r"(val));
-#elif defined(__ppc64__)||(__PPC64__)||(__powerpc64__)
+#elif defined(__ppc64__)||(__PPC64__)||(__powerpc64__)||(__loongarch__)||(__loongarch64)
   return  __builtin_bswap32(val);
 #else
   __asm__("bswap %0" : "=r" (val) : "0" (val));
@@ -110,7 +110,7 @@ inline uint32_t bswap(uint32_t val) {
 inline uint64_t bswap64(uint64_t val) {
 #ifdef __aarch64__
   __asm__("rev %[dst], %[src]" : [dst]"=r"(val) : [src]"r"(val));
-#elif defined(__ppc64__)||(__PPC64__)||(__powerpc64__)
+#elif defined(__ppc64__)||(__PPC64__)||(__powerpc64__)||(__loongarch__)||(__loongarch64)
   return __builtin_bswap64(val);
 #else
 #ifdef __X64


### PR DESCRIPTION

### Description of PR
This PR adds bswap support for LoongArch.

The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.
Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html

### How was this patch tested?
mvn package -Pdist,native -DskipTests  -Dtar


