### PR TITLE
YARN-11461. fix NPE in determineMissingParents (auto queue creation / CS).

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerQueueManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerQueueManager.java
@@ -576,6 +576,11 @@ public class CapacitySchedulerQueueManager implements SchedulerQueueManager<
       firstExistingStaticParent = getQueue(parentCandidate.toString());
     }
 
+    if (firstExistingParent == null || firstExistingStaticParent == null) {
+      throw new SchedulerDynamicEditException("Could not auto-create queue "
+          + queue + " parent queue does not exist.");
+    }
+
     int maximumDepthOfStaticParent = csContext.getConfiguration().getMaximumAutoCreatedQueueDepth(
         firstExistingStaticParent.getQueuePath());
     if (firstStaticParentDistance > maximumDepthOfStaticParent) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerNewQueueAutoCreation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerNewQueueAutoCreation.java
@@ -1251,6 +1251,17 @@ public class TestCapacitySchedulerNewQueueAutoCreation
     Assert.assertNull("root.e.e1-auto should have been removed", eAuto);
   }
 
+  @Test()
+  public void testAutoCreateInvalidParent() throws Exception {
+    startScheduler();
+    Assert.assertThrows(SchedulerDynamicEditException.class,
+        () -> createQueue("invalid.queue"));
+    Assert.assertThrows(SchedulerDynamicEditException.class,
+        () -> createQueue("invalid.queue.longer"));
+    Assert.assertThrows(SchedulerDynamicEditException.class,
+        () -> createQueue("invalidQueue"));
+  }
+
   protected AbstractLeafQueue createQueue(String queuePath) throws YarnException,
       IOException {
     return autoQueueHandler.createQueue(new QueuePath(queuePath));


### PR DESCRIPTION
### How was this patch tested?

I added unit tests and tested it manually as well: test [results](https://issues.apache.org/jira/browse/YARN-11461?focusedCommentId=17704057&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17704057).

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

