### PR TITLE
HDFS-16923. [SBN read] getlisting RPC to observer will throw NPE if path does not exist

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -4173,7 +4173,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       logAuditEvent(false, operationName, src);
       throw e;
     }
-    if (needLocation && isObserver()) {
+    if (dl != null && needLocation && isObserver()) {
       for (HdfsFileStatus fs : dl.getPartialListing()) {
         if (fs instanceof HdfsLocatedFileStatus) {
           LocatedBlocks lbs = ((HdfsLocatedFileStatus) fs).getLocatedBlocks();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
@@ -71,6 +71,7 @@ import org.apache.hadoop.hdfs.tools.GetGroups;
 import org.apache.hadoop.ipc.ObserverRetryOnActiveException;
 import org.apache.hadoop.ipc.metrics.RpcMetrics;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.junit.After;
@@ -650,6 +651,17 @@ public class TestObserverNode {
         fail("Unexpected exception: " + e);
       }
     }
+  }
+
+  @Test
+  public void testGetListingForDeletedDir() throws Exception {
+    Path path = new Path("/dir1/dir2/testFile");
+    dfs.create(path).close();
+
+    assertTrue(dfs.delete(new Path("/dir1/dir2"), true));
+
+    LambdaTestUtils.intercept(FileNotFoundException.class,
+        () -> dfs.listLocatedStatus(new Path("/dir1/dir2")));
   }
 
   @Test


### PR DESCRIPTION
### Description of PR
Jira: [HDFS-16923](https://issues.apache.org/jira/browse/HDFS-16923)

The getlisting rpc will throw NPE if the path does not exist. 

