### PR TITLE
HDFS-18324. Fix race condition in closing IPC connections.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
@@ -1336,7 +1336,7 @@ public class TestIPC {
   /**
    * Test the retry count while used in a retry proxy.
    */
-  @Test(timeout=60000)
+  @Test(timeout=100000)
   public void testRetryProxy() throws IOException {
     final Client client = new Client(LongWritable.class, conf);
     


### PR DESCRIPTION
### Description of PR

Change the rpc request sending so that it will only block for 1 second and make sure the connection
isn't closed.

### How was this patch tested?

The unit tests pass. Because my laptop is a slow x64 I did bump up the timeout for one of the IPC test
cases.

