### PR TITLE
HADOOP-18653. LogLevel servlet to determine log impl before using setLevel

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/LogLevel.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/LogLevel.java
@@ -34,6 +34,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
+import org.slf4j.LoggerFactory;
+
 import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -44,6 +46,7 @@ import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
 import org.apache.hadoop.security.authentication.client.KerberosAuthenticator;
 import org.apache.hadoop.security.ssl.SSLFactory;
 import org.apache.hadoop.util.GenericOptionsParser;
+import org.apache.hadoop.util.GenericsUtil;
 import org.apache.hadoop.util.ServletUtil;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
@@ -338,14 +341,18 @@ public class LogLevel {
         out.println(MARKER
             + "Submitted Class Name: <b>" + logName + "</b><br />");
 
-        Logger log = Logger.getLogger(logName);
+        org.slf4j.Logger log = LoggerFactory.getLogger(logName);
         out.println(MARKER
             + "Log Class: <b>" + log.getClass().getName() +"</b><br />");
         if (level != null) {
           out.println(MARKER + "Submitted Level: <b>" + level + "</b><br />");
         }
 
-        process(log, level, out);
+        if (GenericsUtil.isLog4jLogger(logName)) {
+          process(Logger.getLogger(logName), level, out);
+        } else {
+          out.println("Sorry, " + log.getClass() + " not supported.<br />");
+        }
       }
 
       out.println(FORMS);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/LogLevel.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/LogLevel.java
@@ -351,7 +351,7 @@ public class LogLevel {
         if (GenericsUtil.isLog4jLogger(logName)) {
           process(Logger.getLogger(logName), level, out);
         } else {
-          out.println("Sorry, " + log.getClass() + " not supported.<br />");
+          out.println("Sorry, setting log level is only supported for log4j loggers.<br />");
         }
       }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GenericsUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GenericsUtil.java
@@ -89,10 +89,30 @@ public class GenericsUtil {
     }
     Logger log = LoggerFactory.getLogger(clazz);
     try {
-      Class log4jClass = Class.forName("org.slf4j.impl.Log4jLoggerAdapter");
+      Class<?> log4jClass = Class.forName("org.slf4j.impl.Log4jLoggerAdapter");
       return log4jClass.isInstance(log);
     } catch (ClassNotFoundException e) {
       return false;
     }
   }
+
+  /**
+   * Determine whether the log of the given logger is of Log4J implementation.
+   *
+   * @param logger the logger name, usually class name as string.
+   * @return true if the logger uses Log4J implementation.
+   */
+  public static boolean isLog4jLogger(String logger) {
+    if (logger == null) {
+      return false;
+    }
+    Logger log = LoggerFactory.getLogger(logger);
+    try {
+      Class<?> log4jClass = Class.forName("org.slf4j.impl.Log4jLoggerAdapter");
+      return log4jClass.isInstance(log);
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GenericsUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GenericsUtil.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.util;
 
 import java.lang.reflect.Array;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -32,6 +33,14 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 public class GenericsUtil {
+
+  private static final String SLF4J_LOG4J_ADAPTER_CLASS = "org.slf4j.impl.Log4jLoggerAdapter";
+
+  /**
+   * Set to false only if log4j adapter class is not found in the classpath. Once set to false,
+   * the utility method should not bother re-loading class again.
+   */
+  private static final AtomicBoolean IS_LOG4J_LOGGER = new AtomicBoolean(true);
 
   /**
    * Returns the Class object (of type <code>Class&lt;T&gt;</code>) of the  
@@ -84,14 +93,15 @@ public class GenericsUtil {
    * @return true if the log of <code>clazz</code> is Log4j implementation.
    */
   public static boolean isLog4jLogger(Class<?> clazz) {
-    if (clazz == null) {
+    if (clazz == null || !IS_LOG4J_LOGGER.get()) {
       return false;
     }
     Logger log = LoggerFactory.getLogger(clazz);
     try {
-      Class<?> log4jClass = Class.forName("org.slf4j.impl.Log4jLoggerAdapter");
+      Class<?> log4jClass = Class.forName(SLF4J_LOG4J_ADAPTER_CLASS);
       return log4jClass.isInstance(log);
     } catch (ClassNotFoundException e) {
+      IS_LOG4J_LOGGER.set(false);
       return false;
     }
   }
@@ -103,14 +113,15 @@ public class GenericsUtil {
    * @return true if the logger uses Log4J implementation.
    */
   public static boolean isLog4jLogger(String logger) {
-    if (logger == null) {
+    if (logger == null || !IS_LOG4J_LOGGER.get()) {
       return false;
     }
     Logger log = LoggerFactory.getLogger(logger);
     try {
-      Class<?> log4jClass = Class.forName("org.slf4j.impl.Log4jLoggerAdapter");
+      Class<?> log4jClass = Class.forName(SLF4J_LOG4J_ADAPTER_CLASS);
       return log4jClass.isInstance(log);
     } catch (ClassNotFoundException e) {
+      IS_LOG4J_LOGGER.set(false);
       return false;
     }
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GenericsUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GenericsUtil.java
@@ -96,14 +96,7 @@ public class GenericsUtil {
     if (clazz == null || !IS_LOG4J_LOGGER.get()) {
       return false;
     }
-    Logger log = LoggerFactory.getLogger(clazz);
-    try {
-      Class<?> log4jClass = Class.forName(SLF4J_LOG4J_ADAPTER_CLASS);
-      return log4jClass.isInstance(log);
-    } catch (ClassNotFoundException e) {
-      IS_LOG4J_LOGGER.set(false);
-      return false;
-    }
+    return isLog4jLogger(clazz.getName());
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GenericsUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/GenericsUtil.java
@@ -93,7 +93,7 @@ public class GenericsUtil {
    * @return true if the log of <code>clazz</code> is Log4j implementation.
    */
   public static boolean isLog4jLogger(Class<?> clazz) {
-    if (clazz == null || !IS_LOG4J_LOGGER.get()) {
+    if (clazz == null) {
       return false;
     }
     return isLog4jLogger(clazz.getName());

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestGenericsUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestGenericsUtil.java
@@ -140,7 +140,7 @@ public class TestGenericsUtil {
 
   @Test
   public void testIsLog4jLogger() throws Exception {
-    assertFalse("False if clazz is null", GenericsUtil.isLog4jLogger(null));
+    assertFalse("False if clazz is null", GenericsUtil.isLog4jLogger((Class<?>) null));
     assertTrue("The implementation is Log4j",
         GenericsUtil.isLog4jLogger(TestGenericsUtil.class));
   }


### PR DESCRIPTION
LogLevel GET API is used to set log level for a given class name dynamically. While we have cleaned up the commons-logging references, it would be great to determine whether slf4j log4j adapter is in the classpath before allowing client to set the log level.

Proposed changes:

- Use slf4j logger factory to get the log reference for the given class name
- Use generic utility to identify if the slf4j log4j adapter is in the classpath before using log4j API to update the log level
- If the log4j adapter is not in the classpath, report error in the output
