### PR TITLE
HDFS-16904. Close webhdfs during TestSymlinkHdfs teardown

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/TestSymlinkHdfs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/TestSymlinkHdfs.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.net.URI;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
@@ -37,6 +36,7 @@ import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.web.WebHdfsConstants;
 import org.apache.hadoop.hdfs.web.WebHdfsFileSystem;
 import org.apache.hadoop.hdfs.web.WebHdfsTestUtil;
+import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.AfterClass;
@@ -100,7 +100,7 @@ abstract public class TestSymlinkHdfs extends SymlinkBaseTest {
     if (cluster != null) {
       cluster.shutdown();
     }
-    IOUtils.closeQuietly(webhdfs);
+    IOUtils.closeStream(webhdfs);
   }
 
   @Test(timeout=10000)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/TestSymlinkHdfs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/TestSymlinkHdfs.java
@@ -42,6 +42,8 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 /**
@@ -52,6 +54,9 @@ abstract public class TestSymlinkHdfs extends SymlinkBaseTest {
   {
     GenericTestUtils.setLogLevel(NameNode.stateChangeLog, Level.TRACE);
   }
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      TestSymlinkHdfs.class);
 
   protected static MiniDFSCluster cluster;
   protected static WebHdfsFileSystem webhdfs;
@@ -100,7 +105,7 @@ abstract public class TestSymlinkHdfs extends SymlinkBaseTest {
     if (cluster != null) {
       cluster.shutdown();
     }
-    IOUtils.closeStream(webhdfs);
+    IOUtils.cleanupWithLogger(LOG, webhdfs);
   }
 
   @Test(timeout=10000)


### PR DESCRIPTION
### Description of PR

Switch to org.apache.hadoop.io.IOUtils and closeStream.   This was a requested change to #5342

### How was this patch tested?

Tested by running affected tests:
```
mvn surefire:test -Dtest=TestSymlinkHdfs*
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

