### PR TITLE
HDFS-16989. Large scale block transfer causes too many excess blocks

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -27,6 +28,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 
@@ -79,6 +81,15 @@ public class DatanodeDescriptor extends DatanodeInfo {
     BlockTargetPair(Block block, DatanodeStorageInfo[] targets) {
       this.block = block;
       this.targets = targets;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      BlockTargetPair that = (BlockTargetPair) o;
+      return Objects.equals(block, that.block) &&
+          Arrays.equals(targets, that.targets);
     }
   }
 
@@ -686,7 +697,11 @@ public class DatanodeDescriptor extends DatanodeInfo {
   public void addBlockToBeReplicated(Block block,
       DatanodeStorageInfo[] targets) {
     assert(block != null && targets != null && targets.length > 0);
-    replicateBlocks.offer(new BlockTargetPair(block, targets));
+    BlockTargetPair blockTargetPair = new BlockTargetPair(block, targets);
+    if (!replicateBlocks.contains(blockTargetPair)) {
+      return;
+    }
+    replicateBlocks.offer(blockTargetPair);
   }
 
   /**


### PR DESCRIPTION
detailed description was in https://issues.apache.org/jira/browse/HDFS-16989

![image](https://user-images.githubusercontent.com/25115709/234774457-d44d676e-996f-4f02-81ed-9c5bae4ad95e.png)

![image](https://user-images.githubusercontent.com/25115709/234774586-f9bc4ae5-3a69-43f3-8c9e-c287ab60dd14.png)

<img width="1400" alt="image" src="https://user-images.githubusercontent.com/25115709/234775407-24477c43-46cb-48e4-8dca-676f2ad5517f.png">
