### PR TITLE
HADOOP-18694. Client.Connection#updateAddress needs to ensure that address is resolved before updating

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -590,7 +590,7 @@ public class Client implements AutoCloseable {
       InetSocketAddress currentAddr = NetUtils.createSocketAddrForHost(
                                server.getHostName(), server.getPort());
 
-      if (!server.equals(currentAddr)) {
+      if (!currentAddr.isUnresolved() && !server.equals(currentAddr)) {
         LOG.warn("Address change detected. Old: " + server.toString() +
                                  " New: " + currentAddr.toString());
         server = currentAddr;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -591,8 +591,7 @@ public class Client implements AutoCloseable {
                                server.getHostName(), server.getPort());
 
       if (!currentAddr.isUnresolved() && !server.equals(currentAddr)) {
-        LOG.warn("Address change detected. Old: " + server.toString() +
-                                 " New: " + currentAddr.toString());
+        LOG.warn("Address change detected. Old: {} New: {}", server, currentAddr);
         server = currentAddr;
         // Update the remote address so that reconnections are with the updated address.
         // This avoids thrashing.


### PR DESCRIPTION
### Description of PR
When `Client.Connection#setupConnection` encounters an `IOException`, it will try to update the server address. ([HADOOP-18365](https://issues.apache.org/jira/browse/HADOOP-18365))

When the address is re-parsed, it may be an unresolved address (`UnknownHostException`), which causes `Client.Connection#setupConnection` to fail to reconnect.

```java
while (true) {
  try {
    if (server.isUnresolved()) { 
```

Especially when DN is connected to NN, `BPServiceActor#bpNamenode` is only initialized once, which causes DN to never connect to NN before restarting.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

