### PR TITLE
HDFS-16970. EC: client copy wrong buffer from decode output during pread

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/StripedBlockUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/StripedBlockUtil.java
@@ -915,6 +915,7 @@ public class StripedBlockUtil {
       ByteBuffer tmp;
       int len;
       for (ByteBuffer slice : slices) {
+        src.position(src.position() + slice.position());
         len = slice.remaining();
         tmp = src.duplicate();
         tmp.limit(tmp.position() + len);


### PR DESCRIPTION
### Description of PR
When dfsStripedInputStream do pread from a striped block group and read internal block timeout, so will read parity block for decode and fill original chunk buffer with decoded data.
Here try to fill original chunk buffer with decoded data, but get wrong data. 
The reason is that
1.original chunk buffer already read some bytes before timeout from blockReader 
2.chunkBytebuffer's slice always fill begin 0 position of decodeByteBuffer 
slice bytebuffer will fill from wrong decodeByteBuffer position, so will get wrong data from pread.