### PR TITLE
HDFS-16938. Utility to trigger heartbeat and wait until BP thread queue is fully processed

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPOfferService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPOfferService.java
@@ -660,6 +660,23 @@ class BPOfferService {
     }
   }
 
+  /**
+   * Run an immediate heartbeat from all actors. Wait until heartbeat is processed and BP thread
+   * queue is also processed. This should be used when we need to trigger the heartbeat and also
+   * wait for bpThreadQueue to be fully processed.
+   * Used by tests.
+   *
+   * @throws InterruptedException if interrupted while waiting for the queue to be processed.
+   * @throws IOException if the retries are exhausted and the BP thread queue could not be
+   * successfully processed.
+   */
+  @VisibleForTesting
+  void triggerHeartbeatAndWaitQueueProcessedForTests() throws InterruptedException, IOException {
+    for (BPServiceActor actor : bpServices) {
+      actor.triggerHeartbeatAndWaitUntilQueueProcessed();
+    }
+  }
+
   boolean processCommandFromActor(DatanodeCommand cmd,
       BPServiceActor actor) throws IOException {
     assert bpServices.contains(actor);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.BlockingQueue;
@@ -361,6 +362,35 @@ class BPServiceActor implements Runnable {
         } catch (InterruptedException e) {
           return;
         }
+      }
+    }
+  }
+
+  /**
+   * Trigger the heartbeat and wait for BP thread queue to be fully processed.
+   * To be used as a test utility.
+   *
+   * @throws InterruptedException if interrupted while waiting for the queue to be processed.
+   * @throws IOException if the retries are exhausted and the BP thread queue could not be
+   * successfully processed.
+   */
+  @VisibleForTesting
+  void triggerHeartbeatAndWaitUntilQueueProcessed() throws InterruptedException, IOException {
+    Queue<BPServiceActorAction> bpServiceActorActions;
+    synchronized (bpThreadQueue) {
+      bpServiceActorActions = new LinkedList<>(bpThreadQueue);
+    }
+    triggerHeartbeatForTests();
+    while (!bpServiceActorActions.isEmpty()) {
+      BPServiceActorAction bpServiceActorAction = bpServiceActorActions.remove();
+      int retries = 3;
+      while (!bpServiceActorAction.isReportSuccessfullySent() && retries > 0) {
+        LOG.info("{} has not yet successfully sent report", bpServiceActorAction);
+        Thread.sleep(1000);
+        retries--;
+      }
+      if (retries == 0) {
+        throw new IOException("BP service actor action could not be completed successfully");
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -383,7 +383,7 @@ class BPServiceActor implements Runnable {
     triggerHeartbeatForTests();
     while (!bpServiceActorActions.isEmpty()) {
       BPServiceActorAction bpServiceActorAction = bpServiceActorActions.remove();
-      int retries = 3;
+      int retries = 5;
       while (!bpServiceActorAction.isReportSuccessfullySent() && retries > 0) {
         LOG.info("{} has not yet successfully sent report", bpServiceActorAction);
         Thread.sleep(1000);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActorAction.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActorAction.java
@@ -27,6 +27,10 @@ import org.apache.hadoop.hdfs.server.protocol.DatanodeRegistration;
  * to take several actions.
  */
 public interface BPServiceActorAction {
-  public void reportTo(DatanodeProtocolClientSideTranslatorPB bpNamenode,
-    DatanodeRegistration bpRegistration) throws BPServiceActorActionException;
+
+  void reportTo(DatanodeProtocolClientSideTranslatorPB bpNamenode,
+      DatanodeRegistration bpRegistration) throws BPServiceActorActionException;
+
+  boolean isReportSuccessfullySent();
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ErrorReportAction.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ErrorReportAction.java
@@ -34,7 +34,8 @@ public class ErrorReportAction implements BPServiceActorAction {
 
   final int errorCode;
   final String errorMessage;
-  
+  private boolean isReportSuccessfullySent = false;
+
   public ErrorReportAction(int errorCode, String errorMessage) {
     this.errorCode = errorCode;
     this.errorMessage = errorMessage;
@@ -45,6 +46,7 @@ public class ErrorReportAction implements BPServiceActorAction {
     DatanodeRegistration bpRegistration) throws BPServiceActorActionException {
     try {
       bpNamenode.errorReport(bpRegistration, errorCode, errorMessage);
+      isReportSuccessfullySent = true;
     } catch (RemoteException re) {
       DataNode.LOG.info("trySendErrorReport encountered RemoteException  "
           + "errorMessage: " + errorMessage + "  errorCode: " + errorCode, re);
@@ -52,6 +54,11 @@ public class ErrorReportAction implements BPServiceActorAction {
       throw new BPServiceActorActionException("Error reporting "
           + "an error to namenode.", e);
     }
+  }
+
+  @Override
+  public boolean isReportSuccessfullySent() {
+    return isReportSuccessfullySent;
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ReportBadBlockAction.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ReportBadBlockAction.java
@@ -40,6 +40,7 @@ public class ReportBadBlockAction implements BPServiceActorAction {
   private final ExtendedBlock block;
   private final String storageUuid;
   private final StorageType storageType;
+  private boolean isReportSuccessfullySent = false;
 
   public ReportBadBlockAction(ExtendedBlock block, String storageUuid, 
       StorageType storageType) {
@@ -63,6 +64,7 @@ public class ReportBadBlockAction implements BPServiceActorAction {
 
     try {
       bpNamenode.reportBadBlocks(locatedBlock);
+      isReportSuccessfullySent = true;
     } catch (RemoteException re) {
       DataNode.LOG.info("reportBadBlock encountered RemoteException for "
           + "block:  " + block , re);
@@ -70,6 +72,11 @@ public class ReportBadBlockAction implements BPServiceActorAction {
       throw new BPServiceActorActionException("Failed to report bad block "
           + block + " to namenode.", e);
     }
+  }
+
+  @Override
+  public boolean isReportSuccessfullySent() {
+    return isReportSuccessfullySent;
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/DataNodeTestUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/DataNodeTestUtils.java
@@ -91,7 +91,22 @@ public class DataNodeTestUtils {
       bpos.triggerHeartbeatForTests();
     }
   }
-  
+
+  /**
+   * Trigger the heartbeat and return only when all BP thread queue are successfully processed
+   * i.e. any bad block has been successfully reported to the active namenode.
+   * @param dn datanode
+   * @throws InterruptedException if interrupted while waiting for the queue to be processed.
+   * @throws IOException if the retries are exhausted and the BP thread queue could not be
+   * successfully processed.
+   */
+  public static void triggerHeartbeatAndWaitQueueProcessedForTests(DataNode dn)
+      throws InterruptedException, IOException {
+    for (BPOfferService bpos : dn.getAllBpOs()) {
+      bpos.triggerHeartbeatAndWaitQueueProcessedForTests();
+    }
+  }
+
   public static void triggerBlockReport(DataNode dn) throws IOException {
     for (BPOfferService bpos : dn.getAllBpOs()) {
       bpos.triggerBlockReportForTests();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -1100,7 +1100,7 @@ public class TestFsDatasetImpl {
       block = DFSTestUtil.getFirstBlock(fs, filePath);
       // Test for the overloaded method reportBadBlocks
       dataNode.reportBadBlocks(block, dataNode.getFSDataset().getFsVolumeReferences().get(0));
-      DataNodeTestUtils.triggerHeartbeat(dataNode);
+      DataNodeTestUtils.triggerHeartbeatAndWaitQueueProcessedForTests(dataNode);
       BlockManagerTestUtil.updateState(cluster.getNamesystem().getBlockManager());
       assertEquals("Corrupt replica blocks could not be reflected with the heartbeat", 1,
           cluster.getNamesystem().getCorruptReplicaBlocks());


### PR DESCRIPTION
As a follow-up to HDFS-16935, we should provide utility to trigger heartbeat and wait until BP thread queue is fully processed. This would ensure 100% consistency w.r.t active namenode being able to receive bad block reports from the given datanode. This utility would resolve flakes for the tests that rely on namenode's awareness of the reported bad blocks by datanodes.