### PR TITLE
HDFS-16987. [BugFix] MarkBlockAsCorrupt should not mark a replica as corrupted if the DN has a newest replica

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -3372,10 +3372,10 @@ public class BlockManager implements BlockStatsMXBean {
       // Nothing to re-process
       return;
     }
-    processQueuedMessages(queue);
+    processQueuedMessages(queue, false);
   }
   
-  private void processQueuedMessages(Iterable<ReportedBlockInfo> rbis)
+  private void processQueuedMessages(Iterable<ReportedBlockInfo> rbis, boolean verifyCorruptedBlock)
       throws IOException {
     boolean isPreviousMessageProcessed = true;
     for (ReportedBlockInfo rbi : rbis) {
@@ -3393,7 +3393,7 @@ public class BlockManager implements BlockStatsMXBean {
       } else {
         isPreviousMessageProcessed =
             processAndHandleReportedBlock(rbi.getStorageInfo(), rbi.getBlock(),
-                rbi.getReportedState(), null);
+                rbi.getReportedState(), null, verifyCorruptedBlock);
       }
     }
   }
@@ -3413,7 +3413,7 @@ public class BlockManager implements BlockStatsMXBean {
       LOG.info("Processing {} messages from DataNodes " +
           "that were previously queued during standby state", count);
     }
-    processQueuedMessages(pendingDNMessages.takeAll());
+    processQueuedMessages(pendingDNMessages.takeAll(), true);
     assert pendingDNMessages.count() == 0;
   }
 
@@ -4370,7 +4370,7 @@ public class BlockManager implements BlockStatsMXBean {
       }
     }
     processAndHandleReportedBlock(storageInfo, block, ReplicaState.FINALIZED,
-        delHintNode);
+        delHintNode, false);
   }
 
   /**
@@ -4381,7 +4381,7 @@ public class BlockManager implements BlockStatsMXBean {
    */
   private boolean processAndHandleReportedBlock(
       DatanodeStorageInfo storageInfo, Block block,
-      ReplicaState reportedState, DatanodeDescriptor delHintNode)
+      ReplicaState reportedState, DatanodeDescriptor delHintNode, boolean verifyCorruptedBlock)
       throws IOException {
     // blockReceived reports a finalized block
     Collection<BlockInfoToAdd> toAdd = new LinkedList<>();
@@ -4428,7 +4428,20 @@ public class BlockManager implements BlockStatsMXBean {
       addToInvalidates(b, node);
     }
     for (BlockToMarkCorrupt b : toCorrupt) {
-      markBlockAsCorrupt(b, storageInfo, node);
+      if (!verifyCorruptedBlock) {
+        markBlockAsCorrupt(b, storageInfo, node);
+      } else {
+        // Ignore this corrupted replica, if the storage list already contains this storage.
+        DatanodeStorageInfo otherStorage = b.getStored().findStorageInfo(node);
+        boolean alreadyExist = otherStorage != null;
+        if (alreadyExist) {
+          blockLog.info("BLOCK* processAndHandleReportedBlock: Redundant report request " +
+                  "received for {} on node {} with status {} and size {}.", b.getStored(), node,
+              b.getCorrupted(), b.getCorrupted().getNumBytes());
+        } else {
+          markBlockAsCorrupt(b, storageInfo, node);
+        }
+      }
     }
     return true;
   }
@@ -4492,7 +4505,7 @@ public class BlockManager implements BlockStatsMXBean {
       case RECEIVING_BLOCK:
         receiving++;
         processAndHandleReportedBlock(storageInfo, rdbi.getBlock(),
-                                      ReplicaState.RBW, null);
+                                      ReplicaState.RBW, null, false);
         break;
       default:
         String msg = 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManagerFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManagerFaultInjector.java
@@ -53,4 +53,8 @@ public class BlockManagerFaultInjector {
   @VisibleForTesting
   public void mockAnException() {
   }
+
+  @VisibleForTesting
+  public void mockDelayBlockReceiveAndDelete(String state) {
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -1695,6 +1695,9 @@ public class NameNodeRpcServer implements NamenodeProtocols {
     metrics.incrBlockReceivedAndDeletedOps();
     blockStateChangeLog.debug("*BLOCK* NameNode.blockReceivedAndDeleted: from {} {} blocks.",
         nodeReg, receivedAndDeletedBlocks.length);
+
+    BlockManagerFaultInjector.getInstance().mockDelayBlockReceiveAndDelete(namesystem.getHAState());
+
     final BlockManager bm = namesystem.getBlockManager();
     for (final StorageReceivedDeletedBlocks r : receivedAndDeletedBlocks) {
       bm.enqueueBlockOp(new Runnable() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestHAFailoverRace.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestHAFailoverRace.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.namenode;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
+import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
+import org.apache.hadoop.hdfs.qjournal.MiniQJMHACluster;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockManagerFaultInjector;
+import org.apache.hadoop.test.LambdaTestUtils;
+import org.apache.hadoop.util.Time;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class TestHAFailoverRace {
+  private static final Logger LOG = LoggerFactory.getLogger(TestHAFailoverRace.class);
+  private MiniQJMHACluster cluster;
+
+  @Before
+  public void setUpCluster() throws IOException {
+    Configuration conf = new HdfsConfiguration();
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 10 * 1024 * 1024);
+    MiniQJMHACluster.Builder builder = new MiniQJMHACluster.Builder(conf).setNumNameNodes(2);
+    builder.getDfsBuilder().numDataNodes(3);
+    cluster = builder.build();
+    cluster.getDfsCluster().waitActive();
+    cluster.getDfsCluster().transitionToActive(0);
+  }
+
+  @After
+  public void tearDownCluster() throws IOException {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testCorruptedBlockAfterHAFailover() throws Exception {
+    AtomicBoolean enableBlockReceiveAndDeleted = new AtomicBoolean(false);
+    // Disable blockReceivedAndDeleted RPC for Standby NameNode.
+    BlockManagerFaultInjector.instance = new BlockManagerFaultInjector() {
+      @Override
+      public void mockDelayBlockReceiveAndDelete(String state) {
+        if ("standby".equals(state)) {
+          try {
+            while (!enableBlockReceiveAndDeleted.get()) {
+              LOG.info("I'm waiting.....");
+              Thread.sleep(1000);
+            }
+          } catch (Throwable e) {
+            Assert.fail();
+          }
+        }
+      }
+    };
+
+    DistributedFileSystem fs0 = cluster.getDfsCluster().getFileSystem(0);
+    DistributedFileSystem fs1 = cluster.getDfsCluster().getFileSystem(1);
+    FSNamesystem ns1 = cluster.getDfsCluster().getNamesystem(1);
+
+    // Step1: Create one file
+    Path testPath = new Path("/testCorruptedBlockAfterHAFailover");
+    DFSTestUtil.createFile(fs0, testPath, 1024 * 1024, (short) 3,
+        Time.monotonicNow());
+    LocatedBlocks locatedBlocks = fs0.getClient().getLocatedBlocks(
+        testPath.toUri().getPath(), 0, Long.MAX_VALUE);
+
+    Assert.assertEquals(1, locatedBlocks.getLocatedBlocks().size());
+    Assert.assertEquals(3, locatedBlocks.get(0).getLocations().length);
+    ExtendedBlock lastBlock = locatedBlocks.get(0).getBlock();
+
+    // Step2: Try to append this file
+    DFSTestUtil.appendFile(fs0, testPath, 1024 * 1024);
+    locatedBlocks = fs0.getClient().getLocatedBlocks(
+        testPath.toUri().getPath(), 0, Long.MAX_VALUE);
+    Assert.assertEquals(1, locatedBlocks.getLocatedBlocks().size());
+    Assert.assertEquals(3, locatedBlocks.get(0).getLocations().length);
+    ExtendedBlock lastBlock1 = locatedBlocks.get(0).getBlock();
+    Assert.assertTrue(lastBlock1.getGenerationStamp() > lastBlock.getGenerationStamp());
+
+    // Step3: Switch the Active NameNode to Standby
+    cluster.getDfsCluster().transitionToStandby(0);
+
+    // Step4: Try to replay all edits from journalNode for Standby NameNode
+    ns1.getEditLogTailer().doTailEdits();
+
+    // Step5: Enable BlockReceivedAndDeleted RPCs for Standby NameNode.
+    enableBlockReceiveAndDeleted.set(true);
+
+    LambdaTestUtils.await(300000, 100,
+        () -> ns1.getPendingDataNodeMessageCount() == 3);
+
+    // Step6: Try to switch the original Standby NameNode to Active
+    cluster.getDfsCluster().transitionToActive(1);
+    Assert.assertEquals(0, ns1.getBlockManager().getCorruptBlocks());
+
+    // Step7: Try to append this file again
+    DFSTestUtil.appendFile(fs1, testPath, 1024 * 1024);
+  }
+}


### PR DESCRIPTION
In our prod environment, we encountered an incident where HA failover caused some new corrupted blocks, causing some jobs to fail.

Traced down and found a bug in the processing of all pending DN messages when starting active services.
Suppose NN1 is Active and NN2 is Standby, Active works well and Standby is unstable

The steps to reproduce are as follows:

- Timing 1, client create a file, write some data and close it.

- Timing 2, client append this file, write some data and close it.

- Timing 3, Standby replayed the second closing edits of this file

- Timing 4, Standby processes the blockReceivedAndDeleted of the first create operation

- Timing 5, Standby processed the blockReceivedAndDeleted of the second append operation

- Timing 6, Admin switched the active namenode from NN1 to NN2

- Timing 7, client failed to append some data to this file.

```
org.apache.hadoop.ipc.RemoteException(java.io.IOException): append: lastBlock=blk_1073741825_1002 of src=/testCorruptedBlockAfterHAFailover is not sufficiently replicated yet.
    at org.apache.hadoop.hdfs.server.namenode.FSDirAppendOp.appendFile(FSDirAppendOp.java:138)
    at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.appendFile(FSNamesystem.java:2992)
    at org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer.append(NameNodeRpcServer.java:858)
    at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolServerSideTranslatorPB.append(ClientNamenodeProtocolServerSideTranslatorPB.java:527)
    at org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos$ClientNamenodeProtocol$2.callBlockingMethod(ClientNamenodeProtocolProtos.java)
    at org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:621)
    at org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:589)
    at org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:573)
    at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:1227)
    at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:1221)
    at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:1144)
    at java.security.AccessController.doPrivileged(Native Method)
    at javax.security.auth.Subject.doAs(Subject.java:422)
    at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1953)
    at org.apache.hadoop.ipc.Server$Handler.run(Server.java:3170) 
```
