### PR TITLE
HADOOP-17450. Add Public IOStatistics API -SemaphoredDelegatingExecutor changes

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SemaphoredDelegatingExecutor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SemaphoredDelegatingExecutor.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.Forwarding
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.Futures;
 
 import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.fs.statistics.DurationTracker;
+import org.apache.hadoop.fs.statistics.DurationTrackerFactory;
 
 import java.util.Collection;
 import java.util.List;
@@ -32,6 +34,10 @@ import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.fs.statistics.IOStatisticsSupport.stubDurationTrackerFactory;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.ACTION_EXECUTOR_ACQUIRED;
 
 /**
  * This ExecutorService blocks the submission of new tasks when its queue is
@@ -53,9 +59,30 @@ public class SemaphoredDelegatingExecutor extends
   private final Semaphore queueingPermits;
   private final ExecutorService executorDelegatee;
   private final int permitCount;
+  private final DurationTrackerFactory trackerFactory;
 
   /**
    * Instantiate.
+   * @param executorDelegatee Executor to delegate to
+   * @param permitCount number of permits into the queue permitted
+   * @param fair should the semaphore be "fair"
+   * @param trackerFactory duration tracker factory.
+   */
+  public SemaphoredDelegatingExecutor(
+      ExecutorService executorDelegatee,
+      int permitCount,
+      boolean fair,
+      DurationTrackerFactory trackerFactory) {
+    this.permitCount = permitCount;
+    queueingPermits = new Semaphore(permitCount, fair);
+    this.executorDelegatee = requireNonNull(executorDelegatee);
+    this.trackerFactory = trackerFactory != null
+        ? trackerFactory
+        : stubDurationTrackerFactory();
+  }
+
+  /**
+   * Instantiate without collecting executor aquisition duration information.
    * @param executorDelegatee Executor to delegate to
    * @param permitCount number of permits into the queue permitted
    * @param fair should the semaphore be "fair"
@@ -64,9 +91,7 @@ public class SemaphoredDelegatingExecutor extends
       ExecutorService executorDelegatee,
       int permitCount,
       boolean fair) {
-    this.permitCount = permitCount;
-    queueingPermits = new Semaphore(permitCount, fair);
-    this.executorDelegatee = executorDelegatee;
+    this(executorDelegatee, permitCount, fair, null);
   }
 
   @Override
@@ -102,7 +127,8 @@ public class SemaphoredDelegatingExecutor extends
 
   @Override
   public <T> Future<T> submit(Callable<T> task) {
-    try {
+    try (DurationTracker ignored =
+             trackerFactory.trackDuration(ACTION_EXECUTOR_ACQUIRED)) {
       queueingPermits.acquire();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -113,7 +139,8 @@ public class SemaphoredDelegatingExecutor extends
 
   @Override
   public <T> Future<T> submit(Runnable task, T result) {
-    try {
+    try (DurationTracker ignored =
+             trackerFactory.trackDuration(ACTION_EXECUTOR_ACQUIRED)) {
       queueingPermits.acquire();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -124,7 +151,8 @@ public class SemaphoredDelegatingExecutor extends
 
   @Override
   public Future<?> submit(Runnable task) {
-    try {
+    try (DurationTracker ignored =
+             trackerFactory.trackDuration(ACTION_EXECUTOR_ACQUIRED)) {
       queueingPermits.acquire();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -135,7 +163,8 @@ public class SemaphoredDelegatingExecutor extends
 
   @Override
   public void execute(Runnable command) {
-    try {
+    try (DurationTracker ignored =
+             trackerFactory.trackDuration(ACTION_EXECUTOR_ACQUIRED)) {
       queueingPermits.acquire();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();


### PR DESCRIPTION

This cherrypicks SemaphoredDelegatingExecutor changes from the trunk commit; somehow it didn't get into the backport to branch-3.3.

Adds a constructor which takes a duration tracker, so can track time spent awaiting an executor. 

There may have been a valid reason for the omission., but I don't remember it. Probably related to
the move from guava.

testing: s3a -prefetch branch, aws london

As the rest of the backport is in, if yetus is happy I will merge

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

