### PR TITLE
HDFS-16953. RBF: Mount table store APIs should update cache only if state store record is successfully updated

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/impl/MountTableStoreImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/impl/MountTableStoreImpl.java
@@ -117,7 +117,9 @@ public class MountTableStoreImpl extends MountTableStore {
       AddMountTableEntryResponse response =
           AddMountTableEntryResponse.newInstance();
       response.setStatus(status);
-      updateCacheAllRouters();
+      if (status) {
+        updateCacheAllRouters();
+      }
       return response;
     } else {
       AddMountTableEntryResponse response =
@@ -139,7 +141,9 @@ public class MountTableStoreImpl extends MountTableStore {
       UpdateMountTableEntryResponse response =
           UpdateMountTableEntryResponse.newInstance();
       response.setStatus(status);
-      updateCacheAllRouters();
+      if (status) {
+        updateCacheAllRouters();
+      }
       return response;
     } else {
       UpdateMountTableEntryResponse response =
@@ -170,7 +174,9 @@ public class MountTableStoreImpl extends MountTableStore {
     RemoveMountTableEntryResponse response =
         RemoveMountTableEntryResponse.newInstance();
     response.setStatus(status);
-    updateCacheAllRouters();
+    if (status) {
+      updateCacheAllRouters();
+    }
     return response;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdminCLI.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdminCLI.java
@@ -167,8 +167,9 @@ public class TestRouterAdminCLI {
     assertEquals(0, ToolRunner.run(admin, argv));
     assertEquals(-1, ToolRunner.run(admin, argv));
 
-
     stateStore.loadCache(MountTableStoreImpl.class, true);
+    verifyMountTableContents(src, dest);
+
     GetMountTableEntriesRequest getRequest = GetMountTableEntriesRequest
         .newInstance(src);
     GetMountTableEntriesResponse getResponse = client.getMountTableManager()
@@ -205,6 +206,15 @@ public class TestRouterAdminCLI {
     assertEquals(dest, loc3.getDest());
     assertTrue(mountTable.isReadOnly());
     assertTrue(mountTable.isFaultTolerant());
+  }
+
+  private void verifyMountTableContents(String src, String dest) throws Exception {
+    String[] argv = new String[] {"-ls", "/"};
+    System.setOut(new PrintStream(out));
+    assertEquals(0, ToolRunner.run(admin, argv));
+    String response = out.toString();
+    assertTrue("The response should have " + src + ": " + response, response.contains(src));
+    assertTrue("The response should have " + dest + ": " + response, response.contains(dest));
   }
 
   @Test


### PR DESCRIPTION
RBF Mount table state store APIs addMountTableEntry, updateMountTableEntry and removeMountTableEntry performs cache refresh for all routers regardless of the actual record update result. If the record fails to get updated on zookeeper/file based store impl, reloading the cache for all routers would be unnecessary.

For instance, simultaneously adding new mount point could lead to failure for the second call if first call has not added new entry by the time second call retrieves mount table entry from getMountTableEntries before attempting to call addMountTableEntry.
```
DEBUG [{cluster}/{ip}:8111] ipc.Client - IPC Client (1826699684) connection to nn-0-{ns}.{cluster}/{ip}:8111 from {user}IPC Client (1826699684) connection to nn-0-{ns}.{cluster}/{ip}:8111 from {user} sending #1 org.apache.hadoop.hdfs.protocolPB.RouterAdminProtocol.addMountTableEntry
DEBUG [{cluster}/{ip}:8111 from {user}] ipc.Client - IPC Client (1826699684) connection to nn-0-{ns}.{cluster}/{ip}:8111 from {user} got value #1
DEBUG [main] ipc.ProtobufRpcEngine2 - Call: addMountTableEntry took 24ms
DEBUG [{cluster}/{ip}:8111 from {user}] ipc.Client - IPC Client (1826699684) connection to nn-0-{ns}.{cluster}/{ip}:8111 from {user}: closed
DEBUG [{cluster}/{ip}:8111 from {user}] ipc.Client - IPC Client (1826699684) connection to nn-0-{ns}.{cluster}/{ip}:8111 from {user}: stopped, remaining connections 0
TRACE [main] ipc.ProtobufRpcEngine2 - 1: Response <- nn-0-{ns}.{cluster}/{ip}:8111: addMountTableEntry {status: false}

Cannot add mount point /data503 
```

The failure to write new record:
```
INFO  [IPC Server handler 0 on default port 8111] impl.StateStoreZooKeeperImpl - Cannot write record "/hdfs-federation/MountTable/0SLASH0data503", it already exists 
```
Since the successful call has already refreshed cache for all routers, second call that failed should not have refreshed cache for all routers again as everyone already has updated records in cache.