### PR TITLE
HDFS-16910. Fix incorrectly initializing RandomAccessFile caused flush performance decreased for JN

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/EditLogFileOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/EditLogFileOutputStream.java
@@ -84,9 +84,9 @@ public class EditLogFileOutputStream extends EditLogOutputStream {
     doubleBuf = new EditsDoubleBuffer(size);
     RandomAccessFile rp;
     if (shouldSyncWritesAndSkipFsync) {
-      rp = new RandomAccessFile(name, "rw");
+      rp = new RandomAccessFile(name, "rwd");
     } else {
-      rp = new RandomAccessFile(name, "rws");
+      rp = new RandomAccessFile(name, "rw");
     }
     try {
       fp = new FileOutputStream(rp.getFD()); // open for append

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -2721,10 +2721,10 @@
   <description>
     Specifies whether to flush edit log file channel. When set, expensive
     FileChannel#force calls are skipped and synchronous disk writes are
-    enabled instead by opening the edit log file with RandomAccessFile("rws")
+    enabled instead by opening the edit log file with RandomAccessFile("rwd")
     flags. This can significantly improve the performance of edit log writes
     on the Windows platform.
-    Note that the behavior of the "rws" flags is platform and hardware specific
+    Note that the behavior of the "rwd" flags is platform and hardware specific
     and might not provide the same level of guarantees as FileChannel#force.
     For example, the write will skip the disk-cache on SAS and SCSI devices
     while it might not on SATA devices. This is an expert level setting,


### PR DESCRIPTION
### Description of PR

At present, after our cluster backport patch [HDFS-15882](https://issues.apache.org/jira/browse/HDFS-15882),
when set shouldSyncWritesAndSkipFsync to false, there will be flush performance degradation caused by JN.

Root Cause：
when setting shouldSyncWritesAndSkipFsync to false, the mode of init RandomAccessFile will be `rws`.
even if fc.force(false) is executed when flushAndSync is executed (hopefully, only requires updates to the file's content to be written to storage and the metadata is not update),
but since the mode of RandomAccessFile is `rws`, It will requires updates to both the file's content and its metadata to be written,
there will be flush performance degradation caused by JN.


### For code changes:

Need to update RandomAccessFile's mode from `rws` to `rwd`:

```
rwd: Open for reading and writing, as with "rw", and also require that every update to the file's content be written synchronously to the underlying storage device.

if (shouldSyncWritesAndSkipFsync) {
rp = new RandomAccessFile(name, "rwd");
} else {
rp = new RandomAccessFile(name, "rw");
}
```

In this way, when flushAndSync is executed,
if shouldSyncWritesAndSkipFsync is false and the mode of RandomAccessFile is 'rw', it will call fc.force(false) to execute,
otherwise should use `rwd` to perform the operation.

