### PR TITLE
HDFS-16949 Introduce inverse quantiles for metrics where higher numer…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
@@ -216,15 +216,7 @@ public class MetricsRegistry {
    */
   public synchronized MutableQuantiles newQuantiles(String name, String desc,
       String sampleName, String valueName, int interval) {
-    checkMetricName(name);
-    if (interval <= 0) {
-      throw new MetricsException("Interval should be positive.  Value passed" +
-          " is: " + interval);
-    }
-    MutableQuantiles ret =
-        new MutableQuantiles(name, desc, sampleName, valueName, interval);
-    metricsMap.put(name, ret);
-    return ret;
+      return newQuantiles(name, desc, sampleName, valueName, interval, false);
   }
 
   /**
@@ -238,11 +230,16 @@ public class MetricsRegistry {
    * @return a new quantile estimator object
    * @throws MetricsException if interval is not a positive integer
    */
-  public synchronized MutableQuantiles newQuantiles(String name, String desc, String sampleName, 
-                                                    String valueName, int interval, boolean inverseQuantiles) {
-      MutableQuantiles ret = newQuantiles(name, desc, sampleName, valueName, interval);
-      ret.inverseQuantiles = inverseQuantiles;
-      return ret;
+  public synchronized MutableQuantiles newQuantiles(String name, String desc, String sampleName, String valueName, 
+                                                    int interval, boolean inverseQuantiles) {
+    checkMetricName(name);
+    if (interval <= 0) {
+      throw new MetricsException("Interval should be positive. Value passed is: " + interval);
+    }
+    MutableQuantiles ret =
+        new MutableQuantiles(name, desc, sampleName, valueName, interval, inverseQuantiles);
+    metricsMap.put(name, ret);
+    return ret;
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
@@ -215,7 +215,7 @@ public class MetricsRegistry {
    * @throws MetricsException if interval is not a positive integer
    */
   public synchronized MutableQuantiles newQuantiles(String name, String desc,
-    String sampleName, String valueName, int interval) {
+                                                    String sampleName, String valueName, int interval) {
     return newQuantiles(name, desc, sampleName, valueName, interval, false);
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
@@ -235,7 +235,7 @@ public class MetricsRegistry {
                                                     int interval, boolean inverseQuantiles) {
     checkMetricName(name);
     if (interval <= 0) {
-      throw new MetricsException("Interval should be positive. Value passed is: " + interval);
+      throw new MetricsException("Interval should be positive.  Value passed is: " + interval);
     }
     MutableQuantiles ret =
         new MutableQuantiles(name, desc, sampleName, valueName, interval, inverseQuantiles);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
@@ -215,12 +215,12 @@ public class MetricsRegistry {
    * @throws MetricsException if interval is not a positive integer
    */
   public synchronized MutableQuantiles newQuantiles(String name, String desc,
-      String sampleName, String valueName, int interval) {
-      return newQuantiles(name, desc, sampleName, valueName, interval, false);
+    String sampleName, String valueName, int interval) {
+    return newQuantiles(name, desc, sampleName, valueName, interval, false);
   }
 
   /**
-   * Create a mutable metric that estimates quantiles of a stream of values
+   * Create a mutable metric that estimates quantiles of a stream of values.
    * @param name of the metric
    * @param desc metric description
    * @param sampleName of the metric (e.g., "Ops")
@@ -230,7 +230,8 @@ public class MetricsRegistry {
    * @return a new quantile estimator object
    * @throws MetricsException if interval is not a positive integer
    */
-  public synchronized MutableQuantiles newQuantiles(String name, String desc, String sampleName, String valueName,
+  public synchronized MutableQuantiles newQuantiles(String name, String desc,
+                                                    String sampleName, String valueName,
                                                     int interval, boolean inverseQuantiles) {
     checkMetricName(name);
     if (interval <= 0) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
@@ -228,6 +228,24 @@ public class MetricsRegistry {
   }
 
   /**
+   * Create a mutable metric that estimates quantiles of a stream of values
+   * @param name of the metric
+   * @param desc metric description
+   * @param sampleName of the metric (e.g., "Ops")
+   * @param valueName of the metric (e.g., "Time" or "Latency")
+   * @param interval rollover interval of estimator in seconds
+   * @param inverseQuantiles inverse the quantiles ( e.g. P99 will give the 1st quantile )      
+   * @return a new quantile estimator object
+   * @throws MetricsException if interval is not a positive integer
+   */
+  public synchronized MutableQuantiles newQuantiles(String name, String desc, String sampleName, 
+                                                    String valueName, int interval, boolean inverseQuantiles) {
+      MutableQuantiles ret = newQuantiles(name, desc, sampleName, valueName, interval);
+      ret.inverseQuantiles = inverseQuantiles;
+      return ret;
+  }
+
+  /**
    * Create a mutable metric with stats
    * @param name  of the metric
    * @param desc  metric description

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
@@ -226,11 +226,11 @@ public class MetricsRegistry {
    * @param sampleName of the metric (e.g., "Ops")
    * @param valueName of the metric (e.g., "Time" or "Latency")
    * @param interval rollover interval of estimator in seconds
-   * @param inverseQuantiles inverse the quantiles ( e.g. P99 will give the 1st quantile )      
+   * @param inverseQuantiles inverse the quantiles ( e.g. P99 will give the 1st quantile )
    * @return a new quantile estimator object
    * @throws MetricsException if interval is not a positive integer
    */
-  public synchronized MutableQuantiles newQuantiles(String name, String desc, String sampleName, String valueName, 
+  public synchronized MutableQuantiles newQuantiles(String name, String desc, String sampleName, String valueName,
                                                     int interval, boolean inverseQuantiles) {
     checkMetricName(name);
     if (interval <= 0) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableQuantiles.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.metrics2.MetricsInfo;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.util.InverseQuantiles;
 import org.apache.hadoop.metrics2.util.Quantile;
 import org.apache.hadoop.metrics2.util.QuantileEstimator;
 import org.apache.hadoop.metrics2.util.SampleQuantiles;
@@ -52,7 +53,6 @@ public class MutableQuantiles extends MutableMetric {
       new Quantile(0.75, 0.025), new Quantile(0.90, 0.010),
       new Quantile(0.95, 0.005), new Quantile(0.99, 0.001) };
 
-  protected boolean inverseQuantiles = false;
   private final MetricsInfo numInfo;
   private final MetricsInfo[] quantileInfos;
   private final int interval;
@@ -84,7 +84,7 @@ public class MutableQuantiles extends MutableMetric {
    *          rollover interval (in seconds) of the estimator
    */
   public MutableQuantiles(String name, String description, String sampleName,
-      String valueName, int interval) {
+      String valueName, int interval, boolean inverseQuantiles) {
     String ucName = StringUtils.capitalize(name);
     String usName = StringUtils.capitalize(sampleName);
     String uvName = StringUtils.capitalize(valueName);
@@ -105,8 +105,7 @@ public class MutableQuantiles extends MutableMetric {
           String.format(descTemplate, percentile));
     }
 
-    estimator = new SampleQuantiles(quantiles, inverseQuantiles);
-
+    estimator = inverseQuantiles ? new InverseQuantiles(quantiles) : new SampleQuantiles(quantiles);
     this.interval = interval;
     scheduledTask = scheduler.scheduleWithFixedDelay(new RolloverSample(this),
         interval, interval, TimeUnit.SECONDS);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableQuantiles.java
@@ -82,6 +82,8 @@ public class MutableQuantiles extends MutableMetric {
    *          type of the values
    * @param interval
    *          rollover interval (in seconds) of the estimator
+   * @param inverseQuantiles
+   *          flag to denote if inverse quantiles are requested
    */
   public MutableQuantiles(String name, String description, String sampleName,
       String valueName, int interval, boolean inverseQuantiles) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableQuantiles.java
@@ -52,6 +52,7 @@ public class MutableQuantiles extends MutableMetric {
       new Quantile(0.75, 0.025), new Quantile(0.90, 0.010),
       new Quantile(0.95, 0.005), new Quantile(0.99, 0.001) };
 
+  protected boolean inverseQuantiles = false;
   private final MetricsInfo numInfo;
   private final MetricsInfo[] quantileInfos;
   private final int interval;
@@ -104,7 +105,7 @@ public class MutableQuantiles extends MutableMetric {
           String.format(descTemplate, percentile));
     }
 
-    estimator = new SampleQuantiles(quantiles);
+    estimator = new SampleQuantiles(quantiles, inverseQuantiles);
 
     this.interval = interval;
     scheduledTask = scheduler.scheduleWithFixedDelay(new RolloverSample(this),

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/InverseQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/InverseQuantiles.java
@@ -1,44 +1,46 @@
-package org.apache.hadoop.metrics2.util;
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import org.apache.hadoop.util.Preconditions;
-import java.util.ListIterator;
+package org.apache.hadoop.metrics2.util;
 
 public class InverseQuantiles extends SampleQuantiles{
 
   public InverseQuantiles(Quantile[] quantiles) {
     super(quantiles);
   }
-  
 
   /**
-   * Get the estimated value at the inverse of the specified quantile. 
-   * Eg: return the value at (1 - 0.99)*count position for quantile 0.99.
-   * When count is 100, quantile 0.99 is desired to return the value at the 1st position
-   *
-   * @param quantile Queried quantile, e.g. 0.50 or 0.99.
-   * @return Estimated value at the inverse position of that quantile. 
+   * Get the desired location from the sample for inverse of the specified quantile. 
+   * Eg: return (1 - 0.99)*count position for quantile 0.99.
+   * When count is 100, the desired location for quantile 0.99 is the 1st position
+   * @param quantile queried quantile, e.g. 0.50 or 0.99.
+   * @param count sample size count
+   * @return Desired location inverse position of that quantile.
    */
-  long query(double quantile) {
-    Preconditions.checkState(!samples.isEmpty(), "no data in estimator");
+  int getDesiredLocation(final double quantile, final long count) {
+    return (int) ((1 - quantile) * count);
+  }
 
-    int rankMin = 0;
-    int desired = (int) ((1 - quantile) * count);
-
-    ListIterator<SampleItem> it = samples.listIterator();
-    SampleItem prev;
-    SampleItem cur = it.next();
-    for (int i = 1; i < samples.size(); i++) {
-      prev = cur;
-      cur = it.next();
-
-      rankMin += prev.g;
-
-      if (rankMin + cur.g + cur.delta > desired + (allowableError(i) / 2)) {
-        return prev.value;
-      }
-    }
-
-    // edge case of wanting max value
+  /**
+   * Return the best (minimum) value from given sample
+   * @return minimum value from given sample
+   */
+  long getMaxValue() {
     return samples.get(0).value;
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/InverseQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/InverseQuantiles.java
@@ -1,0 +1,44 @@
+package org.apache.hadoop.metrics2.util;
+
+import org.apache.hadoop.util.Preconditions;
+import java.util.ListIterator;
+
+public class InverseQuantiles extends SampleQuantiles{
+
+  public InverseQuantiles(Quantile[] quantiles) {
+    super(quantiles);
+  }
+  
+
+  /**
+   * Get the estimated value at the inverse of the specified quantile. 
+   * Eg: return the value at (1 - 0.99)*count position for quantile 0.99.
+   * When count is 100, quantile 0.99 is desired to return the value at the 1st position
+   *
+   * @param quantile Queried quantile, e.g. 0.50 or 0.99.
+   * @return Estimated value at the inverse position of that quantile. 
+   */
+  long query(double quantile) {
+    Preconditions.checkState(!samples.isEmpty(), "no data in estimator");
+
+    int rankMin = 0;
+    int desired = (int) ((1 - quantile) * count);
+
+    ListIterator<SampleItem> it = samples.listIterator();
+    SampleItem prev;
+    SampleItem cur = it.next();
+    for (int i = 1; i < samples.size(); i++) {
+      prev = cur;
+      cur = it.next();
+
+      rankMin += prev.g;
+
+      if (rankMin + cur.g + cur.delta > desired + (allowableError(i) / 2)) {
+        return prev.value;
+      }
+    }
+
+    // edge case of wanting max value
+    return samples.get(0).value;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/SampleQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/SampleQuantiles.java
@@ -71,9 +71,11 @@ public class SampleQuantiles implements QuantileEstimator {
    * Array of Quantiles that we care about, along with desired error.
    */
   private final Quantile quantiles[];
+  private boolean inverseQuantiles;
 
-  public SampleQuantiles(Quantile[] quantiles) {
+  public SampleQuantiles(Quantile[] quantiles, boolean inverseQuantiles) {
     this.quantiles = quantiles;
+    this. inverseQuantiles = inverseQuantiles;
     this.samples = new LinkedList<SampleItem>();
   }
 
@@ -200,7 +202,7 @@ public class SampleQuantiles implements QuantileEstimator {
   /**
    * Get the estimated value at the specified quantile.
    * 
-   * @param quantile Queried quantile, e.g. 0.50 or 0.99.
+   * @param quantile Queried quantile, e.g. 0.01, 0.50 or 0.99.
    * @return Estimated value at that quantile.
    */
   private long query(double quantile) {
@@ -243,7 +245,12 @@ public class SampleQuantiles implements QuantileEstimator {
     
     Map<Quantile, Long> values = new TreeMap<Quantile, Long>();
     for (int i = 0; i < quantiles.length; i++) {
-      values.put(quantiles[i], query(quantiles[i].quantile));
+      /* eg : effectiveQuantile for 0.99 with inverseQuantiles will be 0.01. 
+      For inverse quantiles higher numeric value is better and hence we want 
+      to query from the opposite end of the sorted sample
+       */
+      double effectiveQuantile = inverseQuantiles ? 1 - quantiles[i].quantile : quantiles[i].quantile;
+      values.put(quantiles[i], query(effectiveQuantile));
     }
 
     return values;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/SampleQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/SampleQuantiles.java
@@ -52,12 +52,12 @@ public class SampleQuantiles implements QuantileEstimator {
   /**
    * Total number of items in stream
    */
-  private long count = 0;
+  long count = 0;
 
   /**
    * Current list of sampled items, maintained in sorted order with error bounds
    */
-  private LinkedList<SampleItem> samples;
+  LinkedList<SampleItem> samples;
 
   /**
    * Buffers incoming items to be inserted in batch. Items are inserted into 
@@ -71,11 +71,9 @@ public class SampleQuantiles implements QuantileEstimator {
    * Array of Quantiles that we care about, along with desired error.
    */
   private final Quantile quantiles[];
-  private boolean inverseQuantiles;
 
-  public SampleQuantiles(Quantile[] quantiles, boolean inverseQuantiles) {
+  public SampleQuantiles(Quantile[] quantiles) {
     this.quantiles = quantiles;
-    this. inverseQuantiles = inverseQuantiles;
     this.samples = new LinkedList<SampleItem>();
   }
 
@@ -89,7 +87,7 @@ public class SampleQuantiles implements QuantileEstimator {
    * @param rank
    *          the index in the list of samples
    */
-  private double allowableError(int rank) {
+  double allowableError(int rank) {
     int size = samples.size();
     double minError = size + 1;
     for (Quantile q : quantiles) {
@@ -202,10 +200,10 @@ public class SampleQuantiles implements QuantileEstimator {
   /**
    * Get the estimated value at the specified quantile.
    * 
-   * @param quantile Queried quantile, e.g. 0.01, 0.50 or 0.99.
+   * @param quantile Queried quantile, e.g. 0.50 or 0.99.
    * @return Estimated value at that quantile.
    */
-  private long query(double quantile) {
+  long query(double quantile) {
     Preconditions.checkState(!samples.isEmpty(), "no data in estimator");
 
     int rankMin = 0;
@@ -245,12 +243,7 @@ public class SampleQuantiles implements QuantileEstimator {
     
     Map<Quantile, Long> values = new TreeMap<Quantile, Long>();
     for (int i = 0; i < quantiles.length; i++) {
-      /* eg : effectiveQuantile for 0.99 with inverseQuantiles will be 0.01. 
-      For inverse quantiles higher numeric value is better and hence we want 
-      to query from the opposite end of the sorted sample
-       */
-      double effectiveQuantile = inverseQuantiles ? 1 - quantiles[i].quantile : quantiles[i].quantile;
-      values.put(quantiles[i], query(effectiveQuantile));
+      values.put(quantiles[i], query(quantiles[i].quantile));
     }
 
     return values;
@@ -298,7 +291,7 @@ public class SampleQuantiles implements QuantileEstimator {
    * Describes a measured value passed to the estimator, tracking additional
    * metadata required by the CKMS algorithm.
    */
-  private static class SampleItem {
+  static class SampleItem {
     
     /**
      * Value of the sampled item (e.g. a measured latency value)

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/SampleQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/SampleQuantiles.java
@@ -249,7 +249,7 @@ public class SampleQuantiles implements QuantileEstimator {
   }
 
   /**
-   * Returns the number of items that the estimator has processed
+   * Returns the number of items that the estimator has processed.
    * 
    * @return count total number of items processed
    */

--- a/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
@@ -372,7 +372,7 @@ Each metrics record contains tags such as SessionId and Hostname as additional i
 | `BytesRead` | Total number of bytes read from DataNode |
 | `ReadTransferRateNumOps` | Total number of data read transfers |
 | `ReadTransferRateAvgTime` | Average transfer rate of bytes read from DataNode, measured in bytes per second. |
-| `ReadTransferRate`*num*`s(50/75/90/95/99)thPercentileRate` | The 50/75/90/95/99th percentile of the transfer rate of bytes read from DataNode, measured in bytes per second. |
+| `ReadTransferRate`*num*`s(50/75/90/95/99)thPercentileRate` | The 50/75/90/95/99th inverse percentile of the transfer rate of bytes read from DataNode, measured in bytes per second. |
 | `BlocksWritten` | Total number of blocks written to DataNode |
 | `BlocksRead` | Total number of blocks read from DataNode |
 | `BlocksReplicated` | Total number of blocks replicated |

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
@@ -39,7 +39,7 @@ public class TestSampleQuantiles {
 
   @Before
   public void init() {
-    estimator = new SampleQuantiles(quantiles, false);
+    estimator = new SampleQuantiles(quantiles);
   }
 
   /**
@@ -121,7 +121,7 @@ public class TestSampleQuantiles {
   
   @Test
   public void testInverseQuantiles() {
-      SampleQuantiles estimatorWithInverseQuantiles = new SampleQuantiles(quantiles, true);
+      SampleQuantiles estimatorWithInverseQuantiles = new InverseQuantiles(quantiles);
       final int count = 100000;
       Random r = new Random(0xDEADDEAD);
       Long[] values = new Long[count];

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
@@ -120,8 +120,8 @@ public class TestSampleQuantiles {
   }
 
   /**
-   * Correctness test that checks that absolute error of the estimate for inverse quantiles is within
-   * specified error bounds for some randomly permuted streams of items.
+   * Correctness test that checks that absolute error of the estimate for inverse quantiles
+   * is within specified error bounds for some randomly permuted streams of items.
    */
   @Test
   public void testInverseQuantiles() {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
@@ -118,36 +118,39 @@ public class TestSampleQuantiles {
       }
     }
   }
-  
+
+  /**
+   * Correctness test that checks that absolute error of the estimate for inverse quantiles is within
+   * specified error bounds for some randomly permuted streams of items.
+   */
   @Test
   public void testInverseQuantiles() {
-      SampleQuantiles estimatorWithInverseQuantiles = new InverseQuantiles(quantiles);
-      final int count = 100000;
-      Random r = new Random(0xDEADDEAD);
-      Long[] values = new Long[count];
-      for (int i = 0; i < count; i++) {
-          values[i] = (long) (i + 1);
+    SampleQuantiles estimatorWithInverseQuantiles = new InverseQuantiles(quantiles);
+    final int count = 100000;
+    Random r = new Random(0xDEADDEAD);
+    Long[] values = new Long[count];
+    for (int i = 0; i < count; i++) {
+      values[i] = (long) (i + 1);
+    }
+    // Do 10 shuffle/insert/check cycles
+    for (int i = 0; i < 10; i++) {
+      System.out.println("Starting run " + i);
+      Collections.shuffle(Arrays.asList(values), r);
+      estimatorWithInverseQuantiles.clear();
+      for (int j = 0; j < count; j++) {
+        estimatorWithInverseQuantiles.insert(values[j]);
       }
-      // Do 10 shuffle/insert/check cycles
-      for (int i = 0; i < 10; i++) {
-          System.out.println("Starting run " + i);
-          Collections.shuffle(Arrays.asList(values), r);
-          estimatorWithInverseQuantiles.clear();
-          for (int j = 0; j < count; j++) {
-              estimatorWithInverseQuantiles.insert(values[j]);
-          }
-          Map<Quantile, Long> snapshot;
-          snapshot = estimatorWithInverseQuantiles.snapshot();
-          for (Quantile q : quantiles) {
-              long actual = (long) ((1 - q.quantile) * count);
-              long error = (long) ((0.1 - q.error) * count);
-              long estimate = snapshot.get(q);
-              System.out
-                      .println(String.format("For quantile %f Expected %d with error %d, estimated %d",
-                              q.quantile, actual, error, estimate));
-              assertThat(estimate <= actual + error).isTrue();
-              assertThat(estimate >= actual - error).isTrue();
-          }
+      Map<Quantile, Long> snapshot;
+      snapshot = estimatorWithInverseQuantiles.snapshot();
+      for (Quantile q : quantiles) {
+        long actual = (long) ((1 - q.quantile) * count);
+        long error = (long) ((0.1 - q.error) * count);
+        long estimate = snapshot.get(q);
+        System.out.println(String.format("For quantile %f Expected %d with error %d, estimated %d",
+                q.quantile, actual, error, estimate));
+        assertThat(estimate <= actual + error).isTrue();
+        assertThat(estimate >= actual - error).isTrue();
       }
+    }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
@@ -260,8 +260,8 @@ public class DataNodeMetrics {
           "ops", "latency", interval);
       readTransferRateQuantiles[i] = registry.newQuantiles(
           "readTransferRate" + interval + "s",
-          "Rate at which bytes are read from datanode calculated in bytes per second with inverse quantiles",
-          "ops", "rate", interval, true);
+          "Rate at which bytes are read from datanode calculated in bytes per second" +
+          " with inverse quantiles", "ops", "rate", interval, true);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
@@ -260,8 +260,8 @@ public class DataNodeMetrics {
           "ops", "latency", interval);
       readTransferRateQuantiles[i] = registry.newQuantiles(
           "readTransferRate" + interval + "s",
-          "Rate at which bytes are read from datanode calculated in bytes per second",
-          "ops", "rate", interval);
+          "Rate at which bytes are read from datanode calculated in bytes per second with inverse quantiles",
+          "ops", "rate", interval, true);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestMultiThreadedHflush.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestMultiThreadedHflush.java
@@ -53,7 +53,7 @@ public class TestMultiThreadedHflush {
       new Quantile[] {
         new Quantile(0.50, 0.050),
         new Quantile(0.75, 0.025), new Quantile(0.90, 0.010),
-        new Quantile(0.95, 0.005), new Quantile(0.99, 0.001) });
+        new Quantile(0.95, 0.005), new Quantile(0.99, 0.001) }, false);
 
   /*
    * creates a file but does not close it

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestMultiThreadedHflush.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestMultiThreadedHflush.java
@@ -53,7 +53,7 @@ public class TestMultiThreadedHflush {
       new Quantile[] {
         new Quantile(0.50, 0.050),
         new Quantile(0.75, 0.025), new Quantile(0.90, 0.010),
-        new Quantile(0.95, 0.005), new Quantile(0.99, 0.001) }, false);
+        new Quantile(0.95, 0.005), new Quantile(0.99, 0.001) });
 
   /*
    * creates a file but does not close it


### PR DESCRIPTION
…ic value is better

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Currently quantiles are used for latencies, where lower numeric value is better.

Hence p90 gives us a value val(p90) such that 90% of our sample set has a value better (lower) than val(p90)

 

However for metrics such as calculating transfer rates (eg : [HDFS-16917](https://issues.apache.org/jira/browse/HDFS-16917) ) higher numeric value is better. Thus for such metrics the current quantiles dont work.

For these metrics in order for p90 to give a value val(p90) where 90% of the sample set is better (higher) than val(p90) we need to inverse the selection by choosing a value at the (100 - 90)th location instead of the usual 90th position.

Note: There will be error guarantees for percentiles as our quantile implementation following [Cormode, Korn, Muthukrishnan, and Srivastava algorithm](http://dimacs.rutgers.edu/~graham/pubs/papers/bquant-icde.pdf)

### How was this patch tested?

Results from UT testInverseQuantiles()
Starting run 0
For quantile 0.500000 Expected 50000 with error 5000, estimated 50548
For quantile 0.750000 Expected 25000 with error 7500, estimated 27257
For quantile 0.900000 Expected 9999 with error 9000, estimated 12412
For quantile 0.950000 Expected 5000 with error 9500, estimated 8169
For quantile 0.990000 Expected 1000 with error 9900, estimated 6272
Starting run 1
For quantile 0.500000 Expected 50000 with error 5000, estimated 50896
For quantile 0.750000 Expected 25000 with error 7500, estimated 26421
For quantile 0.900000 Expected 9999 with error 9000, estimated 12908
For quantile 0.950000 Expected 5000 with error 9500, estimated 8101
For quantile 0.990000 Expected 1000 with error 9900, estimated 6099
Starting run 2
For quantile 0.500000 Expected 50000 with error 5000, estimated 50945
For quantile 0.750000 Expected 25000 with error 7500, estimated 26571
For quantile 0.900000 Expected 9999 with error 9000, estimated 12159
For quantile 0.950000 Expected 5000 with error 9500, estimated 7951
For quantile 0.990000 Expected 1000 with error 9900, estimated 5624
Starting run 3
For quantile 0.500000 Expected 50000 with error 5000, estimated 51442
For quantile 0.750000 Expected 25000 with error 7500, estimated 27493
For quantile 0.900000 Expected 9999 with error 9000, estimated 12775
For quantile 0.950000 Expected 5000 with error 9500, estimated 8242
For quantile 0.990000 Expected 1000 with error 9900, estimated 5967
Starting run 4
For quantile 0.500000 Expected 50000 with error 5000, estimated 50473
For quantile 0.750000 Expected 25000 with error 7500, estimated 25832
For quantile 0.900000 Expected 9999 with error 9000, estimated 11593
For quantile 0.950000 Expected 5000 with error 9500, estimated 7461
For quantile 0.990000 Expected 1000 with error 9900, estimated 5454
Starting run 5
For quantile 0.500000 Expected 50000 with error 5000, estimated 50826
For quantile 0.750000 Expected 25000 with error 7500, estimated 26946
For quantile 0.900000 Expected 9999 with error 9000, estimated 12894
For quantile 0.950000 Expected 5000 with error 9500, estimated 8087
For quantile 0.990000 Expected 1000 with error 9900, estimated 6481
Starting run 6
For quantile 0.500000 Expected 50000 with error 5000, estimated 51023
For quantile 0.750000 Expected 25000 with error 7500, estimated 26468
For quantile 0.900000 Expected 9999 with error 9000, estimated 12364
For quantile 0.950000 Expected 5000 with error 9500, estimated 7939
For quantile 0.990000 Expected 1000 with error 9900, estimated 6009
Starting run 7
For quantile 0.500000 Expected 50000 with error 5000, estimated 50793
For quantile 0.750000 Expected 25000 with error 7500, estimated 26849
For quantile 0.900000 Expected 9999 with error 9000, estimated 13093
For quantile 0.950000 Expected 5000 with error 9500, estimated 8006
For quantile 0.990000 Expected 1000 with error 9900, estimated 5701
Starting run 8
For quantile 0.500000 Expected 50000 with error 5000, estimated 51106
For quantile 0.750000 Expected 25000 with error 7500, estimated 26671
For quantile 0.900000 Expected 9999 with error 9000, estimated 12757
For quantile 0.950000 Expected 5000 with error 9500, estimated 8537
For quantile 0.990000 Expected 1000 with error 9900, estimated 6224
Starting run 9
For quantile 0.500000 Expected 50000 with error 5000, estimated 50825
For quantile 0.750000 Expected 25000 with error 7500, estimated 27698
For quantile 0.900000 Expected 9999 with error 9000, estimated 11594
For quantile 0.950000 Expected 5000 with error 9500, estimated 8113
For quantile 0.990000 Expected 1000 with error 9900, estimated 5475
### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

