### PR TITLE
HADOOP-18718. Fix several maven build warnings

### DIFF
--- a/hadoop-client-modules/hadoop-client-check-invariants/pom.xml
+++ b/hadoop-client-modules/hadoop-client-check-invariants/pom.xml
@@ -180,7 +180,6 @@
             <configuration>
               <executable>${shell-executable}</executable>
               <workingDirectory>${project.build.testOutputDirectory}</workingDirectory>
-              <requiresOnline>false</requiresOnline>
               <arguments>
                 <argument>ensure-jars-have-correct-contents.sh</argument>
                 <argument>${hadoop-client-artifacts}</argument>

--- a/hadoop-client-modules/hadoop-client-check-test-invariants/pom.xml
+++ b/hadoop-client-modules/hadoop-client-check-test-invariants/pom.xml
@@ -190,7 +190,6 @@
             <configuration>
               <executable>${shell-executable}</executable>
               <workingDirectory>${project.build.testOutputDirectory}</workingDirectory>
-              <requiresOnline>false</requiresOnline>
               <arguments>
                 <argument>ensure-jars-have-correct-contents.sh</argument>
                 <argument>${hadoop-client-artifacts}</argument>

--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -1084,7 +1084,6 @@
                     </goals>
                     <configuration>
                         <executable>${basedir}/../../dev-support/bin/releasedocmaker</executable>
-                        <requiresOnline>true</requiresOnline>
                         <arguments>
                             <argument>--index</argument>
                             <argument>--license</argument>

--- a/hadoop-dist/pom.xml
+++ b/hadoop-dist/pom.xml
@@ -179,7 +179,6 @@
                   <executable>${shell-executable}</executable>
                   <workingDirectory>${project.build.directory}
                   </workingDirectory>
-                  <requiresOnline>false</requiresOnline>
                   <arguments>
                     <argument>
                       ${basedir}/../dev-support/bin/dist-layout-stitching
@@ -198,7 +197,6 @@
                 <configuration>
                   <executable>${shell-executable}</executable>
                   <workingDirectory>${basedir}</workingDirectory>
-                  <requiresOnline>false</requiresOnline>
                   <arguments>
                     <argument>
                       ${basedir}/../dev-support/bin/dist-tools-hooks-maker
@@ -219,7 +217,6 @@
                   <executable>${shell-executable}</executable>
                   <workingDirectory>${project.build.directory}
                   </workingDirectory>
-                  <requiresOnline>false</requiresOnline>
                   <arguments>
                     <argument>${basedir}/../dev-support/bin/dist-tar-stitching
                     </argument>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
@@ -190,12 +190,9 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <systemProperties>
-            <property>
-              <name>derby.stream.error.file</name>
-              <value>${project.build.directory}/derby.log</value>
-            </property>
-          </systemProperties>
+          <systemPropertyVariables>
+            <derby.stream.error.file>${project.build.directory}/derby.log</derby.stream.error.file>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>
@@ -251,10 +248,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <task>
                 <copy file="src/main/resources/hdfs-rbf-default.xml" todir="src/site/resources"/>
                 <copy file="src/main/xsl/configuration.xsl" todir="src/site/resources"/>
-              </tasks>
+              </task>
             </configuration>
           </execution>
         </executions>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
@@ -248,10 +248,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <goal>run</goal>
             </goals>
             <configuration>
-              <task>
+              <target>
                 <copy file="src/main/resources/hdfs-rbf-default.xml" todir="src/site/resources"/>
                 <copy file="src/main/xsl/configuration.xsl" todir="src/site/resources"/>
-              </task>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/hadoop-hdfs-project/hadoop-hdfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/pom.xml
@@ -307,10 +307,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <copy file="src/main/resources/hdfs-default.xml" todir="src/site/resources"/>
                 <copy file="src/main/xsl/configuration.xsl" todir="src/site/resources"/>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/pom.xml
@@ -136,10 +136,10 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <copy file="src/main/resources/mapred-default.xml" todir="src/site/resources"/>
                 <copy file="../../../hadoop-common-project/hadoop-common/src/main/xsl/configuration.xsl" todir="src/site/resources"/>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/hadoop-project-dist/pom.xml
+++ b/hadoop-project-dist/pom.xml
@@ -328,7 +328,6 @@
                 <configuration>
                   <executable>${shell-executable}</executable>
                   <workingDirectory>${project.build.directory}</workingDirectory>
-                  <requiresOnline>false</requiresOnline>
                   <arguments>
                     <argument>${project.parent.basedir}/../dev-support/bin/dist-copynativelibs</argument>
                     <argument>--version=${project.version}</argument>

--- a/hadoop-tools/hadoop-benchmark/pom.xml
+++ b/hadoop-tools/hadoop-benchmark/pom.xml
@@ -72,13 +72,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-          <configuration>
-            <excludeFilterFile>${basedir}/src/main/findbugs/exclude.xml</excludeFilterFile>
-          </configuration>
-      </plugin>
-      <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <configuration>

--- a/hadoop-tools/hadoop-distcp/pom.xml
+++ b/hadoop-tools/hadoop-distcp/pom.xml
@@ -142,24 +142,12 @@
             <include>**/Test*.java</include>
           </includes>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
-          <systemProperties>
-            <property>
-              <name>test.build.data</name>
-              <value>${basedir}/target/test/data</value>
-            </property>
-            <property>
-              <name>hadoop.log.dir</name>
-              <value>target/test/logs</value>
-            </property>
-            <property>
-              <name>org.apache.commons.logging.Log</name>
-              <value>org.apache.commons.logging.impl.SimpleLog</value>
-            </property>
-            <property>
-              <name>org.apache.commons.logging.simplelog.defaultlog</name>
-              <value>warn</value>
-            </property>
-          </systemProperties>
+          <systemPropertyVariables>
+            <test.build.data>${basedir}/target/test/data</test.build.data>
+            <hadoop.log.dir>target/test/logs</hadoop.log.dir>
+            <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
+            <org.apache.commons.logging.simplelog.defaultlog>warn</org.apache.commons.logging.simplelog.defaultlog>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>

--- a/hadoop-tools/hadoop-federation-balance/pom.xml
+++ b/hadoop-tools/hadoop-federation-balance/pom.xml
@@ -152,24 +152,12 @@
             <include>**/Test*.java</include>
           </includes>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
-          <systemProperties>
-            <property>
-              <name>test.build.data</name>
-              <value>${basedir}/target/test/data</value>
-            </property>
-            <property>
-              <name>hadoop.log.dir</name>
-              <value>target/test/logs</value>
-            </property>
-            <property>
-              <name>org.apache.commons.logging.Log</name>
-              <value>org.apache.commons.logging.impl.SimpleLog</value>
-            </property>
-            <property>
-              <name>org.apache.commons.logging.simplelog.defaultlog</name>
-              <value>warn</value>
-            </property>
-          </systemProperties>
+          <systemPropertyVariables>
+            <test.build.data>${basedir}/target/test/data</test.build.data>
+            <hadoop.log.dir>target/test/logs</hadoop.log.dir>
+            <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
+            <org.apache.commons.logging.simplelog.defaultlog>warn</org.apache.commons.logging.simplelog.defaultlog>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
@@ -387,10 +387,10 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <copy file="src/main/resources/yarn-default.xml" todir="src/site/resources"/>
                 <copy file="src/main/xsl/configuration.xsl" todir="src/site/resources"/>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/pom.xml
@@ -176,9 +176,9 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <copy file="src/main/xsl/configuration.xsl" todir="src/site/resources"/>
-              </tasks>
+              </target>
             </configuration>
           </execution>
           <execution>
@@ -188,12 +188,12 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <copy file="${basedir}/../../bin/FederationStateStore/MySQL/FederationStateStoreTables.sql" todir="${project.build.directory}/test-classes/MySQL"/>
                 <copy file="${basedir}/../../bin/FederationStateStore/MySQL/FederationStateStoreStoredProcs.sql" todir="${project.build.directory}/test-classes/MySQL"/>
                 <copy file="${basedir}/../../bin/FederationStateStore/SQLServer/FederationStateStoreTables.sql" todir="${project.build.directory}/test-classes/SQLServer"/>
                 <copy file="${basedir}/../../bin/FederationStateStore/SQLServer/FederationStateStoreStoredProcs.sql" todir="${project.build.directory}/test-classes/SQLServer"/>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -611,6 +611,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
       <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
+        <version>${cyclonedx.version}</version>
       </plugin>
     </plugins>
   </build>
@@ -769,6 +770,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                 </goals>
               </execution>
             </executions>
+            <configuration>
+              <outputFormat>xml</outputFormat>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
### Description of PR

This PR aims to fix the following build warnings which are a subset of the full warnings on Maven 3.9.1.

- To suppress the following, `cyclonedx-maven-plugin` version is added.
```
[WARNING] 'build.plugins.plugin.version' for org.cyclonedx:cyclonedx-maven-plugin is missing. @ org.apache.hadoop:hadoop-main:3.3.9-SNAPSHOT, /Users/stevel/Projects/hadoop-trunk/pom.xml, line 498, column 15
```
 

- To suppress the following, skip JSON SBOM file and only publish XML SBOM file.
```
[WARNING] Unknown keyword additionalItems - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
```

- According to HADOOP-16870 `Use spotbugs-maven-plugin instead of findbugs-maven-plugin`, remove `findbug-maven-plugin`.
```
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:findbugs-maven-plugin is missing. @ line 74, column 15
```

- To suppress the following, remove this unknown field.
```
[WARNING] Parameter 'requiresOnline' is unknown for plugin 'exec-maven-plugin:1.3.1:exec (pre-dist)'
```

- Use `target` instead of `tasks`.
```
[WARNING] Parameter 'tasks' is deprecated: Use target instead
```
 
- Use `systemPropertyVariables` instead of `systemProperties`.
```
[WARNING] Parameter 'systemProperties' is deprecated: Use systemPropertyVariables instead.
```

### How was this patch tested?

Pass the CI and do the manual tests.

```
$ mvn --version
Apache Maven 3.9.1 (2e178502fcdbffc201671fb2537d0cb4b4cc58f8)
Maven home: /opt/homebrew/Cellar/maven/3.9.1/libexec
Java version: 1.8.0_312, vendor: AppleJDK-8.0.312.7.1, runtime: /Library/Java/JavaVirtualMachines/applejdk-8.0.312.7.1.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.16", arch: "x86_64", family: "mac"

$ mvn install -DskipTests -Pdist
...
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

