### PR TITLE
HDFS-16961. The blockReport RPC should throw UnregisteredNodeException when the storedDN is null

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -2963,6 +2963,9 @@ public class BlockManager implements BlockStatsMXBean {
     DatanodeDescriptor node;
     try {
       node = datanodeManager.getDatanode(nodeID);
+      if (node == null) {
+        throw new UnregisteredNodeException(nodeID, null);
+      }
       if (context != null) {
         if (context.getTotalRpcs() == context.getCurRpc() + 1) {
           long leaseId = this.getBlockReportLeaseManager().removeLease(node);


### PR DESCRIPTION
### Description of PR
The blockReport RPC should throw UnregisteredNodeException when the storedDN is null, the related code as bellows:
```
public void removeBRLeaseIfNeeded(final DatanodeID nodeID,
      final BlockReportContext context) throws IOException {
    namesystem.writeLock();
    DatanodeDescriptor node;
    try {
      // Here, if the node is null, we should throw UnregisteredNodeException insteat of NPE
      node = datanodeManager.getDatanode(nodeID);
      if (context != null) {
        if (context.getTotalRpcs() == context.getCurRpc() + 1) {
          long leaseId = this.getBlockReportLeaseManager().removeLease(node);
          BlockManagerFaultInjector.getInstance().
              removeBlockReportLease(node, leaseId);
          node.setLastBlockReportTime(now());
          node.setLastBlockReportMonotonic(Time.monotonicNow());
        }
        if (LOG.isDebugEnabled()) {
          LOG.debug("Processing RPC with index {} out of total {} RPCs in processReport 0x{}",
              context.getCurRpc(), context.getTotalRpcs(), Long.toHexString(context.getReportId()));
        }
      }
    } finally {
      namesystem.writeUnlock("removeBRLeaseIfNeeded");
    }
  }
```


