### PR TITLE
HDFS-16853. IPC shutdown failures.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -390,6 +390,7 @@ public class Client implements AutoCloseable {
     private AtomicLong lastActivity = new AtomicLong();// last I/O activity time
     private AtomicBoolean shouldCloseConnection = new AtomicBoolean();  // indicate if the connection is closed
     private IOException closeException; // close reason
+    private final Object sendRpcRequestLock = new Object();
 
     private final Thread rpcRequestThread;
     private final SynchronousQueue<Pair<Call, ResponseBuffer>> rpcRequestQueue =
@@ -1181,7 +1182,12 @@ public class Client implements AutoCloseable {
       final ResponseBuffer buf = new ResponseBuffer();
       header.writeDelimitedTo(buf);
       RpcWritable.wrap(call.rpcRequest).writeTo(buf);
-      rpcRequestQueue.put(Pair.of(call, buf));
+      synchronized (sendRpcRequestLock) {
+        if (shouldCloseConnection.get()) {
+          return;
+        }
+        rpcRequestQueue.put(Pair.of(call, buf));
+      }
     }
 
     /* Receive a response.
@@ -1244,6 +1250,7 @@ public class Client implements AutoCloseable {
     
     private synchronized void markClosed(IOException e) {
       if (shouldCloseConnection.compareAndSet(false, true)) {
+        while (rpcRequestQueue.poll() != null);
         closeException = e;
         notifyAll();
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -1250,7 +1250,10 @@ public class Client implements AutoCloseable {
     
     private synchronized void markClosed(IOException e) {
       if (shouldCloseConnection.compareAndSet(false, true)) {
-        while (rpcRequestQueue.poll() != null);
+        Pair<Call, ResponseBuffer> request;
+        while ((request = rpcRequestQueue.poll()) != null) {
+          LOG.debug("Clean {} from RpcRequestQueue.", request.getLeft());
+        }
         closeException = e;
         notifyAll();
       }


### PR DESCRIPTION
### Description of PR

Extension of #5162

Trying to address the problem
1. MUST NOT submit into blocking queue while closing
2. MUST NOT call queue.put() in synchronous block.

This design doesn't quite stop (2), though it should
detect and warn if the problem surfaces.
"Possible overlap in queue shutdown and request"

No new tests;

### How was this patch tested?


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

