### PR TITLE
HADOOP-18714. Wrong StringUtils.join() called in AbstractContractRootDirectoryTest

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
@@ -197,7 +197,7 @@ public abstract class AbstractContractRootDirectoryTest extends AbstractFSContra
     }
     FileStatus[] rootListStatus = fs.listStatus(root);
     assertEquals("listStatus on empty root-directory returned found: "
-        + join("\n", rootListStatus),
+        + join(rootListStatus, "\n"),
         0, rootListStatus.length);
     assertNoElements("listFiles(/, false)",
         fs.listFiles(root, false));

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
@@ -195,10 +195,9 @@ public abstract class AbstractContractRootDirectoryTest extends AbstractFSContra
     for (FileStatus status : statuses) {
       ContractTestUtils.assertDeleted(fs, status.getPath(), false, true, false);
     }
-    FileStatus[] rootListStatus = fs.listStatus(root);
-    assertEquals("listStatus on empty root-directory returned found: "
-        + join(rootListStatus, "\n"),
-        0, rootListStatus.length);
+    Assertions.assertThat(fs.listStatus(root))
+        .describedAs("ls /")
+        .hasSize(0);
     assertNoElements("listFiles(/, false)",
         fs.listFiles(root, false));
     assertNoElements("listFiles(/, true)",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix assertion message in `AbstractContractRootDirectoryTest` by calling `join(Object[], String)` instead of `join(T...)` (where `T` was calculated to be `Serializable`).

Steps to reproduce:

1. Make `AbstractContractRootDirectoryTest` fail by commenting out the `assertDeleted` call inside the loop:

https://github.com/apache/hadoop/blob/964c1902c8054dfe13c787222a12fb0daf1aaab9/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java#L194-L201

2. Run `TestHDFSContractRootDirectory`:

```
$ mvn -DfailIfNoTests=false -am -pl :hadoop-hdfs -Dtest=TestHDFSContractRootDirectory clean test
...
[ERROR] Tests run: 9, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.708 s <<< FAILURE! - in org.apache.hadoop.fs.contract.hdfs.TestHDFSContractRootDirectory
[ERROR] testListEmptyRootDirectory(org.apache.hadoop.fs.contract.hdfs.TestHDFSContractRootDirectory)  Time elapsed: 0.011 s  <<< FAILURE!
java.lang.AssertionError: 
listStatus on empty root-directory returned found: 
[Lorg.apache.hadoop.fs.FileStatus;@73344c46 expected:<0> but was:<1>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.apache.hadoop.fs.contract.AbstractContractRootDirectoryTest.testListEmptyRootDirectory(AbstractContractRootDirectoryTest.java:199)
```

https://issues.apache.org/jira/browse/HADOOP-18714

## How was this patch tested?

```
$ mvn -DfailIfNoTests=false -am -pl :hadoop-hdfs -Dtest=TestHDFSContractRootDirectory clean test
...
[ERROR] Tests run: 9, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.711 s <<< FAILURE! - in org.apache.hadoop.fs.contract.hdfs.TestHDFSContractRootDirectory
[ERROR] testListEmptyRootDirectory(org.apache.hadoop.fs.contract.hdfs.TestHDFSContractRootDirectory)  Time elapsed: 0.011 s  <<< FAILURE!
java.lang.AssertionError: listStatus on empty root-directory returned found: HdfsLocatedFileStatus{path=hdfs://localhost:37225/test; isDirectory=true; ...} expected:<0> but was:<1>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.apache.hadoop.fs.contract.AbstractContractRootDirectoryTest.testListEmptyRootDirectory(AbstractContractRootDirectoryTest.java:199)
```