### PR TITLE
HDFS-16982 Use the right Quantiles Array for Inverse Quantiles snapshot

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableInverseQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableInverseQuantiles.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.metrics2.util.Quantile;
-import org.apache.hadoop.metrics2.util.SampleQuantiles;
 import java.text.DecimalFormat;
 import static org.apache.hadoop.metrics2.lib.Interns.info;
 
@@ -65,7 +64,7 @@ public class MutableInverseQuantiles extends MutableQuantiles{
   }
 
   /**
-   * Sets quantileInfo and estimator.
+   * Sets quantileInfo.
    *
    * @param ucName capitalized name of the metric
    * @param uvName capitalized type of the values
@@ -74,8 +73,6 @@ public class MutableInverseQuantiles extends MutableQuantiles{
    * @param df Number formatter for inverse percentile value
    */
   void setQuantiles(String ucName, String uvName, String desc, String lvName, DecimalFormat df) {
-    // Construct the MetricsInfos for inverse quantiles, converting to inverse percentiles
-    setQuantileInfos(INVERSE_QUANTILES.length);
     for (int i = 0; i < INVERSE_QUANTILES.length; i++) {
       double inversePercentile = 100 * (1 - INVERSE_QUANTILES[i].quantile);
       String nameTemplate = ucName + df.format(inversePercentile) + "thInversePercentile" + uvName;
@@ -83,7 +80,14 @@ public class MutableInverseQuantiles extends MutableQuantiles{
           + " with " + getInterval() + " second interval for " + desc;
       addQuantileInfo(i, info(nameTemplate, descTemplate));
     }
+  }
 
-    setEstimator(new SampleQuantiles(INVERSE_QUANTILES));
+  /**
+   * Returns the array of Inverse Quantiles declared in MutableInverseQuantiles.
+   *
+   * @return array of Inverse Quantiles
+   */
+  public synchronized Quantile[] getQuantiles() {
+    return INVERSE_QUANTILES;
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableQuantiles.java
@@ -49,9 +49,9 @@ import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFact
 public class MutableQuantiles extends MutableMetric {
 
   @VisibleForTesting
-  public static final Quantile[] QUANTILES = { new Quantile(0.50, 0.050),
+  public static final Quantile[] QUANTILES = {new Quantile(0.50, 0.050),
       new Quantile(0.75, 0.025), new Quantile(0.90, 0.010),
-      new Quantile(0.95, 0.005), new Quantile(0.99, 0.001) };
+      new Quantile(0.95, 0.005), new Quantile(0.99, 0.001)};
 
   private MetricsInfo numInfo;
   private MetricsInfo[] quantileInfos;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
@@ -52,8 +52,8 @@ public class TestMutableMetrics {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestMutableMetrics.class);
   private static final double EPSILON = 1e-42;
-  public static int SLEEP_TIME = 6000;
-  public static int SAMPLE_COUNT = 1000;
+  private static final int SLEEP_TIME = 6000;
+  private static final int SAMPLE_COUNT = 1000;
 
   /**
    * Test the snapshot method

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
@@ -52,7 +52,7 @@ public class TestMutableMetrics {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestMutableMetrics.class);
   private static final double EPSILON = 1e-42;
-  private static final int SLEEP_TIME = 6000;
+  private static final int SLEEP_TIME_MS = 6 * 1000; // 6 seconds.
   private static final int SAMPLE_COUNT = 1000;
 
   /**
@@ -404,7 +404,7 @@ public class TestMutableMetrics {
     }
     long endTimeMS = System.currentTimeMillis();
 
-    Thread.sleep(SLEEP_TIME - (endTimeMS - startTimeMS));
+    Thread.sleep(SLEEP_TIME_MS - (endTimeMS - startTimeMS));
 
     registry.snapshot(mb, false);
 
@@ -450,7 +450,7 @@ public class TestMutableMetrics {
     }
     long endTimeMS = System.currentTimeMillis();
 
-    Thread.sleep(SLEEP_TIME - (endTimeMS - startTimeMS));
+    Thread.sleep(SLEEP_TIME_MS - (endTimeMS - startTimeMS));
 
     registry.snapshot(mb, false);
 
@@ -584,7 +584,7 @@ public class TestMutableMetrics {
     quantiles.snapshot(mb, true);
     verify(mb).addGauge(
         info("FooNumOps", "Number of ops for stat with 5s interval"), 0L);
-    Thread.sleep(SLEEP_TIME);
+    Thread.sleep(SLEEP_TIME_MS);
     quantiles.snapshot(mb, false);
     verify(mb, times(2)).addGauge(
         info("FooNumOps", "Number of ops for stat with 5s interval"), 0L);
@@ -606,7 +606,7 @@ public class TestMutableMetrics {
     inverseQuantiles.snapshot(mb, true);
     verify(mb).addGauge(
         info("FooNumOps", "Number of ops for stat with 5s interval"), 0L);
-    Thread.sleep(SLEEP_TIME);
+    Thread.sleep(SLEEP_TIME_MS);
     inverseQuantiles.snapshot(mb, false);
     verify(mb, times(2)).addGauge(
         info("FooNumOps", "Number of ops for stat with 5s interval"), 0L);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
@@ -393,7 +393,7 @@ public class MetricsAsserts {
   public static void assertQuantileGauges(String prefix,
       MetricsRecordBuilder rb, String valueName) {
     verify(rb).addGauge(eqName(info(prefix + "NumOps", "")), geq(0L));
-    for (Quantile q : MutableQuantiles.quantiles) {
+    for (Quantile q : MutableQuantiles.QUANTILES) {
       String nameTemplate = prefix + "%dthPercentile" + valueName;
       int percentile = (int) (100 * q.quantile);
       verify(rb).addGauge(
@@ -414,7 +414,7 @@ public class MetricsAsserts {
   public static void assertInverseQuantileGauges(String prefix,
       MetricsRecordBuilder rb, String valueName) {
     verify(rb).addGauge(eqName(info(prefix + "NumOps", "")), geq(0L));
-    for (Quantile q : MutableQuantiles.quantiles) {
+    for (Quantile q : MutableQuantiles.QUANTILES) {
       String nameTemplate = prefix + "%dthInversePercentile" + valueName;
       int percentile = (int) (100 * q.quantile);
       verify(rb).addGauge(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/ContainerMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/ContainerMetrics.java
@@ -155,7 +155,7 @@ public class ContainerMetrics implements MetricsSource {
         .newQuantiles(PMEM_USAGE_QUANTILES_NAME, "Physical memory quantiles",
             "Usage", "MBs", 1);
     ContainerMetricsQuantiles memEstimator =
-        new ContainerMetricsQuantiles(MutableQuantiles.quantiles);
+        new ContainerMetricsQuantiles(MutableQuantiles.QUANTILES);
     pMemMBQuantiles.setEstimator(memEstimator);
 
     this.cpuCoreUsagePercent = registry.newStat(
@@ -166,7 +166,7 @@ public class ContainerMetrics implements MetricsSource {
             "Physical Cpu core percent usage quantiles", "Usage", "Percents",
             1);
     ContainerMetricsQuantiles cpuEstimator =
-        new ContainerMetricsQuantiles(MutableQuantiles.quantiles);
+        new ContainerMetricsQuantiles(MutableQuantiles.QUANTILES);
     cpuCoreUsagePercentQuantiles.setEstimator(cpuEstimator);
     this.milliVcoresUsed = registry.newStat(
         VCORE_USAGE_METRIC_NAME, "1000 times Vcore usage", "Usage",


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
[HDFS-16949](https://issues.apache.org/jira/browse/HDFS-16949) introduced InverseQuantiles. However during snapshot for Inverse Quantiles we were still trying to access values from previous snapshot based on the Quantile Array declared in MutableQuantiles. ( Quantile(.50, .050), Quantile(.75, .025), Quantile(.90, .010), Quantile(.95, .005), Quantile(.99, .001) )

For InverseQuantiles we wont have these values ( except for Quantile(.50, .050) ) thus except for 50 Percentile snapshot wont return any value for the remaining quantiles.

Fix is to use the correct Quantiles Array to retrieve values during snapshot. The new UTs verify this behavior.

@goiri @mkuchenbecker Please review
### How was this patch tested?

Added new UTs verifying the fix ( and fail without it )
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

