### PR TITLE
HADOOP-18450. JavaKeyStoreProvider should throw FileNotFoundException…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/JavaKeyStoreProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/JavaKeyStoreProvider.java
@@ -640,6 +640,10 @@ public class JavaKeyStoreProvider extends KeyProvider {
   private void renameOrFail(Path src, Path dest)
       throws IOException {
     if (!fs.rename(src, dest)) {
+      if (!fs.exists(src)) {
+        throw new FileNotFoundException(src.toUri().toString());
+      }
+
       throw new IOException("Rename unsuccessful : "
           + String.format("'%s' to '%s'", src, dest));
     }


### PR DESCRIPTION
… in renameOrFail

### Description of PR

Attempting to create a key a KMS is configured with the JavaKeystoreProvider and an HDFS store.  The calls to:
```
renameOrFail(Path src, Path dest) throws IOException 
```

... fails with an IOException when it attempts to rename a file.  The calling code catches FileNotFoundException since the src file may not exist.

Example:
```
$ hadoop key create sample
java.io.IOException: Rename unsuccessful : 'hdfs://mycluster/security/kms.jks_NEW' to 'hdfs://mycluster/security/kms.jks_NEW_ORPHANED_1662946593691'
 ```

Update the implementation to check for the file, throwing a FileNotFoundException.

### How was this patch tested?

Running in an Hadoop development environment docker image.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?