### PR TITLE
HDFS-16917 Add transfer rate quantile metrics for DataNode reads

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
@@ -370,7 +370,9 @@ Each metrics record contains tags such as SessionId and Hostname as additional i
 |:---- |:---- |
 | `BytesWritten` | Total number of bytes written to DataNode |
 | `BytesRead` | Total number of bytes read from DataNode |
-| `BytesReadTransferRate`*num*`s(50/75/90/95/99)thPercentileRate` | The 50/75/90/95/99th percentile of the transfer rate of bytes read from the DataNode. The transfer rate is measured in megabytes per second. |
+| `ReadTransferRateMBsNumOps` | Total number of data read transfers |
+| `ReadTransferRateMBsAvgTime` | Average transfer rate of bytes read from DataNode. |
+| `ReadTransferRateMBs`*num*`s(50/75/90/95/99)thPercentileRate` | The 50/75/90/95/99th percentile of the transfer rate of bytes read from DataNode, measured in megabytes per second. |
 | `BlocksWritten` | Total number of blocks written to DataNode |
 | `BlocksRead` | Total number of blocks read from DataNode |
 | `BlocksReplicated` | Total number of blocks replicated |

--- a/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
@@ -370,6 +370,7 @@ Each metrics record contains tags such as SessionId and Hostname as additional i
 |:---- |:---- |
 | `BytesWritten` | Total number of bytes written to DataNode |
 | `BytesRead` | Total number of bytes read from DataNode |
+| `BytesReadTransferRate`*num*`s(50/75/90/95/99)thPercentileRate` | The 50/75/90/95/99th percentile of the transfer rate of bytes read from the DataNode. The transfer rate is measured in megabytes per second. |
 | `BlocksWritten` | Total number of blocks written to DataNode |
 | `BlocksRead` | Total number of blocks read from DataNode |
 | `BlocksReplicated` | Total number of blocks replicated |

--- a/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
@@ -370,9 +370,9 @@ Each metrics record contains tags such as SessionId and Hostname as additional i
 |:---- |:---- |
 | `BytesWritten` | Total number of bytes written to DataNode |
 | `BytesRead` | Total number of bytes read from DataNode |
-| `ReadTransferRateMBsNumOps` | Total number of data read transfers |
-| `ReadTransferRateMBsAvgTime` | Average transfer rate of bytes read from DataNode. |
-| `ReadTransferRateMBs`*num*`s(50/75/90/95/99)thPercentileRate` | The 50/75/90/95/99th percentile of the transfer rate of bytes read from DataNode, measured in megabytes per second. |
+| `ReadTransferRateNumOps` | Total number of data read transfers |
+| `ReadTransferRateAvgTime` | Average transfer rate of bytes read from DataNode, measured in bytes per second. |
+| `ReadTransferRate`*num*`s(50/75/90/95/99)thPercentileRate` | The 50/75/90/95/99th percentile of the transfer rate of bytes read from DataNode, measured in bytes per second. |
 | `BlocksWritten` | Total number of blocks written to DataNode |
 | `BlocksRead` | Total number of blocks read from DataNode |
 | `BlocksReplicated` | Total number of blocks replicated |

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
@@ -69,6 +69,7 @@ import org.apache.commons.cli.PosixParser;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.ParentNotDirectoryException;
 import org.apache.hadoop.fs.UnresolvedLinkException;
+import org.apache.hadoop.hdfs.server.datanode.metrics.DataNodeMetrics;
 import org.apache.hadoop.hdfs.server.namenode.FSDirectory;
 import org.apache.hadoop.hdfs.server.namenode.INodesInPath;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
@@ -1935,5 +1936,19 @@ public class DFSUtil {
 
     return path.charAt(parent.length()) == Path.SEPARATOR_CHAR
         || parent.equals(Path.SEPARATOR);
+  }
+
+  /**
+   * Add transfer rate metrics for valid data read and duration values.
+   * @param metrics metrics for datanodes
+   * @param read bytes read
+   * @param duration read duration
+   */
+  public static void addTransferRateMetric(final DataNodeMetrics metrics, final long read, final long duration) {
+    if (read >= 0 && duration > 0) {
+        metrics.addReadTransferRate(read * 1000 / duration);
+    } else {
+      LOG.warn("Unexpected value for data transfer bytes={} duration={}", read, duration);
+    }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
@@ -1938,18 +1938,18 @@ public class DFSUtil {
   }
 
   /**
-   * Calculate the transfer rate in megabytes/second. Return -1 for any negative input.
+   * Calculate the transfer rate in bytes/second. Return -1 for any negative input.
    * @param bytes bytes
    * @param durationMS duration in milliseconds
-   * @return the number of megabytes/second of the transfer rate
+   * @return the number of bytes/second of the transfer rate
   */
-  public static long transferRateMBs(long bytes, long durationMS) {
+  public static long transferRateBytesPerSecond(long bytes, long durationMS) {
     if (bytes < 0 || durationMS < 0) {
       return -1;
     }
     if (durationMS == 0) {
       durationMS = 1;
     }
-    return bytes / (1024 * 1024) * 1000 / durationMS;
+    return bytes * 1000 / durationMS;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
@@ -1936,4 +1936,17 @@ public class DFSUtil {
     return path.charAt(parent.length()) == Path.SEPARATOR_CHAR
         || parent.equals(Path.SEPARATOR);
   }
+
+  /**
+   * Calculate the transfer rate in megabytes/second.
+   * @param bytes bytes
+   * @param durationMS duration in milliseconds
+   * @return the number of megabytes/second of the transfer rate
+  */
+  public static long transferRateMBs(long bytes, long durationMS) {
+    if (durationMS == 0) {
+      durationMS = 1;
+    }
+    return bytes / (1024 * 1024) * 1000 / durationMS;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
@@ -1936,20 +1936,4 @@ public class DFSUtil {
     return path.charAt(parent.length()) == Path.SEPARATOR_CHAR
         || parent.equals(Path.SEPARATOR);
   }
-
-  /**
-   * Calculate the transfer rate in bytes/second. Return -1 for any negative input.
-   * @param bytes bytes
-   * @param durationMS duration in milliseconds
-   * @return the number of bytes/second of the transfer rate
-  */
-  public static long transferRateBytesPerSecond(long bytes, long durationMS) {
-    if (bytes < 0 || durationMS < 0) {
-      return -1;
-    }
-    if (durationMS == 0) {
-      durationMS = 1;
-    }
-    return bytes * 1000 / durationMS;
-  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
@@ -1938,12 +1938,15 @@ public class DFSUtil {
   }
 
   /**
-   * Calculate the transfer rate in megabytes/second.
+   * Calculate the transfer rate in megabytes/second. Return -1 for any negative input.
    * @param bytes bytes
    * @param durationMS duration in milliseconds
    * @return the number of megabytes/second of the transfer rate
   */
   public static long transferRateMBs(long bytes, long durationMS) {
+    if (bytes < 0 || durationMS < 0) {
+      return -1;
+    }
     if (durationMS == 0) {
       durationMS = 1;
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs.server.datanode;
 
 import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.protobuf.ByteString;
 import javax.crypto.SecretKey;
@@ -632,6 +633,7 @@ class DataXceiver extends Receiver implements Runnable {
       datanode.metrics.incrBytesRead((int) read);
       datanode.metrics.incrBlocksRead();
       datanode.metrics.incrTotalReadTime(duration);
+      datanode.metrics.addBytesReadTransferRate(DFSUtil.transferRateMBs(read, duration));
     } catch ( SocketException ignored ) {
       LOG.trace("{}:Ignoring exception while serving {} to {}",
           dnR, block, remoteAddress, ignored);
@@ -1122,6 +1124,7 @@ class DataXceiver extends Receiver implements Runnable {
       datanode.metrics.incrBytesRead((int) read);
       datanode.metrics.incrBlocksRead();
       datanode.metrics.incrTotalReadTime(duration);
+      datanode.metrics.addBytesReadTransferRate(DFSUtil.transferRateMBs(read, duration));
       
       LOG.info("Copied {} to {}", block, peer.getRemoteAddressString());
     } catch (IOException ioe) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdfs.server.datanode;
 
 import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.protobuf.ByteString;
 import javax.crypto.SecretKey;
@@ -633,7 +632,11 @@ class DataXceiver extends Receiver implements Runnable {
       datanode.metrics.incrBytesRead((int) read);
       datanode.metrics.incrBlocksRead();
       datanode.metrics.incrTotalReadTime(duration);
-      datanode.metrics.addReadTransferRate(DFSUtil.transferRateBytesPerSecond(read, duration));
+      if (read < 0 || duration <= 0) {
+        LOG.warn("Unexpected value for data transfer bytes={} duration={}", read, duration);
+      } else {
+        datanode.metrics.addReadTransferRate(read * 1000 / duration);  
+      }
     } catch ( SocketException ignored ) {
       LOG.trace("{}:Ignoring exception while serving {} to {}",
           dnR, block, remoteAddress, ignored);
@@ -1124,7 +1127,11 @@ class DataXceiver extends Receiver implements Runnable {
       datanode.metrics.incrBytesRead((int) read);
       datanode.metrics.incrBlocksRead();
       datanode.metrics.incrTotalReadTime(duration);
-      datanode.metrics.addReadTransferRate(DFSUtil.transferRateBytesPerSecond(read, duration));
+      if (read < 0 || duration <= 0) {
+        LOG.warn("Unexpected value for data transfer bytes={} duration={}", read, duration);
+      } else {
+        datanode.metrics.addReadTransferRate(read * 1000 / duration);  
+      }
       
       LOG.info("Copied {} to {}", block, peer.getRemoteAddressString());
     } catch (IOException ioe) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
@@ -635,7 +635,7 @@ class DataXceiver extends Receiver implements Runnable {
       if (read < 0 || duration <= 0) {
         LOG.warn("Unexpected value for data transfer bytes={} duration={}", read, duration);
       } else {
-        datanode.metrics.addReadTransferRate(read * 1000 / duration);  
+        datanode.metrics.addReadTransferRate(read * 1000 / duration);
       }
     } catch ( SocketException ignored ) {
       LOG.trace("{}:Ignoring exception while serving {} to {}",
@@ -1130,7 +1130,7 @@ class DataXceiver extends Receiver implements Runnable {
       if (read < 0 || duration <= 0) {
         LOG.warn("Unexpected value for data transfer bytes={} duration={}", read, duration);
       } else {
-        datanode.metrics.addReadTransferRate(read * 1000 / duration);  
+        datanode.metrics.addReadTransferRate(read * 1000 / duration);
       }
       
       LOG.info("Copied {} to {}", block, peer.getRemoteAddressString());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs.server.datanode;
 
 import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.protobuf.ByteString;
 import javax.crypto.SecretKey;
@@ -632,11 +633,7 @@ class DataXceiver extends Receiver implements Runnable {
       datanode.metrics.incrBytesRead((int) read);
       datanode.metrics.incrBlocksRead();
       datanode.metrics.incrTotalReadTime(duration);
-      if (read < 0 || duration <= 0) {
-        LOG.warn("Unexpected value for data transfer bytes={} duration={}", read, duration);
-      } else {
-        datanode.metrics.addReadTransferRate(read * 1000 / duration);
-      }
+      DFSUtil.addTransferRateMetric(datanode.metrics, read, duration);
     } catch ( SocketException ignored ) {
       LOG.trace("{}:Ignoring exception while serving {} to {}",
           dnR, block, remoteAddress, ignored);
@@ -1127,11 +1124,7 @@ class DataXceiver extends Receiver implements Runnable {
       datanode.metrics.incrBytesRead((int) read);
       datanode.metrics.incrBlocksRead();
       datanode.metrics.incrTotalReadTime(duration);
-      if (read < 0 || duration <= 0) {
-        LOG.warn("Unexpected value for data transfer bytes={} duration={}", read, duration);
-      } else {
-        datanode.metrics.addReadTransferRate(read * 1000 / duration);
-      }
+      DFSUtil.addTransferRateMetric(datanode.metrics, read, duration);
       
       LOG.info("Copied {} to {}", block, peer.getRemoteAddressString());
     } catch (IOException ioe) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
@@ -633,7 +633,7 @@ class DataXceiver extends Receiver implements Runnable {
       datanode.metrics.incrBytesRead((int) read);
       datanode.metrics.incrBlocksRead();
       datanode.metrics.incrTotalReadTime(duration);
-      datanode.metrics.addReadTransferRateMBs(DFSUtil.transferRateMBs(read, duration));
+      datanode.metrics.addReadTransferRate(DFSUtil.transferRateBytesPerSecond(read, duration));
     } catch ( SocketException ignored ) {
       LOG.trace("{}:Ignoring exception while serving {} to {}",
           dnR, block, remoteAddress, ignored);
@@ -1124,7 +1124,7 @@ class DataXceiver extends Receiver implements Runnable {
       datanode.metrics.incrBytesRead((int) read);
       datanode.metrics.incrBlocksRead();
       datanode.metrics.incrTotalReadTime(duration);
-      datanode.metrics.addReadTransferRateMBs(DFSUtil.transferRateMBs(read, duration));
+      datanode.metrics.addReadTransferRate(DFSUtil.transferRateBytesPerSecond(read, duration));
       
       LOG.info("Copied {} to {}", block, peer.getRemoteAddressString());
     } catch (IOException ioe) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
@@ -633,7 +633,7 @@ class DataXceiver extends Receiver implements Runnable {
       datanode.metrics.incrBytesRead((int) read);
       datanode.metrics.incrBlocksRead();
       datanode.metrics.incrTotalReadTime(duration);
-      datanode.metrics.addBytesReadTransferRate(DFSUtil.transferRateMBs(read, duration));
+      datanode.metrics.addReadTransferRateMBs(DFSUtil.transferRateMBs(read, duration));
     } catch ( SocketException ignored ) {
       LOG.trace("{}:Ignoring exception while serving {} to {}",
           dnR, block, remoteAddress, ignored);
@@ -1124,7 +1124,7 @@ class DataXceiver extends Receiver implements Runnable {
       datanode.metrics.incrBytesRead((int) read);
       datanode.metrics.incrBlocksRead();
       datanode.metrics.incrTotalReadTime(duration);
-      datanode.metrics.addBytesReadTransferRate(DFSUtil.transferRateMBs(read, duration));
+      datanode.metrics.addReadTransferRateMBs(DFSUtil.transferRateMBs(read, duration));
       
       LOG.info("Copied {} to {}", block, peer.getRemoteAddressString());
     } catch (IOException ioe) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
@@ -61,8 +61,8 @@ public class DataNodeMetrics {
   @Metric MutableCounterLong bytesRead;
   @Metric("Milliseconds spent reading")
   MutableCounterLong totalReadTime;
-  @Metric MutableRate bytesReadTransferRate;
-  final MutableQuantiles[] bytesReadTransferRateQuantiles;
+  @Metric private MutableRate readTransferRateMBs;
+  final private MutableQuantiles[] readTransferRateMBsQuantiles;
   @Metric MutableCounterLong blocksWritten;
   @Metric MutableCounterLong blocksRead;
   @Metric MutableCounterLong blocksReplicated;
@@ -229,7 +229,7 @@ public class DataNodeMetrics {
     sendDataPacketTransferNanosQuantiles = new MutableQuantiles[len];
     ramDiskBlocksEvictionWindowMsQuantiles = new MutableQuantiles[len];
     ramDiskBlocksLazyPersistWindowMsQuantiles = new MutableQuantiles[len];
-    bytesReadTransferRateQuantiles = new MutableQuantiles[len];
+    readTransferRateMBsQuantiles = new MutableQuantiles[len];
 
     for (int i = 0; i < len; i++) {
       int interval = intervals[i];
@@ -258,8 +258,8 @@ public class DataNodeMetrics {
           "ramDiskBlocksLazyPersistWindows" + interval + "s",
           "Time between the RamDisk block write and disk persist in ms",
           "ops", "latency", interval);
-      bytesReadTransferRateQuantiles[i] = registry.newQuantiles(
-          "bytesReadTransferRate" + interval + "s",
+      readTransferRateMBsQuantiles[i] = registry.newQuantiles(
+          "readTransferRateMBs" + interval + "s",
           "Rate at which bytes are read from datanode calculated in megabytes per second",
           "ops", "rate", interval);
     }
@@ -323,9 +323,9 @@ public class DataNodeMetrics {
     }
   }
 
-  public void addBytesReadTransferRate(long transferRateMBs) {
-    bytesReadTransferRate.add(transferRateMBs);
-    for (MutableQuantiles q : bytesReadTransferRateQuantiles) {
+  public void addReadTransferRateMBs(long transferRateMBs) {
+    readTransferRateMBs.add(transferRateMBs);
+    for (MutableQuantiles q : readTransferRateMBsQuantiles) {
       q.add(transferRateMBs);
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
@@ -61,8 +61,8 @@ public class DataNodeMetrics {
   @Metric MutableCounterLong bytesRead;
   @Metric("Milliseconds spent reading")
   MutableCounterLong totalReadTime;
-  @Metric private MutableRate readTransferRateMBs;
-  final private MutableQuantiles[] readTransferRateMBsQuantiles;
+  @Metric private MutableRate readTransferRate;
+  final private MutableQuantiles[] readTransferRateQuantiles;
   @Metric MutableCounterLong blocksWritten;
   @Metric MutableCounterLong blocksRead;
   @Metric MutableCounterLong blocksReplicated;
@@ -229,7 +229,7 @@ public class DataNodeMetrics {
     sendDataPacketTransferNanosQuantiles = new MutableQuantiles[len];
     ramDiskBlocksEvictionWindowMsQuantiles = new MutableQuantiles[len];
     ramDiskBlocksLazyPersistWindowMsQuantiles = new MutableQuantiles[len];
-    readTransferRateMBsQuantiles = new MutableQuantiles[len];
+    readTransferRateQuantiles = new MutableQuantiles[len];
 
     for (int i = 0; i < len; i++) {
       int interval = intervals[i];
@@ -258,9 +258,9 @@ public class DataNodeMetrics {
           "ramDiskBlocksLazyPersistWindows" + interval + "s",
           "Time between the RamDisk block write and disk persist in ms",
           "ops", "latency", interval);
-      readTransferRateMBsQuantiles[i] = registry.newQuantiles(
-          "readTransferRateMBs" + interval + "s",
-          "Rate at which bytes are read from datanode calculated in megabytes per second",
+      readTransferRateQuantiles[i] = registry.newQuantiles(
+          "readTransferRate" + interval + "s",
+          "Rate at which bytes are read from datanode calculated in bytes per second",
           "ops", "rate", interval);
     }
   }
@@ -323,10 +323,10 @@ public class DataNodeMetrics {
     }
   }
 
-  public void addReadTransferRateMBs(long transferRateMBs) {
-    readTransferRateMBs.add(transferRateMBs);
-    for (MutableQuantiles q : readTransferRateMBsQuantiles) {
-      q.add(transferRateMBs);
+  public void addReadTransferRate(long readTransferRate) {
+    this.readTransferRate.add(readTransferRate);
+    for (MutableQuantiles q : readTransferRateQuantiles) {
+      q.add(readTransferRate);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -71,6 +72,7 @@ import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
+import org.apache.hadoop.hdfs.server.datanode.metrics.DataNodeMetrics;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider;
 import org.apache.hadoop.http.HttpConfig;
@@ -1107,5 +1109,19 @@ public class TestDFSUtil {
             + " is not configured.";
     LambdaTestUtils.intercept(IOException.class, expectedErrorMessage,
         ()->DFSUtil.getNNServiceRpcAddressesForCluster(conf));
+  }
+
+  @Test
+  public void testAddTransferRateMetricForValidValues() {
+    DataNodeMetrics mockMetrics = mock(DataNodeMetrics.class);
+    DFSUtil.addTransferRateMetric(mockMetrics, 100, 10);
+    verify(mockMetrics).addReadTransferRate(10000);
+  }
+
+  @Test
+  public void testAddTransferRateMetricForInvalidValue() {
+    DataNodeMetrics mockMetrics = mock(DataNodeMetrics.class);
+    DFSUtil.addTransferRateMetric(mockMetrics, 100, 0);
+    verify(mockMetrics, times(0)).addReadTransferRate(anyLong());
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
@@ -1108,4 +1108,12 @@ public class TestDFSUtil {
     LambdaTestUtils.intercept(IOException.class, expectedErrorMessage,
         ()->DFSUtil.getNNServiceRpcAddressesForCluster(conf));
   }
+  
+  @Test
+  public void testTransferRateBytesPerSecond() {
+    assertEquals(9830, DFSUtil.transferRateBytesPerSecond(983, 100));
+    assertEquals(983000, DFSUtil.transferRateBytesPerSecond(983, 0));
+    assertEquals(-1, DFSUtil.transferRateBytesPerSecond(-983, 100));
+    assertEquals(-1, DFSUtil.transferRateBytesPerSecond(983, -100));
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
@@ -1108,12 +1108,4 @@ public class TestDFSUtil {
     LambdaTestUtils.intercept(IOException.class, expectedErrorMessage,
         ()->DFSUtil.getNNServiceRpcAddressesForCluster(conf));
   }
-  
-  @Test
-  public void testTransferRateBytesPerSecond() {
-    assertEquals(9830, DFSUtil.transferRateBytesPerSecond(983, 100));
-    assertEquals(983000, DFSUtil.transferRateBytesPerSecond(983, 0));
-    assertEquals(-1, DFSUtil.transferRateBytesPerSecond(-983, 100));
-    assertEquals(-1, DFSUtil.transferRateBytesPerSecond(983, -100));
-  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
@@ -380,6 +380,7 @@ public class TestDataNodeMetrics {
   @Test(timeout=120000)
   public void testDataNodeTimeSpend() throws Exception {
     Configuration conf = new HdfsConfiguration();
+    conf.set(DFSConfigKeys.DFS_METRICS_PERCENTILES_INTERVALS_KEY, "" + 60);
     MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).build();
     try {
       final FileSystem fs = cluster.getFileSystem();
@@ -391,6 +392,7 @@ public class TestDataNodeMetrics {
 
       final long startWriteValue = getLongCounter("TotalWriteTime", rb);
       final long startReadValue = getLongCounter("TotalReadTime", rb);
+      assertCounter("ReadTransferRateMBsNumOps", 0L, rb);
       final AtomicInteger x = new AtomicInteger(0);
 
       // Lets Metric system update latest metrics
@@ -410,6 +412,8 @@ public class TestDataNodeMetrics {
           MetricsRecordBuilder rbNew = getMetrics(datanode.getMetrics().name());
           final long endWriteValue = getLongCounter("TotalWriteTime", rbNew);
           final long endReadValue = getLongCounter("TotalReadTime", rbNew);
+          assertCounter("ReadTransferRateMBsNumOps", 1L, rbNew);
+          assertQuantileGauges("ReadTransferRateMBs" + "60s", rbNew, "Rate");
           return endWriteValue > startWriteValue
               && endReadValue > startReadValue;
         }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
@@ -392,7 +392,7 @@ public class TestDataNodeMetrics {
 
       final long startWriteValue = getLongCounter("TotalWriteTime", rb);
       final long startReadValue = getLongCounter("TotalReadTime", rb);
-      assertCounter("ReadTransferRateMBsNumOps", 0L, rb);
+      assertCounter("ReadTransferRateNumOps", 0L, rb);
       final AtomicInteger x = new AtomicInteger(0);
 
       // Lets Metric system update latest metrics
@@ -412,8 +412,8 @@ public class TestDataNodeMetrics {
           MetricsRecordBuilder rbNew = getMetrics(datanode.getMetrics().name());
           final long endWriteValue = getLongCounter("TotalWriteTime", rbNew);
           final long endReadValue = getLongCounter("TotalReadTime", rbNew);
-          assertCounter("ReadTransferRateMBsNumOps", 1L, rbNew);
-          assertQuantileGauges("ReadTransferRateMBs" + "60s", rbNew, "Rate");
+          assertCounter("ReadTransferRateNumOps", 1L, rbNew);
+          assertQuantileGauges("ReadTransferRate" + "60s", rbNew, "Rate");
           return endWriteValue > startWriteValue
               && endReadValue > startReadValue;
         }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Transfer rate metric for datanode reads will be calculated as the rate at which bytes are read ( bytes per ms )
With quantiles we will get a distribution of this rate which will be helpful in identifying slow datanodes.


### How was this patch tested?
Updated Unit Tests to verify metrics will be emitted.

### For code changes:

- [ Y] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

