### PR TITLE
HDFS-16944 Add audit log for RouterAdminServer to save privileged operation log seperately.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAdminServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAdminServer.java
@@ -112,6 +112,8 @@ public class RouterAdminServer extends AbstractService
 
   private static final Logger LOG =
       LoggerFactory.getLogger(RouterAdminServer.class);
+      private static final Logger AUDITLOG =
+      LoggerFactory.getLogger(RouterAdminServer.class.getName() + ".audit");
 
   private Configuration conf;
 
@@ -514,11 +516,11 @@ public class RouterAdminServer extends AbstractService
       safeModeService.setManualSafeMode(true);
       success = verifySafeMode(true);
       if (success) {
-        LOG.info("STATE* Safe mode is ON.\n" + "It was turned on manually. "
+        AUDITLOG.info("STATE* Safe mode is ON.\n" + "It was turned on manually. "
             + "Use \"hdfs dfsrouteradmin -safemode leave\" to turn"
             + " safe mode off.");
       } else {
-        LOG.error("Unable to enter safemode.");
+        AUDITLOG.error("Unable to enter safemode.");
       }
     }
     return EnterSafeModeResponse.newInstance(success);
@@ -535,9 +537,9 @@ public class RouterAdminServer extends AbstractService
       safeModeService.setManualSafeMode(false);
       success = verifySafeMode(false);
       if (success) {
-        LOG.info("STATE* Safe mode is OFF.\n" + "It was turned off manually.");
+        AUDITLOG.info("STATE* Safe mode is OFF.\n" + "It was turned off manually.");
       } else {
-        LOG.error("Unable to leave safemode.");
+        AUDITLOG.error("Unable to leave safemode.");
       }
     }
     return LeaveSafeModeResponse.newInstance(success);
@@ -676,12 +678,12 @@ public class RouterAdminServer extends AbstractService
     if (namespaceExists(nsId)) {
       success = getDisabledNameserviceStore().disableNameservice(nsId);
       if (success) {
-        LOG.info("Nameservice {} disabled successfully.", nsId);
+        AUDITLOG.info("Nameservice {} disabled successfully.", nsId);
       } else {
-        LOG.error("Unable to disable Nameservice {}", nsId);
+        AUDITLOG.error("Unable to disable Nameservice {}", nsId);
       }
     } else {
-      LOG.error("Cannot disable {}, it does not exists", nsId);
+      AUDITLOG.error("Cannot disable {}, it does not exists", nsId);
     }
     return DisableNameserviceResponse.newInstance(success);
   }
@@ -711,12 +713,12 @@ public class RouterAdminServer extends AbstractService
     if (disabled.contains(nsId)) {
       success = store.enableNameservice(nsId);
       if (success) {
-        LOG.info("Nameservice {} enabled successfully.", nsId);
+        AUDITLOG.info("Nameservice {} enabled successfully.", nsId);
       } else {
-        LOG.error("Unable to enable Nameservice {}", nsId);
+        AUDITLOG.error("Unable to enable Nameservice {}", nsId);
       }
     } else {
-      LOG.error("Cannot enable {}, it was not disabled", nsId);
+      AUDITLOG.error("Cannot enable {}, it was not disabled", nsId);
     }
     return EnableNameserviceResponse.newInstance(success);
   }


### PR DESCRIPTION
HDFS-16944 We found that in other components (like namenode in hdfs or resourcemanager in yarn), debug log and audit log are record **seperately**, except `RouterAdminServer`.

There are lots of *simple* logs to help with debugging for the *developers* who can access to the source code. And there are also audit logs record *privileged operations* with more *detailed* information to help *system admins* understand what happened in a real run. 

There is an example in yarn: 
```java
   try {
      // Safety
      userUgi = UserGroupInformation.getCurrentUser();
      user = userUgi.getShortUserName();
    } catch (IOException ie) {
      LOG.warn("Unable to get the current user.", ie); // debug log
      RMAuditLogger.logFailure(user, AuditConstants.SUBMIT_APP_REQUEST,
          ie.getMessage(), "ClientRMService",
          "Exception in submitting application", applicationId, callerContext,
          submissionContext.getQueue()); // audit log
      throw RPCUtil.getRemoteException(ie);
    }
```
So I suggest to add an audit log for `RouterAdminServer` to save privileged operation logs seperately.
The logger' s name may be: 
```java
// hadoop security
public static final Logger AUDITLOG =
      LoggerFactory.getLogger(
          "SecurityLogger." + ServiceAuthorizationManager.class.getName());
// namenode
  public static final Log auditLog = LogFactory.getLog(
      FSNamesystem.class.getName() + ".audit");
```
I choose className.audit finally and record `AUDITLOG` instead of `LOG` for the **privileged operations** that call permission check function `checkSuperuserPrivilege`.
 


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

