### PR TITLE
HADOOP-18705. hadoop-azure: AzureBlobFileSystem should exclude incomp…

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -46,6 +46,7 @@ import java.util.concurrent.Future;
 import javax.annotation.Nullable;
 
 import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.security.ProviderUtils;
 import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -157,6 +158,8 @@ public class AzureBlobFileSystem extends FileSystem
   @Override
   public void initialize(URI uri, Configuration configuration)
       throws IOException {
+    configuration = ProviderUtils.excludeIncompatibleCredentialProviders(
+        configuration, AzureBlobFileSystem.class);
     uri = ensureAuthority(uri, configuration);
     super.initialize(uri, configuration);
     setConf(configuration);
@@ -196,10 +199,6 @@ public class AzureBlobFileSystem extends FileSystem
 
     final AbfsConfiguration abfsConfiguration = abfsStore
         .getAbfsConfiguration();
-
-    // Ensures that configuration excludes incompatible credential providers
-    configuration = abfsConfiguration.getRawConfiguration();
-    setConf(configuration);
 
     clientCorrelationId = TracingContext.validateClientCorrelationID(
         abfsConfiguration.getClientCorrelationId());

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -196,6 +196,11 @@ public class AzureBlobFileSystem extends FileSystem
 
     final AbfsConfiguration abfsConfiguration = abfsStore
         .getAbfsConfiguration();
+
+    // Ensures that configuration excludes incompatible credential providers
+    configuration = abfsConfiguration.getRawConfiguration();
+    setConf(configuration);
+
     clientCorrelationId = TracingContext.validateClientCorrelationID(
         abfsConfiguration.getClientCorrelationId());
     tracingHeaderFormat = abfsConfiguration.getTracingHeaderFormat();

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -199,7 +199,6 @@ public class AzureBlobFileSystem extends FileSystem
 
     final AbfsConfiguration abfsConfiguration = abfsStore
         .getAbfsConfiguration();
-
     clientCorrelationId = TracingContext.validateClientCorrelationID(
         abfsConfiguration.getClientCorrelationId());
     tracingHeaderFormat = abfsConfiguration.getTracingHeaderFormat();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestABFSJceksFiltering.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestABFSJceksFiltering.java
@@ -18,15 +18,15 @@
 
 package org.apache.hadoop.fs.azurebfs;
 
-import org.apache.hadoop.security.alias.CredentialProviderFactory;
 import org.junit.Test;
 
+import org.apache.hadoop.security.alias.CredentialProviderFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 
-public class ITestAzureBlobFileSystemConfiguration extends AbstractAbfsIntegrationTest {
+public class ITestABFSJceksFiltering extends AbstractAbfsIntegrationTest {
 
-  public ITestAzureBlobFileSystemConfiguration() throws Exception {
+  public ITestABFSJceksFiltering() throws Exception {
   }
 
   @Test
@@ -34,9 +34,10 @@ public class ITestAzureBlobFileSystemConfiguration extends AbstractAbfsIntegrati
     Configuration rawConfig = getRawConfiguration();
     rawConfig.set(CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH,
         "jceks://abfs@a@b.c.d/tmp/a.jceks,jceks://file/tmp/secret.jceks");
-    AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.get(rawConfig);
-    assertNotNull("filesystem", fs);
-    String providers = fs.getConf().get(CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH);
-    assertEquals("jceks://file/tmp/secret.jceks", providers);
+    try (AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.get(rawConfig)) {
+      assertNotNull("filesystem", fs);
+      String providers = fs.getConf().get(CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH);
+      assertEquals("jceks://file/tmp/secret.jceks", providers);
+    }
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs;
+
+import org.apache.hadoop.security.alias.CredentialProviderFactory;
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+
+public class ITestAzureBlobFileSystemConfiguration extends AbstractAbfsIntegrationTest {
+
+  public ITestAzureBlobFileSystemConfiguration() throws Exception {
+  }
+
+  @Test
+  public void testIncompatibleCredentialProviderIsExcluded() throws Exception {
+    Configuration rawConfig = getRawConfiguration();
+    rawConfig.set(CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH,
+        "jceks://abfs@a@b.c.d/tmp/a.jceks,jceks://file/tmp/secret.jceks");
+    AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.get(rawConfig);
+    assertNotNull("filesystem", fs);
+    String providers = fs.getConf().get(CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH);
+    assertEquals("jceks://file/tmp/secret.jceks", providers);
+  }
+}


### PR DESCRIPTION
…atible credential providers when binding DelegationTokenManagers

Change-Id: I1ad8b5856a0b8c0b75d4538019d43e7fdb1962d2

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### How was this patch tested?

I tested my change manually with a non-existing jceks file. Without my change I received the error described in the Jira: `Caused by: org.apache.hadoop.fs.PathIOException: 'jceks://abfs@a@b.c.d/tmp/a.jceks': Recursive load of credential provider; if loading a JCEKS file, this means that the filesystem connector is trying to load the same file`.

With my change the job run successfully, I also added some extra debug logs to see if the credential provider path is indeed correct.


NOTE: I added an integration test also, but if it's expensive to run I think we are ok without a test for this.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-18705. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

