### PR TITLE
MAPREDUCE-7435. Manifest Committer OOM on abfs

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSetters.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSetters.java
@@ -29,11 +29,11 @@ import org.apache.hadoop.classification.InterfaceStability;
  * {@link IOStatisticsSnapshot} to also support it.
  * These are the simple setters, they don't provide for increments,
  * decrements, calculation of min/max/mean etc.
- * @since The interface and IOStatisticsSnapshot support came after Hadoop 3.3.5
+ * @since The interface and IOStatisticsSnapshot support was added after Hadoop 3.3.5
  */
 @InterfaceAudience.Public
 @InterfaceStability.Evolving
-public interface IOStatisticsSetters {
+public interface IOStatisticsSetters extends IOStatistics {
 
   /**
    * Set a counter.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSetters.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSetters.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.classification.InterfaceStability;
  * {@link IOStatisticsSnapshot} to also support it.
  * These are the simple setters, they don't provide for increments,
  * decrements, calculation of min/max/mean etc.
- * @since The interface and IOStatisticsSnapshot support was added after Hadoop 3.3.5
+ * @since The interface and IOStatisticsSnapshot support was added <i>after</i> Hadoop 3.3.5
  */
 @InterfaceAudience.Public
 @InterfaceStability.Evolving

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSetters.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSetters.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * Setter for IOStatistics entries.
+ * These operations have been in the read/write API
+ * {@code IOStatisticsStore} since IOStatistics
+ * was added; extracting into its own interface allows for
+ * {@link IOStatisticsSnapshot} to also support it.
+ * These are the simple setters, they don't provide for increments,
+ * decrements, calculation of min/max/mean etc.
+ * @since The interface and IOStatisticsSnapshot support came after Hadoop 3.3.5
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public interface IOStatisticsSetters {
+
+  /**
+   * Set a counter.
+   *
+   * No-op if the counter is unknown.
+   * @param key statistics key
+   * @param value value to set
+   */
+  void setCounter(String key, long value);
+
+  /**
+   * Set a gauge.
+   *
+   * @param key statistics key
+   * @param value value to set
+   */
+  void setGauge(String key, long value);
+
+  /**
+   * Set a maximum.
+   * @param key statistics key
+   * @param value value to set
+   */
+  void setMaximum(String key, long value);
+
+  /**
+   * Set a minimum.
+   * @param key statistics key
+   * @param value value to set
+   */
+  void setMinimum(String key, long value);
+
+  /**
+   * Set a mean statistic to a given value.
+   * @param key statistic key
+   * @param value new value.
+   */
+  void setMeanStatistic(String key, MeanStatistic value);
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSnapshot.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSnapshot.java
@@ -62,7 +62,8 @@ import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.snapshotM
 @InterfaceAudience.Public
 @InterfaceStability.Evolving
 public final class IOStatisticsSnapshot
-    implements IOStatistics, Serializable, IOStatisticsAggregator {
+    implements IOStatistics, Serializable, IOStatisticsAggregator,
+    IOStatisticsSetters{
 
   private static final long serialVersionUID = -1762522703841538084L;
 
@@ -220,6 +221,33 @@ public final class IOStatisticsSnapshot
   @Override
   public synchronized Map<String, MeanStatistic> meanStatistics() {
     return meanStatistics;
+  }
+
+  @Override
+  public synchronized void setCounter(final String key, final long value) {
+    counters().put(key, value);
+  }
+
+  @Override
+  public synchronized void setGauge(final String key, final long value) {
+    gauges().put(key, value);
+
+  }
+
+  @Override
+  public synchronized void setMaximum(final String key, final long value) {
+    maximums().put(key, value);
+
+  }
+
+  @Override
+  public synchronized void setMinimum(final String key, final long value) {
+    minimums().put(key, value);
+  }
+
+  @Override
+  public void setMeanStatistic(final String key, final MeanStatistic value) {
+
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSnapshot.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSnapshot.java
@@ -63,7 +63,7 @@ import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.snapshotM
 @InterfaceStability.Evolving
 public final class IOStatisticsSnapshot
     implements IOStatistics, Serializable, IOStatisticsAggregator,
-    IOStatisticsSetters{
+    IOStatisticsSetters {
 
   private static final long serialVersionUID = -1762522703841538084L;
 
@@ -247,7 +247,7 @@ public final class IOStatisticsSnapshot
 
   @Override
   public void setMeanStatistic(final String key, final MeanStatistic value) {
-
+    meanStatistics().put(key, value);
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/ForwardingIOStatisticsStore.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/ForwardingIOStatisticsStore.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.fs.s3a.statistics.impl;
+package org.apache.hadoop.fs.statistics.impl;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.MeanStatistic;
-import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 
 /**
  * This may seem odd having an IOStatisticsStore which does nothing

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsStore.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsStore.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsAggregator;
 import org.apache.hadoop.fs.statistics.DurationTrackerFactory;
+import org.apache.hadoop.fs.statistics.IOStatisticsSetters;
 import org.apache.hadoop.fs.statistics.MeanStatistic;
 
 /**
@@ -31,6 +32,7 @@ import org.apache.hadoop.fs.statistics.MeanStatistic;
  * use in classes which track statistics for reporting.
  */
 public interface IOStatisticsStore extends IOStatistics,
+    IOStatisticsSetters,
     IOStatisticsAggregator,
     DurationTrackerFactory {
 
@@ -57,24 +59,6 @@ public interface IOStatisticsStore extends IOStatistics,
   long incrementCounter(String key, long value);
 
   /**
-   * Set a counter.
-   *
-   * No-op if the counter is unknown.
-   * @param key statistics key
-   * @param value value to set
-   */
-  void setCounter(String key, long value);
-
-  /**
-   * Set a gauge.
-   *
-   * No-op if the gauge is unknown.
-   * @param key statistics key
-   * @param value value to set
-   */
-  void setGauge(String key, long value);
-
-  /**
    * Increment a gauge.
    * <p>
    * No-op if the gauge is unknown.
@@ -86,14 +70,6 @@ public interface IOStatisticsStore extends IOStatistics,
   long incrementGauge(String key, long value);
 
   /**
-   * Set a maximum.
-   * No-op if the maximum is unknown.
-   * @param key statistics key
-   * @param value value to set
-   */
-  void setMaximum(String key, long value);
-
-  /**
    * Increment a maximum.
    * <p>
    * No-op if the maximum is unknown.
@@ -103,16 +79,6 @@ public interface IOStatisticsStore extends IOStatistics,
    * @return new value or 0 if the key is unknown
    */
   long incrementMaximum(String key, long value);
-
-  /**
-   * Set a minimum.
-   * <p>
-   * No-op if the minimum is unknown.
-   * </p>
-   * @param key statistics key
-   * @param value value to set
-   */
-  void setMinimum(String key, long value);
 
   /**
    * Increment a minimum.
@@ -146,16 +112,6 @@ public interface IOStatisticsStore extends IOStatistics,
    * @param value sample value
    */
   void addMaximumSample(String key, long value);
-
-  /**
-   * Set a mean statistic to a given value.
-   * <p>
-   * No-op if the key is unknown.
-   * </p>
-   * @param key statistic key
-   * @param value new value.
-   */
-  void setMeanStatistic(String key, MeanStatistic value);
 
   /**
    * Add a sample to the mean statistics.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsStoreBuilder.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsStoreBuilder.java
@@ -68,6 +68,17 @@ public interface IOStatisticsStoreBuilder {
       String... prefixes);
 
   /**
+   * A value which is tracked with counter/min/max/mean.
+   * Similar to {@link #withDurationTracking(String...)}
+   * but without the failure option and with the same name
+   * across all categories.
+   * @param prefixes prefixes to add.
+   * @return the builder
+   */
+  IOStatisticsStoreBuilder withSampleTracking(
+      String... prefixes);
+
+  /**
    * Build the collector.
    * @return a new collector.
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsStoreBuilderImpl.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsStoreBuilderImpl.java
@@ -93,6 +93,18 @@ final class IOStatisticsStoreBuilderImpl implements
   }
 
   @Override
+  public IOStatisticsStoreBuilderImpl withSampleTracking(
+      final String... prefixes) {
+    for (String p : prefixes) {
+      withCounters(p);
+      withMinimums(p);
+      withMaximums(p);
+      withMeanStatistics(p);
+    }
+    return this;
+  }
+
+  @Override
   public IOStatisticsStore build() {
     return new IOStatisticsStoreImpl(counters, gauges, minimums,
         maximums, meanStatistics);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/RemoteIterators.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/RemoteIterators.java
@@ -211,7 +211,7 @@ public final class RemoteIterators {
    * This is primarily for tests or when submitting work into a TaskPool.
    * equivalent to
    * <pre>
-   *   for(long l = start, l &lt; finis; l++) yield l;
+   *   for(long l = start, l &lt; excludedFinish; l++) yield l;
    * </pre>
    * @param start start value
    * @param excludedFinish excluded finish
@@ -422,8 +422,8 @@ public final class RemoteIterators {
   /**
    * Wrapper of another remote iterator; IOStatistics
    * and Closeable methods are passed down if implemented.
-   * This class may be subclasses if custom iterators
-   * are needed.
+   * This class may be subclassed within the hadoop codebase
+   * if custom iterators are needed.
    * @param <S> source type
    * @param <T> type of returned value
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/RemoteIterators.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/RemoteIterators.java
@@ -739,11 +739,17 @@ public final class RemoteIterators {
   private static final class HaltableRemoteIterator<S>
       extends WrappingRemoteIterator<S, S> {
 
+    /**
+     * Probe as to whether work should continue.
+     */
     private final CallableRaisingIOE<Boolean> continueWork;
-
 
     /**
      * Wrap an iterator with one which adds a continuation probe.
+     * The probe will be called in the {@link #hasNext()} method, before
+     * the source iterator is itself checked and in {@link #next()}
+     * before retrieval.
+     * That is: it may be called multiple times per iteration.
      * @param source source iterator.
      * @param continueWork predicate which will trigger a fast halt if it returns false.
      */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/RemoteIterators.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/RemoteIterators.java
@@ -207,12 +207,19 @@ public final class RemoteIterators {
 
   /**
    * A remote iterator which simply counts up, stopping once the
-   * value is greater than the finish.
+   * value is greater than the value of {@code excludedFinish}.
    * This is primarily for tests or when submitting work into a TaskPool.
+   * equivalent to
+   * <pre>
+   *   for(long l = start, l &lt; finis; l++) yield l;
+   * </pre>
+   * @param start start value
+   * @param excludedFinish excluded finish
+   * @return an iterator which returns longs from [start, finish)
    */
   public static RemoteIterator<Long> rangeExcludingIterator(
-      final long start, final long finish) {
-    return new RangeExcludingLongIterator(start, finish);
+      final long start, final long excludedFinish) {
+    return new RangeExcludingLongIterator(start, excludedFinish);
   }
 
   /**
@@ -801,21 +808,22 @@ public final class RemoteIterators {
     /**
      * End value.
      */
-    private final long finish;
+    private final long excludedFinish;
 
     /**
      * Construct.
      * @param start start value.
-     * @param finish halt the iterator once the current value is equal to or greater than this.
+     * @param excludedFinish halt the iterator once the current value is equal
+     *          to or greater than this.
      */
-    private RangeExcludingLongIterator(final long start, final long finish) {
+    private RangeExcludingLongIterator(final long start, final long excludedFinish) {
       this.current = start;
-      this.finish = finish;
+      this.excludedFinish = excludedFinish;
     }
 
     @Override
     public boolean hasNext() throws IOException {
-      return current < finish;
+      return current < excludedFinish;
     }
 
     @Override

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/RemoteIterators.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/RemoteIterators.java
@@ -206,6 +206,16 @@ public final class RemoteIterators {
   }
 
   /**
+   * A remote iterator which simply counts up, stopping once the
+   * value is greater than the finish.
+   * This is primarily for tests or when submitting work into a TaskPool.
+   */
+  public static RemoteIterator<Long> rangeExcludingIterator(
+      final long start, final long finish) {
+    return new RangeExcludingLongIterator(start, finish);
+  }
+
+  /**
    * Build a list from a RemoteIterator.
    * @param source source iterator
    * @param <T> type
@@ -773,6 +783,49 @@ public final class RemoteIterators {
     @Override
     protected boolean sourceHasNext() throws IOException {
       return continueWork.apply() && super.sourceHasNext();
+    }
+  }
+
+  /**
+   * A remote iterator which simply counts up, stopping once the
+   * value is greater than the finish.
+   * This is primarily for tests or when submitting work into a TaskPool.
+   */
+  private static final class RangeExcludingLongIterator implements RemoteIterator<Long> {
+
+    /**
+     * Current value.
+     */
+    private long current;
+
+    /**
+     * End value.
+     */
+    private final long finish;
+
+    /**
+     * Construct.
+     * @param start start value.
+     * @param finish halt the iterator once the current value is equal to or greater than this.
+     */
+    private RangeExcludingLongIterator(final long start, final long finish) {
+      this.current = start;
+      this.finish = finish;
+    }
+
+    @Override
+    public boolean hasNext() throws IOException {
+      return current < finish;
+    }
+
+    @Override
+    public Long next() throws IOException {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      final long s = current;
+      current++;
+      return s;
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestIOStatisticsSetters.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestIOStatisticsSetters.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.hadoop.fs.statistics.impl.ForwardingIOStatisticsStore;
+import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertThatStatisticCounter;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertThatStatisticGauge;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertThatStatisticMaximum;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertThatStatisticMean;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertThatStatisticMinimum;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.iostatisticsStore;
+
+/**
+ * Test the {@link IOStatisticsSetters} interface implementations through
+ * a parameterized run with each implementation.
+ * For each of the setters, the value is set, verified,
+ * updated, verified again.
+ * An option known to be undefined in all created IOStatisticsStore instances
+ * is set, to verify it is harmless.
+ */
+
+@RunWith(Parameterized.class)
+
+public class TestIOStatisticsSetters extends AbstractHadoopTestBase {
+
+  public static final String COUNTER = "counter";
+
+  public static final String GAUGE = "gauge";
+
+  public static final String MAXIMUM = "max";
+
+  public static final String MINIMUM = "min";
+
+  public static final String MEAN = "mean";
+
+  private final IOStatisticsSetters ioStatistics;
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> params() {
+    return Arrays.asList(new Object[][]{
+        {new IOStatisticsSnapshot()},
+        {createTestStore()},
+        {new ForwardingIOStatisticsStore(createTestStore())},
+    });
+  }
+
+  /**
+   * Create a test store with the stats used for testing set up.
+   * @return a set up store
+   */
+  private static IOStatisticsStore createTestStore() {
+    return iostatisticsStore()
+        .withCounters(COUNTER)
+        .withGauges(GAUGE)
+        .withMaximums(MAXIMUM)
+        .withMinimums(MINIMUM)
+        .withMeanStatistics(MEAN)
+        .build();
+  }
+
+  public TestIOStatisticsSetters(IOStatisticsSetters ioStatisticsSetters) {
+    this.ioStatistics = ioStatisticsSetters;
+  }
+
+  @Test
+  public void testCounter() throws Throwable {
+    // write
+    ioStatistics.setCounter(COUNTER, 1);
+    assertThatStatisticCounter(ioStatistics, COUNTER)
+        .isEqualTo(1);
+
+    // update
+    ioStatistics.setCounter(COUNTER, 2);
+    assertThatStatisticCounter(ioStatistics, COUNTER)
+        .isEqualTo(2);
+
+    // unknown value
+    ioStatistics.setCounter("c2", 3);
+  }
+
+  @Test
+  public void testMaximum() throws Throwable {
+    // write
+    ioStatistics.setMaximum(MAXIMUM, 1);
+    assertThatStatisticMaximum(ioStatistics, MAXIMUM)
+        .isEqualTo(1);
+
+    // update
+    ioStatistics.setMaximum(MAXIMUM, 2);
+    assertThatStatisticMaximum(ioStatistics, MAXIMUM)
+        .isEqualTo(2);
+
+    // unknown value
+    ioStatistics.setMaximum("mm2", 3);
+  }
+
+  @Test
+  public void testMinimum() throws Throwable {
+    // write
+    ioStatistics.setMinimum(MINIMUM, 1);
+    assertThatStatisticMinimum(ioStatistics, MINIMUM)
+        .isEqualTo(1);
+
+    // update
+    ioStatistics.setMinimum(MINIMUM, 2);
+    assertThatStatisticMinimum(ioStatistics, MINIMUM)
+        .isEqualTo(2);
+
+    // unknown value
+    ioStatistics.setMinimum("c2", 3);
+  }
+
+  @Test
+  public void testGauge() throws Throwable {
+    // write
+    ioStatistics.setGauge(GAUGE, 1);
+    assertThatStatisticGauge(ioStatistics, GAUGE)
+        .isEqualTo(1);
+
+    // update
+    ioStatistics.setGauge(GAUGE, 2);
+    assertThatStatisticGauge(ioStatistics, GAUGE)
+        .isEqualTo(2);
+
+    // unknown value
+    ioStatistics.setGauge("g2", 3);
+  }
+
+  @Test
+  public void testMean() throws Throwable {
+    // write
+    final MeanStatistic mean11 = new MeanStatistic(1, 1);
+    ioStatistics.setMeanStatistic(MEAN, mean11);
+    assertThatStatisticMean(ioStatistics, MEAN)
+        .isEqualTo(mean11);
+
+    // update
+    final MeanStatistic mean22 = new MeanStatistic(2, 2);
+    ioStatistics.setMeanStatistic(MEAN, mean22);
+    assertThatStatisticMean(ioStatistics, MEAN)
+        .isEqualTo(mean22);
+
+    // unknown value
+    ioStatistics.setMeanStatistic("m2", mean11);
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/functional/TestRemoteIterators.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/functional/TestRemoteIterators.java
@@ -299,7 +299,7 @@ public class TestRemoteIterators extends AbstractHadoopTestBase {
     // if the value of "count" has dropped to zero
     final RemoteIterator<Long> it =
         haltableRemoteIterator(
-            rangeExcludingIterator(0,10),
+            rangeExcludingIterator(0, 10),
             () -> count.get() > 0);
 
     verifyInvoked(it, limit, (v) -> count.decrementAndGet());

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitter.java
@@ -58,6 +58,8 @@ import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsTo
 import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.logIOStatisticsAtDebug;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.CAPABILITY_DYNAMIC_PARTITIONING;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.OPT_DIAGNOSTICS_MANIFEST_DIR;
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.OPT_IO_PROCESSORS;
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.OPT_IO_PROCESSORS_DEFAULT;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.OPT_SUMMARY_REPORT_DIR;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.COMMITTER_TASKS_COMPLETED_COUNT;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.COMMITTER_TASKS_FAILED_COUNT;
@@ -393,7 +395,9 @@ public class ManifestCommitter extends PathOutputCommitter implements
       marker = result.getJobSuccessData();
       // update the cached success with the new report.
       setSuccessReport(marker);
-
+      // patch in the #of threads as it is useful
+      marker.putDiagnostic(OPT_IO_PROCESSORS,
+          conf.get(OPT_IO_PROCESSORS, Long.toString(OPT_IO_PROCESSORS_DEFAULT)));
     } catch (IOException e) {
       // failure. record it for the summary
       failure = e;
@@ -688,7 +692,7 @@ public class ManifestCommitter extends PathOutputCommitter implements
    * to date.
    * The report will updated with the current active stage,
    * and if {@code thrown} is non-null, it will be added to the
-   * diagnistics (and the job tagged as a failure).
+   * diagnostics (and the job tagged as a failure).
    * Static for testability.
    * @param activeStage active stage
    * @param config configuration to use.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterConfig.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterConfig.java
@@ -251,6 +251,7 @@ public final class ManifestCommitterConfig implements IOStatisticsSource {
   StageConfig createStageConfig() {
     StageConfig stageConfig = new StageConfig();
     stageConfig
+        .withConfiguration(conf)
         .withIOStatistics(iostatistics)
         .withJobAttemptNumber(jobAttemptNumber)
         .withJobDirectories(dirs)

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterConfig.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterConfig.java
@@ -149,6 +149,11 @@ public final class ManifestCommitterConfig implements IOStatisticsSource {
   private final boolean deleteTargetPaths;
 
   /**
+   * Entry writer queue capacity.
+   */
+  private final int writerQueueCapacity;
+
+  /**
    * Constructor.
    * @param outputPath destination path of the job.
    * @param role role for log messages.
@@ -190,6 +195,9 @@ public final class ManifestCommitterConfig implements IOStatisticsSource {
     this.deleteTargetPaths = conf.getBoolean(
         OPT_DELETE_TARGET_FILES,
         OPT_DELETE_TARGET_FILES_DEFAULT);
+    this.writerQueueCapacity = conf.getInt(
+        OPT_WRITER_QUEUE_CAPACITY,
+        DEFAULT_WRITER_QUEUE_CAPACITY);
 
     // if constructed with a task attempt, build the task ID and path.
     if (context instanceof TaskAttemptContext) {
@@ -252,6 +260,7 @@ public final class ManifestCommitterConfig implements IOStatisticsSource {
     StageConfig stageConfig = new StageConfig();
     stageConfig
         .withConfiguration(conf)
+        .withDeleteTargetPaths(deleteTargetPaths)
         .withIOStatistics(iostatistics)
         .withJobAttemptNumber(jobAttemptNumber)
         .withJobDirectories(dirs)
@@ -263,8 +272,7 @@ public final class ManifestCommitterConfig implements IOStatisticsSource {
         .withTaskAttemptDir(taskAttemptDir)
         .withTaskAttemptId(taskAttemptId)
         .withTaskId(taskId)
-        .withDeleteTargetPaths(deleteTargetPaths);
-
+        .withWriterQueueCapacity(writerQueueCapacity);
     return stageConfig;
   }
 
@@ -322,6 +330,14 @@ public final class ManifestCommitterConfig implements IOStatisticsSource {
 
   public String getName() {
     return name;
+  }
+
+  /**
+   * Get writer queue capacity.
+   * @return the queue capacity
+   */
+  public int getWriterQueueCapacity() {
+    return writerQueueCapacity;
   }
 
   @Override

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterConstants.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterConstants.java
@@ -151,7 +151,7 @@ public final class ManifestCommitterConstants {
   /**
    * Default value:  {@value}.
    */
-  public static final int OPT_IO_PROCESSORS_DEFAULT = 64;
+  public static final int OPT_IO_PROCESSORS_DEFAULT = 32;
 
   /**
    * Directory for saving job summary reports.
@@ -239,6 +239,26 @@ public final class ManifestCommitterConstants {
    */
   public static final String CAPABILITY_DYNAMIC_PARTITIONING =
       "mapreduce.job.committer.dynamic.partitioning";
+
+
+  /**
+   * Queue capacity between task manifest loading an entry file writer.
+   * If more than this number of manifest lists are waiting to be written,
+   * the enqueue is blocking.
+   * There's an expectation that writing to the local file is a lot faster
+   * than the parallelized buffer reads, therefore that this queue can
+   * be emptied at the same rate it is filled.
+   * Value {@value}.
+   */
+  public static final String OPT_WRITER_QUEUE_CAPACITY =
+      OPT_PREFIX + "writer.queue.capacity";
+
+
+  /**
+   * Default value of {@link #OPT_WRITER_QUEUE_CAPACITY}.
+   * Value {@value}.
+   */
+  public static final int DEFAULT_WRITER_QUEUE_CAPACITY = 32;
 
   private ManifestCommitterConstants() {
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterConstants.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterConstants.java
@@ -258,7 +258,7 @@ public final class ManifestCommitterConstants {
    * Default value of {@link #OPT_WRITER_QUEUE_CAPACITY}.
    * Value {@value}.
    */
-  public static final int DEFAULT_WRITER_QUEUE_CAPACITY = 32;
+  public static final int DEFAULT_WRITER_QUEUE_CAPACITY = OPT_IO_PROCESSORS_DEFAULT;
 
   private ManifestCommitterConstants() {
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/files/DiagnosticKeys.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/files/DiagnosticKeys.java
@@ -34,6 +34,9 @@ public final class DiagnosticKeys {
   public static final String STAGE = "stage";
   public static final String EXCEPTION = "exception";
   public static final String STACKTRACE = "stacktrace";
+  public static final String TOTAL_MEMORY = "total.memory";
+  public static final String FREE_MEMORY = "free.memory";
+  public static final String HEAP_MEMORY = "heap.memory";
 
 
   /** Directory where manifests were renamed: {@value}. */

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/files/DirEntry.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/files/DirEntry.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.mapreduce.lib.output.committer.manifest.files;
 
+import java.io.DataInput;
+import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Objects;
@@ -28,6 +30,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Writable;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.AbstractManifestData.marshallPath;
@@ -37,12 +40,13 @@ import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.Ab
 /**
  * A directory entry in the task manifest.
  * Uses shorter field names for smaller files.
- * Hash and equals are on dir name only; there's no real expectation
- * that those operations are needed.
+ * Hash and equals are on dir name only.
+ * Can be serialized as a java object, json object
+ * or hadoop writable.
  */
 @InterfaceAudience.Public
 @InterfaceStability.Unstable
-public final class DirEntry implements Serializable {
+public final class DirEntry implements Serializable, Writable {
 
   private static final long serialVersionUID = 5658520530209859765L;
 
@@ -65,7 +69,7 @@ public final class DirEntry implements Serializable {
   private int level;
 
   /**
-   * Constructor only for use by jackson.
+   * Constructor for use by jackson/writable.
    * Do Not Delete.
    */
   private DirEntry() {
@@ -175,6 +179,20 @@ public final class DirEntry implements Serializable {
   @Override
   public int hashCode() {
     return Objects.hash(dir);
+  }
+
+  @Override
+  public void write(final DataOutput out) throws IOException {
+    out.writeUTF(dir);
+    out.writeInt(type);
+    out.writeInt(level);
+  }
+
+  @Override
+  public void readFields(final DataInput in) throws IOException {
+    dir = in.readUTF();
+    type = in.readInt();
+    level = in.readInt();
   }
 
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/files/FileEntry.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/files/FileEntry.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableUtils;
 
+import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.AbstractManifestData.marshallPath;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.AbstractManifestData.unmarshallPath;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.AbstractManifestData.verify;
@@ -196,9 +197,9 @@ public final class FileEntry implements Serializable, Writable {
 
   @Override
   public void write(final DataOutput out) throws IOException {
-    Text.writeString(out, source);
-    Text.writeString(out, dest);
-    Text.writeString(out, etag);
+    Text.writeString(out, requireNonNull(source, "null source"));
+    Text.writeString(out, requireNonNull(dest, "null dest"));
+    Text.writeString(out, etag != null ? etag : "");
     WritableUtils.writeVLong(out, size);
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/files/FileEntry.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/files/FileEntry.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.mapreduce.lib.output.committer.manifest.files;
 
+import java.io.DataInput;
+import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Objects;
@@ -29,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Writable;
 
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.AbstractManifestData.marshallPath;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.AbstractManifestData.unmarshallPath;
@@ -42,7 +45,7 @@ import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.Ab
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public final class FileEntry implements Serializable {
+public final class FileEntry implements Serializable, Writable {
 
   private static final long serialVersionUID = -550288489009777867L;
 
@@ -62,7 +65,7 @@ public final class FileEntry implements Serializable {
   private String etag;
 
   /**
-   * Constructor only for use by jackson.
+   * Constructor for use by jackson/writable
    * Do Not Delete.
    */
   private FileEntry() {
@@ -179,6 +182,22 @@ public final class FileEntry implements Serializable {
     return size == that.size && source.equals(that.source) && dest.equals(
         that.dest) &&
         Objects.equals(etag, that.etag);
+  }
+
+  @Override
+  public void write(final DataOutput out) throws IOException {
+    out.writeUTF(source);
+    out.writeUTF(dest);
+    out.writeUTF(etag);
+    out.writeLong(size);
+  }
+
+  @Override
+  public void readFields(final DataInput in) throws IOException {
+    source = in.readUTF();
+    dest = in.readUTF();
+    etag = in.readUTF();
+    size = in.readLong();
   }
 
   @Override

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/EntryFileIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/EntryFileIO.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.FileEntry;
+import org.apache.hadoop.util.Preconditions;
+import org.apache.hadoop.util.concurrent.HadoopExecutors;
+import org.apache.hadoop.util.functional.FutureIO;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Read or write entry file.
+ * This can be used to create a simple reader, or to create
+ * a writer queue where different threads can queue data for
+ * writing.
+ * The entry file is a SequenceFile with KV = {NullWritable, FileEntry};
+ */
+public class EntryFileIO {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      EntryFileIO.class);
+
+  /** Configuration used to load filesystems. */
+  private final Configuration conf;
+
+  /**
+   * ctor.
+   * @param conf Configuration used to load filesystems
+   */
+  public EntryFileIO(final Configuration conf) {
+    this.conf = conf;
+  }
+
+  /**
+   * Create a writer to a local file.
+   * @param file file
+   * @return the writer
+   * @throws IOException fail to open the file
+   */
+  public SequenceFile.Writer createWriter(File file) throws IOException {
+    return createWriter(new Path(file.toURI()));
+  }
+
+  public SequenceFile.Writer createWriter(Path path) throws IOException {
+    return SequenceFile.createWriter(conf,
+        SequenceFile.Writer.file(path),
+        SequenceFile.Writer.keyClass(NullWritable.class),
+        SequenceFile.Writer.valueClass(FileEntry.class));
+  }
+
+
+  /**
+   * Reader is created with sequential reads.
+   * @param file file
+   * @return the reader
+   * @throws IOException failure to open
+   */
+  public SequenceFile.Reader createReader(File file) throws IOException {
+    return createReader(new Path(file.toURI()));
+  }
+
+  /**
+   * Reader is created with sequential reads.
+   * @param path path
+   * @return the reader
+   * @throws IOException failure to open
+   */
+  public SequenceFile.Reader createReader(Path path) throws IOException {
+    return new SequenceFile.Reader(conf,
+        SequenceFile.Reader.file(path));
+  }
+
+  /**
+   * Iterator to retrieve file entries from the sequence file.
+   * Closeable: cast and invoke to close the reader.
+   * @param reader reader;
+   * @return iterator
+   */
+  public RemoteIterator<FileEntry> iterateOver(SequenceFile.Reader reader) {
+    return new EntryIterator(reader);
+  }
+
+  /**
+   * Create and start an entry writer.
+   * @param writer writer
+   * @param capacity queue capacity
+   * @return the writer.
+   */
+  public EntryWriter launchEntryWriter(SequenceFile.Writer writer, int capacity) {
+    final EntryWriter ew = new EntryWriter(writer, capacity);
+    ew.start();
+    return ew;
+  }
+
+  /**
+   * Writer takes a list of entries at a time; queues for writing.
+   * A special
+   */
+  public final class EntryWriter implements Closeable {
+
+    private final SequenceFile.Writer writer;
+
+    private final Queue<List<FileEntry>> queue;
+
+    /**
+     * stop flag.
+     */
+    private final AtomicBoolean stop = new AtomicBoolean(false);
+
+    private final AtomicBoolean active = new AtomicBoolean(false);
+
+    /**
+     * Executor of writes.
+     */
+    private ExecutorService executor;
+
+    /**
+     * Future invoked.
+     */
+    private Future<Integer> future;
+
+    /**
+     * count of files opened; only updated in one thread
+     * so volatile.
+     */
+    private volatile int count;
+
+    /**
+     * any failure.
+     */
+    private volatile IOException failure;
+
+    /**
+     * Create.
+     * @param writer writer
+     * @param capacity capacity.
+     */
+    private EntryWriter(SequenceFile.Writer writer, int capacity) {
+      this.writer = writer;
+      this.queue = new ArrayBlockingQueue<>(capacity);
+    }
+
+    /**
+     * Is the writer active?
+     * @return true if the processor thread is live
+     */
+    public boolean isActive() {
+      return active.get();
+    }
+
+    /**
+     * Get count of files processed.
+     * @return the count
+     */
+    public int getCount() {
+      return count;
+    }
+
+    /**
+     * Any failure.
+     * @return any IOException caught when writing the output
+     */
+    public IOException getFailure() {
+      return failure;
+    }
+
+    /**
+     * Start the thread.
+     */
+    private void start() {
+      Preconditions.checkState(executor == null, "already started");
+      active.set(true);
+      executor = HadoopExecutors.newSingleThreadExecutor();
+      future = executor.submit(this::processor);
+    }
+
+    /**
+     * Add a list of entries to the queue.
+     * @param entries entries.
+     * @return whether the queue worked.
+     */
+    public boolean enqueue(List<FileEntry> entries) {
+      if (active.get()) {
+        queue.add(entries);
+        return false;
+      } else {
+        LOG.debug("Queue inactive; discarding {} entries", entries.size());
+        return false;
+      }
+    }
+
+    /**
+     * Queue and process entries until done.
+     * @return count of entries written.
+     * @throws UncheckedIOException on write failure
+     */
+    private int processor() {
+      int count = 0;
+      while (!stop.get()) {
+        queue.poll().forEach(this::append);
+      }
+      return count;
+    }
+
+    /**
+     * write one entry.
+     * @param entry entry to write
+     * @throws UncheckedIOException on write failure
+     */
+    private void append(FileEntry entry) {
+      if (failure != null) {
+        try {
+          writer.append(NullWritable.get(), entry);
+          count++;
+        } catch (IOException e) {
+          failure = e;
+          throw new UncheckedIOException(e);
+        }
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (stop.getAndSet(true)) {
+        // already stopped
+        return;
+      }
+      LOG.debug("Shutting down writer");
+      // signal queue closure by
+      // clearing the current list
+      // and queue an empty list
+      queue.clear();
+      queue.add(new ArrayList<>());
+      try {
+        // wait for the op to finish.
+        final int count = FutureIO.awaitFuture(future);
+        LOG.debug("Processed {} files", count);
+        // close the stream
+      } finally {
+        writer.close();
+      }
+    }
+  }
+
+  /**
+   * Iterator to retrieve file entries from the sequence file.
+   * Closeable.
+   */
+  private final class EntryIterator implements RemoteIterator<FileEntry>, Closeable {
+
+    private final SequenceFile.Reader reader;
+
+    private FileEntry fetched;
+
+    private EntryIterator(final SequenceFile.Reader reader) {
+      this.reader = requireNonNull(reader);
+    }
+
+    @Override
+    public void close() throws IOException {
+      reader.close();
+    }
+
+    @Override
+    public boolean hasNext() throws IOException {
+      return fetched != null || fetchNext();
+    }
+
+    private boolean fetchNext() throws IOException {
+      FileEntry readBack = new FileEntry();
+      if (reader.next(NullWritable.get(), readBack)) {
+        fetched = readBack;
+        return true;
+      } else {
+        fetched = null;
+        return false;
+      }
+    }
+
+    @Override
+    public FileEntry next() throws IOException {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      final FileEntry r = fetched;
+      fetched = null;
+      return r;
+    }
+  }
+
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/EntryFileIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/EntryFileIO.java
@@ -340,18 +340,21 @@ public class EntryFileIO {
      * @return count of entries written.
      * @throws UncheckedIOException on write failure
      */
-    @SuppressWarnings("SwitchStatementWithoutDefaultBranch")
     private int processor() {
       Thread.currentThread().setName("EntryIOWriter");
       try {
         while (!stop.get()) {
           final QueueEntry queueEntry = queue.take();
           switch (queueEntry.action) {
-          case stop:
-            LOG.debug("List termination initiated");
+
+          case stop:  // stop the operation
+            LOG.debug("Stop processing");
             stop.set(true);
             break;
-          case write:
+
+          case write:  // write data
+          default:  // here to shut compiler up
+            // write
             final List<FileEntry> entries = queueEntry.entries;
             LOG.debug("Adding block of {} entries", entries.size());
             for (FileEntry entry : entries) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/EntryFileIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/EntryFileIO.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -78,7 +79,7 @@ public class EntryFileIO {
    * @throws IOException fail to open the file
    */
   public SequenceFile.Writer createWriter(File file) throws IOException {
-    return createWriter(new Path(file.toURI()));
+    return createWriter(toPath(file));
   }
 
   public SequenceFile.Writer createWriter(Path path) throws IOException {
@@ -96,7 +97,7 @@ public class EntryFileIO {
    * @throws IOException failure to open
    */
   public SequenceFile.Reader createReader(File file) throws IOException {
-    return createReader(new Path(file.toURI()));
+    return createReader(toPath(file));
   }
 
   /**
@@ -131,6 +132,42 @@ public class EntryFileIO {
     ew.start();
     return ew;
   }
+
+  /**
+   * Write a sequence of entries to the writer.
+   * @param writer writer
+   * @param entries entries
+   * @param close close the stream afterwards
+   * @return number of entries written
+   * @throws IOException write failure.
+   */
+  public static int write(SequenceFile.Writer writer, 
+      Collection<FileEntry> entries,
+      boolean close)
+      throws IOException {
+    try {
+      for (FileEntry entry: entries) {
+        writer.append(NullWritable.get(), entry);
+      }
+      writer.flush();
+    } finally {
+      if (close) {
+        writer.close();
+      }
+    }
+    return entries.size();
+  }
+
+
+  /**
+   * Given a file, create a Path.
+   * @param file file
+   * @return path to the file
+   */
+  public static Path toPath(final File file) {
+    return new Path(file.toURI());
+  }
+
 
   /**
    * Writer takes a list of entries at a time; queues for writing.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/InternalConstants.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/InternalConstants.java
@@ -129,15 +129,4 @@ public final class InternalConstants {
   public static final Set<String> UNSUPPORTED_FS_SCHEMAS =
       ImmutableSet.of("s3a", "wasb");
 
-  /**
-   * Queue capacity between task manifest loading an entry file writer.
-   * If more than this number of manifest lists are waiting to be written,
-   * the enqueue is blocking.
-   * There's an expectation that writing to the local file is a lot faster
-   * than the parallelized buffer reads, therefore that this queue can
-   * be emptied at the same rate it is filled.
-   * Value {@value}.
-   */
-  public static final int ENTRY_WRITER_QUEUE_CAPACITY = 32;
-
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/InternalConstants.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/InternalConstants.java
@@ -40,6 +40,7 @@ import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.Manifest
  */
 @InterfaceAudience.Private
 public final class InternalConstants {
+
   private InternalConstants() {
   }
 
@@ -127,4 +128,16 @@ public final class InternalConstants {
   /** Schemas of filesystems we know to not work with this committer. */
   public static final Set<String> UNSUPPORTED_FS_SCHEMAS =
       ImmutableSet.of("s3a", "wasb");
+
+  /**
+   * Queue capacity between task manifest loading an entry file writer.
+   * If more than this number of manifest lists are waiting to be written,
+   * the enqueue is blocking.
+   * There's an expectation that writing to the local file is a lot faster
+   * than the parallelized buffer reads, therefore that this queue can
+   * be emptied at the same rate it is filled.
+   * Value {@value}.
+   */
+  public static final int ENTRY_WRITER_QUEUE_CAPACITY = 32;
+
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/InternalConstants.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/InternalConstants.java
@@ -127,5 +127,4 @@ public final class InternalConstants {
   /** Schemas of filesystems we know to not work with this committer. */
   public static final Set<String> UNSUPPORTED_FS_SCHEMAS =
       ImmutableSet.of("s3a", "wasb");
-
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/InternalConstants.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/InternalConstants.java
@@ -40,7 +40,6 @@ import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.Manifest
  */
 @InterfaceAudience.Private
 public final class InternalConstants {
-
   private InternalConstants() {
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/LoadedManifestData.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/LoadedManifestData.java
@@ -25,6 +25,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.DirEntry;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages.LoadManifestsStage;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Information about the loaded manifest data;
  * Returned from {@link LoadManifestsStage} and then
@@ -49,13 +51,19 @@ public final class LoadedManifestData {
    */
   private final int fileCount;
 
+  /**
+   * Data about the loaded manifests
+   * @param directories directories
+   * @param entrySequenceData Path in local fs to the entry sequence data.
+   * @param fileCount number of files.
+   */
   public LoadedManifestData(
       final Collection<DirEntry> directories,
-      final Path entrySequenceFile,
+      final Path entrySequenceData,
       final int fileCount) {
-    this.directories = directories;
+    this.directories = requireNonNull(directories);
     this.fileCount = fileCount;
-    this.entrySequenceData = entrySequenceFile;
+    this.entrySequenceData = requireNonNull(entrySequenceData);
   }
 
   public Collection<DirEntry> getDirectories() {
@@ -66,11 +74,25 @@ public final class LoadedManifestData {
     return fileCount;
   }
 
+  /**
+   * Get the path to the entry sequence data file.
+   * @return the path
+   */
   public Path getEntrySequenceData() {
     return entrySequenceData;
   }
 
+  /**
+   * Get the entry sequence data as a file;
+   */
   public File getEntrySequenceFile() {
     return new File(entrySequenceData.toUri());
+  }
+
+  /**
+   * Delete the entry sequence file.
+   */
+  public void deleteEntrySequenceFile() {
+    getEntrySequenceFile().delete();
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/LoadedManifestData.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/LoadedManifestData.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl;
 
+import java.io.File;
 import java.util.Collection;
 
 import org.apache.hadoop.fs.Path;
@@ -41,7 +42,7 @@ public final class LoadedManifestData {
    * files to rename.
    * This will be a sequence file of long -> FileEntry
    */
-  private final Path entrySequenceFile;
+  private final Path entrySequenceData;
 
   /**
    * How many files will be renamed.
@@ -54,7 +55,7 @@ public final class LoadedManifestData {
       final int fileCount) {
     this.directories = directories;
     this.fileCount = fileCount;
-    this.entrySequenceFile = entrySequenceFile;
+    this.entrySequenceData = entrySequenceFile;
   }
 
   public Collection<DirEntry> getDirectories() {
@@ -65,8 +66,11 @@ public final class LoadedManifestData {
     return fileCount;
   }
 
-  public Path getEntrySequenceFile() {
-    return entrySequenceFile;
+  public Path getEntrySequenceData() {
+    return entrySequenceData;
   }
 
+  public File getEntrySequenceFile() {
+    return new File(entrySequenceData.toUri());
+  }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/LoadedManifestData.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/LoadedManifestData.java
@@ -52,7 +52,7 @@ public final class LoadedManifestData {
   private final int fileCount;
 
   /**
-   * Data about the loaded manifests
+   * Data about the loaded manifests.
    * @param directories directories
    * @param entrySequenceData Path in local fs to the entry sequence data.
    * @param fileCount number of files.
@@ -83,7 +83,7 @@ public final class LoadedManifestData {
   }
 
   /**
-   * Get the entry sequence data as a file;
+   * Get the entry sequence data as a file.
    */
   public File getEntrySequenceFile() {
     return new File(entrySequenceData.toUri());
@@ -91,8 +91,9 @@ public final class LoadedManifestData {
 
   /**
    * Delete the entry sequence file.
+   * @return whether or not the delete was successful.
    */
-  public void deleteEntrySequenceFile() {
-    getEntrySequenceFile().delete();
+  public boolean deleteEntrySequenceFile() {
+    return getEntrySequenceFile().delete();
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/LoadedManifestData.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/LoadedManifestData.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl;
+
+import java.util.Collection;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.DirEntry;
+import org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages.LoadManifestsStage;
+
+/**
+ * Information about the loaded manifest data;
+ * Returned from {@link LoadManifestsStage} and then
+ * used for renaming the work.
+ */
+public final class LoadedManifestData {
+
+  /**
+   * Directories.
+   */
+  private final Collection<DirEntry> directories;
+
+  /**
+   * Path of the intermediate cache of
+   * files to rename.
+   * This will be a sequence file of long -> FileEntry
+   */
+  private final Path entrySequenceFile;
+
+  /**
+   * How many files will be renamed.
+   */
+  private final int fileCount;
+
+  public LoadedManifestData(
+      final Collection<DirEntry> directories,
+      final Path entrySequenceFile,
+      final int fileCount) {
+    this.directories = directories;
+    this.fileCount = fileCount;
+    this.entrySequenceFile = entrySequenceFile;
+  }
+
+  public Collection<DirEntry> getDirectories() {
+    return directories;
+  }
+
+  public int getFileCount() {
+    return fileCount;
+  }
+
+  public Path getEntrySequenceFile() {
+    return entrySequenceFile;
+  }
+
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/ManifestCommitterSupport.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/ManifestCommitterSupport.java
@@ -89,10 +89,7 @@ public final class ManifestCommitterSupport {
     final IOStatisticsStoreBuilder store
         = iostatisticsStore();
 
-    store.withCounters(COUNTER_STATISTICS);
-    store.withMaximums(COUNTER_STATISTICS);
-    store.withMinimums(COUNTER_STATISTICS);
-    store.withMeanStatistics(COUNTER_STATISTICS);
+    store.withSampleTracking(COUNTER_STATISTICS);
     store.withDurationTracking(DURATION_STATISTICS);
     return store;
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/ManifestCommitterSupport.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/ManifestCommitterSupport.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
-import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -55,8 +54,6 @@ import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.Manifest
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.JOB_TASK_MANIFEST_SUBDIR;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.MANIFEST_COMMITTER_CLASSNAME;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.MANIFEST_SUFFIX;
-import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.OPT_IO_PROCESSORS;
-import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.OPT_IO_PROCESSORS_DEFAULT;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.OPT_STORE_OPERATIONS_CLASS;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.SPARK_WRITE_UUID;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.SUMMARY_FILENAME_FORMAT;
@@ -235,12 +232,10 @@ public final class ManifestCommitterSupport {
    */
   public static void addHeapInformation(IOStatisticsSetters ioStatisticsSetters,
       String stage) {
-    // force a gc. bit of bad form but it makes for better numbers
-    System.gc();
     final long totalMemory = Runtime.getRuntime().totalMemory();
+    final long freeMemory = Runtime.getRuntime().freeMemory();
     final String prefix = "stage.";
     ioStatisticsSetters.setGauge(prefix + stage + "." + TOTAL_MEMORY, totalMemory);
-    final long freeMemory = Runtime.getRuntime().freeMemory();
     ioStatisticsSetters.setGauge(prefix + stage + "." + FREE_MEMORY, freeMemory);
     ioStatisticsSetters.setGauge(prefix + stage + "." + HEAP_MEMORY, totalMemory - freeMemory);
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/AbstractJobOrTaskStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/AbstractJobOrTaskStage.java
@@ -686,11 +686,18 @@ public abstract class AbstractJobOrTaskStage<IN, OUT>
     return operations.storeSupportsResilientCommit();
   }
 
+  /**
+   * Maybe delete the destination.
+   * This routine is optimized for the data not existing, as HEAD seems to cost less
+   * than a DELETE; assuming most calls don't have data, this is faster.
+   * @param deleteDest should an attempt to delete the dest be made?
+   * @param dest destination path
+   * @throws IOException IO failure, including permissions.
+   */
   private void maybeDeleteDest(final boolean deleteDest, final Path dest) throws IOException {
-    if (deleteDest) {
-      // delete the destination, always, knowing that it's a no-op if
-      // the data isn't there. Skipping the change saves one round trip
-      // to actually look for the file/object
+
+    if (deleteDest && getFileStatusOrNull(dest) != null) {
+
       boolean deleted = delete(dest, true);
       // log the outcome in case of emergency diagnostics traces
       // being needed.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/AbstractJobOrTaskStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/AbstractJobOrTaskStage.java
@@ -161,7 +161,7 @@ public abstract class AbstractJobOrTaskStage<IN, OUT>
       getRequiredTaskAttemptId();
       getRequiredTaskAttemptDir();
       stageName = String.format("[Task-Attempt %s]", getRequiredTaskAttemptId());
-    } else  {
+    } else {
       stageName = String.format("[Job-Attempt %s/%02d]",
           stageConfig.getJobId(),
           stageConfig.getJobAttemptNumber());
@@ -310,6 +310,15 @@ public abstract class AbstractJobOrTaskStage<IN, OUT>
           statistic,
           wait.toMillis());
     }
+  }
+
+
+  /**
+   * Get the operations callbacks.
+   * @return the operations invocable against the destination.
+   */
+  public ManifestStoreOperations getOperations() {
+    return operations;
   }
 
   @Override

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CleanupJobStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CleanupJobStage.java
@@ -295,7 +295,7 @@ public class CleanupJobStage extends
      * @param statisticName stage name to report
      * @param enabled is the stage enabled?
      * @param deleteTaskAttemptDirsInParallel delete task attempt dirs in
-     *        parallel?
+     * parallel?
      * @param suppressExceptions suppress exceptions?
      */
     public Arguments(

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CommitJobStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CommitJobStage.java
@@ -72,7 +72,7 @@ public class CommitJobStage extends
         storeSupportsResilientCommit());
 
     // once the manifest has been loaded, a temp file needs to be
-    // deleted; so track teh value.
+    // deleted; so track the value.
     LoadedManifestData loadedManifestData = null;
 
     try {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CommitJobStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CommitJobStage.java
@@ -82,9 +82,9 @@ public class CommitJobStage extends
     final StageConfig stageConfig = getStageConfig();
     LoadManifestsStage.Result result = new LoadManifestsStage(stageConfig).apply(
         new LoadManifestsStage.Arguments(
-            File.createTempFile("manifest", ".list"), false,
+            File.createTempFile("manifest", ".list"),
+            false,
             ENTRY_WRITER_QUEUE_CAPACITY));
-    List<TaskManifest> manifests = result.getManifests();
     LoadManifestsStage.SummaryInfo summary = result.getSummary();
     final LoadedManifestData manifestData = result.getLoadedManifestData();
 
@@ -112,7 +112,7 @@ public class CommitJobStage extends
     // and hence all aggregate stats from the tasks.
     ManifestSuccessData successData;
     successData = new RenameFilesStage(stageConfig).apply(
-        Pair.of(manifests, dirStageResults.getCreatedDirectories()));
+        Pair.of(manifestData, dirStageResults.getCreatedDirectories()));
     if (LOG.isDebugEnabled()) {
       LOG.debug("{}: _SUCCESS file summary {}", getName(), successData.toJson());
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CommitJobStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CommitJobStage.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
@@ -77,8 +78,9 @@ public class CommitJobStage extends
     addHeapInformation(heapInfo, "setup");
     // load the manifests
     final StageConfig stageConfig = getStageConfig();
-    LoadManifestsStage.Result result
-        = new LoadManifestsStage(stageConfig).apply(true);
+    LoadManifestsStage.Result result = new LoadManifestsStage(stageConfig).apply(
+        new LoadManifestsStage.Arguments(
+            File.createTempFile("manifest", ".list"), false));
     List<TaskManifest> manifests = result.getManifests();
     LoadManifestsStage.SummaryInfo summary = result.getSummary();
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CommitJobStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CommitJobStage.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.LoadedMani
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.SUCCESS_MARKER_FILE_LIMIT;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.COMMITTER_BYTES_COMMITTED_COUNT;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.COMMITTER_FILES_COMMITTED_COUNT;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_STAGE_JOB_COMMIT;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CommitJobStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CommitJobStage.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.ManifestS
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.LoadedManifestData;
 
 import static java.util.Objects.requireNonNull;
-import static org.apache.commons.io.FileUtils.byteCountToDisplaySize;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.COMMITTER_BYTES_COMMITTED_COUNT;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.COMMITTER_FILES_COMMITTED_COUNT;
@@ -94,7 +93,7 @@ public class CommitJobStage extends
       LOG.info("{}: Committing job with file count: {}; total size {} bytes",
           getName(),
           summary.getFileCount(),
-          byteCountToDisplaySize(summary.getTotalFileSize()));
+          String.format("%,d", summary.getTotalFileSize()));
       addHeapInformation(heapInfo, OP_STAGE_JOB_LOAD_MANIFESTS);
 
 
@@ -178,7 +177,7 @@ public class CommitJobStage extends
       // the result
       return new Result(successPath, successData);
     } finally {
-      // cleanup
+      // cleanup; return code is ignored.
       if (loadedManifestData != null) {
         loadedManifestData.deleteEntrySequenceFile();
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CreateOutputDirectoriesStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CreateOutputDirectoriesStage.java
@@ -21,7 +21,9 @@ package org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -37,7 +39,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.DirEntry;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.EntryStatus;
-import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.TaskManifest;
 import org.apache.hadoop.util.functional.TaskPool;
 
 import static java.util.Objects.requireNonNull;
@@ -75,16 +76,14 @@ import static org.apache.hadoop.util.OperationDuration.humanTime;
  */
 public class CreateOutputDirectoriesStage extends
     AbstractJobOrTaskStage<
-        List<TaskManifest>,
+        Collection<DirEntry>,
         CreateOutputDirectoriesStage.Result> {
 
   private static final Logger LOG = LoggerFactory.getLogger(
       CreateOutputDirectoriesStage.class);
 
   /**
-   * Directories as a map of (path, path).
-   * Using a map rather than any set for efficient concurrency; the
-   * concurrent sets don't do lookups so fast.
+   * Directories as a map of (path, DirMapState).
    */
   private final Map<Path, DirMapState> dirMap = new ConcurrentHashMap<>();
 
@@ -101,20 +100,20 @@ public class CreateOutputDirectoriesStage extends
 
   @Override
   protected Result executeStage(
-      final List<TaskManifest> taskManifests)
+      final Collection<DirEntry> manifestDirs)
       throws IOException {
 
-    final List<Path> directories = createAllDirectories(taskManifests);
+    final List<Path> directories = createAllDirectories(manifestDirs);
     LOG.debug("{}: Created {} directories", getName(), directories.size());
     return new Result(new HashSet<>(directories), dirMap);
   }
 
   /**
-   * For each task, build the list of directories it wants.
-   * @param taskManifests task manifests
+   * Build the list of directories to create.
+   * @param manifestDirs dir entries from the manifests
    * @return the list of paths which have been created.
    */
-  private List<Path> createAllDirectories(final List<TaskManifest> taskManifests)
+  private List<Path> createAllDirectories(final Collection<DirEntry> manifestDirs)
       throws IOException {
 
     // all directories which need to exist across all
@@ -128,32 +127,27 @@ public class CreateOutputDirectoriesStage extends
     // will be created at that path.
     final Set<Path> filesToDelete = new HashSet<>();
 
-    // iterate through the task manifests
-    // and all output dirs into the set of dirs to
-    // create.
-    // hopefully there is a lot of overlap, so the
-    // final number of dirs to create is small.
-    for (TaskManifest task: taskManifests) {
-      final List<DirEntry> destDirectories = task.getDestDirectories();
-      Collections.sort(destDirectories, (o1, o2) ->
-          o1.getLevel() - o2.getLevel());
-      for (DirEntry entry: destDirectories) {
-        // add the dest entry
-        final Path path = entry.getDestPath();
-        if (!leaves.containsKey(path)) {
-          leaves.put(path, entry);
+    // sort the values of dir map by directory level: parent dirs will
+    // come first in the sorting
+    List<DirEntry> destDirectories = new ArrayList<>(manifestDirs);
 
-          // if it is a file to delete, record this.
-          if (entry.getStatus() == EntryStatus.file) {
-            filesToDelete.add(path);
-          }
-          final Path parent = path.getParent();
-          if (parent != null && leaves.containsKey(parent)) {
-            // there's a parent dir, move it from the leaf list
-            // to parent list
-            parents.put(parent,
-                leaves.remove(parent));
-          }
+    Collections.sort(destDirectories, Comparator.comparingInt(DirEntry::getLevel));
+    // iterate through the directory map
+    for (DirEntry entry: destDirectories) {
+      // add the dest entry
+      final Path path = entry.getDestPath();
+      if (!leaves.containsKey(path)) {
+        leaves.put(path, entry);
+
+        // if it is a file to delete, record this.
+        if (entry.getStatus() == EntryStatus.file) {
+          filesToDelete.add(path);
+        }
+        final Path parent = path.getParent();
+        if (parent != null && leaves.containsKey(parent)) {
+          // there's a parent dir, move it from the leaf list
+          // to parent list
+          parents.put(parent, leaves.remove(parent));
         }
       }
     }
@@ -168,7 +162,9 @@ public class CreateOutputDirectoriesStage extends
 
     // Now the real work.
     final int createCount = leaves.size();
-    LOG.info("Preparing {} directory/directories", createCount);
+    LOG.info("Preparing {} directory/directories; {} parent dirs implicitly created",
+        createCount, parents.size());
+
     // now probe for and create the leaf dirs, which are those at the
     // bottom level
     Duration d = measureDurationOfInvocation(getIOStatistics(), OP_CREATE_DIRECTORIES, () ->
@@ -188,7 +184,7 @@ public class CreateOutputDirectoriesStage extends
 
   /**
    * report a single directory failure.
-   * @param path path which could not be deleted
+   * @param dirEntry dir which could not be deleted
    * @param e exception raised.
    */
   private void reportMkDirFailure(DirEntry dirEntry, Exception e) {
@@ -274,8 +270,8 @@ public class CreateOutputDirectoriesStage extends
    * Try to efficiently and robustly create a directory in a method which is
    * expected to be executed in parallel with operations creating
    * peer directories.
-   * @param path path to create
-   * @return true if dir created/found
+   * @param dirEntry dir to create
+   * @return Outcome
    * @throws IOException IO Failure.
    */
   private DirMapState maybeCreateOneDirectory(DirEntry dirEntry) throws IOException {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/LoadManifestsStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/LoadManifestsStage.java
@@ -127,6 +127,7 @@ public class LoadManifestsStage extends
     entryWriter = entryFileIO.launchEntryWriter(
             entryFileIO.createWriter(entrySequenceFile),
             arguments.queueCapacity);
+    List<TaskManifest> manifestList;
     try {
 
       // sync fs before the listj
@@ -137,7 +138,8 @@ public class LoadManifestsStage extends
       final RemoteIterator<FileStatus> manifestFiles =
           haltableRemoteIterator(listManifests(), () -> entryWriter.isActive());
 
-      final List<TaskManifest> manifestList = loadAllManifests(manifestFiles);
+      manifestList = loadAllManifests(manifestFiles);
+
       LOG.info("{}: Summary of {} manifests loaded in {}: {}",
           getName(),
           manifestList.size(),
@@ -160,7 +162,7 @@ public class LoadManifestsStage extends
         entrySequenceFile,
         entryWriter.getCount());
 
-    return new LoadManifestsStage.Result(summaryInfo, loadedManifestData, null);
+    return new LoadManifestsStage.Result(summaryInfo, loadedManifestData, manifestList);
   }
 
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/RenameFilesStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/RenameFilesStage.java
@@ -109,7 +109,7 @@ public class RenameFilesStage extends
     createdDirectories = args.getRight();
     final EntryFileIO entryFileIO = new EntryFileIO(getStageConfig().getConf());
     final SequenceFile.Reader reader =
-        entryFileIO.createReader(manifestData.getEntrySequenceFile());
+        entryFileIO.createReader(manifestData.getEntrySequenceData());
 
 
     final ManifestSuccessData success = createManifestOutcome(getStageConfig(),

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/RenameFilesStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/RenameFilesStage.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.FileEntry;
@@ -36,7 +36,6 @@ import org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.EntryFileI
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.LoadedManifestData;
 import org.apache.hadoop.util.functional.TaskPool;
 
-import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.SUCCESS_MARKER_FILE_LIMIT;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_STAGE_JOB_COMMIT;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_STAGE_JOB_RENAME_FILES;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.ManifestCommitterSupport.createManifestOutcome;
@@ -59,7 +58,7 @@ import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.Man
  */
 public class RenameFilesStage extends
     AbstractJobOrTaskStage<
-        Pair<LoadedManifestData, Set<Path>>,
+        Triple<LoadedManifestData, Set<Path>, Integer>,
         ManifestSuccessData> {
 
   private static final Logger LOG = LoggerFactory.getLogger(
@@ -106,12 +105,12 @@ public class RenameFilesStage extends
    */
   @Override
   protected ManifestSuccessData executeStage(
-      Pair<LoadedManifestData, Set<Path>> args)
+      Triple<LoadedManifestData, Set<Path>, Integer> args)
       throws IOException {
 
 
     final LoadedManifestData manifestData = args.getLeft();
-    createdDirectories = args.getRight();
+    createdDirectories = args.getMiddle();
     final EntryFileIO entryFileIO = new EntryFileIO(getStageConfig().getConf());
 
 
@@ -140,7 +139,7 @@ public class RenameFilesStage extends
     // enough for simple testing
     success.setFilenamePaths(
         committed
-            .subList(0, Math.min(committed.size(), SUCCESS_MARKER_FILE_LIMIT))
+            .subList(0, Math.min(committed.size(), args.getRight()))
             .stream().map(FileEntry::getDestPath)
             .collect(Collectors.toList()));
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/StageConfig.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/StageConfig.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.TaskManifest;
@@ -151,6 +152,13 @@ public class StageConfig {
    * Name for logging.
    */
   private String name = "";
+
+  /**
+   * Configuration used where needed.
+   * Default value is a configuration with the normal constructor;
+   * jobs should override this with what was passed down.j
+   */
+  private Configuration conf = new Configuration();
 
   public StageConfig() {
   }
@@ -403,6 +411,24 @@ public class StageConfig {
    */
   public String getName() {
     return name;
+  }
+
+  /**
+   * Set configuration.
+   * @param value new value
+   * @return the builder
+   */
+  public StageConfig withConfiguration(Configuration value) {
+    conf = value;
+    return this;
+  }
+
+  /**
+   * Get configuration.
+   * @return the configuration
+   */
+  public Configuration getConf() {
+    return conf;
   }
 
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/StageConfig.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/StageConfig.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.util.functional.TaskPool;
 
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.DEFAULT_WRITER_QUEUE_CAPACITY;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.SUCCESS_MARKER;
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.SUCCESS_MARKER_FILE_LIMIT;
 
 /**
  * Stage Config.
@@ -165,6 +166,11 @@ public class StageConfig {
    * Entry writer queue capacity.
    */
   private int writerQueueCapacity = DEFAULT_WRITER_QUEUE_CAPACITY;
+
+  /**
+   * Number of marker files to include in success file.
+   */
+  private int successMarkerFileLimit = SUCCESS_MARKER_FILE_LIMIT;
 
   public StageConfig() {
   }
@@ -580,6 +586,22 @@ public class StageConfig {
 
   public boolean getDeleteTargetPaths() {
     return deleteTargetPaths;
+  }
+
+  /**
+   * Number of marker files to include in success file.
+   * @param value new value
+   * @return the builder
+   */
+  public StageConfig withSuccessMarkerFileLimit(final int value) {
+    checkOpen();
+
+    successMarkerFileLimit = value;
+    return this;
+  }
+
+  public int getSuccessMarkerFileLimit() {
+    return successMarkerFileLimit;
   }
 
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/StageConfig.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/StageConfig.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.util.Progressable;
 import org.apache.hadoop.util.functional.TaskPool;
 
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.DEFAULT_WRITER_QUEUE_CAPACITY;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.SUCCESS_MARKER;
 
 /**
@@ -156,9 +157,14 @@ public class StageConfig {
   /**
    * Configuration used where needed.
    * Default value is a configuration with the normal constructor;
-   * jobs should override this with what was passed down.j
+   * jobs should override this with what was passed down.
    */
   private Configuration conf = new Configuration();
+
+  /**
+   * Entry writer queue capacity.
+   */
+  private int writerQueueCapacity = DEFAULT_WRITER_QUEUE_CAPACITY;
 
   public StageConfig() {
   }
@@ -429,6 +435,24 @@ public class StageConfig {
    */
   public Configuration getConf() {
     return conf;
+  }
+
+  /**
+   * Get writer queue capacity.
+   * @return the queue capacity
+   */
+  public int getWriterQueueCapacity() {
+    return writerQueueCapacity;
+  }
+
+  /**
+   * Set writer queue capacity.
+   * @param value new value
+   * @return the builder
+   */
+  public StageConfig withWriterQueueCapacity(final int value) {
+    writerQueueCapacity = value;
+    return this;
   }
 
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/ValidateRenamedFilesStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/ValidateRenamedFilesStage.java
@@ -139,7 +139,8 @@ public class ValidateRenamedFilesStage extends
 
       // etags, if the source had one.
       final String sourceEtag = entry.getEtag();
-      if (isNotBlank(sourceEtag)) {
+      if (getOperations().storePreservesEtagsThroughRenames(destStatus.getPath())
+          && isNotBlank(sourceEtag)) {
         final String destEtag = ManifestCommitterSupport.getEtag(destStatus);
         if (!sourceEtag.equals(destEtag)) {
           LOG.warn("Etag of dest file {}: {} does not match that of manifest entry {}",

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/ValidateRenamedFilesStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/ValidateRenamedFilesStage.java
@@ -22,23 +22,21 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.FileEntry;
-import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.TaskManifest;
+import org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.EntryFileIO;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.ManifestCommitterSupport;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.OutputValidationException;
 import org.apache.hadoop.util.functional.TaskPool;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_STAGE_JOB_VALIDATE_OUTPUT;
-import static org.apache.hadoop.thirdparty.com.google.common.collect.Iterables.concat;
 
 /**
  * This stage validates all files by scanning the manifests
@@ -50,16 +48,11 @@ import static org.apache.hadoop.thirdparty.com.google.common.collect.Iterables.c
  */
 public class ValidateRenamedFilesStage extends
     AbstractJobOrTaskStage<
-        List<TaskManifest>,
+        Path,
         List<FileEntry>> {
 
   private static final Logger LOG = LoggerFactory.getLogger(
       ValidateRenamedFilesStage.class);
-
-  /**
-   * Set this to halt all workers.
-   */
-  private final AtomicBoolean halt = new AtomicBoolean();
 
   /**
    * List of all files committed.
@@ -93,34 +86,27 @@ public class ValidateRenamedFilesStage extends
    * has a file in the destination of the same size.
    * If two tasks have both written the same file or
    * a source file was changed after the task was committed,
-   * then a mistmatch will be detected -provided the file
+   * then a mismatch will be detected -provided the file
    * length is now different.
-   * @param taskManifests list of manifests.
+   * @param entryFile path to entry file
    * @return list of files committed.
    */
   @Override
   protected List<FileEntry> executeStage(
-      final List<TaskManifest> taskManifests)
+      final Path entryFile)
       throws IOException {
 
-    // set the list of files to be as big as the number of tasks.
-    // synchronized to stop complaints.
-    synchronized (this) {
-      filesCommitted = new ArrayList<>(taskManifests.size());
+    final EntryFileIO entryFileIO = new EntryFileIO(getStageConfig().getConf());
+
+    try (SequenceFile.Reader reader = entryFileIO.createReader(entryFile)) {
+      // iterate over the entries in the file.
+      TaskPool.foreach(entryFileIO.iterateOver(reader))
+          .executeWith(getIOProcessors())
+          .stopOnFailure()
+          .run(this::validateOneFile);
+
+      return getFilesCommitted();
     }
-
-    // validate all the files.
-
-    final Iterable<FileEntry> filesToCommit = concat(taskManifests.stream()
-        .map(TaskManifest::getFilesToCommit)
-        .collect(Collectors.toList()));
-
-    TaskPool.foreach(filesToCommit)
-        .executeWith(getIOProcessors())
-        .stopOnFailure()
-        .run(this::validateOneFile);
-
-    return getFilesCommitted();
   }
 
   /**
@@ -132,10 +118,6 @@ public class ValidateRenamedFilesStage extends
   private void validateOneFile(FileEntry entry) throws IOException {
     updateAuditContext(OP_STAGE_JOB_VALIDATE_OUTPUT);
 
-    if (halt.get()) {
-      // told to stop
-      return;
-    }
     // report progress back
     progress();
     // look validate the file.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/manifest_committer.md
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/manifest_committer.md
@@ -243,7 +243,7 @@ Caveats
 
 This is a secondary scale option.
 It controls the size of the queue for storing lists of files to rename from
-the manifests loaded from the target filesystem, manifests loaded 
+the manifests loaded from the target filesystem, manifests loaded
 from a pool of worker threads, and the single thread which saves
 the entries from each manifest to an intermediate file in the local filesystem.
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/manifest_committer.md
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/manifest_committer.md
@@ -261,7 +261,7 @@ this queue size should not be a limit on manifest load performance.
 
 It can help limit the amount of memory consumed during manifest load during
 job commit.
-The maximumum number of loaded manifests will be
+The maximum number of loaded manifests will be:
 
 ```
 mapreduce.manifest.committer.writer.queue.capacity + mapreduce.manifest.committer.io.threads

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/manifest_committer.md
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/manifest_committer.md
@@ -207,23 +207,28 @@ in the option `mapreduce.manifest.committer.io.threads`.
 
 Larger values may be used.
 
-XML
+Hadoop XML configuration
 ```xml
 <property>
   <name>mapreduce.manifest.committer.io.threads</name>
-  <value>200</value>
+  <value>32</value>
 </property>
 ```
 
-spark-defaults.conf
-```
-spark.hadoop.mapreduce.manifest.committer.io.threads 200
+In `spark-defaults.conf`
+
+```properties
+spark.hadoop.mapreduce.manifest.committer.io.threads 32
 ```
 
 A larger value than that of the number of cores allocated to
 the MapReduce AM or Spark Driver does not directly overload
 the CPUs, as the threads are normally waiting for (slow) IO
 against the object store/filesystem to complete.
+
+Manifest loading in job commit may be memory intensive;
+the larger the number of threads, the more manifests which
+will be loaded simultaneously.
 
 Caveats
 * In Spark, multiple jobs may be committed in the same process,
@@ -232,6 +237,36 @@ Caveats
 * Azure rate throttling may be triggered if too many IO requests
   are made against the store. The rate throttling option
   `mapreduce.manifest.committer.io.rate` can help avoid this.
+
+
+### `mapreduce.manifest.committer.writer.queue.capacity`
+
+This is a secondary scale option.
+It controls the size of the queue for storing lists of files to rename from
+the manifests loaded from the target filesystem, manifests loaded 
+from a pool of worker threads, and the single thread which saves
+the entries from each manifest to an intermediate file in the local filesystem.
+
+Once the queue is full, all manifest loading threads will block.
+
+```xml
+<property>
+  <name>mapreduce.manifest.committer.writer.queue.capacity</name>
+  <value>32</value>
+</property>
+```
+
+As the local filesystem is usually much faster to write to than any cloud store,
+this queue size should not be a limit on manifest load performance.
+
+It can help limit the amount of memory consumed during manifest load during
+job commit.
+The maximumum number of loaded manifests will be
+
+```
+mapreduce.manifest.committer.writer.queue.capacity + mapreduce.manifest.committer.io.threads
+```
+
 
 
 ## <a name="deleting"></a> Optional: deleting target files in Job Commit
@@ -611,13 +646,14 @@ spark.hadoop.mapreduce.manifest.committer.summary.report.directory  (optional: U
 There are some advanced options which are intended for development and testing,
 rather than production use.
 
-| Option | Meaning | Default Value |
-|--------|---------|---------------|
-| `mapreduce.manifest.committer.store.operations.classname` | Classname for Manifest Store Operations | `""` |
-| `mapreduce.manifest.committer.validate.output` | Perform output validation? | `false` |
+| Option | Meaning                                      | Default Value |
+|--------|----------------------------------------------|---------------|
+| `mapreduce.manifest.committer.store.operations.classname` | Classname for Manifest Store Operations      | `""`          |
+| `mapreduce.manifest.committer.validate.output` | Perform output validation?                   | `false`       |
+| `mapreduce.manifest.committer.writer.queue.capacity` | Queue capacity for writing intermediate file | `32`          |
 
 
-## Validating output  `mapreduce.manifest.committer.validate.output`
+### Validating output  `mapreduce.manifest.committer.validate.output`
 
 The option `mapreduce.manifest.committer.validate.output` triggers a check of every renamed file to
 verify it has the expected length.
@@ -626,7 +662,7 @@ This adds the overhead of a `HEAD` request per file, and so is recommended for t
 
 There is no verification of the actual contents.
 
-## Controlling storage integration `mapreduce.manifest.committer.store.operations.classname`
+### Controlling storage integration `mapreduce.manifest.committer.store.operations.classname`
 
 The manifest committer interacts with filesystems through implementations of the interface
 `ManifestStoreOperations`.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
@@ -756,66 +756,75 @@ public class TestFileOutputCommitter {
     conf.setInt(FileOutputCommitter.FILEOUTPUTCOMMITTER_ALGORITHM_VERSION,
         version);
 
-    conf.setClass("fs.file.impl", RLFS.class, FileSystem.class);
+    final String fileImpl = "fs.file.impl";
+    final String fileImplClassname = "org.apache.hadoop.fs.LocalFileSystem";
+    conf.setClass(fileImpl, RLFS.class, FileSystem.class);
     FileSystem.closeAll();
 
-    final JobContext jContext = new JobContextImpl(conf, taskID.getJobID());
-    final FileOutputCommitter amCommitter =
-        new FileOutputCommitter(outDir, jContext);
-    amCommitter.setupJob(jContext);
-
-    final TaskAttemptContext[] taCtx = new TaskAttemptContextImpl[2];
-    taCtx[0] = new TaskAttemptContextImpl(conf, taskID);
-    taCtx[1] = new TaskAttemptContextImpl(conf, taskID1);
-
-    final TextOutputFormat[] tof = new TextOutputFormat[2];
-    for (int i = 0; i < tof.length; i++) {
-      tof[i] = new TextOutputFormat() {
-        @Override
-        public Path getDefaultWorkFile(TaskAttemptContext context,
-            String extension) throws IOException {
-          final FileOutputCommitter foc = (FileOutputCommitter)
-              getOutputCommitter(context);
-          return new Path(new Path(foc.getWorkPath(), SUB_DIR),
-              getUniqueFile(context, getOutputName(context), extension));
-        }
-      };
-    }
-
-    final ExecutorService executor = HadoopExecutors.newFixedThreadPool(2);
     try {
-      for (int i = 0; i < taCtx.length; i++) {
-        final int taskIdx = i;
-        executor.submit(new Callable<Void>() {
+      final JobContext jContext = new JobContextImpl(conf, taskID.getJobID());
+      final FileOutputCommitter amCommitter =
+          new FileOutputCommitter(outDir, jContext);
+      amCommitter.setupJob(jContext);
+
+      final TaskAttemptContext[] taCtx = new TaskAttemptContextImpl[2];
+      taCtx[0] = new TaskAttemptContextImpl(conf, taskID);
+      taCtx[1] = new TaskAttemptContextImpl(conf, taskID1);
+
+      final TextOutputFormat[] tof = new TextOutputFormat[2];
+      for (int i = 0; i < tof.length; i++) {
+        tof[i] = new TextOutputFormat() {
           @Override
-          public Void call() throws IOException, InterruptedException {
-            final OutputCommitter outputCommitter =
-                tof[taskIdx].getOutputCommitter(taCtx[taskIdx]);
-            outputCommitter.setupTask(taCtx[taskIdx]);
-            final RecordWriter rw =
-                tof[taskIdx].getRecordWriter(taCtx[taskIdx]);
-            writeOutput(rw, taCtx[taskIdx]);
-            outputCommitter.commitTask(taCtx[taskIdx]);
-            return null;
+          public Path getDefaultWorkFile(TaskAttemptContext context,
+              String extension) throws IOException {
+            final FileOutputCommitter foc = (FileOutputCommitter)
+                getOutputCommitter(context);
+            return new Path(new Path(foc.getWorkPath(), SUB_DIR),
+                getUniqueFile(context, getOutputName(context), extension));
           }
-        });
+        };
       }
+
+      final ExecutorService executor = HadoopExecutors.newFixedThreadPool(2);
+      try {
+        for (int i = 0; i < taCtx.length; i++) {
+          final int taskIdx = i;
+          executor.submit(new Callable<Void>() {
+            @Override
+            public Void call() throws IOException, InterruptedException {
+              final OutputCommitter outputCommitter =
+                  tof[taskIdx].getOutputCommitter(taCtx[taskIdx]);
+              outputCommitter.setupTask(taCtx[taskIdx]);
+              final RecordWriter rw =
+                  tof[taskIdx].getRecordWriter(taCtx[taskIdx]);
+              writeOutput(rw, taCtx[taskIdx]);
+              outputCommitter.commitTask(taCtx[taskIdx]);
+              return null;
+            }
+          });
+        }
+      } finally {
+        executor.shutdown();
+        while (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
+          LOG.info("Awaiting thread termination!");
+        }
+      }
+
+      amCommitter.commitJob(jContext);
+      final RawLocalFileSystem lfs = new RawLocalFileSystem();
+      lfs.setConf(conf);
+      assertFalse("Must not end up with sub_dir/sub_dir",
+          lfs.exists(new Path(OUT_SUB_DIR, SUB_DIR)));
+
+      // validate output
+      validateContent(OUT_SUB_DIR);
+      FileUtil.fullyDelete(new File(outDir.toString()));
     } finally {
-      executor.shutdown();
-      while (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
-        LOG.info("Awaiting thread termination!");
-      }
+      // needed to avoid this test contaminating others in the same JVM
+      FileSystem.closeAll();
+      conf.set(fileImpl, fileImplClassname);
+      conf.set(fileImpl, fileImplClassname);
     }
-
-    amCommitter.commitJob(jContext);
-    final RawLocalFileSystem lfs = new RawLocalFileSystem();
-    lfs.setConf(conf);
-    assertFalse("Must not end up with sub_dir/sub_dir",
-        lfs.exists(new Path(OUT_SUB_DIR, SUB_DIR)));
-
-    // validate output
-    validateContent(OUT_SUB_DIR);
-    FileUtil.fullyDelete(new File(outDir.toString()));
   }
 
   @Test

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
@@ -823,7 +823,6 @@ public class TestFileOutputCommitter {
       // needed to avoid this test contaminating others in the same JVM
       FileSystem.closeAll();
       conf.set(fileImpl, fileImplClassname);
-      conf.set(fileImpl, fileImplClassname);
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/AbstractManifestCommitterTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/AbstractManifestCommitterTest.java
@@ -74,6 +74,7 @@ import static org.apache.hadoop.fs.statistics.IOStatisticsSupport.snapshotIOStat
 import static org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter.SUCCESSFUL_JOB_OUTPUT_DIR_MARKER;
 import static org.apache.hadoop.mapreduce.lib.output.PathOutputCommitterFactory.COMMITTER_FACTORY_CLASS;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConfig.createCloseableTaskSubmitter;
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.DEFAULT_WRITER_QUEUE_CAPACITY;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.JOB_ID_SOURCE_MAPREDUCE;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.MANIFEST_COMMITTER_FACTORY;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.OPT_DIAGNOSTICS_MANIFEST_DIR;
@@ -796,7 +797,8 @@ public abstract class AbstractManifestCommitterTest
         .withJobDirectories(attemptDirs)
         .withName(String.format(NAME_FORMAT_JOB_ATTEMPT, jobId))
         .withOperations(getStoreOperations())
-        .withProgressable(getProgressCounter());
+        .withProgressable(getProgressCounter())
+        .withWriterQueueCapacity(DEFAULT_WRITER_QUEUE_CAPACITY);
 
     // if there's a task attempt ID set, set up its details
     if (taskIndex >= 0) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/AbstractManifestCommitterTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/AbstractManifestCommitterTest.java
@@ -798,6 +798,7 @@ public abstract class AbstractManifestCommitterTest
         .withName(String.format(NAME_FORMAT_JOB_ATTEMPT, jobId))
         .withOperations(getStoreOperations())
         .withProgressable(getProgressCounter())
+        .withSuccessMarkerFileLimit(100_000)
         .withWriterQueueCapacity(DEFAULT_WRITER_QUEUE_CAPACITY);
 
     // if there's a task attempt ID set, set up its details

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/AbstractManifestCommitterTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/AbstractManifestCommitterTest.java
@@ -787,6 +787,7 @@ public abstract class AbstractManifestCommitterTest
             jobId, jobAttemptNumber);
     StageConfig config = new StageConfig();
     config
+        .withConfiguration(getConfiguration())
         .withIOProcessors(getSubmitter())
         .withIOStatistics(getStageStatistics())
         .withJobId(jobId)

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterTestSupport.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterTestSupport.java
@@ -28,7 +28,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
@@ -55,7 +54,6 @@ import org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.EntryFileI
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.LoadedManifestData;
 import org.apache.hadoop.util.functional.RemoteIterators;
 
-import static java.util.Comparator.naturalOrder;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.MANIFEST_COMMITTER_CLASSNAME;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.SUCCESS_MARKER;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterTestSupport.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterTestSupport.java
@@ -76,7 +76,7 @@ public final class ManifestCommitterTestSupport {
    * default number of task attempts for some tests.
    * Value: {@value}.
    */
-  public static final int NUMBER_OF_TASK_ATTEMPTS = 200;
+  public static final int NUMBER_OF_TASK_ATTEMPTS = 2000;
 
   private ManifestCommitterTestSupport() {
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterTestSupport.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterTestSupport.java
@@ -83,6 +83,13 @@ public final class ManifestCommitterTestSupport {
    */
   public static final int NUMBER_OF_TASK_ATTEMPTS = 2000;
 
+  /**
+   * Smaller number of task attempts for some tests against object
+   * stores where IO overhead is higher.
+   * Value: {@value}.
+   */
+  public static final int NUMBER_OF_TASK_ATTEMPTS_SMALL = 200;
+
   private ManifestCommitterTestSupport() {
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestJobThroughManifestCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestJobThroughManifestCommitter.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.lib.output.committer.manifest;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
@@ -482,7 +483,8 @@ public class TestJobThroughManifestCommitter
 
     // load manifests stage will load all the task manifests again
     List<TaskManifest> manifests = new LoadManifestsStage(getJobStageConfig())
-        .apply(true).getManifests();
+        .apply(new LoadManifestsStage.Arguments(
+                    File.createTempFile("manifest", ".list"), true)).getManifests();
     // Now verify their files exist, returning the list of renamed files.
     List<String> committedFiles = new ValidateRenamedFilesStage(getJobStageConfig())
         .apply(manifests)

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestJobThroughManifestCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestJobThroughManifestCommitter.java
@@ -514,7 +514,7 @@ public class TestJobThroughManifestCommitter
         .containsAll(successData.getFilenames());
 
     // delete an entry, repeat
-    getFileSystem().delete(validatedEntries.get(0).getDestPath());
+    getFileSystem().delete(validatedEntries.get(0).getDestPath(), false);
     intercept(OutputValidationException.class, () ->
         new ValidateRenamedFilesStage(getJobStageConfig())
             .apply(loadedManifestData.getEntrySequenceData()));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestJobThroughManifestCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestJobThroughManifestCommitter.java
@@ -146,6 +146,8 @@ public class TestJobThroughManifestCommitter
 
   /**
    * Loaded manifest data, set in job commit and used in validation.
+   * This is static so it can be passed from where it is loaded
+   * {@link #test_0400_loadManifests()} to subsequent tests.
    */
   private static LoadedManifestData
       loadedManifestData;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestJobThroughManifestCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestJobThroughManifestCommitter.java
@@ -447,7 +447,7 @@ public class TestJobThroughManifestCommitter
     describe("Load all manifests; committed must be TA01 and TA10");
     File entryFile = File.createTempFile("entry", ".seq");
     LoadManifestsStage.Arguments args = new LoadManifestsStage.Arguments(
-        entryFile, false, InternalConstants.ENTRY_WRITER_QUEUE_CAPACITY);
+        entryFile, true, InternalConstants.ENTRY_WRITER_QUEUE_CAPACITY);
     LoadManifestsStage.Result result
         = new LoadManifestsStage(getJobStageConfig()).apply(args);
     String summary = result.getSummary().toString();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestLoadManifestsStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestLoadManifestsStage.java
@@ -123,7 +123,8 @@ public class TestLoadManifestsStage extends AbstractManifestCommitterTest {
     executeTaskAttempts(taskAttemptCount, filesPerTaskAttempt);
 
     IOStatisticsSnapshot heapInfo = new IOStatisticsSnapshot();
-    addHeapInformation(heapInfo, "initial");
+
+    heapinfo(heapInfo, "initial");
 
     LOG.info("Loading in the manifests");
 
@@ -140,7 +141,7 @@ public class TestLoadManifestsStage extends AbstractManifestCommitterTest {
     LOG.info("\nJob statistics after loading {}",
         ioStatisticsToPrettyString(getStageStatistics()));
     LOG.info("Heap size = {}", heapSize());
-    addHeapInformation(heapInfo, "load.manifests");
+    heapinfo(heapInfo, "load.manifests");
 
 
     Assertions.assertThat(summary.getManifestCount())
@@ -165,7 +166,7 @@ public class TestLoadManifestsStage extends AbstractManifestCommitterTest {
         stageConfig)
         .apply(loadManifestsResult.getLoadedManifestData().getDirectories())
         .getCreatedDirectories();
-    addHeapInformation(heapInfo, "create.directories");
+    heapinfo(heapInfo, "create.directories");
 
     // but after the merge process, only one per generated file output
     // dir exists
@@ -177,7 +178,7 @@ public class TestLoadManifestsStage extends AbstractManifestCommitterTest {
     // go straight to cleanup
     new CleanupJobStage(stageConfig).apply(
         new CleanupJobStage.Arguments("", true, true, false));
-    addHeapInformation(heapInfo, "cleanup");
+    heapinfo(heapInfo, "cleanup");
 
     ManifestSuccessData success = createManifestOutcome(stageConfig, OP_STAGE_JOB_COMMIT);
     success.snapshotIOStatistics(getStageStatistics());
@@ -195,6 +196,16 @@ public class TestLoadManifestsStage extends AbstractManifestCommitterTest {
     ManifestPrinter showManifest = new ManifestPrinter();
     ManifestSuccessData manifestSuccessData =
         showManifest.loadAndPrintManifest(summaryFS, path);
+  }
+
+  /**
+   * Force a GC then add heap info.
+   * @param stats stats to update
+   * @param stage stage name
+   */
+  private static void heapinfo(final IOStatisticsSnapshot stats, final String stage) {
+    System.gc();
+    addHeapInformation(stats, stage);
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestLoadManifestsStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestLoadManifestsStage.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.statistics.IOStatisticsSnapshot;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.ManifestPrinter;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.ManifestSuccessData;
-import org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.InternalConstants;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages.CleanupJobStage;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages.CreateOutputDirectoriesStage;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages.LoadManifestsStage;
@@ -39,6 +38,7 @@ import org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages.SetupJob
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages.StageConfig;
 
 import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsToPrettyString;
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.DEFAULT_WRITER_QUEUE_CAPACITY;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.OPT_SUMMARY_REPORT_DIR;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_STAGE_JOB_COMMIT;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.ManifestCommitterSupport.addHeapInformation;
@@ -132,9 +132,10 @@ public class TestLoadManifestsStage extends AbstractManifestCommitterTest {
         stageConfig);
     entryFile = File.createTempFile("entry", ".seq");
     LoadManifestsStage.Arguments args = new LoadManifestsStage.Arguments(
-        entryFile, false, InternalConstants.ENTRY_WRITER_QUEUE_CAPACITY);
-    LoadManifestsStage.Result result = stage.apply(args);
-    LoadManifestsStage.SummaryInfo summary = result.getSummary();
+        entryFile, false, DEFAULT_WRITER_QUEUE_CAPACITY);
+
+    LoadManifestsStage.Result loadManifestsResult = stage.apply(args);
+    LoadManifestsStage.SummaryInfo summary = loadManifestsResult.getSummary();
 
     LOG.info("\nJob statistics after loading {}",
         ioStatisticsToPrettyString(getStageStatistics()));
@@ -162,7 +163,7 @@ public class TestLoadManifestsStage extends AbstractManifestCommitterTest {
     // now let's see about aggregating a large set of directories
     Set<Path> createdDirectories = new CreateOutputDirectoriesStage(
         stageConfig)
-        .apply(result.getLoadedManifestData().getDirectories())
+        .apply(loadManifestsResult.getLoadedManifestData().getDirectories())
         .getCreatedDirectories();
     addHeapInformation(heapInfo, "create.directories");
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestLoadManifestsStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestLoadManifestsStage.java
@@ -133,7 +133,7 @@ public class TestLoadManifestsStage extends AbstractManifestCommitterTest {
         stageConfig);
     entryFile = File.createTempFile("entry", ".seq");
     LoadManifestsStage.Arguments args = new LoadManifestsStage.Arguments(
-        entryFile, false, DEFAULT_WRITER_QUEUE_CAPACITY);
+        entryFile, DEFAULT_WRITER_QUEUE_CAPACITY);
 
     LoadManifestsStage.Result loadManifestsResult = stage.apply(args);
     LoadManifestsStage.SummaryInfo summary = loadManifestsResult.getSummary();
@@ -142,7 +142,6 @@ public class TestLoadManifestsStage extends AbstractManifestCommitterTest {
         ioStatisticsToPrettyString(getStageStatistics()));
     LOG.info("Heap size = {}", heapSize());
     heapinfo(heapInfo, "load.manifests");
-
 
     Assertions.assertThat(summary.getManifestCount())
         .describedAs("Manifest count of  %s", summary)
@@ -193,9 +192,7 @@ public class TestLoadManifestsStage extends AbstractManifestCommitterTest {
     final FileSystem summaryFS = path.getFileSystem(conf);
     success.save(summaryFS, path, true);
     LOG.info("Saved summary to {}", path);
-    ManifestPrinter showManifest = new ManifestPrinter();
-    ManifestSuccessData manifestSuccessData =
-        showManifest.loadAndPrintManifest(summaryFS, path);
+    new ManifestPrinter().loadAndPrintManifest(summaryFS, path);
   }
 
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestRenameStageFailure.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestRenameStageFailure.java
@@ -29,7 +29,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Assume;
 import org.junit.Test;
 
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.fs.CommonPathCapabilities;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -50,6 +50,7 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.verifyFileContents;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertThatStatisticCounter;
 import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsToPrettyString;
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.SUCCESS_MARKER_FILE_LIMIT;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_COMMIT_FILE_RENAME;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterTestSupport.saveManifest;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.ManifestCommitterSupport.getEtag;
@@ -243,7 +244,7 @@ public class TestRenameStageFailure extends AbstractManifestCommitterTest {
     // delete target paths and it works
     try {
       new RenameFilesStage(stageConfig.withDeleteTargetPaths(true))
-          .apply(Pair.of(manifestData, Collections.emptySet()));
+          .apply(Triple.of(manifestData, Collections.emptySet(), SUCCESS_MARKER_FILE_LIMIT));
     } finally {
       manifestData.getEntrySequenceFile().delete();
     }
@@ -365,7 +366,7 @@ public class TestRenameStageFailure extends AbstractManifestCommitterTest {
     E ex;
     try {
       ex = intercept(exceptionClass, errorText, () ->
-          stage.apply(Pair.of(manifestData, Collections.emptySet())));
+          stage.apply(Triple.of(manifestData, Collections.emptySet(), SUCCESS_MARKER_FILE_LIMIT)));
     } finally {
       manifestData.getEntrySequenceFile().delete();
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestRenameStageFailure.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestRenameStageFailure.java
@@ -86,6 +86,9 @@ public class TestRenameStageFailure extends AbstractManifestCommitterTest {
   /** resilient commit expected? */
   private boolean resilientCommit;
 
+  /**
+   * Entry file IO.
+   */
   private EntryFileIO entryFileIO;
 
   protected boolean isResilientCommit() {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/TestEntryFileIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/TestEntryFileIO.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.FileEntry;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+import org.apache.hadoop.util.functional.RemoteIterators;
+
+/**
+ * Test {@link EntryFileIO}.
+ */
+public class TestEntryFileIO extends AbstractHadoopTestBase {
+
+  private EntryFileIO entryFileIO;
+
+  private File entryFile;
+
+  @Before
+  public void setup() throws Exception {
+    entryFileIO = new EntryFileIO(new Configuration());
+  }
+  /**
+   * Teardown.
+   * @throws Exception on any failure
+   */
+  @After
+  public void teardown() throws Exception {
+    Thread.currentThread().setName("teardown");
+    if (entryFile != null) {
+      entryFile.delete();
+    }
+  }
+
+
+  @Test
+  public void testCreateWriteReadFile() throws Throwable {
+    entryFile = File.createTempFile("entry", ".seq");
+    final FileEntry source = new FileEntry("source", "dest", 100, "etag");
+    SequenceFile.Writer writer = entryFileIO.createWriter(entryFile);
+    writer.append(NullWritable.get(), source);
+    writer.flush();
+    writer.close();
+    Assertions.assertThat(entryFile.length())
+        .describedAs("Length of file %s", entryFile)
+        .isGreaterThan(0);
+
+    FileEntry readBack = new FileEntry();
+    try (SequenceFile.Reader reader = entryFileIO.createReader(entryFile)) {
+      reader.next(NullWritable.get(), readBack);
+    }
+    Assertions.assertThat(readBack)
+        .describedAs("entry read back from sequence file")
+        .isEqualTo(source);
+
+    final RemoteIterator<FileEntry> it =
+        entryFileIO.iterateOver(entryFileIO.createReader(entryFile));
+    List<FileEntry> entries = new ArrayList<>();
+    RemoteIterators.foreach(it, entries::add);
+    Assertions.assertThat(entries)
+        .hasSize(1)
+        .element(0)
+        .isEqualTo(source);
+
+  }
+
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/TestEntryFileIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/TestEntryFileIO.java
@@ -193,6 +193,7 @@ public class TestEntryFileIO extends AbstractManifestCommitterTest {
     // now use the iterator to access it.
     List<FileEntry> files = new ArrayList<>();
     Assertions.assertThat(foreach(iterateOverEntryFile(), files::add))
+        .describedAs("Count of iterations over entries in an entry file with no entries")
         .isEqualTo(0);
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/TestEntryFileIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/TestEntryFileIO.java
@@ -19,8 +19,10 @@
 package org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.api.Assertions;
 import org.junit.After;
@@ -33,13 +35,19 @@ import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.FileEntry;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
-import org.apache.hadoop.util.functional.RemoteIterators;
+
+import static org.apache.hadoop.util.functional.RemoteIterators.foreach;
 
 /**
  * Test {@link EntryFileIO}.
  */
 public class TestEntryFileIO extends AbstractHadoopTestBase {
 
+  public static final FileEntry ENTRY = new FileEntry("source", "dest", 100, "etag");
+
+  /**
+   * Entry file instance.
+   */
   private EntryFileIO entryFileIO;
 
   private File entryFile;
@@ -47,7 +55,9 @@ public class TestEntryFileIO extends AbstractHadoopTestBase {
   @Before
   public void setup() throws Exception {
     entryFileIO = new EntryFileIO(new Configuration());
+    createEntryFile();
   }
+
   /**
    * Teardown.
    * @throws Exception on any failure
@@ -55,40 +65,152 @@ public class TestEntryFileIO extends AbstractHadoopTestBase {
   @After
   public void teardown() throws Exception {
     Thread.currentThread().setName("teardown");
-    if (entryFile != null) {
-      entryFile.delete();
+    if (getEntryFile() != null) {
+      getEntryFile().delete();
     }
   }
 
 
+  private void createEntryFile() throws IOException {
+    setEntryFile(File.createTempFile("entry", ".seq"));
+  }
+
+  /**
+   * reference to any temp file created.
+   */
+  private File getEntryFile() {
+    return entryFile;
+  }
+
+  private void setEntryFile(File entryFile) {
+    this.entryFile = entryFile;
+  }
+
+
+  /**
+   * Create a file with one entry
+   */
   @Test
-  public void testCreateWriteReadFile() throws Throwable {
-    entryFile = File.createTempFile("entry", ".seq");
-    final FileEntry source = new FileEntry("source", "dest", 100, "etag");
-    SequenceFile.Writer writer = entryFileIO.createWriter(entryFile);
+  public void testCreateWriteReadFileOneEntry() throws Throwable {
+
+    final FileEntry source = ENTRY;
+
+    // do an explicit close to help isolate any failure.
+    SequenceFile.Writer writer = createWriter();
     writer.append(NullWritable.get(), source);
     writer.flush();
     writer.close();
-    Assertions.assertThat(entryFile.length())
-        .describedAs("Length of file %s", entryFile)
-        .isGreaterThan(0);
 
     FileEntry readBack = new FileEntry();
-    try (SequenceFile.Reader reader = entryFileIO.createReader(entryFile)) {
+    try (SequenceFile.Reader reader = readEntryFile()) {
       reader.next(NullWritable.get(), readBack);
     }
     Assertions.assertThat(readBack)
         .describedAs("entry read back from sequence file")
         .isEqualTo(source);
 
+    // now use the iterator to access it.
     final RemoteIterator<FileEntry> it =
-        entryFileIO.iterateOver(entryFileIO.createReader(entryFile));
-    List<FileEntry> entries = new ArrayList<>();
-    RemoteIterators.foreach(it, entries::add);
-    Assertions.assertThat(entries)
+        iterateOverEntryFile();
+    List<FileEntry> files = new ArrayList<>();
+    foreach(it, files::add);
+    Assertions.assertThat(files)
         .hasSize(1)
         .element(0)
         .isEqualTo(source);
+    final EntryFileIO.EntryIterator et = (EntryFileIO.EntryIterator) it;
+    Assertions.assertThat(et)
+        .describedAs("entry iterator %s", et)
+        .matches(p -> p.isClosed())
+        .extracting(p -> p.getCount())
+        .isEqualTo(1);
+  }
+
+  private SequenceFile.Writer createWriter() throws IOException {
+    return entryFileIO.createWriter(getEntryFile());
+  }
+
+  private RemoteIterator<FileEntry> iterateOverEntryFile() throws IOException {
+    return entryFileIO.iterateOver(readEntryFile());
+  }
+
+  private SequenceFile.Reader readEntryFile() throws IOException {
+    assertEntryFileNonEmpty();
+
+    return entryFileIO.createReader(getEntryFile());
+  }
+
+  /**
+   * Create a file with one entry
+   */
+  @Test
+  public void testCreateEmptyFile() throws Throwable {
+
+    final File file = getEntryFile();
+
+    entryFileIO.createWriter(file).close();
+
+    // now use the iterator to access it.
+    List<FileEntry> files = new ArrayList<>();
+    Assertions.assertThat(foreach(iterateOverEntryFile(), files::add))
+        .isEqualTo(0);
+  }
+
+  private void assertEntryFileNonEmpty() {
+    Assertions.assertThat(getEntryFile().length())
+        .describedAs("Length of file %s", getEntryFile())
+        .isGreaterThan(0);
+  }
+
+  /**
+   * Generate lots of data and write.
+   */
+  @Test
+  public void testLargeStreamingWrite() throws Throwable {
+
+    // list of 100 entries at a time
+    int listSize = 100;
+    // and the number of block writes
+    int writes = 100;
+    List<FileEntry> list = new ArrayList<>(listSize);
+    for (int i = 0; i < listSize; i++) {
+      list.add(new FileEntry("source" + i, "dest" + i, i, "etag-" + i));
+    }
+    // just for debugging/regression testing
+    Assertions.assertThat(list).hasSize(listSize);
+    int total = listSize * writes;
+
+    try (EntryFileIO.EntryWriter out = entryFileIO.launchEntryWriter(createWriter(), 2)) {
+      Assertions.assertThat(out.isActive())
+          .describedAs("out.isActive in ()", out)
+          .isTrue();
+      for (int i = 0; i < writes; i++) {
+        Assertions.assertThat(out.enqueue(list))
+            .describedAs("enqueue of list")
+            .isTrue();
+      }
+      out.close();
+      out.maybeRaiseWriteException();
+      Assertions.assertThat(out.isActive())
+          .describedAs("out.isActive in ()", out)
+          .isFalse();
+
+      Assertions.assertThat(out.getCount())
+          .describedAs("total elements written")
+          .isEqualTo(total);
+    }
+    AtomicInteger count = new AtomicInteger();
+    foreach(iterateOverEntryFile(), e -> {
+      final int elt = count.getAndIncrement();
+      final int index = elt % listSize;
+      Assertions.assertThat(e)
+          .describedAs("element %d in file mapping to index %d", elt, index)
+          .isEqualTo(list.get(index));
+    });
+    Assertions.assertThat(count.get())
+        .describedAs("total elements read")
+        .isEqualTo(total);
+
 
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.fs.s3a.statistics.S3AInputStreamStatistics;
 import org.apache.hadoop.fs.s3a.statistics.StatisticTypeEnum;
 import org.apache.hadoop.fs.s3a.statistics.impl.AbstractS3AStatisticsSource;
 import org.apache.hadoop.fs.s3a.statistics.impl.CountingChangeTracker;
-import org.apache.hadoop.fs.s3a.statistics.impl.ForwardingIOStatisticsStore;
+import org.apache.hadoop.fs.statistics.impl.ForwardingIOStatisticsStore;
 import org.apache.hadoop.fs.statistics.DurationTrackerFactory;
 import org.apache.hadoop.fs.statistics.IOStatisticsLogging;
 import org.apache.hadoop.fs.statistics.IOStatisticsSource;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/commit/AbfsManifestStoreOperations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/commit/AbfsManifestStoreOperations.java
@@ -62,6 +62,11 @@ public class AbfsManifestStoreOperations extends
    */
   private ResilientCommitByRename resilientCommitByRename;
 
+  /**
+   * Are etags preserved in renames?
+   */
+  private boolean etagsPreserved;
+
   @Override
   public AzureBlobFileSystem getFileSystem() {
     return (AzureBlobFileSystem) super.getFileSystem();
@@ -83,15 +88,22 @@ public class AbfsManifestStoreOperations extends
     super.bindToFileSystem(filesystem, path);
     try {
       resilientCommitByRename = getFileSystem().createResilientCommitSupport(path);
+      // this also means that etags are preserved.
+      etagsPreserved = true;
       LOG.debug("Bonded to filesystem with resilient commits under path {}", path);
     } catch (UnsupportedOperationException e) {
       LOG.debug("No resilient commit support under path {}", path);
     }
   }
 
+  /**
+   * Etags are preserved through Gen2 stores, but not wasb stores.
+   * @param path path to probe.
+   * @return true if this store preserves etags.
+   */
   @Override
   public boolean storePreservesEtagsThroughRenames(final Path path) {
-    return true;
+    return etagsPreserved;
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/AbfsCommitTestHelper.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/AbfsCommitTestHelper.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.azurebfs.commit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.azurebfs.contract.ABFSContractTestBinding;
+import org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants;
 
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_READ_SMALL_FILES_COMPLETELY;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.OPT_STORE_OPERATIONS_CLASS;
@@ -46,6 +47,13 @@ final class AbfsCommitTestHelper {
         AbfsManifestStoreOperations.NAME);
     // turn on small file read if not explicitly set to a value.
     conf.setBooleanIfUnset(AZURE_READ_SMALL_FILES_COMPLETELY, true);
+    // use a larger thread pool to compensate for latencies
+    final String size = Integer.toString(192);
+    conf.setIfUnset(ManifestCommitterConstants.OPT_IO_PROCESSORS, size);
+    conf.setIfUnset(ManifestCommitterConstants.OPT_WRITER_QUEUE_CAPACITY, size);
+    // no need for parallel delete here as we aren't at the scale where unified delete
+    // is going to time out
+    conf.setBooleanIfUnset(ManifestCommitterConstants.OPT_CLEANUP_PARALLEL_DELETE, false);
 
     return conf;
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/AbfsCommitTestHelper.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/AbfsCommitTestHelper.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.azurebfs.commit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.azurebfs.contract.ABFSContractTestBinding;
 
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_READ_SMALL_FILES_COMPLETELY;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.OPT_STORE_OPERATIONS_CLASS;
 
 /**
@@ -43,6 +44,8 @@ final class AbfsCommitTestHelper {
     // use ABFS Store operations
     conf.set(OPT_STORE_OPERATIONS_CLASS,
         AbfsManifestStoreOperations.NAME);
+    // turn on small file read if not explicitly set to a value.
+    conf.setBooleanIfUnset(AZURE_READ_SMALL_FILES_COMPLETELY, true);
 
     return conf;
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsLoadManifestsStage.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsLoadManifestsStage.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.azure.integration.AzureTestConstants;
 import org.apache.hadoop.fs.azurebfs.contract.ABFSContractTestBinding;
 import org.apache.hadoop.fs.azurebfs.contract.AbfsFileSystemContract;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterTestSupport;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.TestLoadManifestsStage;
 
 /**
@@ -58,4 +59,11 @@ public class ITestAbfsLoadManifestsStage extends TestLoadManifestsStage {
     return AzureTestConstants.SCALE_TEST_TIMEOUT_MILLIS;
   }
 
+  /**
+   * @return a smaller number of TAs than the base test suite does.
+   */
+  @Override
+  protected int numberOfTaskAttempts() {
+    return ManifestCommitterTestSupport.NUMBER_OF_TASK_ATTEMPTS_SMALL;
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsLoadManifestsStage.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsLoadManifestsStage.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.fs.azurebfs.commit;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.azure.integration.AzureTestConstants;
 import org.apache.hadoop.fs.azurebfs.contract.ABFSContractTestBinding;
 import org.apache.hadoop.fs.azurebfs.contract.AbfsFileSystemContract;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
@@ -50,6 +51,11 @@ public class ITestAbfsLoadManifestsStage extends TestLoadManifestsStage {
   @Override
   protected AbstractFSContract createContract(final Configuration conf) {
     return new AbfsFileSystemContract(conf, binding.isSecureMode());
+  }
+
+  @Override
+  protected int getTestTimeoutMillis() {
+    return AzureTestConstants.SCALE_TEST_TIMEOUT_MILLIS;
   }
 
 }


### PR DESCRIPTION

* Add heap information to gauges in _SUCCESS
* which includes pulling up part of impl.IOStatisticsStore into a public IOStatisticsSetters interface with the put{Counter, Gauge, etc} methods only.
* TestLoadManifests scaled up with #of tasks and #of files in each task to generate more load.

Summary: abfs uses a lot more heap during the load phase than file; possibly due to buffering.

### How was this patch tested?

* modified existing tests
* azure tests in progress

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

