### PR TITLE
HDFS-16988. Improve NameServices info at JournalNode web UI

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/journal/jn.js
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/journal/jn.js
@@ -61,7 +61,9 @@
 
     function workaround(journals) {
         for (var i in journals){
-            journals[i]['NameService']= journals[i]['modelerType'].split("-")[1];
+            var str= journals[i]['modelerType'];
+            var index= str.indexOf("-");
+            journals[i]['NameService']= str.substr(index + 1, str.length);
         }
 
         return journals;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/journal/jn.js
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/journal/jn.js
@@ -63,7 +63,7 @@
         for (var i in journals){
             var str= journals[i]['modelerType'];
             var index= str.indexOf("-");
-            journals[i]['NameService']= str.substr(index + 1, str.length);
+            journals[i]['NameService']= str.substr(index + 1);
         }
 
         return journals;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR   

If the NameServices is named xxx-abc-edg, only xxx will be displayed on the JN web UI.

If NS1 is named xxx-abc-edg, NS2 is named xxx-lmn-xyz. Show both NS as xxx on the JN web UI.

### How was this patch tested?
* before   
![image](https://user-images.githubusercontent.com/32935220/233831314-a78c1799-b7ce-4422-b575-668dd7539b00.png)
* after   
![image](https://user-images.githubusercontent.com/32935220/233831341-36f510dc-b120-4287-a7e3-33dcfe01de20.png)


### For code changes:

issue:   
https://issues.apache.org/jira/browse/HDFS-16988

