### PR TITLE
HDFS-16962. The blockReport RPC should not update the lastBlockReportTime if this blockReport is ignored

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -2958,7 +2958,7 @@ public class BlockManager implements BlockStatsMXBean {
   }
 
   public void removeBRLeaseIfNeeded(final DatanodeID nodeID,
-      final BlockReportContext context) throws IOException {
+      final BlockReportContext context, final boolean canUpdateLastReportTime) throws IOException {
     namesystem.writeLock();
     DatanodeDescriptor node;
     try {
@@ -2968,8 +2968,10 @@ public class BlockManager implements BlockStatsMXBean {
           long leaseId = this.getBlockReportLeaseManager().removeLease(node);
           BlockManagerFaultInjector.getInstance().
               removeBlockReportLease(node, leaseId);
-          node.setLastBlockReportTime(now());
-          node.setLastBlockReportMonotonic(Time.monotonicNow());
+          if (canUpdateLastReportTime) {
+            node.setLastBlockReportTime(now());
+            node.setLastBlockReportMonotonic(Time.monotonicNow());
+          }
         }
         if (LOG.isDebugEnabled()) {
           LOG.debug("Processing RPC with index {} out of total {} RPCs in processReport 0x{}",

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -1638,6 +1638,7 @@ public class NameNodeRpcServer implements NamenodeProtocols {
         nodeReg, reports.length);
     final BlockManager bm = namesystem.getBlockManager(); 
     boolean noStaleStorages = false;
+    boolean canUpdateLastReportTime = false;
     try {
       if (bm.checkBlockReportLease(context, nodeReg)) {
         for (int r = 0; r < reports.length; r++) {
@@ -1652,6 +1653,7 @@ public class NameNodeRpcServer implements NamenodeProtocols {
             bm.processReport(nodeReg, reports[index].getStorage(),
                 blocks, context));
         }
+        canUpdateLastReportTime = true;
       } else {
         throw new InvalidBlockReportLeaseException(context.getReportId(), context.getLeaseId());
       }
@@ -1660,7 +1662,7 @@ public class NameNodeRpcServer implements NamenodeProtocols {
           nodeReg);
       return RegisterCommand.REGISTER;
     }
-    bm.removeBRLeaseIfNeeded(nodeReg, context);
+    bm.removeBRLeaseIfNeeded(nodeReg, context, canUpdateLastReportTime);
 
     BlockManagerFaultInjector.getInstance().
         incomingBlockReportRpc(nodeReg, context);


### PR DESCRIPTION
The blockReport RPC should not update the lastBlockReportTime if this blockReport is ignored. the related code as bellows:

```
public DatanodeCommand blockReport(final DatanodeRegistration nodeReg,
      String poolId, final StorageBlockReport[] reports,
      final BlockReportContext context) throws IOException {
  // code placeholder
  ...
  try {
    // this blockReport may be ignored if bm.checkBlockReportLease return false
    if (bm.checkBlockReportLease(context, nodeReg)) {
      // code placeholder
      ...
    } 
  }
  // If this blockReport is ignored, the removeBRLeaseIfNeeded should not update the lastBlockReportTime
  bm.removeBRLeaseIfNeeded(nodeReg, context);

  // code placeholder
  ...

  return null;
} 
```