### PR TITLE
HDFS-16973. RBF: MountTableResolver cache size lookup should take read lock

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
@@ -678,11 +678,16 @@ public class MountTableResolver
    * @return Size of the cache.
    * @throws IOException If the cache is not initialized.
    */
-  protected long getCacheSize() throws IOException{
-    if (this.locationCache != null) {
-      return this.locationCache.size();
+  protected long getCacheSize() throws IOException {
+    this.readLock.lock();
+    try {
+      if (this.locationCache != null) {
+        return this.locationCache.size();
+      }
+      throw new IOException("localCache is null");
+    } finally {
+      this.readLock.unlock();
     }
-    throw new IOException("localCache is null");
   }
 
   @VisibleForTesting

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestMountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestMountTableResolver.java
@@ -552,6 +552,10 @@ public class TestMountTableResolver {
 
     assertEquals(100000, mountTable.getMountPoints("/").size());
     assertEquals(100000, mountTable.getMounts("/").size());
+    for (int i = 0; i < 20; i++) {
+      mountTable.getDestinationForPath("/" + i);
+    }
+    assertEquals(TEST_MAX_CACHE_SIZE, mountTable.getCacheSize());
 
     // Add 1000 entries in deep list
     mountTable.refreshEntries(emptyList);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestMountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestMountTableResolver.java
@@ -552,8 +552,14 @@ public class TestMountTableResolver {
 
     assertEquals(100000, mountTable.getMountPoints("/").size());
     assertEquals(100000, mountTable.getMounts("/").size());
+    // test concurrency for mount table cache size when it gets updated frequently
     for (int i = 0; i < 20; i++) {
       mountTable.getDestinationForPath("/" + i);
+      if (i >= 10) {
+        assertEquals(TEST_MAX_CACHE_SIZE, mountTable.getCacheSize());
+      } else {
+        assertEquals(i + 1, mountTable.getCacheSize());
+      }
     }
     assertEquals(TEST_MAX_CACHE_SIZE, mountTable.getCacheSize());
 


### PR DESCRIPTION
Mount table resolver location cache gets invalidated by taking write lock as part of addEntry/removeEntry/refreshEntries calls. Since the write lock exclusively updates the cache, getDestinationForPath already takes read lock before accessing the cache. Similarly, retrieval of the cache size should also take the read lock.