### PR TITLE
HDFS-16918. Optionally shut down datanode if it does not stay connected to active namenode

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -2032,5 +2032,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final long DFS_LEASE_HARDLIMIT_DEFAULT =
       HdfsClientConfigKeys.DFS_LEASE_HARDLIMIT_DEFAULT;
 
-
+  public static final String DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT =
+      "dfs.datanode.health.activennconnect.timeout";
+  // disabled by default
+  public static final long DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT_DEFAULT = 0;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/HdfsServerConstants.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/HdfsServerConstants.java
@@ -393,4 +393,29 @@ public interface HdfsServerConstants {
   byte MAX_BLOCKS_IN_GROUP = 16;
   // maximum bandwidth per datanode 1TB/sec.
   long MAX_BANDWIDTH_PER_DATANODE = 1099511627776L;
+
+  enum BPServiceActorAttributes {
+    NAMENODE_ADDRESS("NamenodeAddress"),
+    NAMENODE_HA_STATE("NamenodeHaState"),
+    BLOCK_POOL_ID("BlockPoolID"),
+    BP_ACTOR_STATE("ActorState"),
+    LAST_HEARTBEAT("LastHeartbeat"),
+    LAST_HEARTBEAT_RESPONSE_TIME("LastHeartbeatResponseTime"),
+    LAST_BLOCK_REPORT("LastBlockReport"),
+    MAX_BLOCK_REPORT_SIZE("maxBlockReportSize"),
+    MAX_DATA_LENGTH("maxDataLength"),
+    IS_SLOW_NODE("isSlownode");
+
+    private final String value;
+
+    BPServiceActorAttributes(final String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+  }
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.hdfs.protocol.RollingUpgradeStatus;
 import org.apache.hadoop.hdfs.protocol.UnregisteredNodeException;
 import org.apache.hadoop.hdfs.protocolPB.DatanodeLifelineProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdfs.protocolPB.DatanodeProtocolClientSideTranslatorPB;
+import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.BPServiceActorAttributes;
 import org.apache.hadoop.hdfs.server.common.IncorrectVersionException;
 import org.apache.hadoop.hdfs.server.common.DataNodeLockManager.LockLevel;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
@@ -200,20 +201,27 @@ class BPServiceActor implements Runnable {
   }
 
   Map<String, String> getActorInfoMap() {
-    final Map<String, String> info = new HashMap<String, String>();
-    info.put("NamenodeAddress", getNameNodeAddress());
-    info.put("NamenodeHaState", state != null ? state.toString() : "Unknown");
-    info.put("BlockPoolID", bpos.getBlockPoolId());
-    info.put("ActorState", getRunningState());
-    info.put("LastHeartbeat",
+    final Map<String, String> info = new HashMap<>();
+    info.put(BPServiceActorAttributes.NAMENODE_ADDRESS.toString(),
+        getNameNodeAddress());
+    info.put(BPServiceActorAttributes.NAMENODE_HA_STATE.toString(),
+        state != null ? state.toString() : "Unknown");
+    info.put(BPServiceActorAttributes.BLOCK_POOL_ID.toString(),
+        bpos.getBlockPoolId());
+    info.put(BPServiceActorAttributes.BP_ACTOR_STATE.toString(),
+        getRunningState());
+    info.put(BPServiceActorAttributes.LAST_HEARTBEAT.toString(),
         String.valueOf(getScheduler().getLastHearbeatTime()));
-    info.put("LastHeartbeatResponseTime",
+    info.put(BPServiceActorAttributes.LAST_HEARTBEAT_RESPONSE_TIME.toString(),
         String.valueOf(getScheduler().getLastHeartbeatResponseTime()));
-    info.put("LastBlockReport",
+    info.put(BPServiceActorAttributes.LAST_BLOCK_REPORT.toString(),
         String.valueOf(getScheduler().getLastBlockReportTime()));
-    info.put("maxBlockReportSize", String.valueOf(getMaxBlockReportSize()));
-    info.put("maxDataLength", String.valueOf(maxDataLength));
-    info.put("isSlownode", String.valueOf(isSlownode));
+    info.put(BPServiceActorAttributes.MAX_BLOCK_REPORT_SIZE.toString(),
+        String.valueOf(getMaxBlockReportSize()));
+    info.put(BPServiceActorAttributes.MAX_DATA_LENGTH.toString(),
+        String.valueOf(maxDataLength));
+    info.put(BPServiceActorAttributes.IS_SLOW_NODE.toString(),
+        String.valueOf(isSlownode));
     return info;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeHealthChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeHealthChecker.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.datanode;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.ha.HAServiceProtocol;
+import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.BPServiceActorAttributes;
+import org.apache.hadoop.util.Time;
+
+/**
+ * Datanode health checker. If dfs.datanode.health.activennconnect.timeout is configured with
+ * value in milliseconds > 0, the health checker will periodically ensure that the given datanode
+ * is healthy and stays connected to active namenode. If the datanode cannot stay healthy or
+ * connected to the active namenode for the given time duration, the datanode health checker
+ * would try to shut down the datanode.
+ */
+@InterfaceAudience.Private
+public class DataNodeHealthChecker {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataNodeHealthChecker.class);
+
+  public static final String DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT =
+      "dfs.datanode.health.activennconnect.timeout";
+  // disabled by default
+  private static final long DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT_DEFAULT = 0;
+
+  public static final String DFS_DATANODE_HEATHCHECK_RUN_INTERVAL =
+      "dfs.datanode.heathcheck.run.interval";
+  private static final long DFS_DATANODE_HEATHCHECK_RUN_INTERVAL_DEFAULT = 2000;
+
+  public static final String DFS_DATANODE_HEATHCHECK_RUN_INIT_DELAY =
+      "dfs.datanode.heathcheck.run.init.delay";
+  private static final long DFS_DATANODE_HEATHCHECK_RUN_INIT_DELAY_DEFAULT = 5000;
+
+  private final DataNode dataNode;
+  private ScheduledExecutorService executorService;
+  private final long executorServicePeriod;
+  private final long executorServiceInitDelay;
+  private final long activeNNConnectionTimeoutForHealthyDN;
+
+  public DataNodeHealthChecker(DataNode dataNode) {
+    this.dataNode = dataNode;
+    this.executorService = null;
+    this.executorServicePeriod = this.dataNode.getConf()
+        .getLong(DFS_DATANODE_HEATHCHECK_RUN_INTERVAL,
+            DFS_DATANODE_HEATHCHECK_RUN_INTERVAL_DEFAULT);
+    this.executorServiceInitDelay = this.dataNode.getConf()
+        .getLong(DFS_DATANODE_HEATHCHECK_RUN_INIT_DELAY,
+            DFS_DATANODE_HEATHCHECK_RUN_INIT_DELAY_DEFAULT);
+    this.activeNNConnectionTimeoutForHealthyDN = this.dataNode.getConf()
+        .getLong(DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT,
+            DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT_DEFAULT);
+  }
+
+  public void initiateHealthCheck() {
+    if (this.activeNNConnectionTimeoutForHealthyDN > 0) {
+      this.executorService = Executors.newSingleThreadScheduledExecutor(
+          new ThreadFactoryBuilder().setDaemon(true).setNameFormat("DN-HealthCheck").build());
+      long initCheckTime = Time.monotonicNow();
+      Runnable runnable =
+          new DataNodeHeathCheckThread(this.dataNode, this.activeNNConnectionTimeoutForHealthyDN,
+              initCheckTime);
+      executorService.scheduleWithFixedDelay(runnable, this.executorServiceInitDelay,
+          this.executorServicePeriod, TimeUnit.MILLISECONDS);
+    } else {
+      LOGGER.trace("To terminate the datanode if it does not stay healthy or connected to "
+              + "active namenode for given time duration, provide positive time duration "
+              + "value in millies for config {}", DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT);
+    }
+  }
+
+  public void shutdown() {
+    if (executorService != null) {
+      executorService.shutdown();
+      try {
+        executorService.awaitTermination(5, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        LOGGER.warn("Interrupted while awaiting the datanode health check service termination",
+            e);
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  private static class DataNodeHeathCheckThread implements Runnable {
+
+    private final DataNode dataNode;
+    private final long activeNNConnectionTimeoutForHealthyDN; // value > 0
+    private long initCheckTime;
+    private boolean isErrorLogged = false;
+
+    private DataNodeHeathCheckThread(DataNode dataNode,
+        long activeNNConnectionTimeoutForHealthyDN, long initCheckTime) {
+      this.dataNode = dataNode;
+      this.activeNNConnectionTimeoutForHealthyDN = activeNNConnectionTimeoutForHealthyDN;
+      this.initCheckTime = initCheckTime;
+    }
+
+    @Override
+    public void run() {
+      if (this.dataNode.isDatanodeFullyStarted(true)) {
+        this.initCheckTime = Time.monotonicNow();
+        checkForActiveNamenodeHeartbeatResponse();
+      } else {
+        LOGGER.trace("Datanode {} is not fully started and connected to active namenode yet.",
+            this.dataNode);
+        if ((Time.monotonicNow() - this.initCheckTime)
+            > this.activeNNConnectionTimeoutForHealthyDN) {
+          attemptToShutDownDatanode();
+        }
+      }
+    }
+
+    private void checkForActiveNamenodeHeartbeatResponse() {
+      List<Map<String, String>> bpServiceActorInfoList = dataNode.getBPServiceActorInfoMap();
+      Set<String> blockPoolsConnectedToActiveNN = new HashSet<>();
+      Set<String> allBlockPools = new HashSet<>();
+      for (Map<String, String> bpServiceActorInfo : bpServiceActorInfoList) {
+        String blockPoolId =
+            bpServiceActorInfo.get(BPServiceActorAttributes.BLOCK_POOL_ID.toString());
+        if (blockPoolsConnectedToActiveNN.contains(blockPoolId)) {
+          continue;
+        }
+        String connectedNamenodeStatus =
+            bpServiceActorInfo.get(BPServiceActorAttributes.NAMENODE_HA_STATE.toString());
+        if (!HAServiceProtocol.HAServiceState.ACTIVE.toString().equals(connectedNamenodeStatus)) {
+          continue;
+        }
+        String lastHeartbeatResp = bpServiceActorInfo.get(
+            BPServiceActorAttributes.LAST_HEARTBEAT_RESPONSE_TIME.toString());
+        // last heartbeat response time, convert from seconds to milliseconds
+        long lastHeartbeatResponseTime =
+            TimeUnit.SECONDS.toMillis(Long.parseLong(lastHeartbeatResp));
+
+        // all BPs are added here.
+        allBlockPools.add(blockPoolId);
+        // only if the given BP has heartbeat response from active namenode within the
+        // time duration allowed, add BP in the blockPoolsConnectedToActiveNN set, else
+        // consider it as candidate for datanode shutdown.
+        if (lastHeartbeatResponseTime <= this.activeNNConnectionTimeoutForHealthyDN) {
+          blockPoolsConnectedToActiveNN.add(blockPoolId);
+        } else {
+          LOGGER.info(
+              "For BP id {}, last heartbeat response time: {}, "
+                  + "active namenode connection timeout: {}", blockPoolId,
+              lastHeartbeatResponseTime, activeNNConnectionTimeoutForHealthyDN);
+        }
+      }
+      // if at least one BP offer service is not able to receive heartbeat response from active
+      // namenode within activeNNConnectionTimeoutForHealthyDN ms, terminate the datanode.
+      if (allBlockPools.size() > blockPoolsConnectedToActiveNN.size()) {
+        LOGGER.debug("All BPs: {}, BPs connected to active namenode: {}", allBlockPools,
+            blockPoolsConnectedToActiveNN);
+        attemptToShutDownDatanode();
+      }
+    }
+
+    private void attemptToShutDownDatanode() {
+      if (!isErrorLogged) {
+        LOGGER.error(
+            "Datanode {} has not stayed healthy and connected to active namenode for {}ms. "
+                + "Will attempt to stop the datanode.", this.dataNode,
+            this.activeNNConnectionTimeoutForHealthyDN);
+        // just in case the scheduler makes multiple attempts to shut down datanode, it will
+        // not cause any issues in the datanode shut down, however we can avoid logging
+        // the same error log for multiple attempts made by the multiple scheduler runs.
+        isErrorLogged = true;
+      }
+      try {
+        // this shuts down datanode asynchronously
+        this.dataNode.shutdownDatanode(false);
+      } catch (IOException e) {
+        if (!DataNode.SHUTDOWN_ALREADY_IN_PROGRESS.equals(e.getMessage())) {
+          LOGGER.error("Error while calling datanode shutdown.", e);
+        }
+      }
+    }
+  }
+
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeHealthChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeHealthChecker.java
@@ -90,7 +90,8 @@ public class DataNodeHealthChecker {
     } else {
       LOGGER.trace("To terminate the datanode if it does not stay healthy or connected to "
               + "active namenode for given time duration, provide positive time duration "
-              + "value in millies for config {}", DFSConfigKeys.DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT);
+              + "value in millies for config {}",
+          DFSConfigKeys.DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeHealthChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeHealthChecker.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.ha.HAServiceProtocol;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.BPServiceActorAttributes;
 import org.apache.hadoop.util.Time;
 
@@ -47,11 +48,6 @@ import org.apache.hadoop.util.Time;
 public class DataNodeHealthChecker {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DataNodeHealthChecker.class);
-
-  public static final String DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT =
-      "dfs.datanode.health.activennconnect.timeout";
-  // disabled by default
-  private static final long DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT_DEFAULT = 0;
 
   public static final String DFS_DATANODE_HEATHCHECK_RUN_INTERVAL =
       "dfs.datanode.heathcheck.run.interval";
@@ -77,8 +73,8 @@ public class DataNodeHealthChecker {
         .getLong(DFS_DATANODE_HEATHCHECK_RUN_INIT_DELAY,
             DFS_DATANODE_HEATHCHECK_RUN_INIT_DELAY_DEFAULT);
     this.activeNNConnectionTimeoutForHealthyDN = this.dataNode.getConf()
-        .getLong(DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT,
-            DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT_DEFAULT);
+        .getLong(DFSConfigKeys.DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT,
+            DFSConfigKeys.DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT_DEFAULT);
   }
 
   public void initiateHealthCheck() {
@@ -94,7 +90,7 @@ public class DataNodeHealthChecker {
     } else {
       LOGGER.trace("To terminate the datanode if it does not stay healthy or connected to "
               + "active namenode for given time duration, provide positive time duration "
-              + "value in millies for config {}", DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT);
+              + "value in millies for config {}", DFSConfigKeys.DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT);
     }
   }
 
@@ -111,7 +107,7 @@ public class DataNodeHealthChecker {
     }
   }
 
-  private static class DataNodeHeathCheckThread implements Runnable {
+  private static final class DataNodeHeathCheckThread implements Runnable {
 
     private final DataNode dataNode;
     private final long activeNNConnectionTimeoutForHealthyDN; // value > 0

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6472,4 +6472,15 @@
       Enables observer reads for clients. This should only be enabled when clients are using routers.
     </description>
   </property>
+  <property>
+    <name>dfs.datanode.health.activennconnect.timeout</name>
+    <value>0</value>
+    <description>
+      If the value is greater than 0, each datanode would try to determine if it is healthy i.e.
+      all block pools are correctly initialized and able to heartbeat to active namenode. At any
+      given time, if the datanode looses connection to active namenode for the duration of
+      milliseconds represented by the value of this config, it will attempt to shut down itself.
+      If the value is 0, datanode would not perform any such checks.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMXBean.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.protocol.datatransfer.sasl.SaslDataTransferTestCase;
+import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.BPServiceActorAttributes;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
@@ -315,10 +316,11 @@ public class TestDataNodeMXBean extends SaslDataTransferTestCase {
       cluster.waitDatanodeConnectedToActive(datanode, 5000);
 
       // Verify that last heartbeat sent to both namenodes in last 5 sec.
-      assertLastHeartbeatSentTime(datanode, "LastHeartbeat");
+      assertLastHeartbeatSentTime(datanode, BPServiceActorAttributes.LAST_HEARTBEAT.toString());
       // Verify that last heartbeat response from both namenodes have been received within
       // last 5 sec.
-      assertLastHeartbeatSentTime(datanode, "LastHeartbeatResponseTime");
+      assertLastHeartbeatSentTime(datanode,
+          BPServiceActorAttributes.LAST_HEARTBEAT_RESPONSE_TIME.toString());
 
 
       NameNode sbNameNode = cluster.getNameNode(1);
@@ -334,9 +336,11 @@ public class TestDataNodeMXBean extends SaslDataTransferTestCase {
         Map<String, String> bpServiceActorInfo2 = bpServiceActorInfo.get(1);
 
         long lastHeartbeatResponseTime1 =
-            Long.parseLong(bpServiceActorInfo1.get("LastHeartbeatResponseTime"));
+            Long.parseLong(bpServiceActorInfo1.get(
+                BPServiceActorAttributes.LAST_HEARTBEAT_RESPONSE_TIME.toString()));
         long lastHeartbeatResponseTime2 =
-            Long.parseLong(bpServiceActorInfo2.get("LastHeartbeatResponseTime"));
+            Long.parseLong(bpServiceActorInfo2.get(
+                BPServiceActorAttributes.LAST_HEARTBEAT_RESPONSE_TIME.toString()));
 
         LOG.info("Last heartbeat response from namenode 1: {}", lastHeartbeatResponseTime1);
         LOG.info("Last heartbeat response from namenode 2: {}", lastHeartbeatResponseTime2);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeHealthChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeHealthChecker.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.datanode;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.MiniDFSNNTopology;
+import org.apache.hadoop.hdfs.server.namenode.NameNode;
+import org.apache.hadoop.test.GenericTestUtils;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests to validate the datanode behaviour when it is either not healthy or does not
+ * stay connected to active namenode for long time.
+ */
+public class TestDatanodeHealthChecker {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestDatanodeHealthChecker.class);
+
+  @Test
+  public void testDatanodeShutdownWhenActiveNNDown() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    // if datanode cannot receive heartbeat response from active namenode in 3s,
+    // datanodehealthchecker would terminate it.
+    conf.setLong(DataNodeHealthChecker.DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT, 3000);
+    conf.setLong(DataNodeHealthChecker.DFS_DATANODE_HEATHCHECK_RUN_INTERVAL, 1000);
+
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3)
+        .build()) {
+
+      cluster.waitActive();
+
+      NameNode nameNode = cluster.getNameNode();
+      List<DataNode> dataNodes = cluster.getDataNodes();
+
+      cluster.waitDatanodeConnectedToActive(dataNodes.get(0), 2000);
+      cluster.waitDatanodeConnectedToActive(dataNodes.get(1), 2000);
+      cluster.waitDatanodeConnectedToActive(dataNodes.get(2), 2000);
+
+      LOGGER.info("The cluster is up. Namenode state: {}, Num of datanodes: {}",
+          nameNode.getState(), dataNodes.size());
+
+      Thread.sleep(5000);
+
+      assertTrue(dataNodes.get(0).shouldRun());
+      assertTrue(dataNodes.get(1).shouldRun());
+      assertTrue(dataNodes.get(2).shouldRun());
+
+      LOGGER.info("Shutting down namenode");
+
+      nameNode.stop();
+      nameNode.join();
+
+      // in some time, all datanodes should be shutdown
+      GenericTestUtils.waitFor(() -> !dataNodes.get(0).shouldRun(), 100, 7000,
+          "Datanode should not be running after loosing connection to active namenode. "
+              + "Waited 7000 ms for datanode to be shutdown");
+      GenericTestUtils.waitFor(() -> !dataNodes.get(1).shouldRun(), 100, 7000,
+          "Datanode should not be running after loosing connection to active namenode. "
+              + "Waited 7000 ms for datanode to be shutdown");
+      GenericTestUtils.waitFor(() -> !dataNodes.get(2).shouldRun(), 100, 7000,
+          "Datanode should not be running after loosing connection to active namenode. "
+              + "Waited 7000 ms for datanode to be shutdown");
+    }
+  }
+
+  @Test
+  public void testDatanodeShutdownWithMultipleNNs() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    // if datanode cannot receive heartbeat response from active namenode in 3s,
+    // datanodehealthchecker would terminate it.
+    conf.setLong(DataNodeHealthChecker.DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT, 3000);
+    conf.setLong(DataNodeHealthChecker.DFS_DATANODE_HEATHCHECK_RUN_INTERVAL, 1000);
+    conf.setLong(DataNodeHealthChecker.DFS_DATANODE_HEATHCHECK_RUN_INIT_DELAY, 7000);
+
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .nnTopology(MiniDFSNNTopology.simpleHATopology(2)).numDataNodes(2)
+        .build()) {
+      cluster.waitActive();
+      cluster.transitionToActive(0);
+      cluster.transitionToStandby(1);
+
+      NameNode activeNamenode = cluster.getNameNode(0);
+      NameNode standbyNamenode = cluster.getNameNode(1);
+      List<DataNode> dataNodes = cluster.getDataNodes();
+
+      cluster.waitDatanodeConnectedToActive(dataNodes.get(0), 5000);
+      cluster.waitDatanodeConnectedToActive(dataNodes.get(1), 5000);
+
+      LOGGER.info("The cluster is up. Namenode state: {}, Num of datanodes: {}",
+          activeNamenode.getState(), dataNodes.size());
+
+      Thread.sleep(5000);
+
+      assertTrue(dataNodes.get(0).shouldRun());
+      assertTrue(dataNodes.get(1).shouldRun());
+
+      LOGGER.info("Shutting down namenode");
+
+      activeNamenode.stop();
+      activeNamenode.join();
+      standbyNamenode.stop();
+      standbyNamenode.join();
+
+      // in some time, all datanodes should be shutdown
+      GenericTestUtils.waitFor(() -> !dataNodes.get(0).shouldRun(), 100, 7000,
+          "Datanode should not be running after loosing connection to active namenode. "
+              + "Waited 7000 ms for datanode to be shutdown");
+      GenericTestUtils.waitFor(() -> !dataNodes.get(1).shouldRun(), 100, 7000,
+          "Datanode should not be running after loosing connection to active namenode. "
+              + "Waited 7000 ms for datanode to be shutdown");
+    }
+  }
+
+  @Test
+  public void testDatanodeHealthyWhenActiveNNIsDown() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3)
+        .build()) {
+
+      cluster.waitActive();
+
+      NameNode nameNode = cluster.getNameNode();
+      List<DataNode> dataNodes = cluster.getDataNodes();
+
+      cluster.waitDatanodeConnectedToActive(dataNodes.get(0), 2000);
+      cluster.waitDatanodeConnectedToActive(dataNodes.get(1), 2000);
+      cluster.waitDatanodeConnectedToActive(dataNodes.get(2), 2000);
+
+      LOGGER.info("The cluster is up. Namenode state: {}, Num of datanodes: {}",
+          nameNode.getState(), dataNodes.size());
+
+      assertTrue(dataNodes.get(0).shouldRun());
+      assertTrue(dataNodes.get(1).shouldRun());
+      assertTrue(dataNodes.get(2).shouldRun());
+
+      nameNode.stop();
+      nameNode.join();
+
+      Thread.sleep(5000);
+
+      // health of the datanodes is not affected after loosing connection to active namenode
+      assertTrue(dataNodes.get(0).shouldRun());
+      assertTrue(dataNodes.get(1).shouldRun());
+      assertTrue(dataNodes.get(2).shouldRun());
+    }
+  }
+
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeHealthChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeHealthChecker.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
@@ -46,7 +47,7 @@ public class TestDatanodeHealthChecker {
     Configuration conf = new HdfsConfiguration();
     // if datanode cannot receive heartbeat response from active namenode in 3s,
     // datanodehealthchecker would terminate it.
-    conf.setLong(DataNodeHealthChecker.DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT, 3000);
+    conf.setLong(DFSConfigKeys.DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT, 3000);
     conf.setLong(DataNodeHealthChecker.DFS_DATANODE_HEATHCHECK_RUN_INTERVAL, 1000);
 
     try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3)
@@ -93,7 +94,7 @@ public class TestDatanodeHealthChecker {
     Configuration conf = new HdfsConfiguration();
     // if datanode cannot receive heartbeat response from active namenode in 3s,
     // datanodehealthchecker would terminate it.
-    conf.setLong(DataNodeHealthChecker.DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT, 3000);
+    conf.setLong(DFSConfigKeys.DFS_DATANODE_HEALTH_ACTIVENNCONNECT_TIMEOUT, 3000);
     conf.setLong(DataNodeHealthChecker.DFS_DATANODE_HEATHCHECK_RUN_INTERVAL, 1000);
     conf.setLong(DataNodeHealthChecker.DFS_DATANODE_HEATHCHECK_RUN_INIT_DELAY, 7000);
 


### PR DESCRIPTION
While deploying Hdfs on Envoy proxy setup, depending on the socket timeout configured at envoy, the network connection issues or packet loss could be observed. All of envoys basically form a transparent communication mesh in which each app can send and receive packets to and from localhost and is unaware of the network topology.

The primary purpose of Envoy is to make the network transparent to applications, in order to identify network issues reliably. However, sometimes such proxy based setup could result into socket connection issues b/ datanode and namenode.

Many deployment frameworks provide auto-start functionality when any of the hadoop daemons are stopped. If a given datanode does not stay connected to active namenode in the cluster i.e. does not receive heartbeat response in time from active namenode (even though active namenode is not terminated), it would not be much useful. We should be able to provide configurable behavior such that if a given datanode cannot receive heartbeat response from active namenode in configurable time duration, it should terminate itself to avoid impacting the availability SLA. This is specifically helpful when the underlying deployment or observability framework (e.g. K8S) can start up the datanode automatically upon it's shutdown (unless it is being restarted as part of rolling upgrade) and help the newly brought up datanode (in case of k8s, a new pod with dynamically changing nodes) establish new socket connection to active and standby namenodes. This should be an opt-in behavior and not default one.

In a distributed system, it is essential to have robust fail-fast mechanisms in place to prevent issues related to network partitioning. The system must be designed to prevent further degradation of availability and consistency in the event of a network partition. Several distributed systems offer fail-safe approaches, and for some, partition tolerance is critical to the extent that even a few seconds of heartbeat loss can trigger the removal of an application server instance from the cluster. For instance, a majority of zooKeeper clients utilize the ephemeral nodes for this purpose to make system reliable, fault-tolerant and strongly consistent in the event of network partition.

From the hdfs architecture viewpoint, it is crucial to understand the critical role that active and observer namenode play in file system operations. In a large-scale cluster, if the datanodes holding the same block (primary and replicas) lose connection to both active and observer namenodes for a significant amount of time, delaying the process of shutting down such datanodes and restarting it to re-establish the connection with the namenodes (assuming the active namenode is alive, assumption is important in the even of network partition to reestablish the connection) will further deteriorate the availability of the service. This scenario underscores the importance of resolving network partitioning.

This is a real use case for hdfs and it is not prudent to assume that every deployment or cluster management application must be able to restart datanodes based on JMX metrics, as this would introduce another application to resolve the network partition impact of hdfs. Besides, popular cluster management applications are not typically used in all cloud-native env. Even if these cluster management applications are deployed, certain security constraints may restrict their access to JMX metrics and prevent them from interfering with hdfs operations. The applications that can only trigger alerts for users based on set parameters (for instance, missing blocks > 0) are allowed to access JMX metrics.