### PR TITLE
YARN-11463. Node Labels root directory creation doesn't have a retry logic

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -137,6 +137,16 @@ public class YarnConfiguration extends Configuration {
   // Resource types configs
   ////////////////////////////
 
+  public static final String NODE_STORE_ROOT_DIR_NUM_RETRIES =
+      YARN_PREFIX + "nodestore-rootdir.num-retries";
+
+  public static final int NODE_STORE_ROOT_DIR_NUM_DEFAULT_RETRIES = 3;
+
+  public static final String NODE_STORE_ROOT_DIR_RETRY_INTERVAL =
+      YARN_PREFIX + "nodestore-rootdir.retry-interval-ms";
+
+  public static final int NODE_STORE_ROOT_DIR_RETRY_DEFAULT_INTERVAL = 1000;
+
   public static final String RESOURCE_TYPES =
       YarnConfiguration.YARN_PREFIX + "resource-types";
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -137,16 +137,6 @@ public class YarnConfiguration extends Configuration {
   // Resource types configs
   ////////////////////////////
 
-  public static final String NODE_STORE_ROOT_DIR_NUM_RETRIES =
-      YARN_PREFIX + "nodestore-rootdir.num-retries";
-
-  public static final int NODE_STORE_ROOT_DIR_NUM_DEFAULT_RETRIES = 3;
-
-  public static final String NODE_STORE_ROOT_DIR_RETRY_INTERVAL =
-      YARN_PREFIX + "nodestore-rootdir.retry-interval-ms";
-
-  public static final int NODE_STORE_ROOT_DIR_RETRY_DEFAULT_INTERVAL = 1000;
-
   public static final String RESOURCE_TYPES =
       YarnConfiguration.YARN_PREFIX + "resource-types";
 
@@ -226,6 +216,16 @@ public class YarnConfiguration extends Configuration {
       + "application.max-tag.length";
 
   public static final int DEFAULT_RM_APPLICATION_MAX_TAG_LENGTH = 100;
+
+  public static final String NODE_STORE_ROOT_DIR_NUM_RETRIES =
+      RM_PREFIX + "nodestore-rootdir.num-retries";
+
+  public static final int NODE_STORE_ROOT_DIR_NUM_DEFAULT_RETRIES = 1000;
+
+  public static final String NODE_STORE_ROOT_DIR_RETRY_INTERVAL =
+      RM_PREFIX + "nodestore-rootdir.retry-interval-ms";
+
+  public static final int NODE_STORE_ROOT_DIR_RETRY_DEFAULT_INTERVAL = 1000;
 
   public static final String RM_APPLICATION_MASTER_SERVICE_PROCESSORS =
       RM_PREFIX + "application-master-service.processors";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/store/AbstractFSNodeStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/store/AbstractFSNodeStore.java
@@ -66,9 +66,10 @@ public abstract class AbstractFSNodeStore<M> {
     this.manager = mgr;
     initFileSystem(conf);
     // mkdir of root dir path with retry logic
-    int maxRetries = 3;
+    int maxRetries = conf.getInt(YarnConfiguration.NODE_STORE_ROOT_DIR_NUM_RETRIES,
+        YarnConfiguration.NODE_STORE_ROOT_DIR_NUM_DEFAULT_RETRIES);
     int retryCount = 0;
-    boolean success = false;
+    boolean success = fs.mkdirs(fsWorkingPath);
 
     while (!success && retryCount < maxRetries) {
       try {
@@ -83,7 +84,8 @@ public abstract class AbstractFSNodeStore<M> {
           throw e;
         }
         try {
-          Thread.sleep(1000 * retryCount);
+          Thread.sleep(conf.getInt(YarnConfiguration.NODE_STORE_ROOT_DIR_RETRY_INTERVAL,
+              YarnConfiguration.NODE_STORE_ROOT_DIR_RETRY_DEFAULT_INTERVAL));
         } catch (InterruptedException ie) {
           throw new RuntimeException(ie);
         }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -5177,4 +5177,20 @@
     <value>1</value>
   </property>
 
+  <property>
+    <description>
+      Number of Retries while trying to make root directory for node store.
+    </description>
+    <name>yarn.nodestore-rootdir.num-retries</name>
+    <value>3</value>
+  </property>
+
+  <property>
+    <description>
+      Interval in ms between retries while trying to make root directory for node store.
+    </description>
+    <name>yarn.nodestore-rootdir.retry-interval-ms</name>
+    <value>1000</value>
+  </property>
+
 </configuration>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -5181,15 +5181,15 @@
     <description>
       Number of Retries while trying to make root directory for node store.
     </description>
-    <name>yarn.nodestore-rootdir.num-retries</name>
-    <value>3</value>
+    <name>yarn.resourcemanager.nodestore-rootdir.num-retries</name>
+    <value>1000</value>
   </property>
 
   <property>
     <description>
       Interval in ms between retries while trying to make root directory for node store.
     </description>
-    <name>yarn.nodestore-rootdir.retry-interval-ms</name>
+    <name>yarn.resourcemanager.nodestore-rootdir.retry-interval-ms</name>
     <value>1000</value>
   </property>
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/TestFileSystemNodeLabelsStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/TestFileSystemNodeLabelsStore.java
@@ -359,9 +359,6 @@ public class TestFileSystemNodeLabelsStore extends NodeLabelTestBase {
 
     mockStore.setFs(mockFs);
     verifyMkdirsCount(mockStore, true, 1);
-    verifyMkdirsCount(mockStore, false, 2);
-    verifyMkdirsCount(mockStore, true, 3);
-    verifyMkdirsCount(mockStore, false, 4);
   }
 
   private void verifyMkdirsCount(FileSystemNodeLabelsStore store,


### PR DESCRIPTION
### Description of PR

Node Labels root directory creation doesn't have a retry logic

JIRA - YARN-11463


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

