### PR TITLE
HDFS-16949 Update ReadTransferRate to ReadLatencyPerGB for effectiv…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
@@ -370,9 +370,9 @@ Each metrics record contains tags such as SessionId and Hostname as additional i
 |:---- |:---- |
 | `BytesWritten` | Total number of bytes written to DataNode |
 | `BytesRead` | Total number of bytes read from DataNode |
-| `ReadTransferRateNumOps` | Total number of data read transfers |
-| `ReadTransferRateAvgTime` | Average transfer rate of bytes read from DataNode, measured in bytes per second. |
-| `ReadTransferRate`*num*`s(50/75/90/95/99)thPercentileRate` | The 50/75/90/95/99th percentile of the transfer rate of bytes read from DataNode, measured in bytes per second. |
+| `ReadLatencyPerGBNumOps` | Total number of data reads |
+| `ReadLatencyPerGBAvgTime` | Average time taken to read 1 GB data from DataNode, measured in seconds per GB. |
+| `ReadLatencyPerGB`*num*`s(50/75/90/95/99)thPercentileLatency` | The 50/75/90/95/99th percentile of the time taken to read 1 GB data from DataNode, measured in seconds per GB. |
 | `BlocksWritten` | Total number of blocks written to DataNode |
 | `BlocksRead` | Total number of blocks read from DataNode |
 | `BlocksReplicated` | Total number of blocks replicated |

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
@@ -1939,16 +1939,17 @@ public class DFSUtil {
   }
 
   /**
-   * Add transfer rate metrics for valid data read and duration values.
+   * Add time taken in seconds to read a GB of data metric for valid data read and duration values.
    * @param metrics metrics for datanodes
    * @param read bytes read
-   * @param duration read duration
+   * @param duration read duration in milliseconds
    */
-  public static void addTransferRateMetric(final DataNodeMetrics metrics, final long read, final long duration) {
-    if (read >= 0 && duration > 0) {
-        metrics.addReadTransferRate(read * 1000 / duration);
+  public static void addReadLatencyPerGBMetric(final DataNodeMetrics metrics,
+                                               final long read, final long duration) {
+    if (read > 0 && duration >= 0) {
+      metrics.addReadLatencyPerGB(duration * 1000_000 / read);
     } else {
-      LOG.warn("Unexpected value for data transfer bytes={} duration={}", read, duration);
+      LOG.warn("Unexpected value for data read bytes={} duration={}", read, duration);
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
@@ -633,7 +633,7 @@ class DataXceiver extends Receiver implements Runnable {
       datanode.metrics.incrBytesRead((int) read);
       datanode.metrics.incrBlocksRead();
       datanode.metrics.incrTotalReadTime(duration);
-      DFSUtil.addTransferRateMetric(datanode.metrics, read, duration);
+      DFSUtil.addReadLatencyPerGBMetric(datanode.metrics, read, duration);
     } catch ( SocketException ignored ) {
       LOG.trace("{}:Ignoring exception while serving {} to {}",
           dnR, block, remoteAddress, ignored);
@@ -1124,7 +1124,7 @@ class DataXceiver extends Receiver implements Runnable {
       datanode.metrics.incrBytesRead((int) read);
       datanode.metrics.incrBlocksRead();
       datanode.metrics.incrTotalReadTime(duration);
-      DFSUtil.addTransferRateMetric(datanode.metrics, read, duration);
+      DFSUtil.addReadLatencyPerGBMetric(datanode.metrics, read, duration);
       
       LOG.info("Copied {} to {}", block, peer.getRemoteAddressString());
     } catch (IOException ioe) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
@@ -61,8 +61,8 @@ public class DataNodeMetrics {
   @Metric MutableCounterLong bytesRead;
   @Metric("Milliseconds spent reading")
   MutableCounterLong totalReadTime;
-  @Metric private MutableRate readTransferRate;
-  final private MutableQuantiles[] readTransferRateQuantiles;
+  @Metric private MutableRate readLatencyPerGB;
+  final private MutableQuantiles[] readLatencyPerGBQuantiles;
   @Metric MutableCounterLong blocksWritten;
   @Metric MutableCounterLong blocksRead;
   @Metric MutableCounterLong blocksReplicated;
@@ -229,7 +229,7 @@ public class DataNodeMetrics {
     sendDataPacketTransferNanosQuantiles = new MutableQuantiles[len];
     ramDiskBlocksEvictionWindowMsQuantiles = new MutableQuantiles[len];
     ramDiskBlocksLazyPersistWindowMsQuantiles = new MutableQuantiles[len];
-    readTransferRateQuantiles = new MutableQuantiles[len];
+    readLatencyPerGBQuantiles = new MutableQuantiles[len];
 
     for (int i = 0; i < len; i++) {
       int interval = intervals[i];
@@ -258,10 +258,10 @@ public class DataNodeMetrics {
           "ramDiskBlocksLazyPersistWindows" + interval + "s",
           "Time between the RamDisk block write and disk persist in ms",
           "ops", "latency", interval);
-      readTransferRateQuantiles[i] = registry.newQuantiles(
-          "readTransferRate" + interval + "s",
-          "Rate at which bytes are read from datanode calculated in bytes per second",
-          "ops", "rate", interval);
+      readLatencyPerGBQuantiles[i] = registry.newQuantiles(
+          "readLatencyPerGB" + interval + "s",
+          "Time taken in seconds for reading data from datanode per GB",
+          "ops", "latency", interval);
     }
   }
 
@@ -323,10 +323,10 @@ public class DataNodeMetrics {
     }
   }
 
-  public void addReadTransferRate(long readTransferRate) {
-    this.readTransferRate.add(readTransferRate);
-    for (MutableQuantiles q : readTransferRateQuantiles) {
-      q.add(readTransferRate);
+  public void addReadLatencyPerGB(long readLatencyPerGB) {
+    this.readLatencyPerGB.add(readLatencyPerGB);
+    for (MutableQuantiles q : readLatencyPerGBQuantiles) {
+      q.add(readLatencyPerGB);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
@@ -1112,16 +1112,16 @@ public class TestDFSUtil {
   }
 
   @Test
-  public void testAddTransferRateMetricForValidValues() {
+  public void testAddReadLatencyPerGBMetricForValidValues() {
     DataNodeMetrics mockMetrics = mock(DataNodeMetrics.class);
-    DFSUtil.addTransferRateMetric(mockMetrics, 100, 10);
-    verify(mockMetrics).addReadTransferRate(10000);
+    DFSUtil.addReadLatencyPerGBMetric(mockMetrics, 3333333333L, 99999L);
+    verify(mockMetrics).addReadLatencyPerGB(29L);
   }
 
   @Test
-  public void testAddTransferRateMetricForInvalidValue() {
+  public void testAddReadLatencyPerGBMetricForInvalidValue() {
     DataNodeMetrics mockMetrics = mock(DataNodeMetrics.class);
-    DFSUtil.addTransferRateMetric(mockMetrics, 100, 0);
-    verify(mockMetrics, times(0)).addReadTransferRate(anyLong());
+    DFSUtil.addReadLatencyPerGBMetric(mockMetrics, 0, 1000);
+    verify(mockMetrics, times(0)).addReadLatencyPerGB(anyLong());
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
@@ -392,7 +392,7 @@ public class TestDataNodeMetrics {
 
       final long startWriteValue = getLongCounter("TotalWriteTime", rb);
       final long startReadValue = getLongCounter("TotalReadTime", rb);
-      assertCounter("ReadTransferRateNumOps", 0L, rb);
+      assertCounter("ReadLatencyPerGBNumOps", 0L, rb);
       final AtomicInteger x = new AtomicInteger(0);
 
       // Lets Metric system update latest metrics
@@ -412,8 +412,8 @@ public class TestDataNodeMetrics {
           MetricsRecordBuilder rbNew = getMetrics(datanode.getMetrics().name());
           final long endWriteValue = getLongCounter("TotalWriteTime", rbNew);
           final long endReadValue = getLongCounter("TotalReadTime", rbNew);
-          assertCounter("ReadTransferRateNumOps", 1L, rbNew);
-          assertQuantileGauges("ReadTransferRate" + "60s", rbNew, "Rate");
+          assertCounter("ReadLatencyPerGBNumOps", 1L, rbNew);
+          assertQuantileGauges("ReadLatencyPerGB" + "60s", rbNew);
           return endWriteValue > startWriteValue
               && endReadValue > startReadValue;
         }


### PR DESCRIPTION
…e percentile metrics

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
PR #5397  added ReadTransferRate quantiles to calculate the rate which data is read per unit of time.

With percentiles the values are sorted in ascending order and hence for the transfer rate p90 gives us the value where 90 percent rates are lower (worse), p99 gives us the value where 99 percent values are lower (worse).

Note that value(p90) < p(99) thus p99 is a better transfer rate as compared to p90.

However as the percentile increases the value should become worse in order to know how good our system is.

Hence instead of calculating the data read transfer rate, we should calculate it's inverse. We will instead calculate the time taken for a GB of data to be read. ( seconds / GB )

After this the p90 value will give us 90 percentage of total values where the time taken is less than value(p90), similarly for p99 and others.

Also p(90) < p(99) and here p(99) will become a worse value (taking more time each byte) as compared to p(90)

### How was this patch tested?

Updated Unit Tests.
### For code changes:

- [Y ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ NA ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ NA ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ NA ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

