### PR TITLE
HADOOP-18624. Leaked calls in Client.java may cause ObserverNameNode OOM

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -1467,10 +1467,12 @@ public class Client implements AutoCloseable {
     final Connection connection = getConnection(remoteId, call, serviceClass,
         fallbackToSimpleAuth);
 
+    boolean success = false;
     try {
       checkAsyncCall();
       try {
         connection.sendRpcRequest(call);                 // send the rpc request
+        success = true;
       } catch (RejectedExecutionException e) {
         throw new IOException("connection has been closed", e);
       } catch (InterruptedException ie) {
@@ -1485,6 +1487,10 @@ public class Client implements AutoCloseable {
         releaseAsyncCall();
       }
       throw e;
+    } finally {
+      if (!success) {
+        connection.calls.remove(call.id);
+      }
     }
 
     if (isAsynchronousMode()) {


### PR DESCRIPTION
### Description of PR

Jira: [HADOOP-18624](https://issues.apache.org/jira/browse/HADOOP-18624)

Leaked calls may cause ObserverNameNode OOM.

During Observer Namenode tailing edits from JournalNode, it will cancel slow request with an interruptException if there are a majority of successful responses. 

There is a bug in Client.java, it will not clean the interrupted call from the calls. The leaked calls may cause ObserverNameNode OOM.

```
public void sendRpcRequest(final Call call)
        throws InterruptedException, IOException {
      if (shouldCloseConnection.get()) {
        return;
      }
      ...
      while (!shouldCloseConnection.get()) {
        // the bug is here, if the rpcRequestQueue is full and there is a interrupt exception, it will cause that the call is only stored into the calls, and not inserted into rpcRequestQueue, so that there is no chance to remove it from the calls until the connection is closed.
        if (rpcRequestQueue.offer(Pair.of(call, buf), 1, TimeUnit.SECONDS)) {
          break;
        }
      }
    }
```

