### PR TITLE
HADOOP-18706: Improve S3ABlockOutputStream recovery

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
@@ -232,7 +232,7 @@ class S3ABlockOutputStream extends OutputStream implements
         LOG.error("Number of partitions in stream exceeds limit for S3: "
              + Constants.MAX_MULTIPART_COUNT +  " write may fail.");
       }
-      activeBlock = blockFactory.create(blockCount, this.blockSize, statistics);
+      activeBlock = blockFactory.create(key, blockCount, this.blockSize, statistics);
     }
     return activeBlock;
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
@@ -729,7 +729,7 @@ class S3ABlockOutputStream extends OutputStream implements
   /**
    * Shared processing of Syncable operation reporting/downgrade.
    */
-  private void handleSyncableInvocation() {
+  private void handleSyncableInvocation() throws IOException {
     final UnsupportedOperationException ex
         = new UnsupportedOperationException(E_NOT_SYNCABLE);
     if (!downgradeSyncableExceptions) {
@@ -741,6 +741,7 @@ class S3ABlockOutputStream extends OutputStream implements
         key);
     // and log at debug
     LOG.debug("Downgrading Syncable call", ex);
+    flush();
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
@@ -232,7 +232,9 @@ class S3ABlockOutputStream extends OutputStream implements
         LOG.error("Number of partitions in stream exceeds limit for S3: "
              + Constants.MAX_MULTIPART_COUNT +  " write may fail.");
       }
-      activeBlock = blockFactory.create(writeOperationHelper.getAuditSpan().getSpanId(), key, blockCount, this.blockSize, statistics);
+      activeBlock = blockFactory.create(
+        writeOperationHelper.getAuditSpan().getSpanId(),
+        key, blockCount, this.blockSize, statistics);
     }
     return activeBlock;
   }
@@ -729,8 +731,9 @@ class S3ABlockOutputStream extends OutputStream implements
   /**
    * Shared processing of Syncable operation reporting/downgrade.
    *
-   * Syncable API is not supported, so calls to hsync/hflush will throw an UnsupportedOperationException unless the
-   * stream was constructed with {@link #downgradeSyncableExceptions} set to true, in which case the stream is flushed.
+   * Syncable API is not supported, so calls to hsync/hflush will throw an
+   * UnsupportedOperationException unless the stream was constructed with
+   * {@link #downgradeSyncableExceptions} set to true, in which case the stream is flushed.
    * @throws IOException IO Problem
    * @throws UnsupportedOperationException if downgrade syncable exceptions is set to false
    */

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
@@ -232,7 +232,7 @@ class S3ABlockOutputStream extends OutputStream implements
         LOG.error("Number of partitions in stream exceeds limit for S3: "
              + Constants.MAX_MULTIPART_COUNT +  " write may fail.");
       }
-      activeBlock = blockFactory.create(key, blockCount, this.blockSize, statistics);
+      activeBlock = blockFactory.create(writeOperationHelper.getAuditSpan().getSpanId(), key, blockCount, this.blockSize, statistics);
     }
     return activeBlock;
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
@@ -728,6 +728,11 @@ class S3ABlockOutputStream extends OutputStream implements
 
   /**
    * Shared processing of Syncable operation reporting/downgrade.
+   *
+   * Syncable API is not supported, so calls to hsync/hflush will throw an UnsupportedOperationException unless the
+   * stream was constructed with {@link #downgradeSyncableExceptions} set to true, in which case the stream is flushed.
+   * @throws IOException IO Problem
+   * @throws UnsupportedOperationException if downgrade syncable exceptions is set to false
    */
   private void handleSyncableInvocation() throws IOException {
     final UnsupportedOperationException ex

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ADataBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ADataBlocks.java
@@ -825,9 +825,8 @@ final class S3ADataBlocks {
         throws IOException {
       Preconditions.checkArgument(limit != 0,
           "Invalid block size: %d [%s]", limit, key);
-      File destFile = getOwner()
-          .createTmpFileForWrite(String.format("s3ablock-%04d-%s-%s-", index, spanId, escapeS3Key(key)),
-              limit, getOwner().getConf());
+      String prefix = String.format("s3ablock-%04d-%s-%s-", index, spanId, escapeS3Key(key));
+      File destFile = getOwner().createTmpFileForWrite(prefix, limit, getOwner().getConf());
       return new DiskBlock(destFile, limit, index, statistics);
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ADataBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ADataBlocks.java
@@ -175,12 +175,13 @@ final class S3ADataBlocks {
     /**
      * Create a block.
      *
+     * @param key of s3 object being written to
      * @param index index of block
      * @param limit limit of the block.
      * @param statistics stats to work with
      * @return a new block.
      */
-    abstract DataBlock create(long index, long limit,
+    abstract DataBlock create(String key, long index, long limit,
         BlockOutputStreamStatistics statistics)
         throws IOException;
 
@@ -391,11 +392,11 @@ final class S3ADataBlocks {
     }
 
     @Override
-    DataBlock create(long index, long limit,
+    DataBlock create(String key, long index, long limit,
         BlockOutputStreamStatistics statistics)
         throws IOException {
       Preconditions.checkArgument(limit > 0,
-          "Invalid block size: %d", limit);
+          "Invalid block size: %d [%s]", limit, key);
       return new ByteArrayBlock(0, limit, statistics);
     }
 
@@ -516,11 +517,11 @@ final class S3ADataBlocks {
     }
 
     @Override
-    ByteBufferBlock create(long index, long limit,
+    ByteBufferBlock create(String key, long index, long limit,
         BlockOutputStreamStatistics statistics)
         throws IOException {
       Preconditions.checkArgument(limit > 0,
-          "Invalid block size: %d", limit);
+          "Invalid block size: %d [%s]", limit, key);
       return new ByteBufferBlock(index, limit, statistics);
     }
 
@@ -798,6 +799,8 @@ final class S3ADataBlocks {
    * Buffer blocks to disk.
    */
   static class DiskBlockFactory extends BlockFactory {
+    private static final String ESCAPED_FORWARD_SLASH = "EFS";
+    private static final String ESCAPED_BACKSLASH = "EBS";
 
     DiskBlockFactory(S3AFileSystem owner) {
       super(owner);
@@ -806,6 +809,7 @@ final class S3ADataBlocks {
     /**
      * Create a temp file and a {@link DiskBlock} instance to manage it.
      *
+     * @param key of the s3 object being written
      * @param index block index
      * @param limit limit of the block. -1 means "no limit"
      * @param statistics statistics to update
@@ -813,16 +817,22 @@ final class S3ADataBlocks {
      * @throws IOException IO problems
      */
     @Override
-    DataBlock create(long index,
+    DataBlock create(String key, long index,
         long limit,
         BlockOutputStreamStatistics statistics)
         throws IOException {
       Preconditions.checkArgument(limit != 0,
-          "Invalid block size: %d", limit);
+          "Invalid block size: %d [%s]", limit, key);
       File destFile = getOwner()
-          .createTmpFileForWrite(String.format("s3ablock-%04d-", index),
+          .createTmpFileForWrite(String.format("s3ablock-%04d-%s-", index, escapeS3Key(key)),
               limit, getOwner().getConf());
       return new DiskBlock(destFile, limit, index, statistics);
+    }
+
+    protected static String escapeS3Key(String key) {
+      return key
+        .replace("\\", ESCAPED_BACKSLASH)
+        .replace("/", ESCAPED_FORWARD_SLASH);
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ADataBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ADataBlocks.java
@@ -175,13 +175,14 @@ final class S3ADataBlocks {
     /**
      * Create a block.
      *
-     * @param key of s3 object being written to
+     * @param spanId id of the audit span
+     * @param key key of s3 object being written to
      * @param index index of block
      * @param limit limit of the block.
      * @param statistics stats to work with
      * @return a new block.
      */
-    abstract DataBlock create(String key, long index, long limit,
+    abstract DataBlock create(String spanId, String key, long index, long limit,
         BlockOutputStreamStatistics statistics)
         throws IOException;
 
@@ -392,7 +393,7 @@ final class S3ADataBlocks {
     }
 
     @Override
-    DataBlock create(String key, long index, long limit,
+    DataBlock create(String spanId, String key, long index, long limit,
         BlockOutputStreamStatistics statistics)
         throws IOException {
       Preconditions.checkArgument(limit > 0,
@@ -517,7 +518,7 @@ final class S3ADataBlocks {
     }
 
     @Override
-    ByteBufferBlock create(String key, long index, long limit,
+    ByteBufferBlock create(String spanId, String key, long index, long limit,
         BlockOutputStreamStatistics statistics)
         throws IOException {
       Preconditions.checkArgument(limit > 0,
@@ -809,6 +810,7 @@ final class S3ADataBlocks {
     /**
      * Create a temp file and a {@link DiskBlock} instance to manage it.
      *
+     * @param spanId id of the audit span
      * @param key of the s3 object being written
      * @param index block index
      * @param limit limit of the block. -1 means "no limit"
@@ -817,14 +819,14 @@ final class S3ADataBlocks {
      * @throws IOException IO problems
      */
     @Override
-    DataBlock create(String key, long index,
+    DataBlock create(String spanId, String key, long index,
         long limit,
         BlockOutputStreamStatistics statistics)
         throws IOException {
       Preconditions.checkArgument(limit != 0,
           "Invalid block size: %d [%s]", limit, key);
       File destFile = getOwner()
-          .createTmpFileForWrite(String.format("s3ablock-%04d-%s-", index, escapeS3Key(key)),
+          .createTmpFileForWrite(String.format("s3ablock-%04d-%s-%s-", index, spanId, escapeS3Key(key)),
               limit, getOwner().getConf());
       return new DiskBlock(destFile, limit, index, statistics);
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperationHelper.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperationHelper.java
@@ -217,6 +217,7 @@ public class WriteOperationHelper implements WriteOperations {
    * Get the audit span this object was created with.
    * @return the audit span
    */
+  @Override
   public AuditSpan getAuditSpan() {
     return auditSpan;
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperations.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperations.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.s3a.impl.PutObjectOptions;
 import org.apache.hadoop.fs.statistics.DurationTrackerFactory;
+import org.apache.hadoop.fs.store.audit.AuditSpan;
 import org.apache.hadoop.fs.store.audit.AuditSpanSource;
 import org.apache.hadoop.util.functional.CallableRaisingIOE;
 
@@ -304,6 +305,12 @@ public interface WriteOperations extends AuditSpanSource, Closeable {
    * @return the configuration.
    */
   Configuration getConf();
+
+  /**
+   * Get the audit span this object was created with.
+   * @return the audit span
+   */
+  AuditSpan getAuditSpan();
 
   /**
    * Create a S3 Select request for the destination path.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
@@ -136,7 +136,7 @@ public class ITestS3ABlockOutputArray extends AbstractS3ATestBase {
         new S3AInstrumentation(new URI("s3a://example"));
     BlockOutputStreamStatistics outstats
         = instrumentation.newOutputStreamStatistics(null);
-    S3ADataBlocks.DataBlock block = factory.create("object/key", 1, BLOCK_SIZE, outstats);
+    S3ADataBlocks.DataBlock block = factory.create("spanId", "object/key", 1, BLOCK_SIZE, outstats);
     block.write(dataset, 0, dataset.length);
     S3ADataBlocks.BlockUploadData uploadData = block.startUpload();
     InputStream stream = uploadData.getUploadStream();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
@@ -136,7 +136,7 @@ public class ITestS3ABlockOutputArray extends AbstractS3ATestBase {
         new S3AInstrumentation(new URI("s3a://example"));
     BlockOutputStreamStatistics outstats
         = instrumentation.newOutputStreamStatistics(null);
-    S3ADataBlocks.DataBlock block = factory.create(1, BLOCK_SIZE, outstats);
+    S3ADataBlocks.DataBlock block = factory.create("object/key", 1, BLOCK_SIZE, outstats);
     block.write(dataset, 0, dataset.length);
     S3ADataBlocks.BlockUploadData uploadData = block.startUpload();
     InputStream stream = uploadData.getUploadStream();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
@@ -114,10 +114,11 @@ public class ITestS3ABlockOutputArray extends AbstractS3ATestBase {
          S3ADataBlocks.DataBlock dataBlock =
            diskBlockFactory.create("spanId", s3Key, 1, blockSize, null);
     ) {
+      String tmpDir = getConfiguration().get("hadoop.tmp.dir");
       boolean created = Arrays.stream(
-        Objects.requireNonNull(new File(getConfiguration().get("hadoop.tmp.dir")).listFiles()))
+        Objects.requireNonNull(new File(tmpDir).listFiles()))
           .anyMatch(f -> f.getName().contains("very_long_s3_key"));
-      assertTrue(created);
+      assertTrue(String.format("tmp file should have been created locally in %s", tmpDir), created);
       LOG.info(dataBlock.toString()); // block file name/location can be viewed in failsafe-report
     }
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
@@ -111,7 +111,7 @@ public class ITestS3ABlockOutputArray extends AbstractS3ATestBase {
     try (S3ADataBlocks.BlockFactory diskBlockFactory =
            new S3ADataBlocks.DiskBlockFactory(getFileSystem());
          S3ADataBlocks.DataBlock dataBlock =
-            diskBlockFactory.create("spanId", s3Key, 1, blockSize, null);
+             diskBlockFactory.create("spanId", s3Key, 1, blockSize, null);
     ) {
       String tmpDir = getConfiguration().get("hadoop.tmp.dir");
       boolean created = Arrays.stream(

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
@@ -33,7 +33,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -93,7 +92,7 @@ public class ITestS3ABlockOutputArray extends AbstractS3ATestBase {
   @Test
   public void testDiskBlockCreate() throws IOException {
     String s3Key = // 1024 char
-      "very_long_s3_key__very_long_s3_key__very_long_s3_key__very_long_s3_key__" +
+        "very_long_s3_key__very_long_s3_key__very_long_s3_key__very_long_s3_key__" +
         "very_long_s3_key__very_long_s3_key__very_long_s3_key__very_long_s3_key__" +
         "very_long_s3_key__very_long_s3_key__very_long_s3_key__very_long_s3_key__" +
         "very_long_s3_key__very_long_s3_key__very_long_s3_key__very_long_s3_key__" +
@@ -112,11 +111,11 @@ public class ITestS3ABlockOutputArray extends AbstractS3ATestBase {
     try (S3ADataBlocks.BlockFactory diskBlockFactory =
            new S3ADataBlocks.DiskBlockFactory(getFileSystem());
          S3ADataBlocks.DataBlock dataBlock =
-           diskBlockFactory.create("spanId", s3Key, 1, blockSize, null);
+            diskBlockFactory.create("spanId", s3Key, 1, blockSize, null);
     ) {
       String tmpDir = getConfiguration().get("hadoop.tmp.dir");
       boolean created = Arrays.stream(
-        Objects.requireNonNull(new File(tmpDir).listFiles()))
+          Objects.requireNonNull(new File(tmpDir).listFiles()))
           .anyMatch(f -> f.getName().contains("very_long_s3_key"));
       assertTrue(String.format("tmp file should have been created locally in %s", tmpDir), created);
       LOG.info(dataBlock.toString()); // block file name/location can be viewed in failsafe-report

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestDataBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestDataBlocks.java
@@ -51,7 +51,7 @@ public class TestDataBlocks extends Assert {
              new S3ADataBlocks.ByteBufferBlockFactory(null)) {
       int limit = 128;
       S3ADataBlocks.ByteBufferBlockFactory.ByteBufferBlock block
-          = factory.create("object/key", 1, limit, null);
+          = factory.create("spanId", "s3\\object/key", 1, limit, null);
       assertOutstandingBuffers(factory, 1);
 
       byte[] buffer = ContractTestUtils.toAsciiByteArray("test data");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestDataBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestDataBlocks.java
@@ -51,7 +51,7 @@ public class TestDataBlocks extends Assert {
              new S3ADataBlocks.ByteBufferBlockFactory(null)) {
       int limit = 128;
       S3ADataBlocks.ByteBufferBlockFactory.ByteBufferBlock block
-          = factory.create(1, limit, null);
+          = factory.create("object/key", 1, limit, null);
       assertOutstandingBuffers(factory, 1);
 
       byte[] buffer = ContractTestUtils.toAsciiByteArray("test data");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
@@ -38,7 +38,10 @@ import static org.apache.hadoop.fs.s3a.audit.AuditTestSupport.noopAuditor;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -156,6 +159,7 @@ public class TestS3ABlockOutputStream extends AbstractS3AMockTest {
     stream = spy(new S3ABlockOutputStream(builder));
     intercept(UnsupportedOperationException.class, () -> stream.hflush());
     intercept(UnsupportedOperationException.class, () -> stream.hsync());
+    verify(stream, never()).flush();
   }
 
   /**
@@ -169,8 +173,11 @@ public class TestS3ABlockOutputStream extends AbstractS3AMockTest {
     builder.withDowngradeSyncableExceptions(true);
     stream = spy(new S3ABlockOutputStream(builder));
 
+    verify(stream, never()).flush();
     stream.hflush();
+    verify(stream, times(1)).flush();
     stream.hsync();
+    verify(stream, times(2)).flush();
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.s3a.impl.PutObjectOptions;
 import org.apache.hadoop.fs.s3a.statistics.impl.EmptyS3AStatisticsContext;
 import org.apache.hadoop.fs.s3a.test.MinimalWriteOperationHelperCallbacks;
 import org.apache.hadoop.fs.statistics.IOStatisticsContext;
+import org.apache.hadoop.fs.store.audit.AuditSpan;
 import org.apache.hadoop.util.Progressable;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,6 +63,9 @@ public class TestS3ABlockOutputStream extends AbstractS3AMockTest {
         mock(S3ADataBlocks.BlockFactory.class);
     long blockSize = Constants.DEFAULT_MULTIPART_SIZE;
     WriteOperationHelper oHelper = mock(WriteOperationHelper.class);
+    AuditSpan auditSpan = mock(AuditSpan.class);
+    when(auditSpan.getSpanId()).thenReturn("spanId");
+    when(oHelper.getAuditSpan()).thenReturn(auditSpan);
     PutTracker putTracker = mock(PutTracker.class);
     final S3ABlockOutputStream.BlockOutputStreamBuilder builder =
         S3ABlockOutputStream.builder()


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

This PR improves the ability to recovery partial S3A uploads.
1. Changed the handleSyncableInvocation() to call flush() after warning that the syncable API isn't supported. This mirrors the downgradeSyncable behavior of BufferedIOStatisticsOutputStream and RawLocalFileSystem.
2. Changed the DiskBlock temporary file names to include the S3 key to allow partial uploads to be recovered.

### How was this patch tested?

Unit testing and regression testing with Accumulo
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

