### PR TITLE
[HDFS-16971] Add read metrics for remote reads in FileSystem Statistics #5534

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4266,7 +4266,7 @@ public abstract class FileSystem extends Configured
     public void increaseRemoteBytesReadTime(long duration) {
       getThreadStatistics().remoteBytesReadTime += duration;
     }
-    
+
     /**
      * Apply the given aggregator to all StatisticsData objects associated with
      * this Statistics object.
@@ -4413,7 +4413,7 @@ public abstract class FileSystem extends Configured
       }
       return bytesRead;
     }
-    
+
     /**
      * Get total time taken for bytes read from remote.
      * @return time taken for remote bytes read.
@@ -4432,7 +4432,7 @@ public abstract class FileSystem extends Configured
         }
       });
     }
-    
+
     /**
      * Get all statistics data.
      * MR or other frameworks can use the method to get all statistics at once.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -3942,7 +3942,7 @@ public abstract class FileSystem extends Configured
       private volatile long bytesReadDistanceOfThreeOrFour;
       private volatile long bytesReadDistanceOfFiveOrLarger;
       private volatile long bytesReadErasureCoded;
-      private volatile long remoteBytesReadTime;
+      private volatile long remoteBytesReadTimeMS;
 
       /**
        * Add another StatisticsData object to this one.
@@ -3960,7 +3960,7 @@ public abstract class FileSystem extends Configured
         this.bytesReadDistanceOfFiveOrLarger +=
             other.bytesReadDistanceOfFiveOrLarger;
         this.bytesReadErasureCoded += other.bytesReadErasureCoded;
-        this.remoteBytesReadTime += other.remoteBytesReadTime;
+        this.remoteBytesReadTimeMS += other.remoteBytesReadTimeMS;
       }
 
       /**
@@ -3979,7 +3979,7 @@ public abstract class FileSystem extends Configured
         this.bytesReadDistanceOfFiveOrLarger =
             -this.bytesReadDistanceOfFiveOrLarger;
         this.bytesReadErasureCoded = -this.bytesReadErasureCoded;
-        this.remoteBytesReadTime = -this.remoteBytesReadTime;
+        this.remoteBytesReadTimeMS = -this.remoteBytesReadTimeMS;
       }
 
       @Override
@@ -4029,8 +4029,8 @@ public abstract class FileSystem extends Configured
         return bytesReadErasureCoded;
       }
 
-      public long getRemoteBytesReadTime() {
-        return remoteBytesReadTime;
+      public long getRemoteBytesReadTimeMS() {
+        return remoteBytesReadTimeMS;
       }
     }
 
@@ -4261,10 +4261,10 @@ public abstract class FileSystem extends Configured
 
     /**
      * Increment the time taken to read bytes from remote in the statistics.
-     * @param duration time taken to read bytes from remote
+     * @param duration time taken in ms to read bytes from remote
      */
     public void increaseRemoteBytesReadTime(long duration) {
-      getThreadStatistics().remoteBytesReadTime += duration;
+      getThreadStatistics().remoteBytesReadTimeMS += duration;
     }
 
     /**
@@ -4415,20 +4415,20 @@ public abstract class FileSystem extends Configured
     }
 
     /**
-     * Get total time taken for bytes read from remote.
-     * @return time taken for remote bytes read.
+     * Get total time taken in ms for bytes read from remote.
+     * @return time taken in ms for remote bytes read.
      */
     public long getRemoteBytesReadTime() {
       return visitAll(new StatisticsAggregator<Long>() {
-        private long remoteBytesReadTime = 0;
+        private long remoteBytesReadTimeMS = 0;
 
         @Override
         public void accept(StatisticsData data) {
-          remoteBytesReadTime += data.remoteBytesReadTime;
+          remoteBytesReadTimeMS += data.remoteBytesReadTimeMS;
         }
 
         public Long aggregate() {
-          return remoteBytesReadTime;
+          return remoteBytesReadTimeMS;
         }
       });
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -3942,7 +3942,7 @@ public abstract class FileSystem extends Configured
       private volatile long bytesReadDistanceOfThreeOrFour;
       private volatile long bytesReadDistanceOfFiveOrLarger;
       private volatile long bytesReadErasureCoded;
-      private volatile long remoteBytesReadTimeMS;
+      private volatile long remoteReadTimeMS;
 
       /**
        * Add another StatisticsData object to this one.
@@ -3960,7 +3960,7 @@ public abstract class FileSystem extends Configured
         this.bytesReadDistanceOfFiveOrLarger +=
             other.bytesReadDistanceOfFiveOrLarger;
         this.bytesReadErasureCoded += other.bytesReadErasureCoded;
-        this.remoteBytesReadTimeMS += other.remoteBytesReadTimeMS;
+        this.remoteReadTimeMS += other.remoteReadTimeMS;
       }
 
       /**
@@ -3979,7 +3979,7 @@ public abstract class FileSystem extends Configured
         this.bytesReadDistanceOfFiveOrLarger =
             -this.bytesReadDistanceOfFiveOrLarger;
         this.bytesReadErasureCoded = -this.bytesReadErasureCoded;
-        this.remoteBytesReadTimeMS = -this.remoteBytesReadTimeMS;
+        this.remoteReadTimeMS = -this.remoteReadTimeMS;
       }
 
       @Override
@@ -4029,8 +4029,8 @@ public abstract class FileSystem extends Configured
         return bytesReadErasureCoded;
       }
 
-      public long getRemoteBytesReadTimeMS() {
-        return remoteBytesReadTimeMS;
+      public long getRemoteReadTimeMS() {
+        return remoteReadTimeMS;
       }
     }
 
@@ -4261,10 +4261,10 @@ public abstract class FileSystem extends Configured
 
     /**
      * Increment the time taken to read bytes from remote in the statistics.
-     * @param duration time taken in ms to read bytes from remote
+     * @param durationMS time taken in ms to read bytes from remote
      */
-    public void increaseRemoteBytesReadTime(long duration) {
-      getThreadStatistics().remoteBytesReadTimeMS += duration;
+    public void increaseRemoteReadTime(final long durationMS) {
+      getThreadStatistics().remoteReadTimeMS += durationMS;
     }
 
     /**
@@ -4418,17 +4418,17 @@ public abstract class FileSystem extends Configured
      * Get total time taken in ms for bytes read from remote.
      * @return time taken in ms for remote bytes read.
      */
-    public long getRemoteBytesReadTime() {
+    public long getRemoteReadTime() {
       return visitAll(new StatisticsAggregator<Long>() {
-        private long remoteBytesReadTimeMS = 0;
+        private long remoteReadTimeMS = 0;
 
         @Override
         public void accept(StatisticsData data) {
-          remoteBytesReadTimeMS += data.remoteBytesReadTimeMS;
+          remoteReadTimeMS += data.remoteReadTimeMS;
         }
 
         public Long aggregate() {
-          return remoteBytesReadTimeMS;
+          return remoteReadTimeMS;
         }
       });
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystemStorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystemStorageStatistics.java
@@ -48,7 +48,7 @@ public class FileSystemStorageStatistics extends StorageStatistics {
       "bytesReadDistanceOfThreeOrFour",
       "bytesReadDistanceOfFiveOrLarger",
       "bytesReadErasureCoded",
-      "remoteBytesReadTime"
+      "remoteBytesReadTimeMS"
   };
 
   private static class LongStatisticIterator
@@ -108,7 +108,7 @@ public class FileSystemStorageStatistics extends StorageStatistics {
       return data.getBytesReadDistanceOfFiveOrLarger();
     case "bytesReadErasureCoded":
       return data.getBytesReadErasureCoded();
-    case "remoteBytesReadTime":
+    case "remoteBytesReadTimeMS":
       return data.getRemoteBytesReadTimeMS();
     default:
       return null;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystemStorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystemStorageStatistics.java
@@ -109,7 +109,7 @@ public class FileSystemStorageStatistics extends StorageStatistics {
     case "bytesReadErasureCoded":
       return data.getBytesReadErasureCoded();
     case "remoteBytesReadTime":
-      return data.getRemoteBytesReadTime();
+      return data.getRemoteBytesReadTimeMS();
     default:
       return null;
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystemStorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystemStorageStatistics.java
@@ -48,7 +48,7 @@ public class FileSystemStorageStatistics extends StorageStatistics {
       "bytesReadDistanceOfThreeOrFour",
       "bytesReadDistanceOfFiveOrLarger",
       "bytesReadErasureCoded",
-      "remoteBytesReadTimeMS"
+      "remoteReadTimeMS"
   };
 
   private static class LongStatisticIterator
@@ -108,8 +108,8 @@ public class FileSystemStorageStatistics extends StorageStatistics {
       return data.getBytesReadDistanceOfFiveOrLarger();
     case "bytesReadErasureCoded":
       return data.getBytesReadErasureCoded();
-    case "remoteBytesReadTimeMS":
-      return data.getRemoteBytesReadTimeMS();
+    case "remoteReadTimeMS":
+      return data.getRemoteReadTimeMS();
     default:
       return null;
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystemStorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystemStorageStatistics.java
@@ -47,7 +47,8 @@ public class FileSystemStorageStatistics extends StorageStatistics {
       "bytesReadDistanceOfOneOrTwo",
       "bytesReadDistanceOfThreeOrFour",
       "bytesReadDistanceOfFiveOrLarger",
-      "bytesReadErasureCoded"
+      "bytesReadErasureCoded",
+      "remoteBytesReadTime"
   };
 
   private static class LongStatisticIterator
@@ -107,6 +108,8 @@ public class FileSystemStorageStatistics extends StorageStatistics {
       return data.getBytesReadDistanceOfFiveOrLarger();
     case "bytesReadErasureCoded":
       return data.getBytesReadErasureCoded();
+    case "remoteBytesReadTime":
+      return data.getRemoteBytesReadTime();
     default:
       return null;
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileSystemStorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileSystemStorageStatistics.java
@@ -53,7 +53,7 @@ public class TestFileSystemStorageStatistics {
       "bytesReadDistanceOfThreeOrFour",
       "bytesReadDistanceOfFiveOrLarger",
       "bytesReadErasureCoded",
-      "remoteBytesReadTime"
+      "remoteBytesReadTimeMS"
   };
 
   private FileSystem.Statistics statistics =
@@ -130,7 +130,7 @@ public class TestFileSystemStorageStatistics {
       return statistics.getBytesReadByDistance(5);
     case "bytesReadErasureCoded":
       return statistics.getBytesReadErasureCoded();
-    case "remoteBytesReadTime":
+    case "remoteBytesReadTimeMS":
       return statistics.getRemoteBytesReadTime();
     default:
       return 0;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileSystemStorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileSystemStorageStatistics.java
@@ -52,7 +52,8 @@ public class TestFileSystemStorageStatistics {
       "bytesReadDistanceOfOneOrTwo",
       "bytesReadDistanceOfThreeOrFour",
       "bytesReadDistanceOfFiveOrLarger",
-      "bytesReadErasureCoded"
+      "bytesReadErasureCoded",
+      "remoteBytesReadTime"
   };
 
   private FileSystem.Statistics statistics =
@@ -74,6 +75,7 @@ public class TestFileSystemStorageStatistics {
     statistics.incrementBytesReadByDistance(1, RandomUtils.nextInt(0, 100));
     statistics.incrementBytesReadByDistance(3, RandomUtils.nextInt(0, 100));
     statistics.incrementBytesReadErasureCoded(RandomUtils.nextInt(0, 100));
+    statistics.increaseRemoteBytesReadTime(RandomUtils.nextInt(0, 100));
   }
 
   @Test
@@ -128,6 +130,8 @@ public class TestFileSystemStorageStatistics {
       return statistics.getBytesReadByDistance(5);
     case "bytesReadErasureCoded":
       return statistics.getBytesReadErasureCoded();
+    case "remoteBytesReadTime":
+      return statistics.getRemoteBytesReadTime();
     default:
       return 0;
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileSystemStorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileSystemStorageStatistics.java
@@ -53,7 +53,7 @@ public class TestFileSystemStorageStatistics {
       "bytesReadDistanceOfThreeOrFour",
       "bytesReadDistanceOfFiveOrLarger",
       "bytesReadErasureCoded",
-      "remoteBytesReadTimeMS"
+      "remoteReadTimeMS"
   };
 
   private FileSystem.Statistics statistics =
@@ -75,7 +75,7 @@ public class TestFileSystemStorageStatistics {
     statistics.incrementBytesReadByDistance(1, RandomUtils.nextInt(0, 100));
     statistics.incrementBytesReadByDistance(3, RandomUtils.nextInt(0, 100));
     statistics.incrementBytesReadErasureCoded(RandomUtils.nextInt(0, 100));
-    statistics.increaseRemoteBytesReadTime(RandomUtils.nextInt(0, 100));
+    statistics.increaseRemoteReadTime(RandomUtils.nextInt(0, 100));
   }
 
   @Test
@@ -130,8 +130,8 @@ public class TestFileSystemStorageStatistics {
       return statistics.getBytesReadByDistance(5);
     case "bytesReadErasureCoded":
       return statistics.getBytesReadErasureCoded();
-    case "remoteBytesReadTimeMS":
-      return statistics.getRemoteBytesReadTime();
+    case "remoteReadTimeMS":
+      return statistics.getRemoteReadTime();
     default:
       return 0;
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -3090,13 +3090,13 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
     }
   }
 
-  void updateFileSystemReadStats(int distance, int nRead, long readTimeMS) {
+  void updateFileSystemReadStats(int distance, int readBytes, long readTimeMS) {
     if (stats != null) {
-      stats.incrementBytesRead(nRead);
-      stats.incrementBytesReadByDistance(distance, nRead);
+      stats.incrementBytesRead(readBytes);
+      stats.incrementBytesReadByDistance(distance, readBytes);
       if (distance > 0) {
         //remote read
-        stats.increaseRemoteBytesReadTime(readTimeMS);
+        stats.increaseRemoteReadTime(readTimeMS);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -3090,13 +3090,13 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
     }
   }
 
-  void updateFileSystemReadStats(int distance, int nRead, long duration) {
+  void updateFileSystemReadStats(int distance, int nRead, long readTimeMS) {
     if (stats != null) {
       stats.incrementBytesRead(nRead);
       stats.incrementBytesReadByDistance(distance, nRead);
       if (distance > 0) {
         //remote read
-        stats.increaseRemoteBytesReadTime(duration);
+        stats.increaseRemoteBytesReadTime(readTimeMS);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -3090,10 +3090,14 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
     }
   }
 
-  void updateFileSystemReadStats(int distance, int nRead) {
+  void updateFileSystemReadStats(int distance, int nRead, long duration) {
     if (stats != null) {
       stats.incrementBytesRead(nRead);
       stats.incrementBytesReadByDistance(distance, nRead);
+      if (distance > 0) {
+        //remote read
+        stats.increaseRemoteBytesReadTime(duration);
+      }
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -851,8 +851,9 @@ public class DFSInputStream extends FSInputStream
                   locatedBlocks.getFileLength() - pos);
             }
           }
+          long beginRead = Time.monotonicNow();
           int result = readBuffer(strategy, realLen, corruptedBlocks);
-
+          long duration = Time.monotonicNow() - beginRead;
           if (result >= 0) {
             pos += result;
           } else {
@@ -861,7 +862,7 @@ public class DFSInputStream extends FSInputStream
           }
           updateReadStatistics(readStatistics, result, blockReader);
           dfsClient.updateFileSystemReadStats(blockReader.getNetworkDistance(),
-              result);
+              result, duration);
           if (readStatistics.getBlockType() == BlockType.STRIPED) {
             dfsClient.updateFileSystemECReadStats(result);
           }
@@ -1184,6 +1185,7 @@ public class DFSInputStream extends FSInputStream
         ByteBuffer tmp = buf.duplicate();
         tmp.limit(tmp.position() + len);
         tmp = tmp.slice();
+        long beginRead = Time.monotonicNow();
         int nread = 0;
         int ret;
         while (true) {
@@ -1193,11 +1195,12 @@ public class DFSInputStream extends FSInputStream
           }
           nread += ret;
         }
+        long duration = Time.monotonicNow() - beginRead;
         buf.position(buf.position() + nread);
 
         IOUtilsClient.updateReadStatistics(readStatistics, nread, reader);
         dfsClient.updateFileSystemReadStats(
-            reader.getNetworkDistance(), nread);
+            reader.getNetworkDistance(), nread, duration);
         if (readStatistics.getBlockType() == BlockType.STRIPED) {
           dfsClient.updateFileSystemECReadStats(nread);
         }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -853,7 +853,7 @@ public class DFSInputStream extends FSInputStream
           }
           long beginRead = Time.monotonicNow();
           int result = readBuffer(strategy, realLen, corruptedBlocks);
-          long duration = Time.monotonicNow() - beginRead;
+          long readTimeMS = Time.monotonicNow() - beginRead;
           if (result >= 0) {
             pos += result;
           } else {
@@ -862,7 +862,7 @@ public class DFSInputStream extends FSInputStream
           }
           updateReadStatistics(readStatistics, result, blockReader);
           dfsClient.updateFileSystemReadStats(blockReader.getNetworkDistance(),
-              result, duration);
+              result, readTimeMS);
           if (readStatistics.getBlockType() == BlockType.STRIPED) {
             dfsClient.updateFileSystemECReadStats(result);
           }
@@ -1195,12 +1195,12 @@ public class DFSInputStream extends FSInputStream
           }
           nread += ret;
         }
-        long duration = Time.monotonicNow() - beginRead;
+        long readTimeMS = Time.monotonicNow() - beginRead;
         buf.position(buf.position() + nread);
 
         IOUtilsClient.updateReadStatistics(readStatistics, nread, reader);
         dfsClient.updateFileSystemReadStats(
-            reader.getNetworkDistance(), nread, duration);
+            reader.getNetworkDistance(), nread, readTimeMS);
         if (readStatistics.getBlockType() == BlockType.STRIPED) {
           dfsClient.updateFileSystemECReadStats(nread);
         }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -851,9 +851,9 @@ public class DFSInputStream extends FSInputStream
                   locatedBlocks.getFileLength() - pos);
             }
           }
-          long beginRead = Time.monotonicNow();
+          long beginReadMS = Time.monotonicNow();
           int result = readBuffer(strategy, realLen, corruptedBlocks);
-          long readTimeMS = Time.monotonicNow() - beginRead;
+          long readTimeMS = Time.monotonicNow() - beginReadMS;
           if (result >= 0) {
             pos += result;
           } else {
@@ -1185,7 +1185,7 @@ public class DFSInputStream extends FSInputStream
         ByteBuffer tmp = buf.duplicate();
         tmp.limit(tmp.position() + len);
         tmp = tmp.slice();
-        long beginRead = Time.monotonicNow();
+        long beginReadMS = Time.monotonicNow();
         int nread = 0;
         int ret;
         while (true) {
@@ -1195,7 +1195,7 @@ public class DFSInputStream extends FSInputStream
           }
           nread += ret;
         }
-        long readTimeMS = Time.monotonicNow() - beginRead;
+        long readTimeMS = Time.monotonicNow() - beginReadMS;
         buf.position(buf.position() + nread);
 
         IOUtilsClient.updateReadStatistics(readStatistics, nread, reader);

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
@@ -331,8 +331,8 @@ public class DFSStripedInputStream extends DFSInputStream {
    * its ThreadLocal.
    *
    * @param stats striped read stats
-   * @param duration read time metrics             
-   *              
+   * @param duration read time metrics
+   *
    */
   void updateReadStats(final StripedBlockUtil.BlockReadStats stats, long duration) {
     if (stats == null) {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
@@ -331,17 +331,17 @@ public class DFSStripedInputStream extends DFSInputStream {
    * its ThreadLocal.
    *
    * @param stats striped read stats
-   * @param duration read time metrics
+   * @param readTimeMS read time metrics in ms
    *
    */
-  void updateReadStats(final StripedBlockUtil.BlockReadStats stats, long duration) {
+  void updateReadStats(final StripedBlockUtil.BlockReadStats stats, long readTimeMS) {
     if (stats == null) {
       return;
     }
     updateReadStatistics(readStatistics, stats.getBytesRead(),
         stats.isShortCircuit(), stats.getNetworkDistance());
     dfsClient.updateFileSystemReadStats(stats.getNetworkDistance(),
-        stats.getBytesRead(), duration);
+        stats.getBytesRead(), readTimeMS);
     assert readStatistics.getBlockType() == BlockType.STRIPED;
     dfsClient.updateFileSystemECReadStats(stats.getBytesRead());
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
@@ -331,15 +331,17 @@ public class DFSStripedInputStream extends DFSInputStream {
    * its ThreadLocal.
    *
    * @param stats striped read stats
+   * @param duration read time metrics             
+   *              
    */
-  void updateReadStats(final StripedBlockUtil.BlockReadStats stats) {
+  void updateReadStats(final StripedBlockUtil.BlockReadStats stats, long duration) {
     if (stats == null) {
       return;
     }
     updateReadStatistics(readStatistics, stats.getBytesRead(),
         stats.isShortCircuit(), stats.getNetworkDistance());
     dfsClient.updateFileSystemReadStats(stats.getNetworkDistance(),
-        stats.getBytesRead());
+        stats.getBytesRead(), duration);
     assert readStatistics.getBlockType() == BlockType.STRIPED;
     dfsClient.updateFileSystemECReadStats(stats.getBytesRead());
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
@@ -354,9 +354,9 @@ abstract class StripeReader {
         long beginRead = Time.monotonicNow();
         StripingChunkReadResult r = StripedBlockUtil
             .getNextCompletedStripedRead(service, futures, 0);
-        long duration = Time.monotonicNow() - beginRead;
+        long readTimeMS = Time.monotonicNow() - beginRead;
 
-        dfsStripedInputStream.updateReadStats(r.getReadStats(), duration);
+        dfsStripedInputStream.updateReadStats(r.getReadStats(), readTimeMS);
         DFSClient.LOG.debug("Read task returned: {}, for stripe {}",
             r, alignedStripe);
         StripingChunk returnedChunk = alignedStripe.chunks[r.index];

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
@@ -351,10 +351,10 @@ abstract class StripeReader {
     // first read failure
     while (!futures.isEmpty()) {
       try {
-        long beginRead = Time.monotonicNow();
+        long beginReadMS = Time.monotonicNow();
         StripingChunkReadResult r = StripedBlockUtil
             .getNextCompletedStripedRead(service, futures, 0);
-        long readTimeMS = Time.monotonicNow() - beginRead;
+        long readTimeMS = Time.monotonicNow() - beginReadMS;
 
         dfsStripedInputStream.updateReadStats(r.getReadStats(), readTimeMS);
         DFSClient.LOG.debug("Read task returned: {}, for stripe {}",

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
@@ -351,9 +351,12 @@ abstract class StripeReader {
     // first read failure
     while (!futures.isEmpty()) {
       try {
+        long beginRead = Time.monotonicNow();
         StripingChunkReadResult r = StripedBlockUtil
             .getNextCompletedStripedRead(service, futures, 0);
-        dfsStripedInputStream.updateReadStats(r.getReadStats());
+        long duration = Time.monotonicNow() - beginRead;
+
+        dfsStripedInputStream.updateReadStats(r.getReadStats(), duration);
         DFSClient.LOG.debug("Read task returned: {}, for stripe {}",
             r, alignedStripe);
         StripingChunk returnedChunk = alignedStripe.chunks[r.index];


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
In Filesystem.java, currently it only collects bytes read not the corresponding timing of reads.
In particular, we're interested in time spent on remote reads(not local reads). Adding timing info will help us understand it better and further analyze how locality of DN behaves.

### How was this patch tested?
Ran hadoop-common and hadoop-hdsf related unit tests locally with and without the change.


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

