### PR TITLE
HADOOP-18675: Fix CachedSASToken noisy log errors when SAS token has YYYY-MM-DD expiration

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/CachedSASToken.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/CachedSASToken.java
@@ -20,11 +20,9 @@ package org.apache.hadoop.fs.azurebfs.utils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.time.chrono.ChronoLocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/CachedSASToken.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/CachedSASToken.java
@@ -20,10 +20,16 @@ package org.apache.hadoop.fs.azurebfs.utils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.chrono.ChronoLocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.slf4j.Logger;
@@ -39,6 +45,13 @@ import static java.time.temporal.ChronoUnit.SECONDS;
  */
 public final class CachedSASToken {
   public static final Logger LOG = LoggerFactory.getLogger(CachedSASToken.class);
+
+  private static final DateTimeFormatter isoDateMidnight = new DateTimeFormatterBuilder()
+          .append(DateTimeFormatter.ISO_DATE)
+          .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+          .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+          .toFormatter();
+
   private final long minExpirationInSeconds;
   private String sasToken;
   private OffsetDateTime sasExpiry;
@@ -114,8 +127,20 @@ public final class CachedSASToken {
     OffsetDateTime seDate = OffsetDateTime.MIN;
     try {
       seDate = OffsetDateTime.parse(seValue, DateTimeFormatter.ISO_DATE_TIME);
-    } catch (DateTimeParseException ex) {
-      LOG.error("Error parsing se query parameter ({}) from SAS.", seValue, ex);
+    } catch (DateTimeParseException dateTimeException) {
+      try {
+        TemporalAccessor dt = isoDateMidnight.parseBest(seValue, OffsetDateTime::from, LocalDateTime::from);
+        if (dt instanceof OffsetDateTime) {
+          seDate = (OffsetDateTime) dt;
+        } else if (dt instanceof LocalDateTime) {
+          seDate = ((LocalDateTime) dt).atOffset(ZoneOffset.UTC);
+        } else {
+          throw dateTimeException;
+        }
+      } catch (DateTimeParseException dateOnlyException) {
+        // log original exception
+        LOG.error("Error parsing se query parameter ({}) from SAS as ISO_DATE_TIME or ISO_DATE.", seValue, dateTimeException);
+      }
     }
 
     String signedKeyExpiry = "ske=";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/CachedSASToken.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/CachedSASToken.java
@@ -44,7 +44,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 public final class CachedSASToken {
   public static final Logger LOG = LoggerFactory.getLogger(CachedSASToken.class);
 
-  private static final DateTimeFormatter isoDateMidnight = new DateTimeFormatterBuilder()
+  private static final DateTimeFormatter ISO_DATE_MIDNIGHT = new DateTimeFormatterBuilder()
           .append(DateTimeFormatter.ISO_DATE)
           .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
           .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
@@ -127,7 +127,7 @@ public final class CachedSASToken {
       seDate = OffsetDateTime.parse(seValue, DateTimeFormatter.ISO_DATE_TIME);
     } catch (DateTimeParseException dateTimeException) {
       try {
-        TemporalAccessor dt = isoDateMidnight.parseBest(seValue, OffsetDateTime::from, LocalDateTime::from);
+        TemporalAccessor dt = ISO_DATE_MIDNIGHT.parseBest(seValue, OffsetDateTime::from, LocalDateTime::from);
         if (dt instanceof OffsetDateTime) {
           seDate = (OffsetDateTime) dt;
         } else if (dt instanceof LocalDateTime) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TestCachedSASToken.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TestCachedSASToken.java
@@ -79,6 +79,31 @@ public final class TestCachedSASToken {
   }
 
   @Test
+  public void testValidExpirationParsing() {
+    CachedSASToken cachedSasToken = new CachedSASToken();
+    String[] values = {
+      "2123-03-24T00:06:46Z", // sample timestamp from azure portal
+      "2124-03-30", // sample YYYY-MM-DD date format generated from az cli
+      "2125-03-30Z", // sample YYYY-MM-DD[offset] date format
+    };
+
+    for (String se : values) {
+      cachedSasToken.setForTesting(null, null);
+      String token = "se=" + se;
+
+      // set first time and ensure reference equality
+      cachedSasToken.update(token);
+      String cachedToken = cachedSasToken.get();
+      Assert.assertTrue(token == cachedToken);
+
+      // update with same token and ensure reference equality
+      cachedSasToken.update(token);
+      cachedToken = cachedSasToken.get();
+      Assert.assertTrue(token == cachedToken);
+    }
+  }
+
+  @Test
   public void testGetExpiration() throws IOException {
     CachedSASToken cachedSasToken = new CachedSASToken();
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
When using SAS tokens with expiration dates in the format YYYY-MM-DD, a frequent error appears in the logs. The cause is that the code expects ISO_DATE_TIME, but ISO_DATE type formats are acceptable as well. 

### How was this patch tested?
Added tests that the expiration is properly parsed using the previous failing format.
Ran `mvn test -Dtest="TestCachedSASToken"`



### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

