### PR TITLE
YARN-11449. Fix for Intermittent NPE while getting node labels for queue

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/QueueNodeLabelsSettings.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/QueueNodeLabelsSettings.java
@@ -53,9 +53,15 @@ public class QueueNodeLabelsSettings {
   }
 
   private void initializeAccessibleLabels(CapacitySchedulerConfiguration configuration) {
-    this.accessibleLabels = configuration.getAccessibleNodeLabels(queuePath.getFullPath());
-    // Inherit labels from parent if not set
-    if (this.accessibleLabels == null && parent != null) {
+    Set<String> nodeLabels = configuration.getAccessibleNodeLabels(queuePath.getFullPath());
+    if (null != nodeLabels) {
+      // Reading "accessibleLabels" can cause NPE without ReadLock.
+      // Since getAccessibleNodeLabels() can return null, If someone access
+      // "accessibleLabels" before assigning it from parent can cause NPE.
+      // So use local instance and assign it only if not null
+      this.accessibleLabels = nodeLabels;
+    } else if (null != parent) {
+      // Inherit labels from parent if not set
       this.accessibleLabels = parent.getAccessibleNodeLabels();
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestLeafQueue.java
@@ -5431,4 +5431,23 @@ public class TestLeafQueue {
     rm.stop();
     rm.close();
   }
+
+  @Test
+  public void testLeafHasAllNodeLabelsOfItsRoot() throws IOException {
+
+    CapacitySchedulerConfiguration conf = csConf;
+    String rootChild = root.getChildQueues().get(0).getQueuePath();
+    ParentQueue rootQueue = (ParentQueue) cs.getRootQueue();
+    ConfiguredNodeLabels nodeLabelsForAllQueues =
+        rootQueue.getQueueContext().getQueueManager().getConfiguredNodeLabelsForAllQueues();
+
+    QueueNodeLabelsSettings labelsSettings =
+        new QueueNodeLabelsSettings(conf, root, new QueuePath(rootQueue.getQueuePath(), "test"), nodeLabelsForAllQueues);
+    Assert.assertEquals(labelsSettings.getAccessibleNodeLabels(), "*");
+
+    labelsSettings = new QueueNodeLabelsSettings(conf, root,
+        new QueuePath(rootQueue.getQueuePath(), rootQueue.getChildQueues().get(0).getQueuePath()),
+        nodeLabelsForAllQueues);
+    Assert.assertEquals(labelsSettings.getAccessibleNodeLabels(), "*");
+  }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Jira: [YARN-11449](https://issues.apache.org/jira/browse/YARN-11449)
Accessing "QueueNodeLabelsSettings#accessibleLabels" can cause NPE without ReadLock (writes to this variable is happening with write lock).
Since QueueNodeLabelsSettings.getAccessibleNodeLabels() can return null and If someone accesses QueueNodeLabelsSettings##accessibleLabels before assigning it from the parent can cause NPE.

The issue was found in 2.10 

### How was this patch tested?
Unit Tested

### For code changes:

- [✅] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

