### PR TITLE
HADOOP-18590. Publish SBOM artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <spotbugs-maven-plugin.version>4.2.0</spotbugs-maven-plugin.version>
     <jsonschema2pojo-maven-plugin.version>1.1.1</jsonschema2pojo-maven-plugin.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+    <cyclonedx.version>2.7.6</cyclonedx.version>
 
     <shell-executable>bash</shell-executable>
 
@@ -499,6 +500,19 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
         </plugin>
+        <plugin>
+          <groupId>org.cyclonedx</groupId>
+          <artifactId>cyclonedx-maven-plugin</artifactId>
+          <version>${cyclonedx.version}</version>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>makeBom</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -606,6 +620,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -500,19 +500,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
         </plugin>
-        <plugin>
-          <groupId>org.cyclonedx</groupId>
-          <artifactId>cyclonedx-maven-plugin</artifactId>
-          <version>${cyclonedx.version}</version>
-          <executions>
-            <execution>
-              <phase>package</phase>
-              <goals>
-                <goal>makeBom</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -766,6 +753,26 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
       </build>
     </profile>
 
+    <profile>
+      <id>dist</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-maven-plugin</artifactId>
+            <version>${cyclonedx.version}</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>makeBom</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
 
     <profile>
       <id>sign</id>


### PR DESCRIPTION
### Description of PR

This is a second try of #5281 with new `cyclonedx` plugin `2.7.6` and tested with Maven 3.9.1.

This PR aims to publish SBOM artifacts.

- https://cwiki.apache.org/confluence/display/COMDEV/SBOM

Here is an article to give some context.
- https://www.activestate.com/blog/why-the-us-government-is-mandating-software-bill-of-materials-sbom/

Software Bill of Materials (SBOM) are additional artifacts containing the aggregate of all direct and transitive dependencies of a project. The US Government (based on NIST recommendations) currently accepts only the three most popular SBOM standards as valid, namely: [CycloneDX](https://cyclonedx.org/), [Software Identification (SWID) tag](https://csrc.nist.gov/projects/Software-Identification-SWID), [Software Package Data Exchange® (SPDX)](https://spdx.dev/).

This PR uses [CycloneDX maven plugin](https://github.com/CycloneDX/cyclonedx-maven-plugin) v2.7.6, a lightweight software bill of materials (SBOM) standard designed for use in application security contexts and supply chain component analysis. `cyclonedx-maven-plugin` 2.7.6 is verified in Apache ORC/Parquet/Avro/Arrow/Spark community as of today.

- https://github.com/apache/orc/pull/1463
- https://github.com/apache/parquet-mr/pull/1057
- https://github.com/apache/avro/pull/2174
- https://github.com/apache/arrow/pull/35092
- https://github.com/apache/spark/pull/40726

### How was this patch tested?

Manually. For example, `hadoop-auth-3.4.0-SNAPSHOT.jar` will have `hadoop-auth-3.4.0-SNAPSHOT-cyclonedx.xml` and `hadoop-auth-3.4.0-SNAPSHOT-cyclonedx.json` SBOM files additionally.

```
$ mvn --version
Apache Maven 3.9.1 (2e178502fcdbffc201671fb2537d0cb4b4cc58f8)
Maven home: /opt/homebrew/Cellar/maven/3.9.1/libexec
Java version: 11.0.18, vendor: Apple Inc., runtime: /Library/Java/JavaVirtualMachines/applejdk-11.0.18.10.1.jdk/Contents/Home
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "13.3", arch: "aarch64", family: "mac"

$ ls -l ~/.m2/repository/org/apache/hadoop/hadoop-auth/3.4.0-SNAPSHOT
total 1008
-rw-r--r--  1 dongjoon  staff     373 Apr 13 13:43 _remote.repositories
-rw-r--r--  1 dongjoon  staff  100849 Apr 13 13:42 hadoop-auth-3.4.0-SNAPSHOT-cyclonedx.json
-rw-r--r--  1 dongjoon  staff   85972 Apr 13 13:42 hadoop-auth-3.4.0-SNAPSHOT-cyclonedx.xml
-rw-r--r--  1 dongjoon  staff   84455 Apr 13 13:42 hadoop-auth-3.4.0-SNAPSHOT-sources.jar
-rw-r--r--  1 dongjoon  staff  113598 Apr 13 13:42 hadoop-auth-3.4.0-SNAPSHOT-tests.jar
-rw-r--r--  1 dongjoon  staff  106123 Apr 13 13:42 hadoop-auth-3.4.0-SNAPSHOT.jar
-rw-r--r--  1 dongjoon  staff    8246 Apr 13 13:38 hadoop-auth-3.4.0-SNAPSHOT.pom
-rw-r--r--  1 dongjoon  staff    1537 Apr 13 13:43 maven-metadata-local.xml
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?