### PR TITLE
HADOOP-18623. S3A delegation token implementations to be able to update tokens

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/S3ADelegationTokens.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/S3ADelegationTokens.java
@@ -298,10 +298,10 @@ public class S3ADelegationTokens extends AbstractDTService {
    * @throws IOException failure unmarshalling any token.
    */
   @VisibleForTesting
-  boolean maybeUpdateTokenFromOwner() throws IOException {
+  synchronized boolean maybeUpdateTokenFromOwner() throws IOException {
     Token<AbstractS3ATokenIdentifier> token = selectTokenFromFSOwner();
     if (token == null || boundDT.orElse(null) == token) {
-      return false;;
+      return false;
     } else {
       bindToDelegationToken(token);
       return true;


### PR DESCRIPTION

### Description of PR


Adds the production side changes; no tests

### How was this patch tested?

will let yetus do that

new tests needed
* can you call the callback
* if somehow you update the UGI credentials to add a new binding, does the callback return true
* if the binding is deleted (how?) will it return false

left as homework for others

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

