### PR TITLE
HDFS-16949 Introduce inverse quantiles for metrics where higher numer…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
@@ -228,6 +228,29 @@ public class MetricsRegistry {
   }
 
   /**
+   * Create a mutable inverse metric that estimates inverse quantiles of a stream of values
+   * @param name of the metric
+   * @param desc metric description
+   * @param sampleName of the metric (e.g., "Ops")
+   * @param valueName of the metric (e.g., "Rate")
+   * @param interval rollover interval of estimator in seconds
+   * @return a new inverse quantile estimator object
+   * @throws MetricsException if interval is not a positive integer
+   */
+  public synchronized MutableQuantiles newInverseQuantiles(String name, String desc,
+      String sampleName, String valueName, int interval) {
+    checkMetricName(name);
+    if (interval <= 0) {
+      throw new MetricsException("Interval should be positive.  Value passed" +
+          " is: " + interval);
+    }
+    MutableQuantiles ret =
+        new MutableInverseQuantiles(name, desc, sampleName, valueName, interval);
+    metricsMap.put(name, ret);
+    return ret;
+  }
+
+  /**
    * Create a mutable metric with stats
    * @param name  of the metric
    * @param desc  metric description

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
@@ -301,7 +301,7 @@ public class MetricsRegistry {
   }
 
   /**
-   * Create a mutable rate metric (for throughput measurement)
+   * Create a mutable rate metric (for throughput measurement).
    * @param name  of the metric
    * @param desc  description
    * @param extended  produce extended stat (stdev/min/max etc.) if true

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableInverseQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableInverseQuantiles.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.metrics2.util.Quantile;
 import org.apache.hadoop.metrics2.util.SampleQuantiles;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.text.DecimalFormat;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -33,7 +34,7 @@ import static org.apache.hadoop.metrics2.lib.Interns.info;
 /**
  * Watches a stream of long values, maintaining online estimates of specific
  * quantiles with provably low error bounds. Inverse quantiles are meant for
- * highly accurate low-percentile (e.g. 1st, 5th) latency metrics.
+ * highly accurate low-percentile (e.g. 1st, 5th) metrics.
  * InverseQuantiles are used for metrics where higher the value better it is.
  * ( eg: data transfer rate ).
  * The 1st percentile here corresponds to the 99th inverse percentile metric,
@@ -83,13 +84,14 @@ public class MutableInverseQuantiles extends MutableQuantiles{
         "Number of %s for %s with %ds interval", lsName, desc, intervalSecs)));
     // Construct the MetricsInfos for the inverse quantiles, converting to inverse percentiles
     setQuantileInfos(INVERSE_QUANTILES.length);
-    String nameTemplate = ucName + "%dthInversePercentile" + uvName;
-    String descTemplate = "%d inverse percentile " + lvName + " with " + intervalSecs
+    DecimalFormat df = new DecimalFormat("###.####");
+    String nameTemplate = "thInversePercentile" + uvName;
+    String descTemplate = " inverse percentile " + lvName + " with " + intervalSecs
         + " second interval for " + desc;
     for (int i = 0; i < INVERSE_QUANTILES.length; i++) {
       double inversePercentile = 100 * (1 - INVERSE_QUANTILES[i].quantile);
-      addQuantileInfo(i, info(String.format(nameTemplate, inversePercentile),
-          String.format(descTemplate, inversePercentile)));
+      addQuantileInfo(i, info(ucName + df.format(inversePercentile) + nameTemplate,
+          df.format(inversePercentile) + descTemplate));
     }
 
     setEstimator(new SampleQuantiles(INVERSE_QUANTILES));

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableInverseQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableInverseQuantiles.java
@@ -33,7 +33,7 @@ import static org.apache.hadoop.metrics2.lib.Interns.info;
 
 /**
  * Watches a stream of long values, maintaining online estimates of specific
- * quantiles with provably low error bounds. Inverse quantiles are meant for 
+ * quantiles with provably low error bounds. Inverse quantiles are meant for
  * highly accurate low-percentile (e.g. 1st, 5th) latency metrics.
  * InverseQuantiles are used for metrics where higher the value better it is.
  * ( eg: data transfer rate ).
@@ -45,13 +45,13 @@ import static org.apache.hadoop.metrics2.lib.Interns.info;
 public class MutableInverseQuantiles extends MutableQuantiles{
 
   @VisibleForTesting
-  public static final Quantile[] inverseQuantiles = { new Quantile(0.50, 0.050),
+  public static final Quantile[] INVERSE_QUANTILES = { new Quantile(0.50, 0.050),
       new Quantile(0.25, 0.025), new Quantile(0.10, 0.010),
       new Quantile(0.05, 0.005), new Quantile(0.01, 0.001) };
 
-  private ScheduledFuture<?> scheduledTask = null;
-    
-  private static final ScheduledExecutorService scheduler = Executors
+  private ScheduledFuture<?> scheduledTask;
+
+  private static final ScheduledExecutorService SCHEDULAR = Executors
       .newScheduledThreadPool(1, new ThreadFactoryBuilder().setDaemon(true)
           .setNameFormat("MutableInverseQuantiles-%d").build());
 
@@ -63,7 +63,7 @@ public class MutableInverseQuantiles extends MutableQuantiles{
    * @param description long-form textual description of the metric
    * @param sampleName  type of items in the stream (e.g., "Ops")
    * @param valueName   type of the values
-   * @param interval
+   * @param interval    rollover interval (in seconds) of the estimator
    */
   public MutableInverseQuantiles(String name, String description, String sampleName,
       String valueName, int interval) {
@@ -74,22 +74,22 @@ public class MutableInverseQuantiles extends MutableQuantiles{
     String lsName = StringUtils.uncapitalize(sampleName);
     String lvName = StringUtils.uncapitalize(valueName);
 
-    numInfo = info(ucName + "Num" + usName, String.format(
-        "Number of %s for %s with %ds interval", lsName, desc, interval));
+    setNumInfo(info(ucName + "Num" + usName, String.format(
+        "Number of %s for %s with %ds interval", lsName, desc, interval)));
     // Construct the MetricsInfos for the inverse quantiles, converting to inverse percentiles
-    quantileInfos = new MetricsInfo[inverseQuantiles.length];
+    setQuantileInfos(INVERSE_QUANTILES.length);
     String nameTemplate = ucName + "%dthInversePercentile" + uvName;
     String descTemplate = "%d inverse percentile " + lvName + " with " + interval
         + " second interval for " + desc;
-    for (int i = 0; i < inverseQuantiles.length; i++) {
-      int inversePercentile = (int) (100 * (1 - inverseQuantiles[i].quantile));
-      quantileInfos[i] = info(String.format(nameTemplate, inversePercentile),
-          String.format(descTemplate, inversePercentile));
+    for (int i = 0; i < INVERSE_QUANTILES.length; i++) {
+      int inversePercentile = (int) (100 * (1 - INVERSE_QUANTILES[i].quantile));
+      addQuantileInfo(i, info(String.format(nameTemplate, inversePercentile),
+          String.format(descTemplate, inversePercentile)));
     }
 
-    estimator = new SampleQuantiles(inverseQuantiles);
+    setEstimator(new SampleQuantiles(INVERSE_QUANTILES));
     setInterval(interval);
-    scheduledTask = scheduler.scheduleWithFixedDelay(new RolloverSample(this),
+    scheduledTask = SCHEDULAR.scheduleWithFixedDelay(new RolloverSample(this),
         interval, interval, TimeUnit.SECONDS);
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableInverseQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableInverseQuantiles.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.metrics2.lib;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.metrics2.MetricsInfo;
+import org.apache.hadoop.metrics2.util.Quantile;
+import org.apache.hadoop.metrics2.util.SampleQuantiles;
+import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import static org.apache.hadoop.metrics2.lib.Interns.info;
+
+/**
+ * Watches a stream of long values, maintaining online estimates of specific
+ * quantiles with provably low error bounds. Inverse quantiles are meant for 
+ * highly accurate low-percentile (e.g. 1st, 5th) latency metrics.
+ * InverseQuantiles are used for metrics where higher the value better it is.
+ * ( eg: data transfer rate ).
+ * The 1st percentile here corresponds to the 99th inverse percentile metric,
+ * 5th percentile to 95th and so on.
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public class MutableInverseQuantiles extends MutableQuantiles{
+
+  @VisibleForTesting
+  public static final Quantile[] inverseQuantiles = { new Quantile(0.50, 0.050),
+      new Quantile(0.25, 0.025), new Quantile(0.10, 0.010),
+      new Quantile(0.05, 0.005), new Quantile(0.01, 0.001) };
+
+  private ScheduledFuture<?> scheduledTask = null;
+    
+  private static final ScheduledExecutorService scheduler = Executors
+      .newScheduledThreadPool(1, new ThreadFactoryBuilder().setDaemon(true)
+          .setNameFormat("MutableInverseQuantiles-%d").build());
+
+  /**
+   * Instantiates a new {@link MutableInverseQuantiles} for a metric that rolls itself
+   * over on the specified time interval.
+   *
+   * @param name        of the metric
+   * @param description long-form textual description of the metric
+   * @param sampleName  type of items in the stream (e.g., "Ops")
+   * @param valueName   type of the values
+   * @param interval
+   */
+  public MutableInverseQuantiles(String name, String description, String sampleName,
+      String valueName, int interval) {
+    String ucName = StringUtils.capitalize(name);
+    String usName = StringUtils.capitalize(sampleName);
+    String uvName = StringUtils.capitalize(valueName);
+    String desc = StringUtils.uncapitalize(description);
+    String lsName = StringUtils.uncapitalize(sampleName);
+    String lvName = StringUtils.uncapitalize(valueName);
+
+    numInfo = info(ucName + "Num" + usName, String.format(
+        "Number of %s for %s with %ds interval", lsName, desc, interval));
+    // Construct the MetricsInfos for the inverse quantiles, converting to inverse percentiles
+    quantileInfos = new MetricsInfo[inverseQuantiles.length];
+    String nameTemplate = ucName + "%dthInversePercentile" + uvName;
+    String descTemplate = "%d inverse percentile " + lvName + " with " + interval
+        + " second interval for " + desc;
+    for (int i = 0; i < inverseQuantiles.length; i++) {
+      int inversePercentile = (int) (100 * (1 - inverseQuantiles[i].quantile));
+      quantileInfos[i] = info(String.format(nameTemplate, inversePercentile),
+          String.format(descTemplate, inversePercentile));
+    }
+
+    estimator = new SampleQuantiles(inverseQuantiles);
+    setInterval(interval);
+    scheduledTask = scheduler.scheduleWithFixedDelay(new RolloverSample(this),
+        interval, interval, TimeUnit.SECONDS);
+  }
+
+  public void stop() {
+    if (scheduledTask != null) {
+      scheduledTask.cancel(false);
+    }
+    scheduledTask = null;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableInverseQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableInverseQuantiles.java
@@ -50,9 +50,9 @@ public class MutableInverseQuantiles extends MutableQuantiles{
   }
 
   @VisibleForTesting
-  public static final Quantile[] INVERSE_QUANTILES = { new InversePercentile(50),
+  public static final Quantile[] INVERSE_QUANTILES = {new InversePercentile(50),
       new InversePercentile(25), new InversePercentile(10),
-      new InversePercentile(5), new InversePercentile(1) };
+      new InversePercentile(5), new InversePercentile(1)};
 
   private ScheduledFuture<?> scheduledTask;
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableQuantiles.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.metrics2.lib;
 
 import static org.apache.hadoop.metrics2.lib.Interns.info;
 
+import java.text.DecimalFormat;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -90,18 +91,19 @@ public class MutableQuantiles extends MutableMetric {
     String desc = StringUtils.uncapitalize(description);
     String lsName = StringUtils.uncapitalize(sampleName);
     String lvName = StringUtils.uncapitalize(valueName);
+    DecimalFormat df = new DecimalFormat("###.####");
 
     setNumInfo(info(ucName + "Num" + usName, String.format(
         "Number of %s for %s with %ds interval", lsName, desc, interval)));
     // Construct the MetricsInfos for the quantiles, converting to percentiles
     setQuantileInfos(quantiles.length);
-    String nameTemplate = ucName + "%dthPercentile" + uvName;
-    String descTemplate = "%d percentile " + lvName + " with " + interval
+    String nameTemplate = "thPercentile" + uvName;
+    String descTemplate = " percentile " + lvName + " with " + interval
         + " second interval for " + desc;
     for (int i = 0; i < quantiles.length; i++) {
       double percentile = 100 * quantiles[i].quantile;
-      addQuantileInfo(i, info(String.format(nameTemplate, percentile),
-          String.format(descTemplate, percentile)));
+      addQuantileInfo(i, info(ucName + df.format(percentile) + nameTemplate,
+          df.format(percentile) + descTemplate));
     }
 
     setEstimator(new SampleQuantiles(quantiles));
@@ -166,7 +168,7 @@ public class MutableQuantiles extends MutableMetric {
   /**
    * Set the rollover interval (in seconds) of the estimator.
    *
-   * @param pIntervalSecs (in seconds) of the estimator.
+   * @param pIntervalSecs of the estimator.
    */
   public synchronized void setInterval(int pIntervalSecs) {
     this.intervalSecs = pIntervalSecs;
@@ -175,7 +177,7 @@ public class MutableQuantiles extends MutableMetric {
   /**
    * Get the rollover interval (in seconds) of the estimator.
    *
-   * @return  intervalSecs (in seconds) of the estimator.
+   * @return  intervalSecs of the estimator.
    */
   public synchronized int getInterval() {
     return intervalSecs;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableQuantiles.java
@@ -54,7 +54,7 @@ public class MutableQuantiles extends MutableMetric {
 
   private MetricsInfo numInfo;
   private MetricsInfo[] quantileInfos;
-  private int interval;
+  private int intervalSecs;
 
   private QuantileEstimator estimator;
   private long previousCount = 0;
@@ -99,7 +99,7 @@ public class MutableQuantiles extends MutableMetric {
     String descTemplate = "%d percentile " + lvName + " with " + interval
         + " second interval for " + desc;
     for (int i = 0; i < quantiles.length; i++) {
-      int percentile = (int) (100 * quantiles[i].quantile);
+      double percentile = 100 * quantiles[i].quantile;
       addQuantileInfo(i, info(String.format(nameTemplate, percentile),
           String.format(descTemplate, percentile)));
     }
@@ -138,10 +138,10 @@ public class MutableQuantiles extends MutableMetric {
   /**
    * Set info about the metrics.
    *
-   * @param numInfo info about the metrics.
+   * @param pNumInfo info about the metrics.
    */
-  public synchronized void setNumInfo(MetricsInfo numInfo) {
-    this.numInfo = numInfo;
+  public synchronized void setNumInfo(MetricsInfo pNumInfo) {
+    this.numInfo = pNumInfo;
   }
 
   /**
@@ -166,19 +166,19 @@ public class MutableQuantiles extends MutableMetric {
   /**
    * Set the rollover interval (in seconds) of the estimator.
    *
-   * @param interval (in seconds) of the estimator.
+   * @param pIntervalSecs (in seconds) of the estimator.
    */
-  public synchronized void setInterval(int interval) {
-    this.interval = interval;
+  public synchronized void setInterval(int pIntervalSecs) {
+    this.intervalSecs = pIntervalSecs;
   }
 
   /**
    * Get the rollover interval (in seconds) of the estimator.
    *
-   * @return  interval (in seconds) of the estimator.
+   * @return  intervalSecs (in seconds) of the estimator.
    */
   public synchronized int getInterval() {
-    return interval;
+    return intervalSecs;
   }
 
   public void stop() {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
@@ -126,7 +126,7 @@ public class TestSampleQuantiles {
    */
   @Test
   public void testInverseQuantiles() throws IOException {
-    SampleQuantiles estimator = new SampleQuantiles(MutableInverseQuantiles.inverseQuantiles);
+    SampleQuantiles inverseQuantilesEstimator = new SampleQuantiles(MutableInverseQuantiles.INVERSE_QUANTILES);
     final int count = 100000;
     Random r = new Random(0xDEADDEAD);
     Long[] values = new Long[count];
@@ -137,13 +137,13 @@ public class TestSampleQuantiles {
     for (int i = 0; i < 10; i++) {
       System.out.println("Starting run " + i);
       Collections.shuffle(Arrays.asList(values), r);
-      estimator.clear();
+      inverseQuantilesEstimator.clear();
       for (int j = 0; j < count; j++) {
-        estimator.insert(values[j]);
+        inverseQuantilesEstimator.insert(values[j]);
       }
       Map<Quantile, Long> snapshot;
-      snapshot = estimator.snapshot();
-      for (Quantile q : MutableInverseQuantiles.inverseQuantiles) {
+      snapshot = inverseQuantilesEstimator.snapshot();
+      for (Quantile q : MutableInverseQuantiles.INVERSE_QUANTILES) {
         long actual = (long) (q.quantile * count);
         long error = (long) (q.error * count);
         long estimate = snapshot.get(q);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Random;
 
+import org.apache.hadoop.metrics2.lib.MutableInverseQuantiles;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -113,6 +114,42 @@ public class TestSampleQuantiles {
         System.out
             .println(String.format("Expected %d with error %d, estimated %d",
                 actual, error, estimate));
+        assertThat(estimate <= actual + error).isTrue();
+        assertThat(estimate >= actual - error).isTrue();
+      }
+    }
+  }
+
+  /**
+   * Correctness test that checks that absolute error of the estimate for inverse quantiles
+   * is within specified error bounds for some randomly permuted streams of items.
+   */
+  @Test
+  public void testInverseQuantiles() throws IOException {
+    SampleQuantiles estimator = new SampleQuantiles(MutableInverseQuantiles.inverseQuantiles);
+    final int count = 100000;
+    Random r = new Random(0xDEADDEAD);
+    Long[] values = new Long[count];
+    for (int i = 0; i < count; i++) {
+      values[i] = (long) (i + 1);
+    }
+    // Do 10 shuffle/insert/check cycles
+    for (int i = 0; i < 10; i++) {
+      System.out.println("Starting run " + i);
+      Collections.shuffle(Arrays.asList(values), r);
+      estimator.clear();
+      for (int j = 0; j < count; j++) {
+        estimator.insert(values[j]);
+      }
+      Map<Quantile, Long> snapshot;
+      snapshot = estimator.snapshot();
+      for (Quantile q : MutableInverseQuantiles.inverseQuantiles) {
+        long actual = (long) (q.quantile * count);
+        long error = (long) (q.error * count);
+        long estimate = snapshot.get(q);
+        System.out.println(String.format("For inverse quantile %f " +
+            "Expected %d with error %d, estimated %d",
+                (1 - q.quantile), actual, error, estimate));
         assertThat(estimate <= actual + error).isTrue();
         assertThat(estimate >= actual - error).isTrue();
       }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
@@ -37,10 +37,9 @@ public class TestSampleQuantiles {
       new Quantile(0.95, 0.005), new Quantile(0.99, 0.001) };
 
   SampleQuantiles estimator;
-  Random rnd = new Random(0xDEADDEAD);
   final static int NUM_REPEATS = 10;
 
-    @Before
+  @Before
   public void init() {
     estimator = new SampleQuantiles(quantiles);
   }
@@ -94,6 +93,7 @@ public class TestSampleQuantiles {
   @Test
   public void testQuantileError() throws IOException {
     final int count = 100000;
+    Random rnd = new Random(0xDEADDEAD);
     int[] values = new int[count];
     for (int i = 0; i < count; i++) {
       values[i] = i + 1;
@@ -102,7 +102,7 @@ public class TestSampleQuantiles {
     // Repeat shuffle/insert/check cycles 10 times
     for (int i = 0; i < NUM_REPEATS; i++) {
 
-      // Shuffle  
+      // Shuffle
       Collections.shuffle(Arrays.asList(values), rnd);
       estimator.clear();
 
@@ -130,8 +130,10 @@ public class TestSampleQuantiles {
    */
   @Test
   public void testInverseQuantiles() throws IOException {
-    SampleQuantiles inverseQuantilesEstimator = new SampleQuantiles(MutableInverseQuantiles.INVERSE_QUANTILES);
+    SampleQuantiles inverseQuantilesEstimator =
+        new SampleQuantiles(MutableInverseQuantiles.INVERSE_QUANTILES);
     final int count = 100000;
+    Random rnd = new Random(0xDEADDEAD);
     int[] values = new int[count];
     for (int i = 0; i < count; i++) {
       values[i] = i + 1;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
@@ -93,27 +93,30 @@ public class TestSampleQuantiles {
   public void testQuantileError() throws IOException {
     final int count = 100000;
     Random r = new Random(0xDEADDEAD);
-    Long[] values = new Long[count];
+    int[] values = new int[count];
     for (int i = 0; i < count; i++) {
-      values[i] = (long) (i + 1);
+      values[i] = i + 1;
     }
+
     // Do 10 shuffle/insert/check cycles
     for (int i = 0; i < 10; i++) {
-      System.out.println("Starting run " + i);
+
+      // Shuffle  
       Collections.shuffle(Arrays.asList(values), r);
       estimator.clear();
+
+      // Insert
       for (int j = 0; j < count; j++) {
         estimator.insert(values[j]);
       }
       Map<Quantile, Long> snapshot;
       snapshot = estimator.snapshot();
+
+      // Check
       for (Quantile q : quantiles) {
         long actual = (long) (q.quantile * count);
         long error = (long) (q.error * count);
         long estimate = snapshot.get(q);
-        System.out
-            .println(String.format("Expected %d with error %d, estimated %d",
-                actual, error, estimate));
         assertThat(estimate <= actual + error).isTrue();
         assertThat(estimate >= actual - error).isTrue();
       }
@@ -129,27 +132,29 @@ public class TestSampleQuantiles {
     SampleQuantiles inverseQuantilesEstimator = new SampleQuantiles(MutableInverseQuantiles.INVERSE_QUANTILES);
     final int count = 100000;
     Random r = new Random(0xDEADDEAD);
-    Long[] values = new Long[count];
+    int[] values = new int[count];
     for (int i = 0; i < count; i++) {
-      values[i] = (long) (i + 1);
+      values[i] = i + 1;
     }
+
     // Do 10 shuffle/insert/check cycles
     for (int i = 0; i < 10; i++) {
-      System.out.println("Starting run " + i);
+      // Shuffle
       Collections.shuffle(Arrays.asList(values), r);
       inverseQuantilesEstimator.clear();
+
+      // Insert
       for (int j = 0; j < count; j++) {
         inverseQuantilesEstimator.insert(values[j]);
       }
       Map<Quantile, Long> snapshot;
       snapshot = inverseQuantilesEstimator.snapshot();
+
+      // Check
       for (Quantile q : MutableInverseQuantiles.INVERSE_QUANTILES) {
         long actual = (long) (q.quantile * count);
         long error = (long) (q.error * count);
         long estimate = snapshot.get(q);
-        System.out.println(String.format("For inverse quantile %f " +
-            "Expected %d with error %d, estimated %d",
-                (1 - q.quantile), actual, error, estimate));
         assertThat(estimate <= actual + error).isTrue();
         assertThat(estimate >= actual - error).isTrue();
       }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
@@ -37,8 +37,10 @@ public class TestSampleQuantiles {
       new Quantile(0.95, 0.005), new Quantile(0.99, 0.001) };
 
   SampleQuantiles estimator;
+  Random rnd = new Random(0xDEADDEAD);
+  final static int NUM_REPEATS = 10;
 
-  @Before
+    @Before
   public void init() {
     estimator = new SampleQuantiles(quantiles);
   }
@@ -92,22 +94,21 @@ public class TestSampleQuantiles {
   @Test
   public void testQuantileError() throws IOException {
     final int count = 100000;
-    Random r = new Random(0xDEADDEAD);
     int[] values = new int[count];
     for (int i = 0; i < count; i++) {
       values[i] = i + 1;
     }
 
-    // Do 10 shuffle/insert/check cycles
-    for (int i = 0; i < 10; i++) {
+    // Repeat shuffle/insert/check cycles 10 times
+    for (int i = 0; i < NUM_REPEATS; i++) {
 
       // Shuffle  
-      Collections.shuffle(Arrays.asList(values), r);
+      Collections.shuffle(Arrays.asList(values), rnd);
       estimator.clear();
 
       // Insert
-      for (int j = 0; j < count; j++) {
-        estimator.insert(values[j]);
+      for (int value : values) {
+        estimator.insert(value);
       }
       Map<Quantile, Long> snapshot;
       snapshot = estimator.snapshot();
@@ -131,21 +132,20 @@ public class TestSampleQuantiles {
   public void testInverseQuantiles() throws IOException {
     SampleQuantiles inverseQuantilesEstimator = new SampleQuantiles(MutableInverseQuantiles.INVERSE_QUANTILES);
     final int count = 100000;
-    Random r = new Random(0xDEADDEAD);
     int[] values = new int[count];
     for (int i = 0; i < count; i++) {
       values[i] = i + 1;
     }
 
-    // Do 10 shuffle/insert/check cycles
-    for (int i = 0; i < 10; i++) {
+    // Repeat shuffle/insert/check cycles 10 times
+    for (int i = 0; i < NUM_REPEATS; i++) {
       // Shuffle
-      Collections.shuffle(Arrays.asList(values), r);
+      Collections.shuffle(Arrays.asList(values), rnd);
       inverseQuantilesEstimator.clear();
 
       // Insert
-      for (int j = 0; j < count; j++) {
-        inverseQuantilesEstimator.insert(values[j]);
+      for (int value : values) {
+        inverseQuantilesEstimator.insert(value);
       }
       Map<Quantile, Long> snapshot;
       snapshot = inverseQuantilesEstimator.snapshot();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
@@ -413,13 +413,13 @@ public class MetricsAsserts {
    */
   public static void assertInverseQuantileGauges(String prefix,
       MetricsRecordBuilder rb, String valueName) {
-    verify(rb).addGauge(eqName(info(prefix + "NumOps", "")), geq(0l));
+    verify(rb).addGauge(eqName(info(prefix + "NumOps", "")), geq(0L));
     for (Quantile q : MutableQuantiles.quantiles) {
       String nameTemplate = prefix + "%dthInversePercentile" + valueName;
       int percentile = (int) (100 * q.quantile);
       verify(rb).addGauge(
           eqName(info(String.format(nameTemplate, percentile), "")),
-          geq(0l));
+          geq(0L));
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
@@ -392,13 +392,13 @@ public class MetricsAsserts {
    */
   public static void assertQuantileGauges(String prefix,
       MetricsRecordBuilder rb, String valueName) {
-    verify(rb).addGauge(eqName(info(prefix + "NumOps", "")), geq(0l));
+    verify(rb).addGauge(eqName(info(prefix + "NumOps", "")), geq(0L));
     for (Quantile q : MutableQuantiles.quantiles) {
       String nameTemplate = prefix + "%dthPercentile" + valueName;
       int percentile = (int) (100 * q.quantile);
       verify(rb).addGauge(
           eqName(info(String.format(nameTemplate, percentile), "")),
-          geq(0l));
+          geq(0L));
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
@@ -403,6 +403,27 @@ public class MetricsAsserts {
   }
 
   /**
+   * Asserts that the NumOps and inverse quantiles for a metric have been changed at
+   * some point to a non-zero value, for the specified value name of the
+   * metrics (e.g., "Rate").
+   *
+   * @param prefix of the metric
+   * @param rb MetricsRecordBuilder with the metric
+   * @param valueName the value name for the metric
+   */
+  public static void assertInverseQuantileGauges(String prefix,
+      MetricsRecordBuilder rb, String valueName) {
+    verify(rb).addGauge(eqName(info(prefix + "NumOps", "")), geq(0l));
+    for (Quantile q : MutableQuantiles.quantiles) {
+      String nameTemplate = prefix + "%dthInversePercentile" + valueName;
+      int percentile = (int) (100 * q.quantile);
+      verify(rb).addGauge(
+          eqName(info(String.format(nameTemplate, percentile), "")),
+          geq(0l));
+    }
+  }
+
+  /**
    * Assert a tag of metric as expected.
    * @param name  of the metric tag
    * @param expected  value of the metric tag

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
@@ -258,7 +258,7 @@ public class DataNodeMetrics {
           "ramDiskBlocksLazyPersistWindows" + interval + "s",
           "Time between the RamDisk block write and disk persist in ms",
           "ops", "latency", interval);
-      readTransferRateQuantiles[i] = registry.newQuantiles(
+      readTransferRateQuantiles[i] = registry.newInverseQuantiles(
           "readTransferRate" + interval + "s",
           "Rate at which bytes are read from datanode calculated in bytes per second",
           "ops", "rate", interval);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
@@ -18,7 +18,11 @@
 package org.apache.hadoop.hdfs.server.datanode;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY;
-import static org.apache.hadoop.test.MetricsAsserts.*;
+import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
+import static org.apache.hadoop.test.MetricsAsserts.assertInverseQuantileGauges;
+import static org.apache.hadoop.test.MetricsAsserts.assertQuantileGauges;
+import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
+import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import static org.junit.Assert.*;
 
 import java.io.Closeable;
@@ -410,7 +414,7 @@ public class TestDataNodeMetrics {
           final long endWriteValue = getLongCounter("TotalWriteTime", rbNew);
           final long endReadValue = getLongCounter("TotalReadTime", rbNew);
           assertCounter("ReadTransferRateNumOps", 1L, rbNew);
-          assertInverseQuantileGauges("ReadTransferRate" + "60s", rbNew, "Rate");
+          assertInverseQuantileGauges("ReadTransferRate60s", rbNew, "Rate");
           return endWriteValue > startWriteValue
               && endReadValue > startReadValue;
         }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
@@ -18,10 +18,7 @@
 package org.apache.hadoop.hdfs.server.datanode;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY;
-import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
-import static org.apache.hadoop.test.MetricsAsserts.assertQuantileGauges;
-import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
-import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
+import static org.apache.hadoop.test.MetricsAsserts.*;
 import static org.junit.Assert.*;
 
 import java.io.Closeable;
@@ -413,7 +410,7 @@ public class TestDataNodeMetrics {
           final long endWriteValue = getLongCounter("TotalWriteTime", rbNew);
           final long endReadValue = getLongCounter("TotalReadTime", rbNew);
           assertCounter("ReadTransferRateNumOps", 1L, rbNew);
-          assertQuantileGauges("ReadTransferRate" + "60s", rbNew, "Rate");
+          assertInverseQuantileGauges("ReadTransferRate" + "60s", rbNew, "Rate");
           return endWriteValue > startWriteValue
               && endReadValue > startReadValue;
         }


### PR DESCRIPTION
…ic value is better

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Currently quantiles are used for latencies, where lower numeric value is better.

Hence p90 gives us a value `val(p90)` such that 90% of our sample set has a value better (lower) than `val(p90)`

 

However for metrics such as calculating transfer rates (eg : [HDFS-16917](https://issues.apache.org/jira/browse/HDFS-16917) ) higher numeric value is better. Thus for such metrics the current quantiles dont work.

For these metrics in order for p90 to give a value `val(p90)` where 90% of the sample set is better (higher) than `val(p90)` we need to inverse the selection by choosing a value at the (100 - 90)th location instead of the usual 90th position of the sample size sorted in ascending order.

Note: There will be allowable error percentage for percentiles following [Cormode, Korn, Muthukrishnan, and Srivastava algorithm](http://dimacs.rutgers.edu/~graham/pubs/papers/bquant-icde.pdf)

In another approach #5486 I reversed the loop traversal for finding the position. This did not work as expected because at the 1st, 5th, 10th position the allowable error percentage was on the higher side( 10%, 9.5%, 9%). Note that for optimization we dont store all the values in memory anymore and hence for higher allowable errors less values are stored giving us less accurate values at the 1st, 5th positions & 10th positions.
In the new approach, I am making sure that the allowable error at the 1st, 5th, 10th position is less ( 0.1%, 0.5%, 1%) which gives us more accurate values for the inverse quantiles that we are looking for. This can be seen by comparing the UT results in both the PR descriptions.

### How was this patch tested?
Results from UT testInverseQuantiles()
Starting run 0
For inverse quantile 0.500000 Expected 50000 with error 5000, estimated 49827
For inverse quantile 0.750000 Expected 25000 with error 2500, estimated 24966
For inverse quantile 0.900000 Expected 10000 with error 1000, estimated 10020
For inverse quantile 0.950000 Expected 5000 with error 500, estimated 5011
For inverse quantile 0.990000 Expected 1000 with error 100, estimated 997
Starting run 1
For inverse quantile 0.500000 Expected 50000 with error 5000, estimated 49947
For inverse quantile 0.750000 Expected 25000 with error 2500, estimated 25038
For inverse quantile 0.900000 Expected 10000 with error 1000, estimated 10015
For inverse quantile 0.950000 Expected 5000 with error 500, estimated 5000
For inverse quantile 0.990000 Expected 1000 with error 100, estimated 992
Starting run 2
For inverse quantile 0.500000 Expected 50000 with error 5000, estimated 49825
For inverse quantile 0.750000 Expected 25000 with error 2500, estimated 25052
For inverse quantile 0.900000 Expected 10000 with error 1000, estimated 9952
For inverse quantile 0.950000 Expected 5000 with error 500, estimated 5038
For inverse quantile 0.990000 Expected 1000 with error 100, estimated 997
Starting run 3
For inverse quantile 0.500000 Expected 50000 with error 5000, estimated 50009
For inverse quantile 0.750000 Expected 25000 with error 2500, estimated 24937
For inverse quantile 0.900000 Expected 10000 with error 1000, estimated 9988
For inverse quantile 0.950000 Expected 5000 with error 500, estimated 4997
For inverse quantile 0.990000 Expected 1000 with error 100, estimated 1009
Starting run 4
For inverse quantile 0.500000 Expected 50000 with error 5000, estimated 49790
For inverse quantile 0.750000 Expected 25000 with error 2500, estimated 24893
For inverse quantile 0.900000 Expected 10000 with error 1000, estimated 9975
For inverse quantile 0.950000 Expected 5000 with error 500, estimated 4984
For inverse quantile 0.990000 Expected 1000 with error 100, estimated 1011
Starting run 5
For inverse quantile 0.500000 Expected 50000 with error 5000, estimated 49836
For inverse quantile 0.750000 Expected 25000 with error 2500, estimated 25047
For inverse quantile 0.900000 Expected 10000 with error 1000, estimated 10033
For inverse quantile 0.950000 Expected 5000 with error 500, estimated 4983
For inverse quantile 0.990000 Expected 1000 with error 100, estimated 1008
Starting run 6
For inverse quantile 0.500000 Expected 50000 with error 5000, estimated 49887
For inverse quantile 0.750000 Expected 25000 with error 2500, estimated 25032
For inverse quantile 0.900000 Expected 10000 with error 1000, estimated 10062
For inverse quantile 0.950000 Expected 5000 with error 500, estimated 5000
For inverse quantile 0.990000 Expected 1000 with error 100, estimated 999
Starting run 7
For inverse quantile 0.500000 Expected 50000 with error 5000, estimated 49911
For inverse quantile 0.750000 Expected 25000 with error 2500, estimated 25008
For inverse quantile 0.900000 Expected 10000 with error 1000, estimated 9981
For inverse quantile 0.950000 Expected 5000 with error 500, estimated 4989
For inverse quantile 0.990000 Expected 1000 with error 100, estimated 1003
Starting run 8
For inverse quantile 0.500000 Expected 50000 with error 5000, estimated 49925
For inverse quantile 0.750000 Expected 25000 with error 2500, estimated 24941
For inverse quantile 0.900000 Expected 10000 with error 1000, estimated 10006
For inverse quantile 0.950000 Expected 5000 with error 500, estimated 5013
For inverse quantile 0.990000 Expected 1000 with error 100, estimated 1005
Starting run 9
For inverse quantile 0.500000 Expected 50000 with error 5000, estimated 50001
For inverse quantile 0.750000 Expected 25000 with error 2500, estimated 24990
For inverse quantile 0.900000 Expected 10000 with error 1000, estimated 9951
For inverse quantile 0.950000 Expected 5000 with error 500, estimated 5009
For inverse quantile 0.990000 Expected 1000 with error 100, estimated 1001


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

