### PR TITLE
HDFS-16991. fix testMkdirsRaceWithObserverRead

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
@@ -583,7 +583,6 @@ public class TestObserverNode {
       futures[i] = threadPool.submit(new MkDirRunner(conf2, clientStates[i]));
     }
 
-    Thread.sleep(150); // wait until mkdir is logged
     long activStateId =
         dfsCluster.getNameNode(0).getFSImage().getLastAppliedOrWrittenTxId();
     dfsCluster.rollEditLogAndTail(0);
@@ -638,6 +637,7 @@ public class TestObserverNode {
     public void run() {
       try {
         fs.mkdirs(DIR_PATH);
+        Thread.sleep(150); // wait until mkdir is logged
         clientState.lastSeenStateId = HATestUtil.getLastSeenStateId(fs);
         assertSentTo(fs, 0);
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
@@ -637,7 +637,15 @@ public class TestObserverNode {
     public void run() {
       try {
         fs.mkdirs(DIR_PATH);
-        Thread.sleep(150); // wait until mkdir is logged
+        // wait until mkdir is logged and get last seen stateId
+        GenericTestUtils.waitFor(() -> {
+          try {
+            return HATestUtil.getLastSeenStateId(fs) > 0L;
+          } catch (Exception e) {
+            LOG.warn("Not get last seen stateId yet: " + e.getMessage());
+            return false;
+          }
+        }, 50, 150);
         clientState.lastSeenStateId = HATestUtil.getLastSeenStateId(fs);
         assertSentTo(fs, 0);
 


### PR DESCRIPTION

### Description of PR
see https://issues.apache.org/jira/browse/HDFS-16991

### How was this patch tested?
no unit tests need

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

