### PR TITLE
HDFS-16653.Add error message for maxEvictableMmapedSize related Precondition check suite.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/ShortCircuitCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/ShortCircuitCache.java
@@ -37,6 +37,7 @@ import org.apache.commons.collections.map.LinkedMap;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.hdfs.ExtendedBlockId;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.client.impl.DfsClientConf.ShortCircuitConf;
 import org.apache.hadoop.hdfs.net.DomainPeer;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
@@ -383,7 +384,9 @@ public class ShortCircuitCache implements Closeable {
     this.maxTotalSize = maxTotalSize;
     Preconditions.checkArgument(maxNonMmappedEvictableLifespanMs >= 0);
     this.maxNonMmappedEvictableLifespanMs = maxNonMmappedEvictableLifespanMs;
-    Preconditions.checkArgument(maxEvictableMmapedSize >= 0);
+    Preconditions.checkArgument(maxEvictableMmapedSize >= 0,
+      "Invalid argument: " + HdfsClientConfigKeys.Mmap.CACHE_SIZE_KEY +
+      " must be greater than zero.");
     this.maxEvictableMmapedSize = maxEvictableMmapedSize;
     Preconditions.checkArgument(maxEvictableMmapedLifespanMs >= 0);
     this.maxEvictableMmapedLifespanMs = maxEvictableMmapedLifespanMs;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/ShortCircuitCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/ShortCircuitCache.java
@@ -380,15 +380,18 @@ public class ShortCircuitCache implements Closeable {
   public ShortCircuitCache(int maxTotalSize, long maxNonMmappedEvictableLifespanMs,
       int maxEvictableMmapedSize, long maxEvictableMmapedLifespanMs,
       long mmapRetryTimeoutMs, long staleThresholdMs, int shmInterruptCheckMs) {
-    Preconditions.checkArgument(maxTotalSize >= 0);
+    Preconditions.checkArgument(maxTotalSize >= 0,
+      "Invalid argument: maxTotalSize must be greater than zero.");
     this.maxTotalSize = maxTotalSize;
-    Preconditions.checkArgument(maxNonMmappedEvictableLifespanMs >= 0);
+    Preconditions.checkArgument(maxNonMmappedEvictableLifespanMs >= 0,
+      "Invalid argument: maxNonMmappedEvictableLifespanMs must be greater than zero.");
     this.maxNonMmappedEvictableLifespanMs = maxNonMmappedEvictableLifespanMs;
     Preconditions.checkArgument(maxEvictableMmapedSize >= 0,
       "Invalid argument: " + HdfsClientConfigKeys.Mmap.CACHE_SIZE_KEY +
       " must be greater than zero.");
     this.maxEvictableMmapedSize = maxEvictableMmapedSize;
-    Preconditions.checkArgument(maxEvictableMmapedLifespanMs >= 0);
+    Preconditions.checkArgument(maxEvictableMmapedLifespanMs >= 0,
+      "Invalid argument: maxEvictableMmapedLifespanMs must be greater than zero.");
     this.maxEvictableMmapedLifespanMs = maxEvictableMmapedLifespanMs;
     this.mmapRetryTimeoutMs = mmapRetryTimeoutMs;
     this.staleThresholdMs = staleThresholdMs;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/ShortCircuitCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/ShortCircuitCache.java
@@ -381,17 +381,16 @@ public class ShortCircuitCache implements Closeable {
       int maxEvictableMmapedSize, long maxEvictableMmapedLifespanMs,
       long mmapRetryTimeoutMs, long staleThresholdMs, int shmInterruptCheckMs) {
     Preconditions.checkArgument(maxTotalSize >= 0,
-      "Invalid argument: maxTotalSize must be greater than zero.");
+      "maxTotalSize must be greater than zero.");
     this.maxTotalSize = maxTotalSize;
     Preconditions.checkArgument(maxNonMmappedEvictableLifespanMs >= 0,
-      "Invalid argument: maxNonMmappedEvictableLifespanMs must be greater than zero.");
+      "maxNonMmappedEvictableLifespanMs must be greater than zero.");
     this.maxNonMmappedEvictableLifespanMs = maxNonMmappedEvictableLifespanMs;
     Preconditions.checkArgument(maxEvictableMmapedSize >= 0,
-      "Invalid argument: " + HdfsClientConfigKeys.Mmap.CACHE_SIZE_KEY +
-      " must be greater than zero.");
+      HdfsClientConfigKeys.Mmap.CACHE_SIZE_KEY + " must be greater than zero.");
     this.maxEvictableMmapedSize = maxEvictableMmapedSize;
     Preconditions.checkArgument(maxEvictableMmapedLifespanMs >= 0,
-      "Invalid argument: maxEvictableMmapedLifespanMs must be greater than zero.");
+      "maxEvictableMmapedLifespanMs must be greater than zero.");
     this.maxEvictableMmapedLifespanMs = maxEvictableMmapedLifespanMs;
     this.mmapRetryTimeoutMs = mmapRetryTimeoutMs;
     this.staleThresholdMs = staleThresholdMs;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/ShortCircuitCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/ShortCircuitCache.java
@@ -381,16 +381,16 @@ public class ShortCircuitCache implements Closeable {
       int maxEvictableMmapedSize, long maxEvictableMmapedLifespanMs,
       long mmapRetryTimeoutMs, long staleThresholdMs, int shmInterruptCheckMs) {
     Preconditions.checkArgument(maxTotalSize >= 0,
-      "maxTotalSize must be greater than zero.");
+        "maxTotalSize must be greater than zero.");
     this.maxTotalSize = maxTotalSize;
     Preconditions.checkArgument(maxNonMmappedEvictableLifespanMs >= 0,
-      "maxNonMmappedEvictableLifespanMs must be greater than zero.");
+        "maxNonMmappedEvictableLifespanMs must be greater than zero.");
     this.maxNonMmappedEvictableLifespanMs = maxNonMmappedEvictableLifespanMs;
     Preconditions.checkArgument(maxEvictableMmapedSize >= 0,
-      HdfsClientConfigKeys.Mmap.CACHE_SIZE_KEY + " must be greater than zero.");
+        HdfsClientConfigKeys.Mmap.CACHE_SIZE_KEY + " must be greater than zero.");
     this.maxEvictableMmapedSize = maxEvictableMmapedSize;
     Preconditions.checkArgument(maxEvictableMmapedLifespanMs >= 0,
-      "maxEvictableMmapedLifespanMs must be greater than zero.");
+        "maxEvictableMmapedLifespanMs must be greater than zero.");
     this.maxEvictableMmapedLifespanMs = maxEvictableMmapedLifespanMs;
     this.mmapRetryTimeoutMs = mmapRetryTimeoutMs;
     this.staleThresholdMs = staleThresholdMs;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/shortcircuit/TestShortCircuitCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/shortcircuit/TestShortCircuitCache.java
@@ -80,6 +80,7 @@ import org.apache.hadoop.net.unix.TemporarySocketDirectory;
 import org.apache.hadoop.security.token.SecretManager.InvalidToken;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.DataChecksum;
 import org.apache.hadoop.util.Time;
 import org.junit.Assert;
@@ -177,15 +178,12 @@ public class TestShortCircuitCache {
     LambdaTestUtils.intercept(IllegalArgumentException.class,
         "maxTotalSize must be greater than zero.",
         () -> new ShortCircuitCache(-1, 1, 10, 1, 1, 10000, 0));
-
     LambdaTestUtils.intercept(IllegalArgumentException.class,
         "maxNonMmappedEvictableLifespanMs must be greater than zero.",
         () -> new ShortCircuitCache(10, -1, 10, 1, 1, 10000, 0));
-
     LambdaTestUtils.intercept(IllegalArgumentException.class,
         "dfs.client.mmap.cache.size must be greater than zero.",
         () -> new ShortCircuitCache(10, 1, -1, 1, 1, 10000, 0));
-
     LambdaTestUtils.intercept(IllegalArgumentException.class,
         "maxEvictableMmapedLifespanMs must be greater than zero.",
         () -> new ShortCircuitCache(10, 1, 10, -1, 1, 10000, 0));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/shortcircuit/TestShortCircuitCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/shortcircuit/TestShortCircuitCache.java
@@ -172,6 +172,30 @@ public class TestShortCircuitCache {
     cache.close();
   }
   
+  @Test(timeout=3000)
+  public void testMaxTotalSizeOutlier() throws Exception {
+    ShortCircuitCache cache =
+        new ShortCircuitCache(-1, 1, 10, 1, 1, 10000, 0);
+  }
+  
+  @Test(timeout=3000)
+  public void testMaxNonMmappedEvictableLifespanMsOutlier() throws Exception {
+    ShortCircuitCache cache =
+        new ShortCircuitCache(10, -1, 10, 1, 1, 10000, 0);
+  }
+  
+  @Test(timeout=3000)
+  public void testMaxEvictableMmapedSizeOutlier() throws Exception {
+    ShortCircuitCache cache =
+        new ShortCircuitCache(10, 1, -1, 1, 1, 10000, 0);
+  }
+  
+  @Test(timeout=3000)
+  public void testMaxEvictableMmapedLifespanMsOutlier() throws Exception {
+    ShortCircuitCache cache =
+        new ShortCircuitCache(10, 1, 10, -1, 1, 10000, 0);
+  }
+  
   @Test(timeout=60000)
   public void testAddAndRetrieve() throws Exception {
     final ShortCircuitCache cache =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/shortcircuit/TestShortCircuitCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/shortcircuit/TestShortCircuitCache.java
@@ -172,7 +172,7 @@ public class TestShortCircuitCache {
         new ShortCircuitCache(10, 1, 10, 1, 1, 10000, 0);
     cache.close();
   }
-  
+
   @Test(timeout=5000)
   public void testInvalidConfiguration() throws Exception {
     LambdaTestUtils.intercept(IllegalArgumentException.class,
@@ -188,7 +188,7 @@ public class TestShortCircuitCache {
         "maxEvictableMmapedLifespanMs must be greater than zero.",
         () -> new ShortCircuitCache(10, 1, 10, -1, 1, 10000, 0));
   }
-  
+
   @Test(timeout=60000)
   public void testAddAndRetrieve() throws Exception {
     final ShortCircuitCache cache =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/shortcircuit/TestShortCircuitCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/shortcircuit/TestShortCircuitCache.java
@@ -172,28 +172,23 @@ public class TestShortCircuitCache {
     cache.close();
   }
   
-  @Test(timeout=3000)
-  public void testMaxTotalSizeOutlier() throws Exception {
-    ShortCircuitCache cache =
-        new ShortCircuitCache(-1, 1, 10, 1, 1, 10000, 0);
-  }
-  
-  @Test(timeout=3000)
-  public void testMaxNonMmappedEvictableLifespanMsOutlier() throws Exception {
-    ShortCircuitCache cache =
-        new ShortCircuitCache(10, -1, 10, 1, 1, 10000, 0);
-  }
-  
-  @Test(timeout=3000)
-  public void testMaxEvictableMmapedSizeOutlier() throws Exception {
-    ShortCircuitCache cache =
-        new ShortCircuitCache(10, 1, -1, 1, 1, 10000, 0);
-  }
-  
-  @Test(timeout=3000)
-  public void testMaxEvictableMmapedLifespanMsOutlier() throws Exception {
-    ShortCircuitCache cache =
-        new ShortCircuitCache(10, 1, 10, -1, 1, 10000, 0);
+  @Test(timeout=5000)
+  public void testInvalidConfiguration() throws Exception {
+    LambdaTestUtils.intercept(IllegalArgumentException.class,
+        "maxTotalSize must be greater than zero.",
+        () -> new ShortCircuitCache(-1, 1, 10, 1, 1, 10000, 0));
+
+    LambdaTestUtils.intercept(IllegalArgumentException.class,
+        "maxNonMmappedEvictableLifespanMs must be greater than zero.",
+        () -> new ShortCircuitCache(10, -1, 10, 1, 1, 10000, 0));
+
+    LambdaTestUtils.intercept(IllegalArgumentException.class,
+        "dfs.client.mmap.cache.size must be greater than zero.",
+        () -> new ShortCircuitCache(10, 1, -1, 1, 1, 10000, 0));
+
+    LambdaTestUtils.intercept(IllegalArgumentException.class,
+        "maxEvictableMmapedLifespanMs must be greater than zero.",
+        () -> new ShortCircuitCache(10, 1, 10, -1, 1, 10000, 0));
   }
   
   @Test(timeout=60000)


### PR DESCRIPTION
### Description of PR

When the configuration item “dfs.client.mmap.cache.size” is set to a negative number, it will cause /hadoop/bin hdfs dfsadmin -safemode provides all the operation options including enter, leave, get, wait and forceExit are invalid, the terminal returns security mode is null and no exceptions are thrown.
[[[HDFS-16653](https://issues.apache.org/jira/browse/HDFS-16653)](https://issues.apache.org/jira/browse/HDFS-16653)](https://issues.apache.org/jira/browse/HDFS-16653)

### How was this patch tested?

This patch adds maxEvictableMmapedSize that is "dfs.client.mmap.cache.size" related Precondition check suite error message, and give a clear indication when the configuration is abnormal in order to solve the problem in time and reduce the impact on the safe mode related operations.