### PR TITLE
HADOOP-18714. Wrong StringUtils.join() called in AbstractContractRootDirectoryTest

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
@@ -195,10 +195,9 @@ public abstract class AbstractContractRootDirectoryTest extends AbstractFSContra
     for (FileStatus status : statuses) {
       ContractTestUtils.assertDeleted(fs, status.getPath(), false, true, false);
     }
-    FileStatus[] rootListStatus = fs.listStatus(root);
-    assertEquals("listStatus on empty root-directory returned found: "
-        + join("\n", rootListStatus),
-        0, rootListStatus.length);
+    Assertions.assertThat(fs.listStatus(root))
+        .describedAs("ls /")
+        .hasSize(0);
     assertNoElements("listFiles(/, false)",
         fs.listFiles(root, false));
     assertNoElements("listFiles(/, true)",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Backport #5578 to `branch-3.3`.