### PR TITLE
HADOOP-18635 : Expose distcp counters to user via new DistCpConstants "CONF_LABEL_DI…

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -153,6 +153,14 @@ public class DistCp extends Configured implements Tool {
     Job job = null;
     try {
       job = execute();
+      if (job != null) {
+        Long bytesCopied = job.getCounters().
+            findCounter(CopyMapper.Counter.BYTESCOPIED).getValue();
+        LOG.info("distcp copied {} number of bytes", bytesCopied);
+        //Set the config label so that consumer such as hive can see this distcp counter
+        getConf().set(DistCpConstants.CONF_LABEL_DISTCP_TOTAL_BYTES_COPIED,
+            String.valueOf(bytesCopied));
+      }
     } catch (InvalidInputException e) {
       LOG.error("Invalid input: ", e);
       return DistCpConstants.INVALID_ARGUMENT;
@@ -165,22 +173,14 @@ public class DistCp extends Configured implements Tool {
     } catch (XAttrsNotSupportedException e) {
       LOG.error("XAttrs not supported on at least one file system: ", e);
       return DistCpConstants.XATTRS_NOT_SUPPORTED;
+    } catch (IOException e) {
+      LOG.error("Exception encountered while retrieving distcp counter from job", e);
     } catch (Exception e) {
       LOG.error("Exception encountered ", e);
       return DistCpConstants.UNKNOWN_ERROR;
     } finally {
       //Blocking distcp so close the job after its done
       if (job != null && context.shouldBlock()) {
-        try {
-          Long bytesCopied = job.getCounters().
-              findCounter(CopyMapper.Counter.BYTESCOPIED).getValue();
-          LOG.info("distcp copied {} number of bytes", bytesCopied);
-          //Set the config label so that consumer such as hive can see this distcp counter
-          getConf().set(DistCpConstants.CONF_LABEL_DISTCP_TOTAL_BYTES_COPIED,
-              String.valueOf(bytesCopied));
-        } catch (IOException e) {
-          LOG.error("Exception encountered while retrieving distcp counter from job", e);
-        }
         try {
           job.close();
         } catch (IOException e) {

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -172,10 +172,12 @@ public class DistCp extends Configured implements Tool {
       //Blocking distcp so close the job after its done
       if (job != null && context.shouldBlock()) {
         try {
-          Long bytesCopied = job.getCounters().findCounter(CopyMapper.Counter.BYTESCOPIED).getValue();
+          Long bytesCopied = job.getCounters().
+              findCounter(CopyMapper.Counter.BYTESCOPIED).getValue();
           LOG.info("distcp copied {} number of bytes", bytesCopied);
           //Set the config label so that consumer such as hive can see this distcp counter
-          getConf().set(DistCpConstants.CONF_LABEL_DISTCP_TOTAL_BYTES_COPIED, String.valueOf(bytesCopied));
+          getConf().set(DistCpConstants.CONF_LABEL_DISTCP_TOTAL_BYTES_COPIED,
+              String.valueOf(bytesCopied));
         } catch (IOException e) {
           LOG.error("Exception encountered while retrieving distcp counter from job", e);
         }

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -172,6 +172,14 @@ public class DistCp extends Configured implements Tool {
       //Blocking distcp so close the job after its done
       if (job != null && context.shouldBlock()) {
         try {
+          Long bytesCopied = job.getCounters().findCounter(CopyMapper.Counter.BYTESCOPIED).getValue();
+          LOG.info("distcp copied {} number of bytes", bytesCopied);
+          //Set the config label so that consumer such as hive can see this distcp counter
+          getConf().set(DistCpConstants.CONF_LABEL_DISTCP_TOTAL_BYTES_COPIED, String.valueOf(bytesCopied));
+        } catch (IOException e) {
+          LOG.error("Exception encountered while retrieving distcp counter from job", e);
+        }
+        try {
           job.close();
         } catch (IOException e) {
           LOG.error("Exception encountered while closing distcp job", e);

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
@@ -116,6 +116,11 @@ public final class DistCpConstants {
    */
   public static final String CONF_LABEL_DISTCP_JOB_ID = "distcp.job.id";
 
+  /**
+   * DistCp Counter for consumers of the Distcp
+   */
+  public static final String CONF_LABEL_DISTCP_TOTAL_BYTES_COPIED = "distcp.total.bytes.copied";
+
   /* Meta folder where the job's intermediate data is kept */
   public static final String CONF_LABEL_META_FOLDER = "distcp.meta.folder";
 

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
@@ -117,7 +117,7 @@ public final class DistCpConstants {
   public static final String CONF_LABEL_DISTCP_JOB_ID = "distcp.job.id";
 
   /**
-   * DistCp Counter for consumers of the Distcp
+   * DistCp Counter for consumers of the Distcp.
    */
   public static final String CONF_LABEL_DISTCP_TOTAL_BYTES_COPIED = "distcp.total.bytes.copied";
 

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSystem.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSystem.java
@@ -458,8 +458,8 @@ public class TestDistCpSystem {
     ToolRunner.run(conf, distcpTool, args);
     final long bytesCopied = NumberUtils.toLong(distcpTool.getConf().
             get(CONF_LABEL_DISTCP_TOTAL_BYTES_COPIED), 0);
-    assertEquals("Bytes copied by distcp tool should match source file length",
-        bytesCopied, srcLen);
+    assertEquals("Bytes copied by distcp tool does not match source file length",
+        srcLen, bytesCopied);
 
     String realTgtPath = testDst;
     FileStatus[] dststat = getFileStatus(fs, realTgtPath, srcfiles);

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSystem.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSystem.java
@@ -456,8 +456,10 @@ public class TestDistCpSystem {
     LOG.info("_____ running distcp: " + args[0] + " " + args[1]);
     DistCp distcpTool = new DistCp();
     ToolRunner.run(conf, distcpTool, args);
-    final long bytesCopied = NumberUtils.toLong(distcpTool.getConf().get(CONF_LABEL_DISTCP_TOTAL_BYTES_COPIED), 0);
-    assertEquals("Bytes copied by distcp tool should match source file length", bytesCopied, srcLen);
+    final long bytesCopied = NumberUtils.toLong(distcpTool.getConf().
+            get(CONF_LABEL_DISTCP_TOTAL_BYTES_COPIED), 0);
+    assertEquals("Bytes copied by distcp tool should match source file length",
+        bytesCopied, srcLen);
 
     String realTgtPath = testDst;
     FileStatus[] dststat = getFileStatus(fs, realTgtPath, srcfiles);

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSystem.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSystem.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.tools;
 
 import static org.apache.hadoop.test.GenericTestUtils.getMethodName;
+import static org.apache.hadoop.tools.DistCpConstants.CONF_LABEL_DISTCP_TOTAL_BYTES_COPIED;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -32,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -452,7 +454,10 @@ public class TestDistCpSystem {
     };
 
     LOG.info("_____ running distcp: " + args[0] + " " + args[1]);
-    ToolRunner.run(conf, new DistCp(), args);
+    DistCp distcpTool = new DistCp();
+    ToolRunner.run(conf, distcpTool, args);
+    final long bytesCopied = NumberUtils.toLong(distcpTool.getConf().get(CONF_LABEL_DISTCP_TOTAL_BYTES_COPIED), 0);
+    assertEquals("Bytes copied by distcp tool should match source file length", bytesCopied, srcLen);
 
     String realTgtPath = testDst;
     FileStatus[] dststat = getFileStatus(fs, realTgtPath, srcfiles);


### PR DESCRIPTION
…STCP_TOTAL_BYTES_COPIED".

The constant indicate number of bytes copied by distcp operation. It is exposed via configuration parameter through which user can obtain the value.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

