### PR TITLE
HDFS-16975. FileWithSnapshotFeature.isCurrentFileDeleted is not reloaded from FSImage.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormat.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormat.java
@@ -798,7 +798,10 @@ public class FSImageFormat {
       if (underConstruction) {
         file.toUnderConstruction(clientName, clientMachine);
       }
-      return fileDiffs == null ? file : new INodeFile(file, fileDiffs);
+      if (fileDiffs != null) {
+        file.loadSnapshotFeature(fileDiffs);
+      }
+      return file;
     } else if (numBlocks == -1) {
       //directory
       

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormat.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormat.java
@@ -798,10 +798,7 @@ public class FSImageFormat {
       if (underConstruction) {
         file.toUnderConstruction(clientName, clientMachine);
       }
-      if (fileDiffs != null) {
-        file.loadSnapshotFeature(fileDiffs);
-      }
-      return file;
+      return fileDiffs == null ? file : file.loadSnapshotFeature(fileDiffs);
     } else if (numBlocks == -1) {
       //directory
       

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INode.java
@@ -49,7 +49,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * We keep an in-memory representation of the file/block hierarchy.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INode.java
@@ -239,8 +239,11 @@ public abstract class INode implements INodeAttributes, Diff.Element<byte[]> {
     }
     final INode child = parentDir.getChild(getLocalNameBytes(),
             Snapshot.CURRENT_STATE_ID);
-    // equals(..) compares IDs, will work for references
-    return this.equals(child);
+    if (this == child) {
+      return true;
+    }
+    return child != null && child.isReference() &&
+        this.equals(child.asReference().getReferredINode());
   }
 
   /** Is this inode in the latest snapshot? */
@@ -262,8 +265,11 @@ public abstract class INode implements INodeAttributes, Diff.Element<byte[]> {
       return false;
     }
     final INode child = parentDir.getChild(getLocalNameBytes(), latestSnapshotId);
-    // equals(..) compares IDs, will work for references
-    return this.equals(child);
+    if (this == child) {
+      return true;
+    }
+    return child != null && child.isReference() &&
+        this == child.asReference().getReferredINode();
   }
   
   /** @return true if the given inode is an ancestor directory of this inode. */
@@ -901,7 +907,7 @@ public abstract class INode implements INodeAttributes, Diff.Element<byte[]> {
   }
 
   public void dumpINode(PrintWriter out, StringBuilder prefix,
-    int snapshotId) {
+      int snapshotId) {
     out.print(prefix);
     out.print(" ");
     final String name = getLocalName();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
@@ -454,11 +454,12 @@ public class INodeFile extends INodeWithAdditionalFields
   }
 
   /** Used by FSImage. */
-  public void loadSnapshotFeature(FileDiffList diffs) {
+  public INodeFile loadSnapshotFeature(FileDiffList diffs) {
     final FileWithSnapshotFeature sf = addSnapshotFeature(diffs);
     if (!isInCurrentState()) {
       sf.deleteCurrentFile();
     }
+    return this;
   }
 
   /**
@@ -1098,7 +1099,7 @@ public class INodeFile extends INodeWithAdditionalFields
   }
 
   public void dumpINodeFile(PrintWriter out, StringBuilder prefix,
-    final int snapshotId) {
+      final int snapshotId) {
     dumpINode(out, prefix, snapshotId);
     out.print(", fileSize=" + computeFileSize(snapshotId));
     // only compare the first block

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
@@ -283,12 +283,6 @@ public class INodeFile extends INodeWithAdditionalFields
     setBlocks(that.blocks);
   }
   
-  public INodeFile(INodeFile that, FileDiffList diffs) {
-    this(that);
-    Preconditions.checkArgument(!that.isWithSnapshot());
-    this.addSnapshotFeature(diffs);
-  }
-
   /** @return true unconditionally. */
   @Override
   public final boolean isFile() {
@@ -458,7 +452,15 @@ public class INodeFile extends INodeWithAdditionalFields
     this.addFeature(sf);
     return sf;
   }
-  
+
+  /** Used by FSImage. */
+  public void loadSnapshotFeature(FileDiffList diffs) {
+    final FileWithSnapshotFeature sf = addSnapshotFeature(diffs);
+    if (!isInCurrentState()) {
+      sf.deleteCurrentFile();
+    }
+  }
+
   /**
    * If feature list contains a {@link FileWithSnapshotFeature}, return it;
    * otherwise, return null.
@@ -1092,7 +1094,12 @@ public class INodeFile extends INodeWithAdditionalFields
   @Override
   public void dumpTreeRecursively(PrintWriter out, StringBuilder prefix,
       final int snapshotId) {
-    super.dumpTreeRecursively(out, prefix, snapshotId);
+    dumpINodeFile(out, prefix, snapshotId);
+  }
+
+  public void dumpINodeFile(PrintWriter out, StringBuilder prefix,
+    final int snapshotId) {
+    dumpINode(out, prefix, snapshotId);
     out.print(", fileSize=" + computeFileSize(snapshotId));
     // only compare the first block
     out.print(", blocks=");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/FSImageFormatPBSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/FSImageFormatPBSnapshot.java
@@ -269,7 +269,7 @@ public class FSImageFormatPBSnapshot {
         }
         diffs.addFirst(diff);
       }
-      file.addSnapshotFeature(diffs);
+      file.loadSnapshotFeature(diffs);
       short repl = file.getPreferredBlockReplication();
       for (BlockInfo b : file.getBlocks()) {
         if (b.getReplication() < repl) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/FileWithSnapshotFeature.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/FileWithSnapshotFeature.java
@@ -243,6 +243,6 @@ public class FileWithSnapshotFeature implements INode.Feature {
 
   @Override
   public String toString() {
-    return "" + diffs;
+    return "isCurrentFileDeleted? " + isCurrentFileDeleted + ", " + diffs;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/visitor/NamespacePrintVisitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/visitor/NamespacePrintVisitor.java
@@ -63,7 +63,7 @@ public final class NamespacePrintVisitor implements NamespaceVisitor {
   }
 
   private final PrintWriter out;
-  private final StringBuffer prefix = new StringBuffer();
+  private final StringBuilder prefix = new StringBuilder();
 
   private NamespacePrintVisitor(PrintWriter out) {
     this.out = out;
@@ -74,39 +74,12 @@ public final class NamespacePrintVisitor implements NamespaceVisitor {
   }
 
   private void printINode(INode iNode, int snapshot) {
-    out.print(prefix);
-    out.print(" ");
-    final String name = iNode.getLocalName();
-    out.print(name != null && name.isEmpty()? "/": name);
-    out.print("   (");
-    out.print(iNode.getObjectString());
-    out.print("), ");
-    out.print(iNode.getParentString());
-    out.print(", " + iNode.getPermissionStatus(snapshot));
+    iNode.dumpINode(out, prefix, snapshot);
   }
 
   @Override
   public void visitFile(INodeFile file, int snapshot) {
-    printINode(file, snapshot);
-
-    out.print(", fileSize=" + file.computeFileSize(snapshot));
-    // print only the first block, if it exists
-    out.print(", blocks=");
-    final BlockInfo[] blocks = file.getBlocks();
-    out.print(blocks.length == 0 ? null: blocks[0]);
-    out.println();
-
-    final FileWithSnapshotFeature snapshotFeature
-        = file.getFileWithSnapshotFeature();
-    if (snapshotFeature != null) {
-      if (prefix.length() >= 2) {
-        prefix.setLength(prefix.length() - 2);
-        prefix.append("  ");
-      }
-      out.print(prefix);
-      out.print(snapshotFeature);
-    }
-    out.println();
+    file.dumpINodeFile(out, prefix, snapshot);
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/visitor/NamespacePrintVisitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/visitor/NamespacePrintVisitor.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdfs.server.namenode.visitor;
 
 import org.apache.hadoop.util.Preconditions;
-import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfo;
 import org.apache.hadoop.hdfs.server.namenode.DirectoryWithQuotaFeature;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.INode;
@@ -29,7 +28,6 @@ import org.apache.hadoop.hdfs.server.namenode.INodeSymlink;
 import org.apache.hadoop.hdfs.server.namenode.snapshot.DirectorySnapshottableFeature;
 import org.apache.hadoop.hdfs.server.namenode.snapshot.DirectoryWithSnapshotFeature;
 import org.apache.hadoop.hdfs.server.namenode.snapshot.DirectoryWithSnapshotFeature.DirectoryDiff;
-import org.apache.hadoop.hdfs.server.namenode.snapshot.FileWithSnapshotFeature;
 import org.apache.hadoop.hdfs.server.namenode.snapshot.Snapshot;
 
 import java.io.PrintWriter;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSImageWithSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSImageWithSnapshot.java
@@ -196,10 +196,8 @@ public class TestFSImageWithSnapshot {
     cluster.waitActive();
     fsn = cluster.getNamesystem();
     hdfs = cluster.getFileSystem();
-    
-    INodeDirectory rootNode = fsn.dir.getINode4Write(root.toString())
-        .asDirectory();
-    assertTrue("The children list of root should be empty", 
+    final INodeDirectory rootNode = fsn.dir.getRoot();
+    assertTrue("The children list of root should be empty",
         rootNode.getChildrenList(Snapshot.CURRENT_STATE_ID).isEmpty());
     // one snapshot on root: s1
     DiffList<DirectoryDiff> diffList = rootNode.getDiffs().asList();


### PR DESCRIPTION
### Description of PR

FileWithSnapshotFeature.isCurrentFileDeleted is not serialized to FSImage.
If it is true for any files, it will becomes false after saving to a FSImage and loading it back.

We will fix it by checking `isInCurrentState()` when loading FSImage.

https://issues.apache.org/jira/browse/HDFS-16975

### How was this patch tested?

Added "isCurrentFileDeleted" to `FileWithSnapshotFeature.toString()`.  Then, `TestFSImageWithSnapshot.testSaveLoadImage()` will fail without the fix.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

