### PR TITLE
[YARN-11443]"State" column bug in YARN RM page(fairscheduler).

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/WebPageUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/WebPageUtils.java
@@ -58,9 +58,13 @@ public class WebPageUtils {
     StringBuilder sb = new StringBuilder();
     sb.append("[\n")
       .append("{'sType':'natural', 'aTargets': [0], ")
-      .append("'mRender': parseHadoopID },\n")
-      .append("{'sType':'num-ignore-str', 'aTargets': [7, 8, 9], ")
-      .append("'mRender': renderHadoopDate },\n");
+      .append("'mRender': parseHadoopID },\n");
+    if (isResourceManager) {
+      sb.append("{'sType':'num-ignore-str', 'aTargets': [7, 8, 9], ");
+    } else if (isFairSchedulerPage) {
+      sb.append("{'sType':'num-ignore-str', 'aTargets': [6, 7], ");
+    }
+    sb.append("'mRender': renderHadoopDate },\n");
     if (isResourceManager) {
       // Update following line if any column added in RM page before column 11
       sb.append("{'sType':'num-ignore-str', ")


### PR DESCRIPTION
"State" column in YARN RM web page shows "undefined" while using fairscheduler.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Add a "if" statement for "isFairSchedulerPage", while user using FairScheduler", the columns which need to format as date is 
[6] &[7],  for other case leave as what it is.
### How was this patch tested?
Jenkins

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

