### PR TITLE
HADOOP-18662. ListFiles with recursive fails with FNF.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -2418,7 +2418,8 @@ public abstract class FileSystem extends Configured
             itors.push(curItor);
             curItor = newDirItor;
           } catch (FileNotFoundException ignored) {
-            LOGGER.debug("Directory {} deleted while attempting to recusive listing", stat.getPath());
+            LOGGER.debug("Directory {} deleted while attempting for recursive listing",
+                stat.getPath());
           }
         }
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -2413,8 +2413,13 @@ public abstract class FileSystem extends Configured
         if (stat.isFile()) { // file
           curFile = stat;
         } else if (recursive) { // directory
-          itors.push(curItor);
-          curItor = listLocatedStatus(stat.getPath());
+          try {
+            RemoteIterator<LocatedFileStatus> newDirItor = listLocatedStatus(stat.getPath());
+            itors.push(curItor);
+            curItor = newDirItor;
+          } catch (FileNotFoundException ignored) {
+            LOGGER.debug("Directory {} deleted while attempting to recusive listing", stat.getPath());
+          }
         }
       }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -1595,7 +1595,7 @@ public class TestDistributedFileSystem {
 
   private static RemoteIterator<LocatedFileStatus> getMockedIterator(Path subDir1) {
     return new RemoteIterator<LocatedFileStatus>() {
-      int remainingEntries = 1;
+      private int remainingEntries = 1;
 
       @Override
       public boolean hasNext() throws IOException {


### PR DESCRIPTION
### Description of PR

Make listFiles recursive tolerant to concurrent deletes of subdirectories

### How was this patch tested?

UT.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

