### PR TITLE
YARN-11467. RM failover may fail when the nodes.exclude-path file does not exist

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NodesListManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NodesListManager.java
@@ -220,7 +220,11 @@ public class NodesListManager extends CompositeService implements
 
   public void refreshNodes(Configuration yarnConf)
       throws IOException, YarnException {
-    refreshNodes(yarnConf, false);
+    try {
+      refreshNodes(yarnConf, false);
+    } catch (YarnException | IOException ex) {
+      disableHostsFileReader(ex);
+    }
   }
 
   public void refreshNodes(Configuration yarnConf, boolean graceful)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMHA.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMHA.java
@@ -18,6 +18,10 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager;
 
+import java.io.DataOutputStream;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.UUID;
 import java.util.function.Supplier;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode;
@@ -740,6 +744,88 @@ public class TestRMHA {
     Assert.assertNotNull(
         "ResourceProfilesManager should not be null!",
         rm.getRMContext().getResourceProfilesManager());
+  }
+
+  @Test
+  public void testTransitionedToActiveWithExcludeFileNotExist() throws Exception {
+    final String ERR_UNFORCED_REQUEST = "User request succeeded even when " +
+        "automatic failover is enabled";
+
+    Configuration conf = new YarnConfiguration(configuration);
+    String nodeExcludeFilePath = "/tmp/non-existent-path-" + UUID.randomUUID();
+    conf.set(YarnConfiguration.RM_NODES_EXCLUDE_FILE_PATH, nodeExcludeFilePath);
+
+    DataOutputStream output = null;
+    final File confFile =
+        new File("target/test-classes/"+YarnConfiguration.YARN_SITE_CONFIGURATION_FILE);
+    try {
+      if (confFile.exists()) {
+        confFile.delete();
+      }
+      if (!confFile.createNewFile()) {
+        Assert.fail(
+            "Can not create " + YarnConfiguration.YARN_SITE_CONFIGURATION_FILE);
+      }
+      output = new DataOutputStream(Files.newOutputStream(confFile.toPath()));
+      conf.writeXml(output);
+    } finally {
+      if (output != null) {
+        output.close();
+      }
+    }
+
+    try {
+      rm = new MockRM(conf);
+      rm.init(conf);
+      rm.start();
+      StateChangeRequestInfo requestInfo = new StateChangeRequestInfo(HAServiceProtocol.RequestSource.REQUEST_BY_USER);
+
+      // Transition to standby
+      try {
+        rm.adminService.transitionToStandby(requestInfo);
+        fail(ERR_UNFORCED_REQUEST);
+      } catch (AccessControlException e) {
+        // expected
+      }
+      checkMonitorHealth();
+      checkStandbyRMFunctionality();
+
+      // Transition to active
+      try {
+        rm.adminService.transitionToActive(requestInfo);
+        fail(ERR_UNFORCED_REQUEST);
+      } catch (AccessControlException e) {
+        // expected
+      }
+      checkMonitorHealth();
+      checkStandbyRMFunctionality();
+
+      final String ERR_FORCED_REQUEST =
+          "Forced request by user should work " + "even if automatic failover is enabled";
+      requestInfo = new StateChangeRequestInfo(HAServiceProtocol.RequestSource.REQUEST_BY_USER_FORCED);
+
+      // Transition to standby
+      try {
+        rm.adminService.transitionToStandby(requestInfo);
+      } catch (AccessControlException e) {
+        fail(ERR_FORCED_REQUEST);
+      }
+      checkMonitorHealth();
+      checkStandbyRMFunctionality();
+
+      // Transition to active
+      try {
+        rm.adminService.transitionToActive(requestInfo);
+      } catch (AccessControlException e) {
+        fail(ERR_FORCED_REQUEST);
+      }
+      checkMonitorHealth();
+      checkActiveRMFunctionality();
+    } finally {
+      if (confFile.exists()) {
+        confFile.delete();
+      }
+    }
   }
 
   public void innerTestHAWithRMHostName(boolean includeBindHost) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMHA.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMHA.java
@@ -757,10 +757,10 @@ public class TestRMHA {
 
     DataOutputStream output = null;
     final File confFile =
-        new File("target/test-classes/"+YarnConfiguration.YARN_SITE_CONFIGURATION_FILE);
+         new File("target/test-classes/"+YarnConfiguration.YARN_SITE_CONFIGURATION_FILE);
     final File backupConfFile = new File(
-        "target/test-classes/" + YarnConfiguration.YARN_SITE_CONFIGURATION_FILE
-            + ".backup." + UUID.randomUUID());
+         "target/test-classes/" + YarnConfiguration.YARN_SITE_CONFIGURATION_FILE
+         + ".backup." + UUID.randomUUID());
     boolean hasRenamed = false;
     try {
       if (confFile.exists()) {
@@ -838,6 +838,9 @@ public class TestRMHA {
         } else {
           backupConfFile.renameTo(confFile);
         }
+      }
+      if (rm != null) {
+        rm.stop();
       }
     }
   }


### PR DESCRIPTION
### Description of PR
When RM starts, because the file corresponding to the `yarn.resourcemanager.nodes.include-path` or `yarn.resourcemanager.nodes.exclude-path` configuration item does not exist, it will disable this function.

https://github.com/apache/hadoop/blob/405ed1dde6bcccca1e07e45a356a89c1b583e236/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NodesListManager.java#L552-L570


But in RM failover scenario, because the file does not exist, it will fail.

```java
Caused by: org.apache.hadoop.ha.ServiceFailedException: RefreshAll operation failed
	at org.apache.hadoop.yarn.server.resourcemanager.AdminService.refreshAll(AdminService.java:788)
	at org.apache.hadoop.yarn.server.resourcemanager.AdminService.transitionToActive(AdminService.java:315)
	... 29 more
Caused by: java.nio.file.NoSuchFileException: /tmp/non-existent-path-788aa744-1395-40ca-bdb5-f93bffc92cfb
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214)
	at java.nio.file.Files.newByteChannel(Files.java:361)
	at java.nio.file.Files.newByteChannel(Files.java:407)
	at java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:384)
	at java.nio.file.Files.newInputStream(Files.java:152)
	at org.apache.hadoop.util.HostsFileReader.readFileToMap(HostsFileReader.java:126)
	at org.apache.hadoop.util.HostsFileReader.refreshInternal(HostsFileReader.java:214)
	at org.apache.hadoop.util.HostsFileReader.refresh(HostsFileReader.java:192)
	at org.apache.hadoop.yarn.server.resourcemanager.NodesListManager.refreshHostsReader(NodesListManager.java:258)
	at org.apache.hadoop.yarn.server.resourcemanager.NodesListManager.refreshNodes(NodesListManager.java:232)
	at org.apache.hadoop.yarn.server.resourcemanager.NodesListManager.refreshNodes(NodesListManager.java:224)
	at org.apache.hadoop.yarn.server.resourcemanager.AdminService.refreshNodes(AdminService.java:490)
	at org.apache.hadoop.yarn.server.resourcemanager.AdminService.refreshAll(AdminService.java:778)
```

### How was this patch tested?
add UT

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

