### PR TITLE
HADOOP-18666. A whitelist of endpoints to skip Kerberos authentication doesn't work for ResourceManager and Job History Server

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
@@ -497,7 +497,12 @@ public final class HttpServer2 implements FilterContainer {
               prefix -> this.conf.get(prefix + "type")
                   .equals(PseudoAuthenticationHandler.TYPE))
       ) {
-        server.initSpnego(conf, hostName, usernameConfKey, keytabConfKey);
+        server.initSpnego(
+            conf,
+            hostName,
+            getFilterProperties(conf, authFilterConfigurationPrefixes),
+            usernameConfKey,
+            keytabConfKey);
       }
 
       for (URI ep : endpoints) {
@@ -1340,8 +1345,12 @@ public final class HttpServer2 implements FilterContainer {
   }
 
   private void initSpnego(Configuration conf, String hostName,
-      String usernameConfKey, String keytabConfKey) throws IOException {
+      Properties authFilterConfigurationPrefixes, String usernameConfKey, String keytabConfKey)
+      throws IOException {
     Map<String, String> params = new HashMap<>();
+    for (Map.Entry<Object, Object> entry : authFilterConfigurationPrefixes.entrySet()) {
+      params.put(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
+    }
     String principalInConf = conf.get(usernameConfKey);
     if (principalInConf != null && !principalInConf.isEmpty()) {
       params.put("kerberos.principal", SecurityUtil.getServerPrincipal(


### PR DESCRIPTION


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Thanks to [HADOOP-16527](https://issues.apache.org/jira/browse/HADOOP-16527), we can add a whitelist of endpoints to skip Kerberos authentication such as `/isActive`, `/jmx`, `/prom`.
However, I found that ResourceManager and Job History Server doesn't repect `hadoop.http.authentication.kerberos.endpoint.whitelist`.

To workaround this issue for ResourceManager, set `yarn.resourcemanager.webapp.delegation-token-auth-filter.enabled=true` in yarn-site.xml.
However, there is no workaround for Job History Server.

This bug is caused by HttpServer2#initSpnego call without proper configurations which starts with "hadoop.http.authentication.".


### How was this patch tested?

Manually tested in internal cluster. It works with ResourceManager (without `yarn.resourcemanager.webapp.delegation-token-auth-filter.enabled=true` set), Job History Server.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?

