### PR TITLE
HDFS-16697.Add code to check the minimumRedundantVolumes value and add related log messages.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
@@ -174,6 +174,19 @@ public class NameNodeResourceChecker {
    *         otherwise.
    */
   public boolean hasAvailableDiskSpace() {
+    try {
+      if (minimumRedundantVolumes > volumes.size()){
+        throw new IllegalArgumentException("The value of "
+        + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY
+        + " is " + minimumRedundantVolumes
+        + " which is greater than the total number of existing storage volumes "
+        + volumes.size() + " .");
+      }
+    } catch (IllegalArgumentException e){
+      LOG.warn("The value of " + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY
+        + " is greater than the total number of existing storage volumes"
+        + " and will result in adding resources and still not being able to turn off safe mode.", e);
+    }
     return NameNodeResourcePolicy.areResourcesAvailable(volumes.values(),
         minimumRedundantVolumes);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
@@ -174,19 +174,6 @@ public class NameNodeResourceChecker {
    *         otherwise.
    */
   public boolean hasAvailableDiskSpace() {
-    try {
-      if (minimumRedundantVolumes > volumes.size()){
-        throw new IllegalArgumentException("The value of "
-        + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY
-        + " is " + minimumRedundantVolumes
-        + " which is greater than the total number of existing storage volumes "
-        + volumes.size() + " .");
-      }
-    } catch (IllegalArgumentException e){
-      LOG.warn("The value of " + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY
-        + " is greater than the total number of existing storage volumes"
-        + " and will result in adding resources and still not being able to turn off safe mode.", e);
-    }
     return NameNodeResourcePolicy.areResourcesAvailable(volumes.values(),
         minimumRedundantVolumes);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourcePolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourcePolicy.java
@@ -78,13 +78,14 @@ final class NameNodeResourcePolicy {
       // required resources available.
       return requiredResourceCount > 0;
     } else {
-      if (minimumRedundantResources > resources.size()){
-        LOG.info("Resource not available. Details: redundantResourceCount=" + redundantResourceCount
-            + ", disabledRedundantResourceCount=" + disabledRedundantResourceCount
-            + ", minimumRedundantResources=" + minimumRedundantResources + ".");
+      final boolean areResourceAvailable =
+          redundantResourceCount - disabledRedundantResourceCount >= minimumRedundantResources;
+      if (!areResourceAvailable) {
+        LOG.info("Resources not available. Details: redundantResourceCount={},"
+                + " disabledRedundantResourceCount={}, minimumRedundantResources={}.",
+            redundantResourceCount, disabledRedundantResourceCount, minimumRedundantResources);
       }
-      return redundantResourceCount - disabledRedundantResourceCount >=
-          minimumRedundantResources;
+      return areResourceAvailable;
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourcePolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourcePolicy.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdfs.server.namenode;
 import java.util.Collection;
 
 import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,9 +79,9 @@ final class NameNodeResourcePolicy {
       return requiredResourceCount > 0;
     } else {
       if (minimumRedundantResources > resources.size()){
-        LOG.warn("The value of " + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY
-            + " is greater than the total number of existing storage volumes,"
-            + " which will cause safe mode to not be turned off even if resources are added.");
+        LOG.info("Resource not available. Details: redundantResourceCount=" + redundantResourceCount
+            + ", disabledRedundantResourceCount=" + disabledRedundantResourceCount
+            + ", minimumRedundantResources=" + minimumRedundantResources + ".");
       }
       return redundantResourceCount - disabledRedundantResourceCount >=
           minimumRedundantResources;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourcePolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourcePolicy.java
@@ -20,6 +20,9 @@ package org.apache.hadoop.hdfs.server.namenode;
 import java.util.Collection;
 
 import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Given a set of checkable resources, this class is capable of determining
@@ -38,6 +41,9 @@ final class NameNodeResourcePolicy {
    * @return true if and only if there are sufficient NN resources to
    *         continue logging edits.
    */
+  private static final Logger LOG =
+      LoggerFactory.getLogger(NameNodeResourcePolicy.class.getName());
+
   static boolean areResourcesAvailable(
       Collection<? extends CheckableNameNodeResource> resources,
       int minimumRedundantResources) {
@@ -73,6 +79,11 @@ final class NameNodeResourcePolicy {
       // required resources available.
       return requiredResourceCount > 0;
     } else {
+      if (minimumRedundantResources > resources.size()){
+        LOG.warn("The value of " + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY
+            + " is greater than the total number of existing storage volumes,"
+            + " which will cause safe mode to not be turned off even if resources are added.");
+      }
       return redundantResourceCount - disabledRedundantResourceCount >=
           minimumRedundantResources;
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourcePolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourcePolicy.java
@@ -45,7 +45,7 @@ public class TestNameNodeResourcePolicy {
     NameNodeResourcePolicy.areResourcesAvailable(resources, minimumRedundantResources);
     logCapturer.stopCapturing();
 
-    assertTrue(logCapturer.getOutput().contains("is greater than the total number");
+    assertTrue(logCapturer.getOutput().contains("is greater than the total number"));
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourcePolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourcePolicy.java
@@ -45,7 +45,7 @@ public class TestNameNodeResourcePolicy {
     NameNodeResourcePolicy.areResourcesAvailable(resources, minimumRedundantResources);
     logCapturer.stopCapturing();
 
-    assertTrue(logCapturer.getOutput().contains("is greater than the total number"));
+    assertTrue(logCapturer.getOutput().contains("Resource not available."));
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourcePolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourcePolicy.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 
 import org.junit.Test;
 
+import org.slf4j.LoggerFactory;
 import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 
 public class TestNameNodeResourcePolicy {
@@ -38,11 +39,13 @@ public class TestNameNodeResourcePolicy {
 
     int minimumRedundantResources = 2;
 
-    LogCapturer logCapturer = LogCapturer.captureLogs(NameNodeResourcePolicy.class);
+    LogCapturer logCapturer =
+        LogCapturer.captureLogs(LoggerFactory.getLogger(NameNodeResourcePolicy.class));
+
     NameNodeResourcePolicy.areResourcesAvailable(resources, minimumRedundantResources);
     logCapturer.stopCapturing();
 
-    assertTrue(logCapturer.getOutput().contains("which will cause safe mode"));
+    assertTrue(logCapturer.getOutput().contains("is greater than the total number");
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourcePolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourcePolicy.java
@@ -34,18 +34,11 @@ public class TestNameNodeResourcePolicy {
 
   @Test
   public void testExcessiveMinimumRedundantResources() {
-    Collection<CheckableNameNodeResource> resources =
-        new ArrayList<CheckableNameNodeResource>();
-
-    int minimumRedundantResources = 2;
-
     LogCapturer logCapturer =
         LogCapturer.captureLogs(LoggerFactory.getLogger(NameNodeResourcePolicy.class));
-
-    NameNodeResourcePolicy.areResourcesAvailable(resources, minimumRedundantResources);
+    assertFalse(testResourceScenario(1, 0, 0, 0, 2));
     logCapturer.stopCapturing();
-
-    assertTrue(logCapturer.getOutput().contains("Resource not available."));
+    assertTrue(logCapturer.getOutput().contains("Resources not available."));
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourcePolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourcePolicy.java
@@ -27,6 +27,8 @@ import java.util.Collection;
 
 import org.junit.Test;
 
+import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
+
 public class TestNameNodeResourcePolicy {
 
   @Test
@@ -71,7 +73,18 @@ public class TestNameNodeResourcePolicy {
     assertFalse(testResourceScenario(2, 2, 1, 1, 1));
     assertFalse(testResourceScenario(2, 2, 2, 1, 1));
   }
-  
+
+  @Test
+  public void testExcessiveMinimumRedundantResources() {
+    Collection<CheckableNameNodeResource> resources =
+        new ArrayList<CheckableNameNodeResource>();
+    int minimumRedundantResources = 2;
+    LogCapturer logCapturer = LogCapturer.captureLogs(NameNodeResourcePolicy.class);
+    NameNodeResourcePolicy.areResourcesAvailable(resources, minimumRedundantResources);
+    logCapturer.stopCapturing();
+    assertTrue(logCapturer.getOutput().contains("which will cause safe mode"));
+  }
+
   private static boolean testResourceScenario(
       int numRedundantResources,
       int numRequiredResources,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourcePolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourcePolicy.java
@@ -32,6 +32,20 @@ import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 public class TestNameNodeResourcePolicy {
 
   @Test
+  public void testExcessiveMinimumRedundantResources() {
+    Collection<CheckableNameNodeResource> resources =
+        new ArrayList<CheckableNameNodeResource>();
+
+    int minimumRedundantResources = 2;
+
+    LogCapturer logCapturer = LogCapturer.captureLogs(NameNodeResourcePolicy.class);
+    NameNodeResourcePolicy.areResourcesAvailable(resources, minimumRedundantResources);
+    logCapturer.stopCapturing();
+
+    assertTrue(logCapturer.getOutput().contains("which will cause safe mode"));
+  }
+
+  @Test
   public void testSingleRedundantResource() {
     assertTrue(testResourceScenario(1, 0, 0, 0, 1));
     assertFalse(testResourceScenario(1, 0, 1, 0, 1));
@@ -72,17 +86,6 @@ public class TestNameNodeResourcePolicy {
     assertFalse(testResourceScenario(2, 2, 0, 1, 1));
     assertFalse(testResourceScenario(2, 2, 1, 1, 1));
     assertFalse(testResourceScenario(2, 2, 2, 1, 1));
-  }
-
-  @Test
-  public void testExcessiveMinimumRedundantResources() {
-    Collection<CheckableNameNodeResource> resources =
-        new ArrayList<CheckableNameNodeResource>();
-    int minimumRedundantResources = 2;
-    LogCapturer logCapturer = LogCapturer.captureLogs(NameNodeResourcePolicy.class);
-    NameNodeResourcePolicy.areResourcesAvailable(resources, minimumRedundantResources);
-    logCapturer.stopCapturing();
-    assertTrue(logCapturer.getOutput().contains("which will cause safe mode"));
   }
 
   private static boolean testResourceScenario(


### PR DESCRIPTION
### Description of PR

It is found that “dfs.namenode.resource.checked.volumes.minimum” lacks a condition check and an associated exception handling mechanism, which makes it impossible to find the root cause of the impact when a misconfiguration occurs.
Add a mechanism to check the value of minimumRedundantVolumes and add a log warning message to avoid not being able to locate the cause when it appears that safe mode cannot be turned off.

JIRA:(https://issues.apache.org/jira/browse/HDFS-16697))]

### How was this patch tested?

This patch provides a check of the configuration items，it will printing a warning message in the log when the value is greater than the number of NameNode storage volumes  in order to solve the problem in time and avoid the misconfiguration from affecting the subsequent operations of the program.