### PR TITLE
hdfs auditlog add remote port info

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/AuditLogger.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/AuditLogger.java
@@ -45,16 +45,17 @@ public interface AuditLogger {
    * in a critical section of the NameNode's operation.
    *
    * @param succeeded Whether authorization succeeded.
-   * @param userName Name of the user executing the request.
-   * @param addr Remote address of the request.
-   * @param cmd The requested command.
-   * @param src Path of affected source file.
-   * @param dst Path of affected destination file (if any).
-   * @param stat File information for operations that change the file's
-   *             metadata (permissions, owner, times, etc).
+   * @param userName  Name of the user executing the request.
+   * @param addr      Remote address of the request.
+   * @param port      Remote port.
+   * @param cmd       The requested command.
+   * @param src       Path of affected source file.
+   * @param dst       Path of affected destination file (if any).
+   * @param stat      File information for operations that change the file's
+   *                  metadata (permissions, owner, times, etc).
    */
   void logAuditEvent(boolean succeeded, String userName,
-      InetAddress addr, String cmd, String src, String dst,
+      InetAddress addr, int port, String cmd, String src, String dst,
       FileStatus stat);
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/DefaultAuditLogger.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/DefaultAuditLogger.java
@@ -82,11 +82,11 @@ public abstract class DefaultAuditLogger extends HdfsAuditLogger {
   public abstract void logAuditMessage(String message);
 
   public abstract void logAuditEvent(boolean succeeded, String userName,
-      InetAddress addr, String cmd, String src, String dst, FileStatus status,
+      InetAddress addr, int port, String cmd, String src, String dst, FileStatus status,
       UserGroupInformation ugi, DelegationTokenSecretManager dtSecretManager);
 
   public abstract void logAuditEvent(boolean succeeded, String userName,
-      InetAddress addr, String cmd, String src, String dst, FileStatus status,
+      InetAddress addr, int port, String cmd, String src, String dst, FileStatus status,
       CallerContext callerContext, UserGroupInformation ugi,
       DelegationTokenSecretManager dtSecretManager);
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FsckServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FsckServlet.java
@@ -50,6 +50,7 @@ public class FsckServlet extends DfsServlet {
     final PrintWriter out = response.getWriter();
     final InetAddress remoteAddress =
       InetAddress.getByName(request.getRemoteAddr());
+    final int remotePort = request.getRemotePort();
     final ServletContext context = getServletContext();
     final Configuration conf = NameNodeHttpServer.getConfFromContext(context);
 
@@ -71,7 +72,7 @@ public class FsckServlet extends DfsServlet {
           fsck.fsck();
           success = true;
         } finally {
-          namesystem.logFsckEvent(success, auditSource, remoteAddress);
+          namesystem.logFsckEvent(success, auditSource, remoteAddress, remotePort);
         }
         return null;
       });

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/HdfsAuditLogger.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/HdfsAuditLogger.java
@@ -35,45 +35,43 @@ public abstract class HdfsAuditLogger implements AuditLogger {
 
   @Override
   public void logAuditEvent(boolean succeeded, String userName,
-      InetAddress addr, String cmd, String src, String dst,
+      InetAddress addr, int port, String cmd, String src, String dst,
       FileStatus status) {
-    logAuditEvent(succeeded, userName, addr, cmd, src, dst, status,
+    logAuditEvent(succeeded, userName, addr, port, cmd, src, dst, status,
         null /*callerContext*/, null /*ugi*/, null /*dtSecretManager*/);
   }
 
   /**
    * Same as
-   * {@link #logAuditEvent(boolean, String, InetAddress, String, String, String,
-   * FileStatus)} with additional parameters related to logging delegation token
+   * {@link AuditLogger#logAuditEvent(boolean, String, InetAddress, int, String, String, String, FileStatus)} with additional parameters related to logging delegation token
    * tracking IDs.
-   * 
-   * @param succeeded Whether authorization succeeded.
-   * @param userName Name of the user executing the request.
-   * @param addr Remote address of the request.
-   * @param cmd The requested command.
-   * @param src Path of affected source file.
-   * @param dst Path of affected destination file (if any).
-   * @param stat File information for operations that change the file's metadata
-   *          (permissions, owner, times, etc).
-   * @param callerContext Context information of the caller
-   * @param ugi UserGroupInformation of the current user, or null if not logging
-   *          token tracking information
+   *
+   * @param succeeded       Whether authorization succeeded.
+   * @param userName        Name of the user executing the request.
+   * @param addr            Remote address of the request.
+   * @param port
+   * @param cmd             The requested command.
+   * @param src             Path of affected source file.
+   * @param dst             Path of affected destination file (if any).
+   * @param stat            File information for operations that change the file's metadata
+   *                        (permissions, owner, times, etc).
+   * @param callerContext   Context information of the caller
+   * @param ugi             UserGroupInformation of the current user, or null if not logging
+   *                        token tracking information
    * @param dtSecretManager The token secret manager, or null if not logging
-   *          token tracking information
+   *                        token tracking information
    */
   public abstract void logAuditEvent(boolean succeeded, String userName,
-      InetAddress addr, String cmd, String src, String dst,
+      InetAddress addr, int port, String cmd, String src, String dst,
       FileStatus stat, CallerContext callerContext, UserGroupInformation ugi,
       DelegationTokenSecretManager dtSecretManager);
 
   /**
    * Same as
-   * {@link #logAuditEvent(boolean, String, InetAddress, String, String,
-   * String, FileStatus, CallerContext, UserGroupInformation,
-   * DelegationTokenSecretManager)} without {@link CallerContext} information.
+   * {@link #logAuditEvent(boolean, String, InetAddress, int, String, String, String, FileStatus, CallerContext, UserGroupInformation, DelegationTokenSecretManager)} without {@link CallerContext} information.
    */
   public abstract void logAuditEvent(boolean succeeded, String userName,
-      InetAddress addr, String cmd, String src, String dst,
+      InetAddress addr, int port, String cmd, String src, String dst,
       FileStatus stat, UserGroupInformation ugi,
       DelegationTokenSecretManager dtSecretManager);
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/top/TopAuditLogger.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/top/TopAuditLogger.java
@@ -66,7 +66,7 @@ public class TopAuditLogger implements AuditLogger {
 
   @Override
   public void logAuditEvent(boolean succeeded, String userName,
-      InetAddress addr, String cmd, String src, String dst, FileStatus status) {
+      InetAddress addr, int port, String cmd, String src, String dst, FileStatus status) {
     try {
       topMetrics.report(succeeded, userName, addr, cmd, src, dst, status);
     } catch (Throwable t) {
@@ -79,6 +79,7 @@ public class TopAuditLogger implements AuditLogger {
       sb.append("allowed=").append(succeeded).append("\t");
       sb.append("ugi=").append(userName).append("\t");
       sb.append("ip=").append(addr).append("\t");
+      sb.append("port=").append(port).append("\t");
       sb.append("cmd=").append(cmd).append("\t");
       sb.append("src=").append(src).append("\t");
       sb.append("dst=").append(dst).append("\t");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogAtDebug.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogAtDebug.java
@@ -68,9 +68,9 @@ public class TestAuditLogAtDebug {
   
   private void logDummyCommandToAuditLog(HdfsAuditLogger logger, String command) {
     logger.logAuditEvent(true, "",
-                         Inet4Address.getLoopbackAddress(),
-                         command, "", "",
-                         null, null, null, null);
+                         Inet4Address.getLoopbackAddress(), 0,
+        command, "",
+        "", null, null, null, null);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogger.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogger.java
@@ -647,7 +647,7 @@ public class TestAuditLogger {
     }
 
     public void logAuditEvent(boolean succeeded, String userName,
-        InetAddress addr, String cmd, String src, String dst,
+        InetAddress addr, int port, String cmd, String src, String dst,
         FileStatus stat) {
       remoteAddr = addr.getHostAddress();
       logCount++;
@@ -673,8 +673,8 @@ public class TestAuditLogger {
     }
 
     public void logAuditEvent(boolean succeeded, String userName,
-        InetAddress addr, String cmd, String src, String dst,
-        FileStatus stat) {
+                              InetAddress addr, int port, String cmd, String src, String dst,
+                              FileStatus stat) {
       if (!cmd.equals("datanodeReport")) {
         throw new RuntimeException("uh oh");
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogs.java
@@ -86,6 +86,7 @@ public class TestAuditLogs {
       "allowed=.*?\\s" +
       "ugi=.*?\\s" +
       "ip=/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\s" +
+      "port=.*?\\s" +
       "cmd=.*?\\ssrc=.*?\\sdst=null\\s" +
       "perm=.*?");
   private static final Pattern SUCCESS_PATTERN = Pattern.compile(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystem.java
@@ -320,7 +320,7 @@ public class TestFSNamesystem {
 
     @Override
     public void logAuditEvent(boolean succeeded, String userName,
-        InetAddress addr, String cmd, String src, String dst, FileStatus stat) {
+        InetAddress addr, int port, String cmd, String src, String dst, FileStatus stat) {
     }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
In order to locate the problem more conveniently， hdfs auditlog should add remote port info.


### How was this patch tested?
test the hdfsaduitlog,  it will log remote port info



