### PR TITLE
HDFS-16761. Namenode UI for Datanodes page not loading if any data node is down

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/federationhealth.html
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/federationhealth.html
@@ -390,6 +390,7 @@
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
   </tr>
   {/DeadNodes}
 </table>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
@@ -361,6 +361,7 @@
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
   </tr>
   {/DeadNodes}
 </table>


### PR DESCRIPTION
### Description of PR
There are 12 header cells in the table at the Datanodes page, which didn't align with the number of cells in the Dead Nodes section, where only 11 cells were. Because of this if there was at least one dead datanode in the cluster the Datanode page didn't load on the NN UI. 

### How was this patch tested?
Tested on the NN UI with a dead datanode. 


