### PR TITLE
HADOOP-18629. Hadoop DistCp supports specifying favoredNodes for data copying

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -597,7 +597,7 @@ public class DistributedFileSystem extends FileSystem
    * inherited policy.
    *
    */
-  public HdfsDataOutputStream create(final Path f,
+  private HdfsDataOutputStream create(final Path f,
       final FsPermission permission, final EnumSet<CreateFlag> flag,
       final int bufferSize, final short replication, final long blockSize,
       final Progressable progress, final ChecksumOpt checksumOpt,

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -597,7 +597,7 @@ public class DistributedFileSystem extends FileSystem
    * inherited policy.
    *
    */
-  private HdfsDataOutputStream create(final Path f,
+  public HdfsDataOutputStream create(final Path f,
       final FsPermission permission, final EnumSet<CreateFlag> flag,
       final int bufferSize, final short replication, final long blockSize,
       final Progressable progress, final ChecksumOpt checksumOpt,

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
@@ -206,7 +206,7 @@ public final class DistCpConstants {
   /** Filename of sorted target listing. */
   public static final String TARGET_SORTED_FILE = "target_sorted.seq";
 
-  /** Favored nodes in target cluster */
+  /** Favored nodes in target cluster. */
   public static final String CONF_LABEL_FAVORED_NODES = "distcp.favored.nodes";
 
   public static final String LENGTH_MISMATCH_ERROR_MSG =

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
@@ -206,7 +206,7 @@ public final class DistCpConstants {
   /** Filename of sorted target listing. */
   public static final String TARGET_SORTED_FILE = "target_sorted.seq";
 
-  /** Favored nodes in target cluster. */
+  /** Favored nodes in target hdfs filesystem. */
   public static final String CONF_LABEL_FAVORED_NODES = "distcp.favored.nodes";
 
   public static final String LENGTH_MISMATCH_ERROR_MSG =

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
@@ -206,6 +206,9 @@ public final class DistCpConstants {
   /** Filename of sorted target listing. */
   public static final String TARGET_SORTED_FILE = "target_sorted.seq";
 
+  /** Favored nodes in target cluster */
+  public static final String CONF_LABEL_FAVORED_NODES = "distcp.favored.nodes";
+
   public static final String LENGTH_MISMATCH_ERROR_MSG =
           "Mismatch in length of source:";
 

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpContext.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpContext.java
@@ -179,6 +179,10 @@ public class DistCpContext {
     return options.shouldUpdateRoot();
   }
 
+  public String getFavoredNodes() {
+    return options.getFavoredNodes();
+  }
+
   public final boolean splitLargeFile() {
     return options.getBlocksPerChunk() > 0;
   }

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptionSwitch.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptionSwitch.java
@@ -249,7 +249,11 @@ public enum DistCpOptionSwitch {
   UPDATE_ROOT(DistCpConstants.CONF_LABEL_UPDATE_ROOT,
       new Option("updateRoot", false,
       "Update root directory attributes "
-          + "(eg permissions, ownership ...)"));
+          + "(eg permissions, ownership ...)")),
+
+  FAVORED_NODES(DistCpConstants.CONF_LABEL_FAVORED_NODES,
+      new Option("favoredNodes", true,
+          "Specify favored nodes in target cluster."));
 
   public static final String PRESERVE_STATUS_DEFAULT = "-prbugpct";
   private final String confLabel;

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptionSwitch.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptionSwitch.java
@@ -253,7 +253,7 @@ public enum DistCpOptionSwitch {
 
   FAVORED_NODES(DistCpConstants.CONF_LABEL_FAVORED_NODES,
       new Option("favoredNodes", true,
-          "Specify favored nodes in target cluster."));
+          "Specify favored nodes in target hdfs filesystem."));
 
   public static final String PRESERVE_STATUS_DEFAULT = "-prbugpct";
   private final String confLabel;

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptions.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptions.java
@@ -447,8 +447,9 @@ public final class DistCpOptions {
     DistCpOptionSwitch.addToConf(conf, DistCpOptionSwitch.UPDATE_ROOT,
         String.valueOf(updateRoot));
 
-    DistCpOptionSwitch.addToConf(conf, DistCpOptionSwitch.FAVORED_NODES,
-        String.valueOf(favoredNodes));
+    if (favoredNodes != null) {
+      DistCpOptionSwitch.addToConf(conf, DistCpOptionSwitch.FAVORED_NODES, favoredNodes);
+    }
   }
 
   /**
@@ -831,8 +832,8 @@ public final class DistCpOptions {
       return this;
     }
 
-    public Builder withFavoredNodes(String favoredNodes) {
-      this.favoredNodes = favoredNodes;
+    public Builder withFavoredNodes(String favoredNodesStr) {
+      this.favoredNodes = favoredNodesStr;
       return this;
     }
   }

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptions.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptions.java
@@ -164,6 +164,8 @@ public final class DistCpOptions {
 
   private final boolean updateRoot;
 
+  private final String favoredNodes;
+
   /**
    * File attributes for preserve.
    *
@@ -232,6 +234,8 @@ public final class DistCpOptions {
     this.useIterator = builder.useIterator;
 
     this.updateRoot = builder.updateRoot;
+
+    this.favoredNodes = builder.favoredNodes;
   }
 
   public Path getSourceFileListing() {
@@ -382,6 +386,10 @@ public final class DistCpOptions {
     return updateRoot;
   }
 
+  public String getFavoredNodes() {
+    return favoredNodes;
+  }
+
   /**
    * Add options to configuration. These will be used in the Mapper/committer
    *
@@ -438,6 +446,9 @@ public final class DistCpOptions {
 
     DistCpOptionSwitch.addToConf(conf, DistCpOptionSwitch.UPDATE_ROOT,
         String.valueOf(updateRoot));
+
+    DistCpOptionSwitch.addToConf(conf, DistCpOptionSwitch.FAVORED_NODES,
+        String.valueOf(favoredNodes));
   }
 
   /**
@@ -477,6 +488,7 @@ public final class DistCpOptions {
         ", directWrite=" + directWrite +
         ", useiterator=" + useIterator +
         ", updateRoot=" + updateRoot +
+        ", favoredNodes=" + favoredNodes +
         '}';
   }
 
@@ -531,6 +543,8 @@ public final class DistCpOptions {
     private boolean useIterator = false;
 
     private boolean updateRoot = false;
+
+    private String favoredNodes;
 
     public Builder(List<Path> sourcePaths, Path targetPath) {
       Preconditions.checkArgument(sourcePaths != null && !sourcePaths.isEmpty(),
@@ -814,6 +828,11 @@ public final class DistCpOptions {
 
     public Builder withUpdateRoot(boolean updateRootAttrs) {
       this.updateRoot = updateRootAttrs;
+      return this;
+    }
+
+    public Builder withFavoredNodes(String favoredNodes) {
+      this.favoredNodes = favoredNodes;
       return this;
     }
   }

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptions.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptions.java
@@ -164,6 +164,7 @@ public final class DistCpOptions {
 
   private final boolean updateRoot;
 
+  /** Favored nodes in target hdfs filesystem. */
   private final String favoredNodes;
 
   /**

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/OptionsParser.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/OptionsParser.java
@@ -33,9 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.Path;
 
-import org.apache.hadoop.util.Preconditions;
-
-import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.hadoop.util.Preconditions.checkArgument;
 
 /**
  * The OptionsParser parses out the command-line options passed to DistCp,
@@ -69,7 +67,7 @@ public class OptionsParser {
   }
 
   private static void checkSnapshotsArgs(final String[] snapshots) {
-    Preconditions.checkArgument(snapshots != null && snapshots.length == 2
+    checkArgument(snapshots != null && snapshots.length == 2
         && !StringUtils.isBlank(snapshots[0])
         && !StringUtils.isBlank(snapshots[1]),
         "Must provide both the starting and ending snapshot names");

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/OptionsParser.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/OptionsParser.java
@@ -35,6 +35,8 @@ import org.apache.hadoop.fs.Path;
 
 import org.apache.hadoop.util.Preconditions;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * The OptionsParser parses out the command-line options passed to DistCp,
  * and interprets those specific to DistCp, to create an Options object.
@@ -241,14 +243,14 @@ public class OptionsParser {
 
     if (command.hasOption(DistCpOptionSwitch.FAVORED_NODES.getSwitch())) {
       String favoredNodesStr = getVal(command, DistCpOptionSwitch.FAVORED_NODES.getSwitch().trim());
-      if (StringUtils.isEmpty(favoredNodesStr)) {
-        throw new IllegalArgumentException("favoredNodes is invalid: " + favoredNodesStr);
-      }
+      checkArgument(StringUtils.isNotEmpty(favoredNodesStr),
+          "empty favoredNodes parameter: %s", favoredNodesStr);
+      checkArgument(!favoredNodesStr.endsWith(","),
+          "illegal favoredNodes parameter: %s", favoredNodesStr);
       for (String hostAndPort : favoredNodesStr.split(",")) {
-        if (hostAndPort.split(":").length != 2) {
-          throw new IllegalArgumentException("favoredNodes is invalid: " + favoredNodesStr
-              + ", desired option input format: host1:port1,host2:port2,...");
-        }
+        checkArgument(hostAndPort.split(":").length == 2,
+            "favoredNodes is invalid: %s, " +
+                "desired option input format: host1:port1,host2:port2,...", hostAndPort);
       }
       LOG.info("The value of favoredNodes parameter is [" + favoredNodesStr + "].");
       builder.withFavoredNodes(favoredNodesStr);

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/OptionsParser.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/OptionsParser.java
@@ -239,6 +239,20 @@ public class OptionsParser {
       }
     }
 
+    if (command.hasOption(DistCpOptionSwitch.FAVORED_NODES.getSwitch())) {
+      String favoredNodesStr = getVal(command, DistCpOptionSwitch.FAVORED_NODES.getSwitch().trim());
+      if (StringUtils.isEmpty(favoredNodesStr)) {
+        throw new IllegalArgumentException("favoredNodes is invalid: " + favoredNodesStr);
+      }
+      for (String hostAndPort : favoredNodesStr.split(",")) {
+        if (hostAndPort.split(":").length != 2) {
+          throw new IllegalArgumentException("favoredNodes is invalid: " + favoredNodesStr + ", desired format: ${host}:${port}...");
+        }
+      }
+      LOG.info("The value of favoredNodes parameter is [" + favoredNodesStr + "].");
+      builder.withFavoredNodes(favoredNodesStr);
+    }
+
     return builder.build();
   }
 

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/OptionsParser.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/OptionsParser.java
@@ -246,7 +246,8 @@ public class OptionsParser {
       }
       for (String hostAndPort : favoredNodesStr.split(",")) {
         if (hostAndPort.split(":").length != 2) {
-          throw new IllegalArgumentException("favoredNodes is invalid: " + favoredNodesStr + ", desired format: ${host}:${port}...");
+          throw new IllegalArgumentException("favoredNodes is invalid: " + favoredNodesStr
+              + ", desired option input format: host1:port1,host2:port2,...");
         }
       }
       LOG.info("The value of favoredNodes parameter is [" + favoredNodesStr + "].");

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyMapper.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyMapper.java
@@ -140,6 +140,11 @@ public class CopyMapper extends Mapper<Text, CopyListingFileStatus, Text, Text> 
     } catch (FileNotFoundException ignored) {
     }
 
+    String favoredNodes = conf.get(DistCpOptionSwitch.FAVORED_NODES.getConfigLabel());
+    if (favoredNodes != null) {
+      LOG.info("The value of favoredNodes parameter is [" + favoredNodes + "].");
+    }
+
     startEpoch = System.currentTimeMillis();
   }
 

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/RetriableFileCopyCommand.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/RetriableFileCopyCommand.java
@@ -60,10 +60,10 @@ import org.apache.hadoop.tools.util.ThrottledInputStream;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY;
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY_SEQUENTIAL;
 import static org.apache.hadoop.tools.mapred.CopyMapper.getFileAttributeSettings;
+import static org.apache.hadoop.util.Preconditions.checkArgument;
 import static org.apache.hadoop.util.functional.FutureIO.awaitFuture;
 
 /**

--- a/hadoop-tools/hadoop-distcp/src/site/markdown/DistCp.md.vm
+++ b/hadoop-tools/hadoop-distcp/src/site/markdown/DistCp.md.vm
@@ -364,6 +364,7 @@ Command Line Options
 | `-direct` | Write directly to destination paths | Useful for avoiding potentially very expensive temporary file rename operations when the destination is an object store |
 | `-useiterator` | Uses single threaded listStatusIterator to build listing | Useful for saving memory at the client side. Using this option will ignore the numListstatusThreads option |
 | `-updateRoot` | Update root directory attributes (eg permissions, ownership ...) | Useful if you need to enforce root directory attributes update when using distcp |
+| `-favoredNodes` | Specify favored nodes (Desired option input format: host1:port1,host2:port2,...) | Useful if you need to specify favored nodes when using distcp |
 
 Architecture of DistCp
 ----------------------

--- a/hadoop-tools/hadoop-distcp/src/site/markdown/DistCp.md.vm
+++ b/hadoop-tools/hadoop-distcp/src/site/markdown/DistCp.md.vm
@@ -364,7 +364,7 @@ Command Line Options
 | `-direct` | Write directly to destination paths | Useful for avoiding potentially very expensive temporary file rename operations when the destination is an object store |
 | `-useiterator` | Uses single threaded listStatusIterator to build listing | Useful for saving memory at the client side. Using this option will ignore the numListstatusThreads option |
 | `-updateRoot` | Update root directory attributes (eg permissions, ownership ...) | Useful if you need to enforce root directory attributes update when using distcp |
-| `-favoredNodes` | Specify favored nodes (Desired option input format: host1:port1,host2:port2,...) | Useful if you need to specify favored nodes when using distcp |
+| `-favoredNodes` | Specify favored nodes (Desired option input format: host1:port1,host2:port2,...) | Useful if you need to specify favored nodes in target `hdfs` filesystem when using distcp |
 
 Architecture of DistCp
 ----------------------

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpOptions.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpOptions.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.tools.DistCpOptions.FileAttribute;
 
 import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
 import static org.apache.hadoop.tools.DistCpOptions.MAX_NUM_LISTSTATUS_THREADS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -577,12 +578,14 @@ public class TestDistCpOptions {
 
   @Test
   public void testFavoredNodes() {
+    String favoredNodes = "localhost:50010,localhost:50011";
     final DistCpOptions options = new DistCpOptions.Builder(
         Collections.singletonList(
             new Path("hdfs://localhost:8020/source")),
         new Path("hdfs://localhost:8020/target/"))
-        .withFavoredNodes("localhost:50010")
+        .withFavoredNodes(favoredNodes)
         .build();
-    Assert.assertNotNull(options.getFavoredNodes());
+    assertThat(options.getFavoredNodes()).isNotNull();
+    assertThat(options.getFavoredNodes()).isEqualTo(favoredNodes);
   }
 }

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpOptions.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpOptions.java
@@ -289,7 +289,7 @@ public class TestDistCpOptions {
         "atomicWorkPath=null, logPath=null, sourceFileListing=abc, " +
         "sourcePaths=null, targetPath=xyz, filtersFile='null', " +
         "blocksPerChunk=0, copyBufferSize=8192, verboseLog=false, " +
-        "directWrite=false, useiterator=false, updateRoot=false}";
+        "directWrite=false, useiterator=false, updateRoot=false, favoredNodes=null}";
     String optionString = option.toString();
     Assert.assertEquals(val, optionString);
     Assert.assertNotSame(DistCpOptionSwitch.ATOMIC_COMMIT.toString(),
@@ -573,5 +573,16 @@ public class TestDistCpOptions {
         .withUpdateRoot(true)
         .build();
     Assert.assertTrue(options.shouldUpdateRoot());
+  }
+
+  @Test
+  public void testFavoredNodes() {
+    final DistCpOptions options = new DistCpOptions.Builder(
+        Collections.singletonList(
+            new Path("hdfs://localhost:8020/source")),
+        new Path("hdfs://localhost:8020/target/"))
+        .withFavoredNodes("localhost:50010")
+        .build();
+    Assert.assertNotNull(options.getFavoredNodes());
   }
 }

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSystem.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSystem.java
@@ -615,16 +615,20 @@ public class TestDistCpSystem {
     createFiles(fs, testRoot, srcFiles, -1);
 
     // sad path
-    assertNotEquals(ToolRunner.run(conf, new DistCp(), new String[]{"-favoredNodes", "-i", rootStr, tgtStr}), 0);
-    assertNotEquals(ToolRunner.run(conf, new DistCp(), new String[]{"-favoredNodes", "unknown_host", "-i", rootStr, tgtStr}), 0);
-    assertNotEquals(ToolRunner.run(conf, new DistCp(), new String[]{"-favoredNodes", "unknown_host:10000", "-i", rootStr, tgtStr}), 0);
+    assertNotEquals(ToolRunner.run(conf, new DistCp(),
+        new String[]{"-favoredNodes", "-i", rootStr, tgtStr}), 0);
+    assertNotEquals(ToolRunner.run(conf, new DistCp(),
+        new String[]{"-favoredNodes", "unknown_host", "-i", rootStr, tgtStr}), 0);
+    assertNotEquals(ToolRunner.run(conf, new DistCp(),
+        new String[]{"-favoredNodes", "unknown_host:10000", "-i", rootStr, tgtStr}), 0);
 
     FsShell shell = new FsShell(fs.getConf());
     LOG.info("ls before distcp");
     LOG.info(execCmd(shell, "-lsr", testRoot));
 
     // happy path
-    assertEquals(ToolRunner.run(conf, new DistCp(), new String[]{"-favoredNodes", getFavoredNodes(), "-i", rootStr, tgtStr}), 0);
+    assertEquals(ToolRunner.run(conf, new DistCp(),
+        new String[]{"-favoredNodes", getFavoredNodes(), "-i", rootStr, tgtStr}), 0);
 
     LOG.info("ls after distcp");
     LOG.info(execCmd(shell, "-lsr", testRoot));

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSystem.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSystem.java
@@ -597,7 +597,7 @@ public class TestDistCpSystem {
   }
 
   @Test
-  public void testFavoredNodesOption() throws Exception {
+  public void testFavoredNodes() throws Exception {
     final String testRoot = "/testdir";
     final String testSrc = testRoot + "/" + SRCDAT;
     final String testDst = testRoot + "/" + DSTDAT;
@@ -623,14 +623,14 @@ public class TestDistCpSystem {
     LOG.info("ls before distcp");
     LOG.info(execCmd(shell, "-lsr", testRoot));
 
-    String favoredNodes = getFavoredNode();
-    assertEquals(ToolRunner.run(conf, new DistCp(), new String[]{"-favoredNodes", favoredNodes, "-i", rootStr, tgtStr}), 0);
+    // happy path
+    assertEquals(ToolRunner.run(conf, new DistCp(), new String[]{"-favoredNodes", getFavoredNodes(), "-i", rootStr, tgtStr}), 0);
 
     LOG.info("ls after distcp");
     LOG.info(execCmd(shell, "-lsr", testRoot));
   }
 
-  private String getFavoredNode() {
+  private String getFavoredNodes() {
     DataNode dataNode = cluster.getDataNodes().get(0);
     String hostName = dataNode.ipcServer.getListenerAddress().getHostName();
     int port = dataNode.ipcServer.getListenerAddress().getPort();


### PR DESCRIPTION
### Description of PR
Hadoop DistCp supports specifying favoredNodes for data copying.
Jira: https://issues.apache.org/jira/browse/HADOOP-18629

### How was this patch tested?
Add new UT.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

