### PR TITLE
HDFS-16922. The logic of IncrementalBlockReportManager#addRDBI method may cause missing blocks when cluster is busy.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/IncrementalBlockReportManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/IncrementalBlockReportManager.java
@@ -117,6 +117,10 @@ class IncrementalBlockReportManager {
       }
       return count;
     }
+
+    ReceivedDeletedBlockInfo get(Block block) {
+      return blocks.getOrDefault(block, null);
+    }
   }
 
   /**
@@ -252,7 +256,9 @@ class IncrementalBlockReportManager {
     // Make sure another entry for the same block is first removed.
     // There may only be one such entry.
     for (PerStorageIBR perStorage : pendingIBRs.values()) {
-      if (perStorage.remove(rdbi.getBlock()) != null) {
+      ReceivedDeletedBlockInfo oldRdbi = perStorage.get(rdbi.getBlock());
+      if (oldRdbi != null && oldRdbi.getBlock().getGenerationStamp() < rdbi.getBlock().getGenerationStamp()
+          && perStorage.remove(oldRdbi.getBlock()) != null) {
         break;
       }
     }


### PR DESCRIPTION
The current logic of IncrementalBlockReportManager# addRDBI method could lead to the missing blocks when datanodes in pipeline are I/O busy.

Recently, In our production cluster, it happens. After checking logs and looking up the source code, I found in some special situations, the logic of addRDBI method may cause block missing.

Let me describe the case:
1. suppose that we have three datanode in pipeline.  client->dn1->dn2->dn3. client write data through pipeline. blockid is 
12345, initial GS(generation stamp) is 001.   the block name is blk_12345_001.
2. dn2 and dn3 write blk_12345_001 successfully and notifyNamenodeReceivedBlock.
3. dn1 is slow and does not send ack message to client util the scoket timeout period was exceeded.
4. client throws `SocketTimeoutException` and begins to pipeline recovery. client kicks dn1 out from the pipeline.  So the new pipeline would be `client -> dn2 -> dn3`. client will execute updateBlockForPipeline to get a new generation stamp and an access token. So,  the GS  is 002 now.
5. client executes createBlockOutputStream method to try to build a new pipeline with dn2 and dn3.
6. dn3 is writting the blk_12345_002 , but dn2 is blocked by recoverClose method and does not send ack to client.
7. client throws `SocketTimeoutException` and begins to pipeline recovery. client kicks dn2 out .  In this recovery situation, client does not need to add extra datanode to existing pipeline. so the new pipeline would be `client -> dn3`.
8. dn2 writes blk_12345_002 successfully and notifyNamenodeReceivedBlock.
9. dn3 writes blk_12345_003 successfully.
10. dn3 writes blk_12345_002 successfully and notifyNamenodeReceivedBlock.  in addRDBI method, dn3 would remove  the ReceivedDeletedBlockInfo of blk_12345_003.
11. client executes createBlockOutputStream successfully, then executes updatePipeline RPC.
12. namenode updates the GS of block_12345 to 003 because of updatePipeline RPC.
13. namenode begins to process the IBR of  blk_12345_002 from dn2 and dn3.
14. the GS of storedBlock is greater than reported block, marks it as corrupt.
15. because we do not send IBR of blk_12345_003 , so after a while,  RedundancyMonitor thread detects and then cause the phone alarm of missing blocks.

