### PR TITLE
HDFS-16957. RBF: Exit status of dfsrouteradmin -rm should be non-zero for unsuccessful attempt

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
@@ -371,7 +371,6 @@ public class RouterAdmin extends Configured implements Tool {
               System.out.println("Successfully removed mount point " + argv[i]);
             } else {
               exitCode = -1;
-              System.err.println("Failed to remove mount point " + argv[i]);
             }
           } catch (IOException e) {
             exitCode = -1;
@@ -815,7 +814,7 @@ public class RouterAdmin extends Configured implements Tool {
         mountTable.removeMountTableEntry(request);
     boolean removed = response.getStatus();
     if (!removed) {
-      System.out.println("Cannot remove mount point " + path);
+      System.err.println("Cannot remove mount point " + path);
     }
     return removed;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
@@ -369,6 +369,9 @@ public class RouterAdmin extends Configured implements Tool {
           try {
             if (removeMount(argv[i])) {
               System.out.println("Successfully removed mount point " + argv[i]);
+            } else {
+              exitCode = -1;
+              System.err.println("Failed to remove mount point " + argv[i]);
             }
           } catch (IOException e) {
             exitCode = -1;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdminCLI.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdminCLI.java
@@ -433,10 +433,13 @@ public class TestRouterAdminCLI {
     // remove an invalid mount table
     String invalidPath = "/invalid";
     System.setOut(new PrintStream(out));
+    System.setErr(new PrintStream(err));
     argv = new String[] {"-rm", invalidPath};
-    assertEquals(0, ToolRunner.run(admin, argv));
+    assertEquals(-1, ToolRunner.run(admin, argv));
     assertTrue(out.toString().contains(
         "Cannot remove mount point " + invalidPath));
+    assertEquals("DFS Router Admin should report error for failure to remove mount point",
+        "Failed to remove mount point " + invalidPath + "\n", err.toString());
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdminCLI.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdminCLI.java
@@ -436,10 +436,8 @@ public class TestRouterAdminCLI {
     System.setErr(new PrintStream(err));
     argv = new String[] {"-rm", invalidPath};
     assertEquals(-1, ToolRunner.run(admin, argv));
-    assertTrue(out.toString().contains(
-        "Cannot remove mount point " + invalidPath));
     assertEquals("DFS Router Admin should report error for failure to remove mount point",
-        "Failed to remove mount point " + invalidPath + "\n", err.toString());
+        "Cannot remove mount point " + invalidPath + "\n", err.toString());
   }
 
   @Test
@@ -729,8 +727,11 @@ public class TestRouterAdminCLI {
     // add new mount table with only write permission
     argv = new String[] {"-add", "/testpath2-2", "ns0", "/testdir2-2",
         "-owner", TEST_USER, "-group", TEST_USER, "-mode", "0255"};
+    System.setErr(new PrintStream(err));
     assertEquals(0, ToolRunner.run(admin, argv));
     verifyExecutionResult("/testpath2-2", false, -1, 0);
+    assertEquals("DFS Router Admin should report error for failure to add mount point",
+        "Cannot add mount point /testpath2-2\n", err.toString());
 
     // set mount table entry with read and write permission
     argv = new String[] {"-add", "/testpath2-3", "ns0", "/testdir2-3",


### PR DESCRIPTION
DFS router admin returns non-zero status code for unsuccessful attempt to add or update mount point. However, same is not the case with removal of mount point.

For instance,
```
bin/hdfs dfsrouteradmin -add /data4 ns1 /data4
..
..

Cannot add destination at ns1 /data4


echo $?
255 
```
```
bin/hdfs dfsrouteradmin -rm /data4
..
..
Cannot remove mount point /data4


echo $?
0
```

Removal of mount point should stay consistent with other options and return non-zero (unsuccessful) status code.