### PR TITLE
HDFS-15765. WebHdfs: add support for basic auth and custom API path

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -287,6 +287,9 @@ public interface HdfsClientConfigKeys {
       "dfs.client.output.stream.uniq.default.key";
   String DFS_OUTPUT_STREAM_UNIQ_DEFAULT_KEY_DEFAULT = "DEFAULT";
 
+  String DFS_CLIENT_WEBHDFS_USE_BASE_PATH_KEY = "dfs.client.webhdfs.use-base-path";
+  boolean DFS_CLIENT_WEBHDFS_USE_BASE_PATH_DEFAULT = false;
+
   /**
    * These are deprecated config keys to client code.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/BasicAuthConfigurator.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/BasicAuthConfigurator.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.security.authentication.client.ConnectionConfigurator;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 /**
@@ -52,7 +53,7 @@ public class BasicAuthConfigurator implements ConnectionConfigurator {
     if (credentials != null && !credentials.equals("")) {
       conn.setRequestProperty(
           "AUTHORIZATION",
-          "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes())
+          "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8))
       );
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/BasicAuthConfigurator.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/BasicAuthConfigurator.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.web;
+
+import org.apache.hadoop.security.authentication.client.ConnectionConfigurator;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.Base64;
+
+/**
+ * This class adds basic authentication to the connection,
+ * allowing users to access webhdfs over HTTP with basic authentication,
+ * for example when using Apache Knox.
+ */
+public class BasicAuthConfigurator implements ConnectionConfigurator {
+  private final ConnectionConfigurator parent;
+  private final String credentials;
+
+  /**
+   * @param credentials a string of the form "username:password"
+   */
+  public BasicAuthConfigurator(
+      ConnectionConfigurator parent,
+      String credentials
+  ) {
+    this.parent = parent;
+    this.credentials = credentials;
+  }
+
+  @Override
+  public HttpURLConnection configure(HttpURLConnection conn) throws IOException {
+    if (parent != null) {
+      parent.configure(conn);
+    }
+
+    if (credentials != null && !credentials.equals("")) {
+      conn.setRequestProperty(
+          "AUTHORIZATION",
+          "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes())
+      );
+    }
+
+    return conn;
+  }
+
+  public void destroy() {
+    if (parent != null && parent instanceof SSLConnectionConfigurator) {
+      ((SSLConnectionConfigurator)parent).destroy();
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/BasicAuthConfigurator.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/BasicAuthConfigurator.java
@@ -33,16 +33,6 @@ public class BasicAuthConfigurator implements ConnectionConfigurator {
   private final ConnectionConfigurator parent;
   private final String credentials;
 
-  static public ConnectionConfigurator getConfigurator(
-      ConnectionConfigurator configurator, String basicAuthCred
-  ) {
-    if (basicAuthCred != null && !basicAuthCred.isEmpty()) {
-      return new BasicAuthConfigurator(configurator, basicAuthCred);
-    } else {
-      return configurator;
-    }
-  }
-
   /**
    * @param credentials a string of the form "username:password"
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/BasicAuthConfigurator.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/BasicAuthConfigurator.java
@@ -33,6 +33,16 @@ public class BasicAuthConfigurator implements ConnectionConfigurator {
   private final ConnectionConfigurator parent;
   private final String credentials;
 
+  static public ConnectionConfigurator getConfigurator(
+      ConnectionConfigurator configurator, String basicAuthCred
+  ) {
+    if (basicAuthCred != null && !basicAuthCred.isEmpty()) {
+      return new BasicAuthConfigurator(configurator, basicAuthCred);
+    } else {
+      return configurator;
+    }
+  }
+
   /**
    * @param credentials a string of the form "username:password"
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/BasicAuthConfigurator.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/BasicAuthConfigurator.java
@@ -53,7 +53,9 @@ public class BasicAuthConfigurator implements ConnectionConfigurator {
     if (credentials != null && !credentials.equals("")) {
       conn.setRequestProperty(
           "AUTHORIZATION",
-          "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8))
+          "Basic " + Base64.getEncoder().encodeToString(
+              credentials.getBytes(StandardCharsets.UTF_8)
+          )
       );
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/URLConnectionFactory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/URLConnectionFactory.java
@@ -136,7 +136,7 @@ public class URLConnectionFactory {
       }
     }
 
-    return new BasicAuthConfigurator(conn, basicAuthCredentials);
+    return BasicAuthConfigurator.getConfigurator(conn, basicAuthCredentials);
   }
 
   /**
@@ -166,7 +166,7 @@ public class URLConnectionFactory {
     } catch (Exception e) {
       throw new IOException("Unable to load OAuth2 connection factory.", e);
     }
-    conn = new BasicAuthConfigurator(conn, basicAuthCredentials);
+    conn = BasicAuthConfigurator.getConfigurator(conn, basicAuthCredentials);
     return new URLConnectionFactory(conn);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/URLConnectionFactory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/URLConnectionFactory.java
@@ -136,7 +136,7 @@ public class URLConnectionFactory {
       }
     }
 
-    return BasicAuthConfigurator.getConfigurator(conn, basicAuthCredentials);
+    return createBasicAuthConfigurator(conn, basicAuthCredentials);
   }
 
   /**
@@ -166,7 +166,7 @@ public class URLConnectionFactory {
     } catch (Exception e) {
       throw new IOException("Unable to load OAuth2 connection factory.", e);
     }
-    conn = BasicAuthConfigurator.getConfigurator(conn, basicAuthCredentials);
+    conn = createBasicAuthConfigurator(conn, basicAuthCredentials);
     return new URLConnectionFactory(conn);
   }
 
@@ -236,6 +236,24 @@ public class URLConnectionFactory {
                                   int readTimeout) {
     connection.setConnectTimeout(connectTimeout);
     connection.setReadTimeout(readTimeout);
+  }
+
+  /**
+   * Create a new ConnectionConfigurator wrapping the given one with HTTP Basic Authentication.
+   * It will return the original configurator if no credentials are specified.
+   *
+   * @param configurator  Parent connection configurator.
+   * @param basicAuthCred Credentials for HTTP Basic Authentication in "username:password" format,
+   *                      or null / empty string if no credentials are to be used.
+   */
+  private static ConnectionConfigurator createBasicAuthConfigurator(
+      ConnectionConfigurator configurator, String basicAuthCred
+  ) {
+    if (basicAuthCred != null && !basicAuthCred.isEmpty()) {
+      return new BasicAuthConfigurator(configurator, basicAuthCred);
+    } else {
+      return configurator;
+    }
   }
 
   public void destroy() {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/URLConnectionFactory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/URLConnectionFactory.java
@@ -77,7 +77,7 @@ public class URLConnectionFactory {
   public static URLConnectionFactory newDefaultURLConnectionFactory(
       Configuration conf) {
     ConnectionConfigurator conn = getSSLConnectionConfiguration(
-        DEFAULT_SOCKET_TIMEOUT, DEFAULT_SOCKET_TIMEOUT, conf);
+        DEFAULT_SOCKET_TIMEOUT, DEFAULT_SOCKET_TIMEOUT, conf, null);
 
     return new URLConnectionFactory(conn);
   }
@@ -89,12 +89,28 @@ public class URLConnectionFactory {
   public static URLConnectionFactory newDefaultURLConnectionFactory(
       int connectTimeout, int readTimeout, Configuration conf) {
     ConnectionConfigurator conn = getSSLConnectionConfiguration(
-        connectTimeout, readTimeout, conf);
+        connectTimeout, readTimeout, conf, null);
+    return new URLConnectionFactory(conn);
+  }
+
+  /**
+   * Construct a new URLConnectionFactory based on the configuration. It will
+   * honor connecTimeout and readTimeout when they are specified and allows
+   * specifying credentials for HTTP Basic Authentication in "username:password" format.
+   */
+  public static URLConnectionFactory newDefaultURLConnectionFactory(
+      int connectTimeout, int readTimeout, Configuration conf, String basicAuthCredentials) {
+    ConnectionConfigurator conn = getSSLConnectionConfiguration(
+        connectTimeout, readTimeout, conf, basicAuthCredentials);
     return new URLConnectionFactory(conn);
   }
 
   private static ConnectionConfigurator getSSLConnectionConfiguration(
-      final int connectTimeout, final int readTimeout, Configuration conf) {
+      final int connectTimeout,
+      final int readTimeout,
+      Configuration conf,
+      String basicAuthCredentials
+  ) {
     ConnectionConfigurator conn;
     try {
       conn = new SSLConnectionConfigurator(connectTimeout, readTimeout, conf);
@@ -120,7 +136,7 @@ public class URLConnectionFactory {
       }
     }
 
-    return conn;
+    return new BasicAuthConfigurator(conn, basicAuthCredentials);
   }
 
   /**
@@ -129,6 +145,17 @@ public class URLConnectionFactory {
    */
   public static URLConnectionFactory newOAuth2URLConnectionFactory(
       int connectTimeout, int readTimeout, Configuration conf)
+      throws IOException {
+    return newOAuth2URLConnectionFactory(connectTimeout, readTimeout, conf, null);
+  }
+
+  /**
+   * Construct a new URLConnectionFactory that supports OAuth-based connections.
+   * It will also try to load the SSL configuration when they are specified. Furthermore, it allows
+   * specifying credentials for HTTP Basic Authentication in "username:password" format.
+   */
+  public static URLConnectionFactory newOAuth2URLConnectionFactory(
+      int connectTimeout, int readTimeout, Configuration conf, String basicAuthCredentials)
       throws IOException {
     ConnectionConfigurator conn;
     try {
@@ -139,6 +166,7 @@ public class URLConnectionFactory {
     } catch (Exception e) {
       throw new IOException("Unable to load OAuth2 connection factory.", e);
     }
+    conn = new BasicAuthConfigurator(conn, basicAuthCredentials);
     return new URLConnectionFactory(conn);
   }
 
@@ -213,6 +241,9 @@ public class URLConnectionFactory {
   public void destroy() {
     if (connConfigurator instanceof SSLConnectionConfigurator) {
       ((SSLConnectionConfigurator) connConfigurator).destroy();
+    }
+    if (connConfigurator instanceof BasicAuthConfigurator) {
+      ((BasicAuthConfigurator) connConfigurator).destroy();
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
@@ -315,7 +315,7 @@ public class WebHdfsFileSystem extends FileSystem
         HdfsClientConfigKeys.DFS_CLIENT_WEBHDFS_USE_BASE_PATH_KEY,
         HdfsClientConfigKeys.DFS_CLIENT_WEBHDFS_USE_BASE_PATH_DEFAULT
     );
-    if (uri.getPath() != null && !uri.getPath().equals("") && useBasePath) {
+    if (uri != null && uri.getPath() != null && !uri.getPath().equals("") && useBasePath) {
       pathPrefix = uri.getPath();
       if (pathPrefix.endsWith("/")) {
         pathPrefix = pathPrefix.substring(0, pathPrefix.length() - 1);

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/web/TestBasicAuthConfigurator.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/web/TestBasicAuthConfigurator.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.web;
+
+import org.apache.hadoop.security.authentication.client.ConnectionConfigurator;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+public class TestBasicAuthConfigurator {
+  @Test
+  public void testNullCredentials() throws IOException {
+    ConnectionConfigurator conf = new BasicAuthConfigurator(null, null);
+    HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
+    conf.configure(conn);
+    Mockito.verify(conn, Mockito.never()).setRequestProperty(Mockito.any(), Mockito.any());
+  }
+
+  @Test
+  public void testEmptyCredentials() throws IOException {
+    ConnectionConfigurator conf = new BasicAuthConfigurator(null, "");
+    HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
+    conf.configure(conn);
+    Mockito.verify(conn, Mockito.never()).setRequestProperty(Mockito.any(), Mockito.any());
+  }
+
+  @Test
+  public void testCredentialsSet() throws IOException {
+    ConnectionConfigurator conf = new BasicAuthConfigurator(null, "user:pass");
+    HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
+    conf.configure(conn);
+    Mockito.verify(conn, Mockito.times(1)).setRequestProperty(
+        "AUTHORIZATION",
+        "Basic dXNlcjpwYXNz"
+    );
+  }
+
+  @Test
+  public void testParentConfigurator() throws IOException {
+    ConnectionConfigurator parent = Mockito.mock(ConnectionConfigurator.class);
+    ConnectionConfigurator conf = new BasicAuthConfigurator(parent, "user:pass");
+    HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
+    conf.configure(conn);
+    Mockito.verify(conn, Mockito.times(1)).setRequestProperty(
+        "AUTHORIZATION",
+        "Basic dXNlcjpwYXNz"
+    );
+    Mockito.verify(parent, Mockito.times(1)).configure(conn);
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6472,4 +6472,12 @@
       Enables observer reads for clients. This should only be enabled when clients are using routers.
     </description>
   </property>
+  <property>
+    <name>dfs.client.webhdfs.use-base-path</name>
+    <value>false</value>
+    <description>
+      Enables webhdfs FS clients to use specified filesystem URL path as the prefix for API endpoint.
+      Useful when using a proxy server like Apache Knox, which requires prefixing requests with /gateway/name.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHdfsUrl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHdfsUrl.java
@@ -373,7 +373,7 @@ public class TestWebHdfsUrl {
   }
 
   private WebHdfsFileSystem getWebHdfsFileSystem(UserGroupInformation ugi,
-      Configuration conf, URI uri) throws IOException {
+      Configuration conf, URI fsUri) throws IOException {
     if (UserGroupInformation.isSecurityEnabled()) {
       DelegationTokenIdentifier dtId = new DelegationTokenIdentifier(new Text(
           ugi.getUserName()), null, null);
@@ -384,11 +384,11 @@ public class TestWebHdfsUrl {
       Token<DelegationTokenIdentifier> token = new Token<DelegationTokenIdentifier>(
           dtId, dtSecretManager);
       SecurityUtil.setTokenService(
-          token, NetUtils.createSocketAddr(uri.getAuthority()));
+          token, NetUtils.createSocketAddr(fsUri.getAuthority()));
       token.setKind(WebHdfsConstants.WEBHDFS_TOKEN_KIND);
       ugi.addToken(token);
     }
-    return (WebHdfsFileSystem) FileSystem.get(uri, conf);
+    return (WebHdfsFileSystem) FileSystem.get(fsUri, conf);
   }
 
   private WebHdfsFileSystem getWebHdfsFileSystem(UserGroupInformation ugi,


### PR DESCRIPTION
### Description of PR

`WebHdfsFileSystem` didn't provide any support for HTTP BASIC authentication (username/password). This patch adds that feature. When specifying filesystem URI, the credentials part (`user:pass@`) is now parsed properly and used for `Authorization` header.

Additionally, base path specified in filesystem URL used to be ignored. This patch adds configuration option `dfs.client.webhdfs.use-base-path` that, when enabled, indicates that this path should be used as API prefix. This allows specifying `/gateway/gatewayname` when using WebHdfs for Apache Knox. When base path contains `/webhdfs/v1`, it is ignored, since we always append that.

Option `dfs.client.webhdfs.use-base-path` defaults to false because it could introduce a backward compatibility break. Some WebHdfs users could have typos or something random as path, and before this patch it would simply be ignored. By setting the default to false, we make sure that it won't break any existing setup.

Note that issue HDFS-15765 is also about Kerberos auth. This patch only addresses the base path and basic authentication portion, I didn't investigate the Kerberos auth since we don't use in our setup.

### How was this patch tested?

I tested it with WebHdfs secured by Apache Knox with basic authorization, but without Kerberos. I had a test script that would perform a file upload. I set `dfs.client.webhdfs.use_basepath` to true, and used `swebhdfs://admin:admin-password@localhost:8443/gateway/docker/` as filesystem URI. Without my patch, both the `admin:admin-password` credentials and `/gateway/docker` API base path would be ignored. With it, file upload worked.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

