### PR TITLE
HADOOP-18639 DockerContainerDeletionTask is not removed from the Nodemanager's statestore when the task is completed

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/deletion/task/DockerContainerDeletionTask.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/deletion/task/DockerContainerDeletionTask.java
@@ -56,6 +56,7 @@ public class DockerContainerDeletionTask extends DeletionTask
     LinuxContainerExecutor exec = ((LinuxContainerExecutor)
         getDeletionService().getContainerExecutor());
     exec.removeDockerContainer(containerId);
+    deletionTaskFinished();
   }
 
   /**


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->


### Description of PR

When the DockerContainerDeletionTask is completed, it should be deleted from the NodeManager's statestore, just like the FileDeletionTask.

JIRA : https://issues.apache.org/jira/browse/HADOOP-18639

### How was this patch tested?

- Unit test added
- Deployed it on our own cluster and tested it to make sure it works.

