### PR TITLE
HDFS-16899. Fix TestAddOverReplicatedStripedBlocks#testProcessOverReplicatedAndCorruptStripedBlock failed

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -5617,4 +5617,14 @@ public class BlockManager implements BlockStatsMXBean {
   public boolean getExcludeSlowNodesEnabled(BlockType blockType) {
     return placementPolicies.getPolicy(blockType).getExcludeSlowNodesEnabled();
   }
+
+  @VisibleForTesting
+  public void setPendingPeriodInMs(long newVal) {
+    invalidateBlocks.setPendingPeriodInMs(newVal);
+  }
+
+  @VisibleForTesting
+  public long getPendingPeriodInMs() {
+    return invalidateBlocks.getPendingPeriodInMs();
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/InvalidateBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/InvalidateBlocks.java
@@ -61,7 +61,7 @@ class InvalidateBlocks {
    * The period of pending time for block invalidation since the NameNode
    * startup
    */
-  private final long pendingPeriodInMs;
+  private long pendingPeriodInMs;
   /** the startup time */
   private final long startupTime = Time.monotonicNow();
 
@@ -250,6 +250,16 @@ class InvalidateBlocks {
   @VisibleForTesting
   long getInvalidationDelay() {
     return pendingPeriodInMs - (Time.monotonicNow() - startupTime);
+  }
+
+  @VisibleForTesting
+  public void setPendingPeriodInMs(long newVal) {
+    this.pendingPeriodInMs = newVal;
+  }
+
+  @VisibleForTesting
+  public long getPendingPeriodInMs() {
+    return this.pendingPeriodInMs;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddOverReplicatedStripedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddOverReplicatedStripedBlocks.java
@@ -214,6 +214,10 @@ public class TestAddOverReplicatedStripedBlocks {
     assertEquals(1, bm.countNodes(bm.getStoredBlock(blockInfo))
         .corruptReplicas());
 
+    // Set a larger value for delete invalidation delay time of a block and
+    // avoid the redundant internal blocks will be deleted.
+    long oldPendingPeriodInMs = bm.getPendingPeriodInMs();
+    bm.setPendingPeriodInMs(3600000);
     // let a internal block be over replicated with 2 redundant block.
     blk.setBlockId(groupId + 2);
     cluster.injectBlocks(numDNs - 3, Arrays.asList(blk), bpid);
@@ -240,6 +244,8 @@ public class TestAddOverReplicatedStripedBlocks {
     for (int i = 1; i < groupSize; i++) {
       assertTrue(set.get(i));
     }
+    // restore original settings.
+    bm.setPendingPeriodInMs(oldPendingPeriodInMs);
   }
 
   // This test is going to be rewritten in HDFS-10854. Ignoring this test


### PR DESCRIPTION
### Description of PR

[HDFS-16899](https://issues.apache.org/jira/browse/HDFS-16899)

TestAddOverReplicatedStripedBlocks#testProcessOverReplicatedAndCorruptStripedBlock occasionally appear failed.

Failed code Line is 

```
// verify that all internal blocks exists except b0
// the redundant internal blocks will not be deleted before the corrupted
// block gets reconstructed. but since we set
// DFS_NAMENODE_REPLICATION_MAX_STREAMS_KEY to 0, the reconstruction will
// not happen
lbs = cluster.getNameNodeRpc().getBlockLocations(filePath.toString(), 0,
 fileLen);
bg = (LocatedStripedBlock) (lbs.get(0)); 
assertEquals(groupSize + 1, bg.getBlockIndices().length); //here not equals. 
```
From the perspective of normal logic, the internal blocks that need to be obtained are 10, 8 live and 2 redundant internal blocks, 
but due to the processing logic that occasionally triggers invalidate to remove redundant internal block, 
the final obtained internal blocks value does not meet expectations.

So need avoid the redundant internal blocks will be deleted.
