### PR TITLE
HDFS-16958. EC: Fix bug in processing EC excess redundancy.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -4148,8 +4148,7 @@ public class BlockManager implements BlockStatsMXBean {
       }
     }
 
-    // cardinality of found indicates the expected number of internal blocks
-    final int numOfTarget = found.cardinality();
+    final int numOfTarget = sblk.getRealDataBlockNum();
     final BlockStoragePolicy storagePolicy = storagePolicySuite.getPolicy(
         bc.getStoragePolicyID());
     final List<StorageType> excessTypes = storagePolicy.chooseExcess(


### PR DESCRIPTION
### Description of PR
When processing excess redundancy, the number of internal blocks is computed by traversing `nonExcess`. This way is not accurate, because `nonExcess` excludes replicas in abnormal states, such as corrupt ones, or maintenance ones. `numOfTarget` may be smaller than the actual value, which will result in inaccurate generated `excessTypes`.
