### PR TITLE
[HADOOP-18660] Filesystem Spelling Mistake

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -3602,9 +3602,9 @@ public abstract class FileSystem extends Configured
       } catch (IOException | RuntimeException e) {
         // exception raised during initialization.
         // log summary at warn and full stack at debug
-        LOGGER.warn("Failed to initialize fileystem {}: {}",
+        LOGGER.warn("Failed to initialize filesystem {}: {}",
             uri, e.toString());
-        LOGGER.debug("Failed to initialize fileystem", e);
+        LOGGER.debug("Failed to initialize filesystem", e);
         // then (robustly) close the FS, so as to invoke any
         // cleanup code.
         IOUtils.cleanupWithLogger(LOGGER, fs);

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/pathcapabilities.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/pathcapabilities.md
@@ -31,7 +31,7 @@ There are a number of goals here:
 having to invoke them.
 1. Allow filesystems with their own optional per-instance features to declare
 whether or not they are active for the specific instance.
-1. Allow for fileystem connectors which work with object stores to expose the
+1. Allow for filesystem connectors which work with object stores to expose the
 fundamental difference in semantics of these stores (e.g: files not visible
 until closed, file rename being `O(data)`), directory rename being non-atomic,
 etc.
@@ -122,7 +122,7 @@ will be permitted on that path by the caller.
 *Duration of availability*
 
 As the state of a remote store changes,so may path capabilities. This
-may be due to changes in the local state of the fileystem (e.g. symbolic links
+may be due to changes in the local state of the filesystem (e.g. symbolic links
 or mount points changing), or changes in its functionality (e.g. a feature
 becoming availaible/unavailable due to operational changes, system upgrades, etc.)
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
@@ -150,7 +150,7 @@ public class HttpFSServer {
    * @return FileSystemExecutor response
    *
    * @throws IOException thrown if an IO error occurs.
-   * @throws FileSystemAccessException thrown if a FileSystemAccess releated error occurred. Thrown
+   * @throws FileSystemAccessException thrown if a FileSystemAccess related error occurred. Thrown
    * exceptions are handled by {@link HttpFSExceptionProvider}.
    */
   private <T> T fsExecute(UserGroupInformation ugi, FileSystemAccess.FileSystemExecutor<T> executor)
@@ -161,7 +161,7 @@ public class HttpFSServer {
   }
 
   /**
-   * Returns a filesystem instance. The fileystem instance is wired for release at the completion of
+   * Returns a filesystem instance. The filesystem instance is wired for release at the completion of
    * the current Servlet request via the {@link FileSystemReleaseFilter}.
    * <p>
    * If a do-as user is specified, the current user must be a valid proxyuser, otherwise an
@@ -173,7 +173,7 @@ public class HttpFSServer {
    *
    * @throws IOException thrown if an IO error occurred. Thrown exceptions are
    * handled by {@link HttpFSExceptionProvider}.
-   * @throws FileSystemAccessException thrown if a FileSystemAccess releated error occurred. Thrown
+   * @throws FileSystemAccessException thrown if a FileSystemAccess related error occurred. Thrown
    * exceptions are handled by {@link HttpFSExceptionProvider}.
    */
   private FileSystem createFileSystem(UserGroupInformation ugi)

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
@@ -162,7 +162,7 @@ public class HttpFSServer {
 
   /**
    * Returns a filesystem instance. The filesystem instance is wired for release at the completion
-	* of the current Servlet request via the {@link FileSystemReleaseFilter}.
+   * of the current Servlet request via the {@link FileSystemReleaseFilter}.
    * <p>
    * If a do-as user is specified, the current user must be a valid proxyuser, otherwise an
    * <code>AccessControlException</code> will be thrown.

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
@@ -161,8 +161,8 @@ public class HttpFSServer {
   }
 
   /**
-   * Returns a filesystem instance. The filesystem instance is wired for release at the completion of
-   * the current Servlet request via the {@link FileSystemReleaseFilter}.
+   * Returns a filesystem instance. The filesystem instance is wired for release at the completion
+	* of the current Servlet request via the {@link FileSystemReleaseFilter}.
    * <p>
    * If a do-as user is specified, the current user must be a valid proxyuser, otherwise an
    * <code>AccessControlException</code> will be thrown.

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/servlet/FileSystemReleaseFilter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/servlet/FileSystemReleaseFilter.java
@@ -94,14 +94,14 @@ public abstract class FileSystemReleaseFilter implements Filter {
    * Static method that sets the <code>FileSystem</code> to release back to
    * the {@link FileSystemAccess} service on servlet request completion.
    *
-   * @param fs fileystem instance.
+   * @param fs a filesystem instance.
    */
   public static void setFileSystem(FileSystem fs) {
     FILE_SYSTEM_TL.set(fs);
   }
 
   /**
-   * Abstract method to be implemetned by concrete implementations of the
+   * Abstract method to be implemented by concrete implementations of the
    * filter that return the {@link FileSystemAccess} service to which the filesystem
    * will be returned to.
    *

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/manifest_committer.md
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/manifest_committer.md
@@ -371,11 +371,11 @@ any reports saved to a report directory.
 ## <a name="summaries"></a> Collecting Job Summaries `mapreduce.manifest.committer.summary.report.directory`
 
 The committer can be configured to save the `_SUCCESS` summary files to a report directory,
-irrespective of whether the job succeed or failed, by setting a fileystem path in
+irrespective of whether the job succeed or failed, by setting a filesystem path in
 the option `mapreduce.manifest.committer.summary.report.directory`.
 
 The path does not have to be on the same
-store/filesystem as the destination of work. For example, a local fileystem could be used.
+store/filesystem as the destination of work. For example, a local filesystem could be used.
 
 XML
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-uploader/src/main/java/org/apache/hadoop/mapred/uploader/FrameworkUploader.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-uploader/src/main/java/org/apache/hadoop/mapred/uploader/FrameworkUploader.java
@@ -204,7 +204,7 @@ public class FrameworkUploader implements Runnable {
       } else {
         LOG.warn("Cannot set replication to " +
             initialReplication + " for path: " + targetPath +
-            " on a non-distributed fileystem " +
+            " on a non-distributed filesystem " +
             fileSystem.getClass().getName());
       }
       if (targetStream == null) {
@@ -319,7 +319,7 @@ public class FrameworkUploader implements Runnable {
     } else {
       LOG.info("Cannot set replication to " +
           finalReplication + " for path: " + targetPath +
-          " on a non-distributed fileystem " +
+          " on a non-distributed filesystem " +
           fileSystem.getClass().getName());
     }
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AReadOpContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AReadOpContext.java
@@ -88,7 +88,7 @@ public class S3AReadOpContext extends S3AOpContext {
    * Instantiate.
    * @param path path of read
    * @param invoker invoker for normal retries.
-   * @param stats Fileystem statistics (may be null)
+   * @param stats Filesystem statistics (may be null)
    * @param instrumentation statistics context
    * @param dstFileStatus target file status
    * @param vectoredIOContext context for vectored read operation.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
@@ -811,7 +811,7 @@ public abstract class S3GuardTool extends Configured implements Tool,
     try {
       uri = new URI(s3Path);
     } catch (URISyntaxException e) {
-      throw invalidArgs("Not a valid fileystem path: %s", s3Path);
+      throw invalidArgs("Not a valid filesystem path: %s", s3Path);
     }
     return uri;
   }

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/delegation_tokens.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/delegation_tokens.md
@@ -832,7 +832,7 @@ This tests marshalling and unmarshalling of tokens identifiers.
 
 Tests the lifecycle of session tokens.
 
-#### Integration Test `ITestSessionDelegationInFileystem`.
+#### Integration Test `ITestSessionDelegationInFilesystem`
 
 This collects DTs from one filesystem, and uses that to create a new FS instance and
 then perform filesystem operations. A miniKDC is instantiated.
@@ -841,7 +841,7 @@ then perform filesystem operations. A miniKDC is instantiated.
 the second instance is picking up the DT information.
 * `UserGroupInformation.reset()` can be used to reset user secrets after every test
 case (e.g. teardown), so that issued DTs from one test case do not contaminate the next.
-* It's subclass, `ITestRoleDelegationInFileystem` adds a check that the current credentials
+* It's subclass, `ITestRoleDelegationInFilesystem` adds a check that the current credentials
 in the DT cannot be used to access data on other buckets —that is, the active
 session really is restricted to the target bucket.
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
@@ -1179,8 +1179,7 @@ file using configured SSE-C keyB into that structure.
 ### Instruction file not found for S3 object
 
 Reading an unencrypted file would fail when read through CSE enabled client.
-
-```txt
+```
 java.lang.SecurityException: Instruction file not found for S3 object with bucket name: ap-south-cse, key: unencryptedData.txt
     at com.amazonaws.services.s3.internal.crypto.v2.S3CryptoModuleAE.decipher(S3CryptoModuleAE.java:190)
     at com.amazonaws.services.s3.internal.crypto.v2.S3CryptoModuleAE.getObjectSecurely(S3CryptoModuleAE.java:136)
@@ -1217,7 +1216,6 @@ java.lang.SecurityException: Instruction file not found for S3 object with bucke
     at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:95)
     at org.apache.hadoop.fs.FsShell.main(FsShell.java:390)
 ```
-
 CSE enabled client should read encrypted data only.
 
 ### CSE-KMS method requires KMS key ID
@@ -1225,7 +1223,7 @@ CSE enabled client should read encrypted data only.
 KMS key ID is required for CSE-KMS to encrypt data, not providing one leads
  to failure.
 
-```txt
+```
 2021-07-07 11:33:04,550 WARN fs.FileSystem: Failed to initialize filesystem
 s3a://ap-south-cse/: java.lang.IllegalArgumentException: CSE-KMS
 method requires KMS key ID. Use fs.s3a.encryption.key property to set it.

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
@@ -677,7 +677,7 @@ warning that the SDK resolution chain is in use:
     S3A filesystem client is using the SDK region resolution chain.
 
 2021-06-23 19:56:56,073 [main] WARN  fs.FileSystem (FileSystem.java:createFileSystem(3464)) -
-    Failed to initialize fileystem s3a://osm-pds/planet:
+    Failed to initialize filesystem s3a://osm-pds/planet:
  org.apache.hadoop.fs.s3a.AWSClientIOException: creating AWS S3 client on s3a://osm-pds:
   com.amazonaws.SdkClientException: Unable to find a region via the region provider chain.
   Must provide an explicit region in the builder or setup environment to supply a region.:
@@ -1179,7 +1179,8 @@ file using configured SSE-C keyB into that structure.
 ### Instruction file not found for S3 object
 
 Reading an unencrypted file would fail when read through CSE enabled client.
-```
+
+```txt
 java.lang.SecurityException: Instruction file not found for S3 object with bucket name: ap-south-cse, key: unencryptedData.txt
     at com.amazonaws.services.s3.internal.crypto.v2.S3CryptoModuleAE.decipher(S3CryptoModuleAE.java:190)
     at com.amazonaws.services.s3.internal.crypto.v2.S3CryptoModuleAE.getObjectSecurely(S3CryptoModuleAE.java:136)
@@ -1216,6 +1217,7 @@ java.lang.SecurityException: Instruction file not found for S3 object with bucke
     at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:95)
     at org.apache.hadoop.fs.FsShell.main(FsShell.java:390)
 ```
+
 CSE enabled client should read encrypted data only.
 
 ### CSE-KMS method requires KMS key ID
@@ -1223,8 +1225,8 @@ CSE enabled client should read encrypted data only.
 KMS key ID is required for CSE-KMS to encrypt data, not providing one leads
  to failure.
 
-```
-2021-07-07 11:33:04,550 WARN fs.FileSystem: Failed to initialize fileystem
+```txt
+2021-07-07 11:33:04,550 WARN fs.FileSystem: Failed to initialize filesystem
 s3a://ap-south-cse/: java.lang.IllegalArgumentException: CSE-KMS
 method requires KMS key ID. Use fs.s3a.encryption.key property to set it.
 -ls: CSE-KMS method requires KMS key ID. Use fs.s3a.encryption.key property to

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestRoleDelegationInFilesystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestRoleDelegationInFilesystem.java
@@ -32,8 +32,8 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
  * Subclass of the session test which checks roles; only works if
  * a role ARN has been declared.
  */
-public class ITestRoleDelegationInFileystem extends
-    ITestSessionDelegationInFileystem {
+public class ITestRoleDelegationInFilesystem extends
+    ITestSessionDelegationInFilesystem {
 
   @Override
   public void setup() throws Exception {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFilesystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFilesystem.java
@@ -87,10 +87,10 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
  * UGI to be initialized with security enabled.
  */
 @SuppressWarnings("StaticNonFinalField")
-public class ITestSessionDelegationInFileystem extends AbstractDelegationIT {
+public class ITestSessionDelegationInFilesystem extends AbstractDelegationIT {
 
   private static final Logger LOG =
-      LoggerFactory.getLogger(ITestSessionDelegationInFileystem.class);
+      LoggerFactory.getLogger(ITestSessionDelegationInFilesystem.class);
 
   private static MiniKerberizedHadoopCluster cluster;
 
@@ -595,7 +595,7 @@ public class ITestSessionDelegationInFileystem extends AbstractDelegationIT {
         .withEndpoint(DEFAULT_ENDPOINT)
         .withMetrics(new EmptyS3AStatisticsContext()
             .newStatisticsFromAwsSdk())
-        .withUserAgentSuffix("ITestSessionDelegationInFileystem");
+        .withUserAgentSuffix("ITestSessionDelegationInFilesystem");
     AmazonS3 s3 = factory.createS3Client(landsat, parameters);
 
     return Invoker.once("HEAD", host,


### PR DESCRIPTION
Minor spelling mistake in errors returned from Filesystem.

### Description of PR

minor change.

### How was this patch tested?

it was not but the change is only touching the logging.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
