### PR TITLE
Revert "HADOOP-18676. Fixing jettison vulnerability of hadoop-common lib"

### DIFF
--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -176,14 +176,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <!--
-      adding jettison as direct dependency (as jersey-json's jettison dependency is vulnerable with verison 1.1),
-      so those who depends on hadoop-common externally will get the non-vulnerable jettison
-      -->
-      <groupId>org.codehaus.jettison</groupId>
-      <artifactId>jettison</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
Reverts apache/hadoop#5507


Exclusions must be added to hadoop-client