### PR TITLE
HADOOP-18645. Provide keytab file key name with ServiceStateException

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SecurityUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SecurityUtil.java
@@ -314,7 +314,8 @@ public final class SecurityUtil {
     
     String keytabFilename = conf.get(keytabFileKey);
     if (keytabFilename == null || keytabFilename.length() == 0) {
-      throw new IOException("Running in secure mode, but config doesn't have a keytab");
+      throw new IOException(
+          "Running in secure mode, but config doesn't have a keytab for key: " + keytabFileKey);
     }
 
     String principalConfig = conf.get(userNameKey, System

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterWithSecureStartup.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterWithSecureStartup.java
@@ -56,7 +56,8 @@ public class TestRouterWithSecureStartup {
   @Test
   public void testStartupWithoutKeytab() throws Exception {
     testCluster(DFS_ROUTER_KEYTAB_FILE_KEY,
-        "Running in secure mode, but config doesn't have a keytab");
+        "Running in secure mode, but config doesn't have a keytab for "
+            + "key: dfs.federation.router.keytab.file");
   }
 
   @Test


### PR DESCRIPTION
```
util.ExitUtil - Exiting with status 1: org.apache.hadoop.service.ServiceStateException: java.io.IOException: Running in secure mode, but config doesn't have a keytab
1: org.apache.hadoop.service.ServiceStateException: java.io.IOException: Running in secure mode, but config doesn't have a keytab
  at org.apache.hadoop.util.ExitUtil.terminate(ExitUtil.java:264)
..
..
``` 

When multiple downstreamers use different configs to present the same keytab file, if one of the config key gets missing or overridden as part of config generators, it becomes bit confusing for operators to realize which config is missing for a particular service, especially when keytab file value is already present with different config.

It would be nice to report config key with the stacktrace error message.
