### PR TITLE
YARN-11448 [Federation] Stateless Router Secret Manager

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
@@ -237,7 +237,7 @@ extends AbstractDelegationTokenIdentifier>
 
   // RM
   protected void removeStoredToken(TokenIdent ident) throws IOException {
-
+    return;
   }
   // RM
   protected void updateStoredToken(TokenIdent ident, long renewDate) throws IOException {
@@ -384,6 +384,15 @@ extends AbstractDelegationTokenIdentifier>
       DelegationTokenInformation tokenInfo) throws IOException {
     currentTokens.put(ident, tokenInfo);
     updateStoredToken(ident, tokenInfo.getRenewDate());
+  }
+
+  protected void removeToken(TokenIdent ident) throws IOException {
+    DelegationTokenInformation info = currentTokens.remove(ident);
+    if (info == null) {
+      throw new InvalidToken("Token not found " + formatTokenId(ident));
+    }
+    removeTokenForOwnerStats(ident);
+    removeStoredToken(ident);
   }
 
   /**
@@ -691,13 +700,8 @@ extends AbstractDelegationTokenIdentifier>
       throw new AccessControlException(canceller
           + " is not authorized to cancel the token " + formatTokenId(id));
     }
-    DelegationTokenInformation info = currentTokens.remove(id);
-    if (info == null) {
-      throw new InvalidToken("Token not found " + formatTokenId(id));
-    }
     METRICS.trackRemoveToken(() -> {
-      removeTokenForOwnerStats(id);
-      removeStoredToken(id);
+      removeToken(id);
     });
     return id;
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/SQLDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/SQLDelegationTokenSecretManager.java
@@ -161,7 +161,7 @@ public abstract class SQLDelegationTokenSecretManager<TokenIdent
    *         null if it doesn't exist in the database.
    */
   @Override
-  protected DelegationTokenInformation getTokenInfo(TokenIdent ident) {
+  protected DelegationTokenInformation getTokenInfo(TokenIdent ident) throws IOException {
     // Look for token in local cache
     DelegationTokenInformation tokenInfo = super.getTokenInfo(ident);
 
@@ -302,7 +302,7 @@ public abstract class SQLDelegationTokenSecretManager<TokenIdent
    *         if it doesn't exist in the database.
    */
   @Override
-  protected DelegationKey getDelegationKey(int keyId) {
+  protected DelegationKey getDelegationKey(int keyId) throws IOException {
     // Look for delegation key in local cache
     DelegationKey delegationKey = super.getDelegationKey(keyId);
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/ZKDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/ZKDelegationTokenSecretManager.java
@@ -569,7 +569,7 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
   }
 
   @Override
-  protected DelegationKey getDelegationKey(int keyId) {
+  protected DelegationKey getDelegationKey(int keyId) throws IOException {
     // First check if its I already have this key
     DelegationKey key = allKeys.get(keyId);
     // Then query ZK
@@ -581,6 +581,7 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
         }
       } catch (IOException e) {
         LOG.error("Error retrieving key [" + keyId + "] from ZK", e);
+        throw e;
       }
     }
     return key;
@@ -608,7 +609,7 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
   }
 
   @Override
-  protected DelegationTokenInformation getTokenInfo(TokenIdent ident) {
+  protected DelegationTokenInformation getTokenInfo(TokenIdent ident) throws IOException {
     // First check if I have this..
     DelegationTokenInformation tokenInfo = currentTokens.get(ident);
     // Then query ZK
@@ -621,6 +622,7 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
       } catch (IOException e) {
         LOG.error("Error retrieving tokenInfo [" + ident.getSequenceNumber()
             + "] from ZK", e);
+        throw e;
       }
     }
     return tokenInfo;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestDelegationToken.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestDelegationToken.java
@@ -727,7 +727,7 @@ public class TestDelegationToken {
     if (expectError) {
       LambdaTestUtils.intercept(IOException.class, callable);
     } else {
-      callable.call();
+      Assert.assertThrows(Exception.class, () -> callable.call());
     }
     assertEquals(counterBefore + 1, counter.value());
     assertEquals(statBefore + 1, failureStat.getSamples());

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
@@ -473,9 +473,13 @@ public class TestZKDelegationTokenSecretManager {
     GenericTestUtils.waitFor(new Supplier<Boolean>() {
       @Override
       public Boolean get() {
-        AbstractDelegationTokenSecretManager.DelegationTokenInformation dtinfo =
-            zksm.getTokenInfo(idCancelled);
-        return dtinfo == null;
+        try {
+          AbstractDelegationTokenSecretManager.DelegationTokenInformation dtinfo =
+              zksm.getTokenInfo(idCancelled);
+          return dtinfo == null;
+        } catch (IOException ex) {
+          return false;
+        }
       }
     }, 100, 5000);
 
@@ -508,7 +512,11 @@ public class TestZKDelegationTokenSecretManager {
       @Override
       public Boolean get() {
         LOG.info("Waiting for the expired token to be removed...");
-        return zksm1.getTokenInfo(id1) == null;
+        try {
+          return zksm1.getTokenInfo(id1) == null;
+        } catch (Exception ex) {
+          return false;
+        }
       }
     }, 1000, 5000);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/FederationDelegationTokenStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/FederationDelegationTokenStateStore.java
@@ -114,37 +114,16 @@ public interface FederationDelegationTokenStateStore {
       throws YarnException, IOException;
 
   /**
-   * The Router Supports incrementDelegationTokenSeqNum.
+   * Return a new unique integer lookup key for a new delegation token
    *
    * @return DelegationTokenSeqNum.
    */
-  int incrementDelegationTokenSeqNum();
+  int getNewDelegationTokenKey();
 
   /**
-   * The Router Supports getDelegationTokenSeqNum.
-   *
-   * @return DelegationTokenSeqNum.
-   */
-  int getDelegationTokenSeqNum();
-
-  /**
-   * The Router Supports setDelegationTokenSeqNum.
-   *
-   * @param seqNum DelegationTokenSeqNum.
-   */
-  void setDelegationTokenSeqNum(int seqNum);
-
-  /**
-   * The Router Supports getCurrentKeyId.
+   * Return a new unique integer master key id
    *
    * @return CurrentKeyId.
    */
-  int getCurrentKeyId();
-
-  /**
-   * The Router Supports incrementCurrentKeyId.
-   *
-   * @return CurrentKeyId.
-   */
-  int incrementCurrentKeyId();
+  int generateNewKeyId();
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/FederationDelegationTokenStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/FederationDelegationTokenStateStore.java
@@ -118,12 +118,12 @@ public interface FederationDelegationTokenStateStore {
    *
    * @return DelegationTokenSeqNum.
    */
-  int getNewDelegationTokenKey();
+  int incrementDelegationTokenSeqNum();
 
   /**
    * Return a new unique integer master key id
    *
    * @return CurrentKeyId.
    */
-  int generateNewKeyId();
+  int incrementCurrentKeyId();
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/MemoryFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/MemoryFederationStateStore.java
@@ -555,12 +555,12 @@ public class MemoryFederationStateStore implements FederationStateStore {
   }
 
   @Override
-  public int getNewDelegationTokenKey() {
+  public int incrementDelegationTokenSeqNum() {
     return sequenceNum.incrementAndGet();
   }
 
   @Override
-  public int generateNewKeyId() {
+  public int incrementCurrentKeyId() {
     return masterKeyId.incrementAndGet();
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/SQLFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/SQLFederationStateStore.java
@@ -1836,47 +1836,8 @@ public class SQLFederationStateStore implements FederationStateStore {
    * @return delegationTokenSeqNum.
    */
   @Override
-  public int incrementDelegationTokenSeqNum() {
+  public int getNewDelegationTokenKey() {
     return querySequenceTable(YARN_ROUTER_SEQUENCE_NUM, true);
-  }
-
-  /**
-   * Get DelegationToken SeqNum.
-   *
-   * @return delegationTokenSeqNum.
-   */
-  @Override
-  public int getDelegationTokenSeqNum() {
-    return querySequenceTable(YARN_ROUTER_SEQUENCE_NUM, false);
-  }
-
-  @Override
-  public void setDelegationTokenSeqNum(int seqNum) {
-    Connection connection = null;
-    try {
-      connection = getConnection(false);
-      FederationQueryRunner runner = new FederationQueryRunner();
-      runner.updateSequenceTable(connection, YARN_ROUTER_SEQUENCE_NUM, seqNum);
-    } catch (Exception e) {
-      throw new RuntimeException("Could not update sequence table!!", e);
-    } finally {
-      // Return to the pool the CallableStatement
-      try {
-        FederationStateStoreUtils.returnToPool(LOG, null, connection);
-      } catch (YarnException e) {
-        LOG.error("close connection error.", e);
-      }
-    }
-  }
-
-  /**
-   * Get Current KeyId.
-   *
-   * @return currentKeyId.
-   */
-  @Override
-  public int getCurrentKeyId() {
-    return querySequenceTable(YARN_ROUTER_CURRENT_KEY_ID, false);
   }
 
   /**
@@ -1885,7 +1846,7 @@ public class SQLFederationStateStore implements FederationStateStore {
    * @return CurrentKeyId.
    */
   @Override
-  public int incrementCurrentKeyId() {
+  public int generateNewKeyId() {
     return querySequenceTable(YARN_ROUTER_CURRENT_KEY_ID, true);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/SQLFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/SQLFederationStateStore.java
@@ -1846,7 +1846,7 @@ public class SQLFederationStateStore implements FederationStateStore {
    * @return delegationTokenSeqNum.
    */
   @Override
-  public int getNewDelegationTokenKey() {
+  public int incrementDelegationTokenSeqNum() {
     return querySequenceTable(YARN_ROUTER_SEQUENCE_NUM, true);
   }
 
@@ -1856,7 +1856,7 @@ public class SQLFederationStateStore implements FederationStateStore {
    * @return CurrentKeyId.
    */
   @Override
-  public int generateNewKeyId() {
+  public int incrementCurrentKeyId() {
     return querySequenceTable(YARN_ROUTER_CURRENT_KEY_ID, true);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
@@ -1512,7 +1512,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
    * @return SequenceNum.
    */
   @Override
-  public int getNewDelegationTokenKey() {
+  public int incrementDelegationTokenSeqNum() {
     // The secret manager will keep a local range of seq num which won't be
     // seen by peers, so only when the range is exhausted it will ask zk for
     // another range again
@@ -1559,7 +1559,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
    * @return CurrentKeyId.
    */
   @Override
-  public int generateNewKeyId() {
+  public int incrementCurrentKeyId() {
     try {
       // It should be noted that the BatchSize of MasterKeyId defaults to 1.
       incrSharedCount(keyIdSeqCounter, 1);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
@@ -1501,7 +1501,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
    * @return SequenceNum.
    */
   @Override
-  public int incrementDelegationTokenSeqNum() {
+  public int getNewDelegationTokenKey() {
     // The secret manager will keep a local range of seq num which won't be
     // seen by peers, so only when the range is exhausted it will ask zk for
     // another range again
@@ -1543,46 +1543,12 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   }
 
   /**
-   * Get DelegationToken SeqNum.
-   *
-   * @return delegationTokenSeqNum.
-   */
-  @Override
-  public int getDelegationTokenSeqNum() {
-    return delTokSeqCounter.getCount();
-  }
-
-  /**
-   * Set DelegationToken SeqNum.
-   *
-   * @param seqNum sequenceNum.
-   */
-  @Override
-  public void setDelegationTokenSeqNum(int seqNum) {
-    try {
-      delTokSeqCounter.setCount(seqNum);
-    } catch (Exception e) {
-      throw new RuntimeException("Could not set shared counter !!", e);
-    }
-  }
-
-  /**
-   * Get Current KeyId.
-   *
-   * @return currentKeyId.
-   */
-  @Override
-  public int getCurrentKeyId() {
-    return keyIdSeqCounter.getCount();
-  }
-
-  /**
    * The Router Supports incrementCurrentKeyId.
    *
    * @return CurrentKeyId.
    */
   @Override
-  public int incrementCurrentKeyId() {
+  public int generateNewKeyId() {
     try {
       // It should be noted that the BatchSize of MasterKeyId defaults to 1.
       incrSharedCount(keyIdSeqCounter, 1);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/records/RouterRMDTSecretManagerState.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/records/RouterRMDTSecretManagerState.java
@@ -30,7 +30,7 @@ public class RouterRMDTSecretManagerState {
   // DTIdentifier -> renewDate
   private Map<Integer, RouterStoreToken> delegationTokenState = new HashMap<>();
 
-  private Set<DelegationKey> masterKeyState = new HashSet<>();
+  private Map<Integer, DelegationKey> masterKeyState = new HashMap<>();
 
   private int dtSequenceNumber = 0;
 
@@ -38,7 +38,7 @@ public class RouterRMDTSecretManagerState {
     return delegationTokenState;
   }
 
-  public Set<DelegationKey> getMasterKeyState() {
+  public Map<Integer, DelegationKey> getMasterKeyState() {
     return masterKeyState;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/records/RouterRMDTSecretManagerState.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/records/RouterRMDTSecretManagerState.java
@@ -28,13 +28,13 @@ import java.util.Set;
 public class RouterRMDTSecretManagerState {
 
   // DTIdentifier -> renewDate
-  private Map<RMDelegationTokenIdentifier, RouterStoreToken> delegationTokenState = new HashMap<>();
+  private Map<Integer, RouterStoreToken> delegationTokenState = new HashMap<>();
 
   private Set<DelegationKey> masterKeyState = new HashSet<>();
 
   private int dtSequenceNumber = 0;
 
-  public Map<RMDelegationTokenIdentifier, RouterStoreToken> getTokenState() {
+  public Map<Integer, RouterStoreToken> getTokenState() {
     return delegationTokenState;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
@@ -901,7 +901,7 @@ public final class FederationStateStoreFacade {
    * @return delegationTokenSequenceNumber.
    */
   public int incrementDelegationTokenSeqNum() {
-    return stateStore.getNewDelegationTokenKey();
+    return stateStore.incrementDelegationTokenSeqNum();
   }
 
   /**
@@ -909,8 +909,8 @@ public final class FederationStateStoreFacade {
    *
    * @return currentKeyId.
    */
-  public int generateNewKeyId() {
-    return stateStore.generateNewKeyId();
+  public int incrementCurrentKeyId() {
+    return stateStore.incrementCurrentKeyId();
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
@@ -780,17 +780,14 @@ public final class FederationStateStoreFacade {
   /**
    * The Router Supports GetMasterKeyByDelegationKey.
    *
-   * @param newKey Key used for generating and verifying delegation tokens
+   * @param keyId Master Key identifer that is used to generate the delegation tokens
    * @throws YarnException if the call to the state store is unsuccessful
    * @throws IOException An IO Error occurred
    * @return RouterMasterKeyResponse
    */
-  public RouterMasterKeyResponse getMasterKeyByDelegationKey(DelegationKey newKey)
-      throws YarnException, IOException {
-    LOG.info("Storing master key with keyID {}.", newKey.getKeyId());
-    ByteBuffer keyBytes = ByteBuffer.wrap(newKey.getEncodedKey());
-    RouterMasterKey masterKey = RouterMasterKey.newInstance(newKey.getKeyId(),
-        keyBytes, newKey.getExpiryDate());
+  public RouterMasterKeyResponse getMasterKey(int keyId) throws YarnException, IOException {
+    // TODO - Change interfaces with state store to get master key from key id
+    RouterMasterKey masterKey = RouterMasterKey.newInstance(keyId, null, 0L);
     RouterMasterKeyRequest keyRequest = RouterMasterKeyRequest.newInstance(masterKey);
     return stateStore.getMasterKeyByDelegationKey(keyRequest);
   }
@@ -904,34 +901,7 @@ public final class FederationStateStoreFacade {
    * @return delegationTokenSequenceNumber.
    */
   public int incrementDelegationTokenSeqNum() {
-    return stateStore.incrementDelegationTokenSeqNum();
-  }
-
-  /**
-   * Get SeqNum from stateStore.
-   *
-   * @return delegationTokenSequenceNumber.
-   */
-  public int getDelegationTokenSeqNum() {
-    return stateStore.getDelegationTokenSeqNum();
-  }
-
-  /**
-   * Set SeqNum from stateStore.
-   *
-   * @param seqNum delegationTokenSequenceNumber.
-   */
-  public void setDelegationTokenSeqNum(int seqNum) {
-    stateStore.setDelegationTokenSeqNum(seqNum);
-  }
-
-  /**
-   * Get CurrentKeyId from stateStore.
-   *
-   * @return currentKeyId.
-   */
-  public int getCurrentKeyId() {
-    return stateStore.getCurrentKeyId();
+    return stateStore.getNewDelegationTokenKey();
   }
 
   /**
@@ -939,8 +909,8 @@ public final class FederationStateStoreFacade {
    *
    * @return currentKeyId.
    */
-  public int incrementCurrentKeyId() {
-    return stateStore.incrementCurrentKeyId();
+  public int generateNewKeyId() {
+    return stateStore.generateNewKeyId();
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestMemoryFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestMemoryFederationStateStore.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.yarn.server.federation.store.records.RouterStoreToken;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
-import java.util.Set;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -82,7 +81,7 @@ public class TestMemoryFederationStateStore extends FederationStateStoreBaseTest
         secretManagerState.getTokenState();
     assertNotNull(tokenStateMap);
 
-    assertTrue(tokenStateMap.containsKey(identifier));
+    assertTrue(tokenStateMap.containsKey(identifier.getSequenceNumber()));
 
     YARNDelegationTokenIdentifier tokenIdentifier = token.getTokenIdentifier();
     assertTrue(tokenIdentifier instanceof RMDelegationTokenIdentifier);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestMemoryFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestMemoryFederationStateStore.java
@@ -78,7 +78,7 @@ public class TestMemoryFederationStateStore extends FederationStateStoreBaseTest
         memoryStateStore.getRouterRMSecretManagerState();
     assertNotNull(secretManagerState);
 
-    Map<RMDelegationTokenIdentifier, RouterStoreToken> tokenStateMap =
+    Map<Integer, RouterStoreToken> tokenStateMap =
         secretManagerState.getTokenState();
     assertNotNull(tokenStateMap);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestMemoryFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestMemoryFederationStateStore.java
@@ -59,10 +59,10 @@ public class TestMemoryFederationStateStore extends FederationStateStoreBaseTest
         memoryStateStore.getRouterRMSecretManagerState();
     assertNotNull(secretManagerState);
 
-    Set<DelegationKey> delegationKeys = secretManagerState.getMasterKeyState();
+    Map<Integer, DelegationKey> delegationKeys = secretManagerState.getMasterKeyState();
     assertNotNull(delegationKeys);
 
-    assertTrue(delegationKeys.contains(delegationKey));
+    assertTrue(delegationKeys.containsKey(delegationKey.getKeyId()));
 
     RouterMasterKey resultRouterMasterKey = RouterMasterKey.newInstance(delegationKey.getKeyId(),
         ByteBuffer.wrap(delegationKey.getEncodedKey()), delegationKey.getExpiryDate());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/utils/TestFederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/utils/TestFederationStateStoreFacade.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
@@ -248,8 +249,8 @@ public class TestFederationStateStoreFacade {
   public void testStoreNewMasterKey() throws YarnException, IOException {
     // store delegation key;
     DelegationKey key = new DelegationKey(1234, 4321, "keyBytes".getBytes());
-    Set<DelegationKey> keySet = new HashSet<>();
-    keySet.add(key);
+    Map<Integer, DelegationKey> keySet = new HashMap<>();
+    keySet.put(key.getKeyId(), key);
     facade.storeNewMasterKey(key);
 
     MemoryFederationStateStore federationStateStore =
@@ -263,8 +264,8 @@ public class TestFederationStateStoreFacade {
   public void testRemoveStoredMasterKey() throws YarnException, IOException {
     // store delegation key;
     DelegationKey key = new DelegationKey(4567, 7654, "keyBytes".getBytes());
-    Set<DelegationKey> keySet = new HashSet<>();
-    keySet.add(key);
+    Map<Integer, DelegationKey> keySet = new HashMap<>();
+    keySet.put(key.getKeyId(), key);
     facade.storeNewMasterKey(key);
 
     // check to delete delegationKey

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/federation/FederationStateStoreService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/federation/FederationStateStoreService.java
@@ -424,28 +424,13 @@ public class FederationStateStoreService extends AbstractService
   }
 
   @Override
-  public int incrementDelegationTokenSeqNum() {
-    return stateStoreClient.incrementDelegationTokenSeqNum();
+  public int getNewDelegationTokenKey() {
+    return stateStoreClient.getNewDelegationTokenKey();
   }
 
   @Override
-  public int getDelegationTokenSeqNum() {
-    return stateStoreClient.getDelegationTokenSeqNum();
-  }
-
-  @Override
-  public void setDelegationTokenSeqNum(int seqNum) {
-    stateStoreClient.setDelegationTokenSeqNum(seqNum);
-  }
-
-  @Override
-  public int getCurrentKeyId() {
-    return stateStoreClient.getCurrentKeyId();
-  }
-
-  @Override
-  public int incrementCurrentKeyId() {
-    return stateStoreClient.incrementCurrentKeyId();
+  public int generateNewKeyId() {
+    return stateStoreClient.generateNewKeyId();
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/federation/FederationStateStoreService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/federation/FederationStateStoreService.java
@@ -434,13 +434,13 @@ public class FederationStateStoreService extends AbstractService
   }
 
   @Override
-  public int getNewDelegationTokenKey() {
-    return stateStoreClient.getNewDelegationTokenKey();
+  public int incrementDelegationTokenSeqNum() {
+    return stateStoreClient.incrementDelegationTokenSeqNum();
   }
 
   @Override
-  public int generateNewKeyId() {
-    return stateStoreClient.generateNewKeyId();
+  public int incrementCurrentKeyId() {
+    return stateStoreClient.incrementCurrentKeyId();
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/security/token/delegation/RouterDelegationTokenSupport.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/security/token/delegation/RouterDelegationTokenSupport.java
@@ -41,9 +41,9 @@ public final class RouterDelegationTokenSupport {
     try {
       ByteArrayOutputStream bos = new ByteArrayOutputStream();
       DataOutputStream out = new DataOutputStream(bos);
-      WritableUtils.writeVInt(out, token.password.length);
-      out.write(token.password);
-      out.writeLong(token.renewDate);
+      WritableUtils.writeVInt(out, token.getPassword().length);
+      out.write(token.getPassword());
+      out.writeLong(token.getRenewDate());
       out.flush();
       byte[] tokenInfoBytes = bos.toByteArray();
       return Base64.getUrlEncoder().encodeToString(tokenInfoBytes);
@@ -55,11 +55,11 @@ public final class RouterDelegationTokenSupport {
   public static DelegationTokenInformation decodeDelegationTokenInformation(byte[] tokenBytes)
       throws IOException {
     DataInputStream in = new DataInputStream(new ByteArrayInputStream(tokenBytes));
-    DelegationTokenInformation token = new DelegationTokenInformation(0, null);
     int len = WritableUtils.readVInt(in);
-    token.password = new byte[len];
-    in.readFully(token.password);
-    token.renewDate = in.readLong();
+    byte[] password = new byte[len];
+    in.readFully(password);
+    long renewDate = in.readLong();
+    DelegationTokenInformation token = new DelegationTokenInformation(renewDate, password);
     return token;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/security/RouterDelegationTokenSecretManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/security/RouterDelegationTokenSecretManager.java
@@ -22,9 +22,7 @@ import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenSecret
 import org.apache.hadoop.security.token.delegation.DelegationKey;
 import org.apache.hadoop.security.token.delegation.RouterDelegationTokenSupport;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.security.client.RMDelegationTokenIdentifier;
-import org.apache.hadoop.yarn.security.client.YARNDelegationTokenIdentifier;
 import org.apache.hadoop.yarn.server.federation.store.records.RouterMasterKey;
 import org.apache.hadoop.yarn.server.federation.store.records.RouterMasterKeyResponse;
 import org.apache.hadoop.yarn.server.federation.store.records.RouterRMTokenResponse;
@@ -257,13 +255,8 @@ public class RouterDelegationTokenSecretManager
   }
 
   @Override
-  protected int generateNewKeyId() {
-    return federationFacade.generateNewKeyId();
-  }
-
-  @Override
   protected int incrementCurrentKeyId() {
-    throw new NotImplementedException("Increment current key id is not a valid use case for stateless secret managers");
+    return federationFacade.incrementCurrentKeyId();
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/security/RouterDelegationTokenSecretManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/security/RouterDelegationTokenSecretManager.java
@@ -36,24 +36,24 @@ import java.nio.ByteBuffer;
 import java.util.Base64;
 
 /**
- * A Router specific delegation token secret manager & is designed to be stateless.
+ * A Router specific delegation token secret manager and is designed to be stateless.
  * The secret manager is responsible for generating and accepting the password
  * for each token.
  *
  * Behavioural Differences from AbstractDelegationTokenSecretManager
- * 1) Master Key - Each instance of Router will have its own master key & each instance rolls its own master key.
+ * 1) Master Key - Each instance of Router will have its own master key and each instance rolls its own master key.
  *    Thus there is no concept of a global current key.
  *    The requirement to generate new master keys / delegation tokens is to generate unique INTEGER keys,
  *    which the state store is responsible for (Autoincrement is one of the ways to achieve this).
- *    This key will be regenerated on service restart & thus there is no requirement of an explicit restore mechanism.
- *    Current master key will be stored in memory on each instance & will be used to generate new tokens.
+ *    This key will be regenerated on service restart and thus there is no requirement of an explicit restore mechanism.
+ *    Current master key will be stored in memory on each instance and will be used to generate new tokens.
  *    Master key will be looked up from the state store for Validation / renewal, etc of tokens.
  *
  * 2) Token Expiry - It doesn't take care of token removal on expiry.
  *    Each state store can implement its own way to manage token deletion on expiry.
  *
  * This pretty much replaces all methods of AbstractDelegationTokenSecretManager which is designed for stateful managers
- * TODO - Refactor Secret Manager interfaces to support stateful & stateless secret management
+ * TODO - Refactor Secret Manager interfaces to support stateful and stateless secret management
  */
 public class RouterDelegationTokenSecretManager
     extends AbstractDelegationTokenSecretManager<RMDelegationTokenIdentifier> {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/security/RouterDelegationTokenSecretManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/security/RouterDelegationTokenSecretManager.java
@@ -145,7 +145,7 @@ public class RouterDelegationTokenSecretManager
   }
 
   /**
-   * no-op as expiry of stored tokens is upto the state store in a stateless secret manager
+   * no-op as removal of tokens is handled in removeToken()
    */
   @Override
   public void removeStoredToken(RMDelegationTokenIdentifier identifier) {
@@ -188,7 +188,6 @@ public class RouterDelegationTokenSecretManager
   @Override
   protected void storeToken(RMDelegationTokenIdentifier rmDelegationTokenIdentifier,
       DelegationTokenInformation tokenInfo) throws IOException {
-    this.addTokenForOwnerStats(rmDelegationTokenIdentifier);
     try {
       storeNewToken(rmDelegationTokenIdentifier, tokenInfo);
     } catch (YarnException e) {
@@ -205,6 +204,16 @@ public class RouterDelegationTokenSecretManager
     } catch (YarnException e) {
       e.printStackTrace();
       throw new IOException(e); // Wrap YarnException as an IOException to adhere to updateToken contract
+    }
+  }
+
+  @Override
+  protected void removeToken(RMDelegationTokenIdentifier identifier) throws IOException {
+    try {
+      federationFacade.removeStoredToken(identifier);
+    } catch (YarnException e) {
+      e.printStackTrace();
+      throw new IOException(e); // Wrap YarnException as an IOException to adhere to removeToken contract
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
@@ -1618,7 +1618,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     RouterRMDTSecretManagerState managerState = stateStore.getRouterRMSecretManagerState();
     Assert.assertNotNull(managerState);
 
-    Map<RMDelegationTokenIdentifier, RouterStoreToken> delegationTokenState =
+    Map<Integer, RouterStoreToken> delegationTokenState =
         managerState.getTokenState();
     Assert.assertNotNull(delegationTokenState);
     Assert.assertTrue(delegationTokenState.containsKey(rMDelegationTokenIdentifier));
@@ -1671,7 +1671,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Step3. Compare whether the expirationTime returned to
     // the client is consistent with the renewDate in the stateStore
     RouterRMDTSecretManagerState managerState = stateStore.getRouterRMSecretManagerState();
-    Map<RMDelegationTokenIdentifier, RouterStoreToken> delegationTokenState =
+    Map<Integer, RouterStoreToken> delegationTokenState =
         managerState.getTokenState();
     Assert.assertNotNull(delegationTokenState);
     Assert.assertTrue(delegationTokenState.containsKey(rMDelegationTokenIdentifier));
@@ -1707,7 +1707,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Step3. Query the data in the StateStore and confirm that the Delegation has been deleted.
     // At this point, the size of delegationTokenState should be 0.
     RouterRMDTSecretManagerState managerState = stateStore.getRouterRMSecretManagerState();
-    Map<RMDelegationTokenIdentifier, RouterStoreToken> delegationTokenState =
+    Map<Integer, RouterStoreToken> delegationTokenState =
         managerState.getTokenState();
     Assert.assertNotNull(delegationTokenState);
     Assert.assertEquals(0, delegationTokenState.size());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/security/AbstractSecureRouterTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/security/AbstractSecureRouterTest.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.yarn.server.router.secure;
+package org.apache.hadoop.yarn.server.router.security;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -37,7 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/security/TestSecureLogins.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/security/TestSecureLogins.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.yarn.server.router.secure;
+package org.apache.hadoop.yarn.server.router.security;
 
 import org.apache.commons.collections.MapUtils;
 import org.apache.hadoop.service.Service;


### PR DESCRIPTION
### Description of PR

JIRA - https://issues.apache.org/jira/browse/YARN-11448 

Currently router secret manager requires routers to be stateful & with clients using sticky sessions.

Otherwise, there are several issues mentioned below which lead to the delegation token functionality not working across router instances

Eg:

- allKeys needs to be consistently updated across all router instances
- DB update exceptions are swallowed & returned as a success if just in memory variables are updated
- Purging Delegation Token / Master key on expiry assumes all tokens are available in memory
- APIs like get all tokens return only in memory data which is incorrect

A more scalable & maintainable framework for Router would be to be design it as a stateless service. Given database KV lookups are in the order of < 10 ms, it doesn't add any latency overhead and makes router easier to maintain. Plus a stateless router setup, with no assumptions of stickiness makes the router framework more generic. 

Additionally, some of the functionality around master key ids, delegation token sequence numbers is implemented as globally autoincrement ids which too isn't feasible across all datastores. The actual requirement is to generate unique keys for master key ids / delegation tokens which is a much more simpler & generic solution. Plus certain apis like get sequence no / set sequence no aren't applicable for router and we can avoid providing them to make things much more simpler.  

This patch addresses these functional concerns while working within the interfaces of AbstractDelegationTokenSecretManager. 

As a later patch, we can create better delegation token interfaces to support both stateful & stateless secret managers. 

### How was this patch tested?

Unit Tests - Currently implemented 1 test - testNewTokenVerification - adding more test cases