### PR TITLE
HDFS-16977. Forbid assigned characters in pathname.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSUtilClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSUtilClient.java
@@ -684,6 +684,28 @@ public class DFSUtilClient {
     return true;
   }
 
+  public static boolean checkForbiddenCharacters(String pathname, String[] pathnameForbiddenCharacters) {
+    if (pathnameForbiddenCharacters == null) {
+      return false;
+    }
+    for (int i = 0; i < pathnameForbiddenCharacters.length; i++) {
+      if (pathname.contains(pathnameForbiddenCharacters[i])) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static void formatPathnameForbiddenCharacters(String[] pathnameForbiddenCharacters) {
+    if (pathnameForbiddenCharacters == null) {
+      return;
+    }
+    for (int i = 0; i < pathnameForbiddenCharacters.length; i++) {
+      String element = pathnameForbiddenCharacters[i].trim();
+      pathnameForbiddenCharacters[i] = element.length() == 0 ? " " : element;
+    }
+  }
+
   /**
    * Converts a time duration in milliseconds into DDD:HH:MM:SS format.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -152,6 +152,7 @@ public interface HdfsClientConfigKeys {
   int     DFS_SHORT_CIRCUIT_SHARED_MEMORY_WATCHER_INTERRUPT_CHECK_MS_DEFAULT =
       60000;
   String DFS_CLIENT_SHORT_CIRCUIT_NUM = "dfs.client.short.circuit.num";
+  String DFS_PATHNAME_FORBIDDEN_CHARACTERS = "dfs.pathname.forbidden.characters";
   int DFS_CLIENT_SHORT_CIRCUIT_NUM_DEFAULT = 1;
   String  DFS_CLIENT_SLOW_IO_WARNING_THRESHOLD_KEY =
       "dfs.client.slow.io.warning.threshold.ms";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
@@ -236,6 +236,14 @@ public class DFSUtil {
     return DFSUtilClient.isValidName(src);
   }
 
+  public static boolean checkForbiddenCharacters(String pathname, String[] pathnameForbiddenCharacters) {
+    return DFSUtilClient.checkForbiddenCharacters(pathname, pathnameForbiddenCharacters);
+  }
+
+  public static void formatPathnameForbiddenCharacters(String[] pathnameForbiddenCharacters) {
+    DFSUtilClient.formatPathnameForbiddenCharacters(pathnameForbiddenCharacters);
+  }
+
   /**
    * Checks if a string is a valid path component. For instance, components
    * cannot contain a ":" or "/", and cannot be equal to a reserved component

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -181,6 +181,7 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_HEARTBEAT_RECHEC
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_HEARTBEAT_RECHECK_INTERVAL_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.FS_PROTECTED_DIRECTORIES;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_STORAGE_POLICY_SATISFIER_MODE_KEY;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_PATHNAME_FORBIDDEN_CHARACTERS;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_REPLICATION_MAX_STREAMS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_REPLICATION_MAX_STREAMS_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_REPLICATION_STREAMS_HARD_LIMIT_KEY;
@@ -357,7 +358,8 @@ public class NameNode extends ReconfigurableBase implements
           DFS_DATANODE_MAX_NODES_TO_REPORT_KEY,
           DFS_NAMENODE_RECONSTRUCTION_PENDING_TIMEOUT_SEC_KEY,
           DFS_NAMENODE_DECOMMISSION_BACKOFF_MONITOR_PENDING_LIMIT,
-          DFS_NAMENODE_DECOMMISSION_BACKOFF_MONITOR_PENDING_BLOCKS_PER_LOCK));
+          DFS_NAMENODE_DECOMMISSION_BACKOFF_MONITOR_PENDING_BLOCKS_PER_LOCK,
+          DFS_PATHNAME_FORBIDDEN_CHARACTERS));
 
   private static final String USAGE = "Usage: hdfs namenode ["
       + StartupOption.BACKUP.getName() + "] | \n\t["
@@ -2329,6 +2331,8 @@ public class NameNode extends ReconfigurableBase implements
         (property.equals(DFS_NAMENODE_DECOMMISSION_BACKOFF_MONITOR_PENDING_BLOCKS_PER_LOCK))) {
       return reconfigureDecommissionBackoffMonitorParameters(datanodeManager, property,
           newVal);
+    } else if (property.equals(DFS_PATHNAME_FORBIDDEN_CHARACTERS)) {
+      return reconfigurePathnameForbiddenCharacters(newVal);
     } else {
       throw new ReconfigurationException(property, newVal, getConf().get(
           property));
@@ -2636,6 +2640,15 @@ public class NameNode extends ReconfigurableBase implements
     } catch (IllegalArgumentException e) {
       throw new ReconfigurationException(property, newVal, getConf().get(property), e);
     }
+  }
+
+  private String reconfigurePathnameForbiddenCharacters(String newVal) {
+    if (newVal == null) {
+      newVal = "";
+    }
+    getConf().set(DFS_PATHNAME_FORBIDDEN_CHARACTERS, newVal);
+    namesystem.reloadPathnameForbiddenCharacters(getConf());
+    return newVal;
   }
 
   @Override  // ReconfigurableBase

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -30,6 +30,7 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SERVICE_HANDLER_
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_RPC_ADDRESS_AUXILIARY_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_STATE_CONTEXT_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_STATE_CONTEXT_ENABLED_KEY;
+import static org.apache.hadoop.hdfs.DFSUtil.checkForbiddenCharacters;
 import static org.apache.hadoop.hdfs.server.common.HdfsServerConstants.MAX_PATH_DEPTH;
 import static org.apache.hadoop.hdfs.server.common.HdfsServerConstants.MAX_PATH_LENGTH;
 import static org.apache.hadoop.util.Time.now;
@@ -810,6 +811,10 @@ public class NameNodeRpcServer implements NamenodeProtocols {
       String storagePolicy)
       throws IOException {
     checkNNStartup();
+    if (checkForbiddenCharacters(src, namesystem.getPathnameForbiddenCharacters())) {
+      throw new InvalidPathException(src + ", including forbidden characters: " +
+          Arrays.toString(namesystem.getPathnameForbiddenCharacters()));
+    }
     String clientMachine = getClientMachine();
     stateChangeLog.debug("*DIR* NameNode.create: file {} for {} at {}.",
         src, clientName, clientMachine);
@@ -1046,6 +1051,10 @@ public class NameNodeRpcServer implements NamenodeProtocols {
   @Override // ClientProtocol
   public boolean rename(String src, String dst) throws IOException {
     checkNNStartup();
+    if (checkForbiddenCharacters(dst, namesystem.getPathnameForbiddenCharacters())) {
+      throw new InvalidPathException(dst + ", including forbidden characters: " +
+          Arrays.toString(namesystem.getPathnameForbiddenCharacters()));
+    }
     stateChangeLog.debug("*DIR* NameNode.rename: {} to {}.", src, dst);
     if (!checkPathLength(dst)) {
       throw new IOException("rename: Pathname too long.  Limit "
@@ -1095,6 +1104,10 @@ public class NameNodeRpcServer implements NamenodeProtocols {
   public void rename2(String src, String dst, Options.Rename... options)
       throws IOException {
     checkNNStartup();
+    if (checkForbiddenCharacters(dst, namesystem.getPathnameForbiddenCharacters())) {
+      throw new InvalidPathException(dst + ", including forbidden characters: " +
+          Arrays.toString(namesystem.getPathnameForbiddenCharacters()));
+    }
     stateChangeLog.debug("*DIR* NameNode.rename: {} to {}.", src, dst);
     if (!checkPathLength(dst)) {
       throw new IOException("rename: Pathname too long.  Limit "
@@ -1165,6 +1178,10 @@ public class NameNodeRpcServer implements NamenodeProtocols {
   public boolean mkdirs(String src, FsPermission masked, boolean createParent)
       throws IOException {
     checkNNStartup();
+    if (checkForbiddenCharacters(src, namesystem.getPathnameForbiddenCharacters())) {
+      throw new InvalidPathException(src + ", including forbidden characters: " +
+          Arrays.toString(namesystem.getPathnameForbiddenCharacters()));
+    }
     stateChangeLog.debug("*DIR* NameNode.mkdirs: {}.", src);
     if (!checkPathLength(src)) {
       throw new IOException("mkdirs: Pathname too long.  Limit " 
@@ -1551,6 +1568,10 @@ public class NameNodeRpcServer implements NamenodeProtocols {
   public void createSymlink(String target, String link, FsPermission dirPerms,
       boolean createParent) throws IOException {
     checkNNStartup();
+    if (checkForbiddenCharacters(link, namesystem.getPathnameForbiddenCharacters())) {
+      throw new InvalidPathException(link + ", including forbidden characters: " +
+          Arrays.toString(namesystem.getPathnameForbiddenCharacters()));
+    }
     namesystem.checkOperation(OperationCategory.WRITE);
     CacheEntry cacheEntry = getCacheEntry();
     if (cacheEntry != null && cacheEntry.isSuccess()) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -2889,6 +2889,18 @@
 </property>
 
 <property>
+  <name>dfs.pathname.forbidden.characters</name>
+  <value></value>
+  <description>
+    A comma separated list of characters that are not allowed to be used in pathname
+    when new file or directory is created. This option may be configured both on the
+    server and the client, while config on the client side will be checked first.
+    Recommend to add the character that may lead to ambiguity such as ' ', '*', '|',
+    '&amp;', etc.
+  </description>
+</property>
+
+<property>
   <name>dfs.namenode.caching.enabled</name>
   <value>true</value>
   <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
@@ -873,6 +873,26 @@ public class TestDFSUtil {
     assertFalse(DFSUtil.isValidName("/foo/:/bar"));
     assertFalse(DFSUtil.isValidName("/foo:bar"));
   }
+
+  @Test
+  public void testCheckForbiddenCharacters() {
+    String[] forbiddenCharacters = {"&", "|", "*", " "};
+    String[] nullForbiddenCharactersArray = null;
+    String[] illegalPathname = {"/fo o", "/fo*o", "/fo|o", "/fo&o"};
+    String[] legalPathname = {"/fo!o", "/fo@o", "/fo#o", "/fo$o"};
+    for (String pathname : illegalPathname) {
+      assertTrue(DFSUtil.checkForbiddenCharacters(pathname, forbiddenCharacters));
+    }
+    for (String pathname : illegalPathname) {
+      assertFalse(DFSUtil.checkForbiddenCharacters(pathname, nullForbiddenCharactersArray));
+    }
+    for (String pathname : legalPathname) {
+      assertFalse(DFSUtil.checkForbiddenCharacters(pathname, forbiddenCharacters));
+    }
+    for (String pathname : legalPathname) {
+      assertFalse(DFSUtil.checkForbiddenCharacters(pathname, nullForbiddenCharactersArray));
+    }
+  }
   
   @Test(timeout=5000)
   public void testGetSpnegoKeytabKey() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -100,6 +100,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_MAX_SLOWPEER_COLLECT_NODES_KEY;
 import static org.apache.hadoop.hdfs.client.HdfsAdmin.TRASH_PERMISSION;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_PATHNAME_FORBIDDEN_CHARACTERS;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -441,7 +442,7 @@ public class TestDFSAdmin {
     final List<String> outs = Lists.newArrayList();
     final List<String> errs = Lists.newArrayList();
     getReconfigurableProperties("namenode", address, outs, errs);
-    assertEquals(22, outs.size());
+    assertEquals(23, outs.size());
     assertTrue(outs.get(0).contains("Reconfigurable properties:"));
     assertEquals(DFS_BLOCK_INVALIDATE_LIMIT_KEY, outs.get(1));
     assertEquals(DFS_BLOCK_PLACEMENT_EC_CLASSNAME_KEY, outs.get(2));
@@ -456,6 +457,7 @@ public class TestDFSAdmin {
     assertEquals(DFS_NAMENODE_DECOMMISSION_BACKOFF_MONITOR_PENDING_LIMIT, outs.get(11));
     assertEquals(DFS_NAMENODE_HEARTBEAT_RECHECK_INTERVAL_KEY, outs.get(12));
     assertEquals(DFS_NAMENODE_MAX_SLOWPEER_COLLECT_NODES_KEY, outs.get(13));
+    assertEquals(DFS_PATHNAME_FORBIDDEN_CHARACTERS, outs.get(18));
     assertEquals(errs.size(), 0);
   }
 


### PR DESCRIPTION
JIRA: [HDFS-16977](https://issues.apache.org/jira/browse/HDFS-16977). Forbid assigned characters in pathname when new file or directory is created.