### PR TITLE
HADOOP-18657. Tune ABFS create() retry logic

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/ConcurrentWriteOperationDetectedException.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/ConcurrentWriteOperationDetectedException.java
@@ -29,4 +29,9 @@ public class ConcurrentWriteOperationDetectedException
   public ConcurrentWriteOperationDetectedException(String message) {
     super(message);
   }
+
+  public ConcurrentWriteOperationDetectedException(final String message,
+      final Throwable innerThrowable) {
+    super(message, innerThrowable);
+  }
 }


### PR DESCRIPTION
### Description of PR

Tunes how abfs handles a failure during create which may be due to concurrency *or* load-related retries happening in the store.

* better logging
* happy with the confict being resolved by the file being deleted
* more diagnostics in failure raised

### How was this patch tested?

lease test run already; doing full hadoop-azure test run

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

