### PR TITLE
HADOOP-18681. Upgrade hadoop3 docker scripts to use 3.3.5.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM apache/hadoop-runner
-ARG HADOOP_URL=https://dlcdn.apache.org/hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz
+ARG HADOOP_URL=https://dlcdn.apache.org/hadoop/common/hadoop-3.3.5/hadoop-3.3.5.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && curl -LSs -o hadoop.tar.gz $HADOOP_URL && tar zxf hadoop.tar.gz && rm hadoop.tar.gz && mv hadoop* hadoop && rm -rf /opt/hadoop/share/doc
 WORKDIR /opt/hadoop

--- a/build.sh
+++ b/build.sh
@@ -17,11 +17,11 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -e
 mkdir -p build
-if [ ! -d "$DIR/build/apache-rat-0.13" ]; then
-	curl -LSs https://dlcdn.apache.org/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz -o "$DIR/build/apache-rat.tar.gz"
+if [ ! -d "$DIR/build/apache-rat-0.15" ]; then
+	curl -LSs https://dlcdn.apache.org/creadur/apache-rat-0.15/apache-rat-0.15-bin.tar.gz -o "$DIR/build/apache-rat.tar.gz"
 	cd $DIR/build
 	tar zvxf apache-rat.tar.gz
 	cd -
 fi
-java -jar $DIR/build/apache-rat-0.13/apache-rat-0.13.jar $DIR -e public -e apache-rat-0.13 -e .git -e .gitignore
+java -jar $DIR/build/apache-rat-0.15/apache-rat-0.15.jar $DIR -e public -e apache-rat-0.15 -e .git -e .gitignore
 docker build -t apache/hadoop:3 .


### PR DESCRIPTION
### Description of PR

Upgrade docker3 scripts to point to latest released 3.3.5

### How was this patch tested?
Did:
1. 
**./build.sh** 

```
Output:
 => [6/6] RUN sudo chown -R hadoop:users /opt/hadoop/etc/hadoop/*                                                                                                                                0.4s
 => exporting to image                                                                                                                                                                           4.0s
 => => exporting layers                                                                                                                                                                          4.0s
 => => writing image sha256:bac4072a64798d3c94b29c7a2bfe2758d040267e3dcfefb0773333b47962a18f                                                                                                     0.0s
 => => naming to docker.io/apache/hadoop:3   
```

2.
 **docker-compose up -d --scale datanode=3 --scale nodemanager=3**

Output:
```
Creating docker-hadoop_nodemanager_1     ... done
Creating docker-hadoop_nodemanager_2     ... done
Creating docker-hadoop_nodemanager_3     ... done
Creating docker-hadoop_resourcemanager_1 ... done
Creating docker-hadoop_namenode_1        ... done
Creating docker-hadoop_datanode_1        ... done
Creating docker-hadoop_datanode_2        ... done
Creating docker-hadoop_datanode_3        ... done
```
3.
```
 docker-compose exec resourcemanager yarn jar \
    /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples-3.3.5.jar pi 3 3
```

Output:
```
Job Finished in 14.065 seconds
Estimated value of Pi is 3.55555555555555555556
```


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

