### PR TITLE
HADOOP-18627 Stronger wording in 'secure mode' intro

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/SecureMode.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/SecureMode.md
@@ -20,7 +20,7 @@ Hadoop in Secure Mode
 Introduction
 ------------
 
-In its default configuration, we expect you to make sure attackers don't have access to your Hadoop deployment by restricting all network access. If you want to expose Hadoop to untrusted users, you will have to configure authentication for Hadoop in secure mode as described in this document.
+In its default configuration, we expect you to make sure attackers don't have access to your Hadoop deployment by restricting all network access. If you want any restrictions on who can remotely access data or submit work, you MUST secure authentication and access for your Hadoop cluster as described in this document.
 
 When Hadoop is configured to run in secure mode, each Hadoop service and each user must be authenticated by Kerberos.
 

--- a/hadoop-common-project/hadoop-common/src/site/markdown/SecureMode.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/SecureMode.md
@@ -20,7 +20,9 @@ Hadoop in Secure Mode
 Introduction
 ------------
 
-This document describes how to configure authentication for Hadoop in secure mode. When Hadoop is configured to run in secure mode, each Hadoop service and each user must be authenticated by Kerberos.
+In its default configuration, we expect you to make sure attackers don't have access to your Hadoop deployment by restricting all network access. If you want to expose Hadoop to untrusted users, you will have to configure authentication for Hadoop in secure mode as described in this document.
+
+When Hadoop is configured to run in secure mode, each Hadoop service and each user must be authenticated by Kerberos.
 
 Forward and reverse host lookup for all service hosts must be configured correctly to allow services to authenticate with each other. Host lookups may be configured using either DNS or `/etc/hosts` files. Working knowledge of Kerberos and DNS is recommended before attempting to configure Hadoop services in Secure Mode.
 

--- a/hadoop-common-project/hadoop-common/src/site/markdown/SecureMode.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/SecureMode.md
@@ -20,7 +20,7 @@ Hadoop in Secure Mode
 Introduction
 ------------
 
-In its default configuration, we expect you to make sure attackers don't have access to your Hadoop deployment by restricting all network access. If you want any restrictions on who can remotely access data or submit work, you MUST secure authentication and access for your Hadoop cluster as described in this document.
+In its default configuration, we expect you to make sure attackers don't have access to your Hadoop cluster by restricting all network access. If you want any restrictions on who can remotely access data or submit work, you MUST secure authentication and access for your Hadoop cluster as described in this document.
 
 When Hadoop is configured to run in secure mode, each Hadoop service and each user must be authenticated by Kerberos.
 


### PR DESCRIPTION
### Description of PR

Make it more clear that when exposing Hadoop to untrusted users, 'secure mode' is not optional.

### How was this patch tested?

n/a