### PR TITLE
HDFS-16993. Datanode supports configure TopN DatanodeNetworkCounts

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -491,6 +491,10 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final long DFS_DATANODE_PROCESS_COMMANDS_THRESHOLD_DEFAULT =
       TimeUnit.SECONDS.toMillis(2);
 
+  public static final String DFS_DATANODE_NETWORKERRORS_DISPLAY_TOPCOUNT =
+      "dfs.datanode.networkerrors.display.topcount";
+  public static final int DFS_DATANODE_NETWORKERRORS_DISPLAY_TOPCOUNT_DEFAULT = -1;
+
   public static final String DFS_NAMENODE_DATANODE_REGISTRATION_IP_HOSTNAME_CHECK_KEY = "dfs.namenode.datanode.registration.ip-hostname-check";
   public static final boolean DFS_NAMENODE_DATANODE_REGISTRATION_IP_HOSTNAME_CHECK_DEFAULT = true;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -129,7 +129,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -129,6 +129,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -140,6 +141,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -2760,6 +2762,31 @@ public class DataNode extends ReconfigurableBase
 
   @Override // DataNodeMXBean
   public Map<String, Map<String, Long>> getDatanodeNetworkCounts() {
+    int maxDisplay = getConf().getInt(DFSConfigKeys.DFS_DATANODE_NETWORKERRORS_DISPLAY_TOPCOUNT,
+        DFSConfigKeys.DFS_DATANODE_NETWORKERRORS_DISPLAY_TOPCOUNT_DEFAULT);
+    if (maxDisplay >= 0) {
+      ConcurrentMap<String, Map<String, Long>> map = datanodeNetworkCounts.asMap();
+      Set<Map.Entry<String, Map<String, Long>>> entries = map.entrySet();
+      List<Map.Entry<String, Map<String, Long>>> list = new ArrayList<>(entries);
+      Collections.sort(list, new Comparator<Entry<String, Map<String, Long>>>() {
+        @Override
+        public int compare(Map.Entry<String, Map<String, Long>> o1,
+            Map.Entry<String, Map<String, Long>> o2) {
+          Map<String, Long> value1Map = o1.getValue();
+          Map<String, Long> value2Map = o2.getValue();
+          long compared = value2Map.getOrDefault(DataNode.NETWORK_ERRORS, 0L) -
+              value1Map.getOrDefault(DataNode.NETWORK_ERRORS, 0L);
+          return (int)compared;
+        }
+      });
+      Map<String, Map<String, Long>> resultMap = new ConcurrentHashMap<>();
+      maxDisplay = list.size() > maxDisplay ? maxDisplay : list.size();
+      for (int i = 0; i < maxDisplay; i++) {
+        resultMap.put(list.get(i).getKey(), list.get(i).getValue());
+      }
+      list.clear();
+      return resultMap;
+    }
     return datanodeNetworkCounts.asMap();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -2768,19 +2768,16 @@ public class DataNode extends ReconfigurableBase
       ConcurrentMap<String, Map<String, Long>> map = datanodeNetworkCounts.asMap();
       Set<Map.Entry<String, Map<String, Long>>> entries = map.entrySet();
       List<Map.Entry<String, Map<String, Long>>> list = new ArrayList<>(entries);
-      Collections.sort(list, new Comparator<Entry<String, Map<String, Long>>>() {
-        @Override
-        public int compare(Map.Entry<String, Map<String, Long>> o1,
-            Map.Entry<String, Map<String, Long>> o2) {
-          Map<String, Long> value1Map = o1.getValue();
-          Map<String, Long> value2Map = o2.getValue();
-          long compared = value2Map.getOrDefault(DataNode.NETWORK_ERRORS, 0L) -
-              value1Map.getOrDefault(DataNode.NETWORK_ERRORS, 0L);
-          return (int)compared;
-        }
+      list.sort((o1, o2) -> {
+        Map<String, Long> value1Map = o1.getValue();
+        Map<String, Long> value2Map = o2.getValue();
+        long compared =
+            value2Map.getOrDefault(DataNode.NETWORK_ERRORS, 0L) - value1Map.getOrDefault(
+                DataNode.NETWORK_ERRORS, 0L);
+        return (int) compared;
       });
       Map<String, Map<String, Long>> resultMap = new ConcurrentHashMap<>();
-      maxDisplay = list.size() > maxDisplay ? maxDisplay : list.size();
+      maxDisplay = Math.min(list.size(), maxDisplay);
       for (int i = 0; i < maxDisplay; i++) {
         resultMap.put(list.get(i).getKey(), list.get(i).getValue());
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeFaultInjector.java
@@ -178,4 +178,10 @@ public class DataNodeFaultInjector {
    * leaving a stale copy of {@link DirectoryScanner#diffs}.
    */
   public void waitUntilStorageRemoved() {}
+
+  /*
+   * Increase DatanodeNetworkErrors.
+   * @param dataXceiver
+   */
+  public void incrementDatanodeNetworkErrors(DataXceiver dataXceiver) {}
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
@@ -858,6 +858,7 @@ class DataXceiver extends Receiver implements Runnable {
           mirrorOut.flush();
 
           DataNodeFaultInjector.get().writeBlockAfterFlush();
+          DataNodeFaultInjector.get().incrementDatanodeNetworkErrors(this);
 
           // read connect ack (only for clients, not for replication req)
           if (isClient) {
@@ -1389,6 +1390,11 @@ class DataXceiver extends Receiver implements Runnable {
   
   private void incrDatanodeNetworkErrors() {
     datanode.incrDatanodeNetworkErrors(remoteAddressWithoutPort);
+  }
+
+  @VisibleForTesting
+  public void incrDatanodeNetworkErrorsWithPort() {
+    datanode.incrDatanodeNetworkErrors(remoteAddress);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6574,7 +6574,7 @@
     <value>-1</value>
     <description>
       The number of datanodenetworkerror metric per datanode displays.
-      -1 represents having no limit.
+      negative number represents having no limit.
     </description>
   </property>
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6568,6 +6568,16 @@
       problem. In produce default set false, because it's have little performance loss.
     </description>
   </property>
+
+  <property>
+    <name>dfs.datanode.networkerrors.display.topcount</name>
+    <value>-1</value>
+    <description>
+      The number of datanodenetworkerror metric per datanode displays.
+      -1 represents having no limit.
+    </description>
+  </property>
+
   <property>
     <name>dfs.client.fsck.connect.timeout</name>
     <value>60000ms</value>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
@@ -72,6 +72,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
@@ -243,6 +244,7 @@ public class TestDataNodeMetrics {
       String bpid = cluster.getNameNode().getNamesystem().getBlockPoolId();
       List<DataNode> datanodes = cluster.getDataNodes();
       DataNode datanode = datanodes.get(0);
+
       // Verify both of metrics set to 0 when initialize.
       MetricsRecordBuilder rb = getMetrics(datanode.getMetrics().name());
       assertCounter("CreateRbwOpNumOps", 0L, rb);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdfs.server.datanode;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
+import static org.apache.hadoop.test.MetricsAsserts.assertCounterGt;
 import static org.apache.hadoop.test.MetricsAsserts.assertInverseQuantileGauges;
 import static org.apache.hadoop.test.MetricsAsserts.assertQuantileGauges;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
@@ -88,9 +89,9 @@ public class TestDataNodeMetrics {
     MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).build();
     try {
       FileSystem fs = cluster.getFileSystem();
-      final long LONG_FILE_LEN = Integer.MAX_VALUE+1L; 
+      final long LONG_FILE_LEN = Integer.MAX_VALUE + 1L;
       DFSTestUtil.createFile(fs, new Path("/tmp.txt"),
-          LONG_FILE_LEN, (short)1, 1L);
+          LONG_FILE_LEN, (short) 1, 1L);
       List<DataNode> datanodes = cluster.getDataNodes();
       assertEquals(datanodes.size(), 1);
       DataNode datanode = datanodes.get(0);
@@ -99,7 +100,9 @@ public class TestDataNodeMetrics {
       assertTrue("Expected non-zero number of incremental block reports",
           getLongCounter("IncrementalBlockReportsNumOps", rb) > 0);
     } finally {
-      if (cluster != null) {cluster.shutdown();}
+      if (cluster != null) {
+        cluster.shutdown();
+      }
     }
   }
 
@@ -114,7 +117,7 @@ public class TestDataNodeMetrics {
       // Create and read a 1 byte file
       Path tmpfile = new Path("/tmp.txt");
       DFSTestUtil.createFile(fs, tmpfile,
-          (long)1, (short)1, 1L);
+          (long) 1, (short) 1, 1L);
       DFSTestUtil.readFile(fs, tmpfile);
       List<DataNode> datanodes = cluster.getDataNodes();
       assertEquals(datanodes.size(), 1);
@@ -122,8 +125,8 @@ public class TestDataNodeMetrics {
       MetricsRecordBuilder rb = getMetrics(datanode.getMetrics().name());
       // Expect 2 packets, 1 for the 1 byte read, 1 for the empty packet
       // signaling the end of the block
-      assertCounter("SendDataPacketTransferNanosNumOps", (long)2, rb);
-      assertCounter("SendDataPacketBlockedOnNetworkNanosNumOps", (long)2, rb);
+      assertCounter("SendDataPacketTransferNanosNumOps", (long) 2, rb);
+      assertCounter("SendDataPacketBlockedOnNetworkNanosNumOps", (long) 2, rb);
       // Wait for at least 1 rollover
       Thread.sleep((interval + 1) * 1000);
       // Check that the sendPacket percentiles rolled to non-zero values
@@ -131,7 +134,9 @@ public class TestDataNodeMetrics {
       assertQuantileGauges("SendDataPacketBlockedOnNetworkNanos" + sec, rb);
       assertQuantileGauges("SendDataPacketTransferNanos" + sec, rb);
     } finally {
-      if (cluster != null) {cluster.shutdown();}
+      if (cluster != null) {
+        cluster.shutdown();
+      }
     }
   }
 
@@ -165,7 +170,9 @@ public class TestDataNodeMetrics {
       assertQuantileGauges("FlushNanos" + sec, dnMetrics);
       assertQuantileGauges("FsyncNanos" + sec, dnMetrics);
     } finally {
-      if (cluster != null) {cluster.shutdown();}
+      if (cluster != null) {
+        cluster.shutdown();
+      }
     }
   }
 
@@ -270,8 +277,8 @@ public class TestDataNodeMetrics {
   }
 
   /**
-   * Tests that round-trip acks in a datanode write pipeline are correctly 
-   * measured. 
+   * Tests that round-trip acks in a datanode write pipeline are correctly
+   * measured.
    */
   @Test
   public void testRoundTripAckMetric() throws Exception {
@@ -309,14 +316,14 @@ public class TestDataNodeMetrics {
           break;
         }
       }
-      assertNotNull("Could not find the head of the datanode write pipeline", 
+      assertNotNull("Could not find the head of the datanode write pipeline",
           headNode);
       // Close the file and wait for the metrics to rollover
       Thread.sleep((interval + 1) * 1000);
       // Check the ack was received
       MetricsRecordBuilder dnMetrics = getMetrics(headNode.getMetrics()
           .name());
-      assertTrue("Expected non-zero number of acks", 
+      assertTrue("Expected non-zero number of acks",
           getLongCounter("PacketAckRoundTripTimeNanosNumOps", dnMetrics) > 0);
       assertQuantileGauges("PacketAckRoundTripTimeNanos" + interval
           + "s", dnMetrics);
@@ -327,7 +334,7 @@ public class TestDataNodeMetrics {
     }
   }
 
-  @Test(timeout=60000)
+  @Test(timeout = 60000)
   public void testTimeoutMetric() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     final Path path = new Path("/test");
@@ -378,9 +385,10 @@ public class TestDataNodeMetrics {
   /**
    * This function ensures that writing causes TotalWritetime to increment
    * and reading causes totalReadTime to move.
+   *
    * @throws Exception
    */
-  @Test(timeout=120000)
+  @Test(timeout = 120000)
   public void testDataNodeTimeSpend() throws Exception {
     Configuration conf = new HdfsConfiguration();
     conf.set(DFSConfigKeys.DFS_METRICS_PERCENTILES_INTERVALS_KEY, "" + 60);
@@ -470,16 +478,16 @@ public class TestDataNodeMetrics {
 
       MetricsRecordBuilder rb = getMetrics(datanode.getMetrics().name());
       long dataNodeActiveXceiversCount = MetricsAsserts.getIntGauge(
-              "DataNodeActiveXceiversCount", rb);
+          "DataNodeActiveXceiversCount", rb);
       assertEquals(dataNodeActiveXceiversCount, 0);
 
       Path path = new Path("/counter.txt");
       DFSTestUtil.createFile(fs, path, 204800000, (short) 3, Time
-              .monotonicNow());
+          .monotonicNow());
 
       MetricsRecordBuilder rbNew = getMetrics(datanode.getMetrics().name());
       dataNodeActiveXceiversCount = MetricsAsserts.getIntGauge(
-              "DataNodeActiveXceiversCount", rbNew);
+          "DataNodeActiveXceiversCount", rbNew);
       assertTrue(dataNodeActiveXceiversCount >= 0);
     } finally {
       if (cluster != null) {
@@ -566,12 +574,12 @@ public class TestDataNodeMetrics {
           fs.getClient().getLocatedBlocks(p.toString(), 0).get(0).getBlock();
       try {
         new BlockSender(b, 0, -1, false, true, true,
-                cluster.getDataNodes().get(0), null,
-                CachingStrategy.newDefaultStrategy());
+            cluster.getDataNodes().get(0), null,
+            CachingStrategy.newDefaultStrategy());
         fail("Must throw FileNotFoundException");
       } catch (FileNotFoundException fe) {
         assertTrue("Should throw too many open files",
-                fe.getMessage().contains("Too many open files"));
+            fe.getMessage().contains("Too many open files"));
       }
       cluster.triggerHeartbeats(); // IBR delete ack
       //After DN throws too many open files
@@ -586,7 +594,7 @@ public class TestDataNodeMetrics {
   }
 
   private void verifyBlockLocations(DistributedFileSystem fs, Path p,
-      int expected) throws IOException, TimeoutException, InterruptedException {
+                                    int expected) throws IOException, TimeoutException, InterruptedException {
     final LocatedBlock lb =
         fs.getClient().getLocatedBlocks(p.toString(), 0).get(0);
     GenericTestUtils.waitFor(new Supplier<Boolean>() {
@@ -610,10 +618,12 @@ public class TestDataNodeMetrics {
     MetricsRecordBuilder rb = getMetrics(dn.getMetrics().name());
     assertCounter("HeartbeatsNumOps", 1L, rb);
   }
+
   @Test(timeout = 60000)
   public void testSlowMetrics() throws Exception {
     DataNodeFaultInjector dnFaultInjector = new DataNodeFaultInjector() {
-      @Override public void delay() {
+      @Override
+      public void delay() {
         try {
           Thread.sleep(310);
         } catch (InterruptedException e) {
@@ -640,7 +650,8 @@ public class TestDataNodeMetrics {
       final AtomicInteger x = new AtomicInteger(0);
 
       GenericTestUtils.waitFor(new Supplier<Boolean>() {
-        @Override public Boolean get() {
+        @Override
+        public Boolean get() {
           x.getAndIncrement();
           try {
             DFSTestUtil
@@ -735,7 +746,7 @@ public class TestDataNodeMetrics {
       cluster.waitActive();
       FileSystem fs = cluster.getFileSystem();
       Path testFile = new Path("/testNodeLocalMetrics.txt");
-      DFSTestUtil.createFile(fs, testFile, 10L, (short)1, 1L);
+      DFSTestUtil.createFile(fs, testFile, 10L, (short) 1, 1L);
       DFSTestUtil.readFile(fs, testFile);
       List<DataNode> datanodes = cluster.getDataNodes();
       assertEquals(1, datanodes.size());
@@ -814,6 +825,57 @@ public class TestDataNodeMetrics {
           return readXceiversCount == 0;
         }
       }, 100, 10000);
+    }
+  }
+
+  @Test(timeout = 60000)
+  public void testDatanodeNetworkErrorsMetricDefaultConf() throws Exception {
+    final Configuration conf = new HdfsConfiguration();
+    conf.setStrings("dfs.client.block.write.replace-datanode-on-failure.policy", "NEVER");
+    conf.setInt("dfs.client.block.write.replace-datanode-on-failure.min-replication", 0);
+    final MiniDFSCluster cluster =
+        new MiniDFSCluster.Builder(conf).numDataNodes(6).build();
+    final List<FSDataOutputStream> streams = Lists.newArrayList();
+    DataNodeFaultInjector oldInjector = DataNodeFaultInjector.get();
+
+    try {
+      for (int i = 0; i < 3; i++) {
+        final Path path = new Path("/test" + i);
+        final FSDataOutputStream out =
+            cluster.getFileSystem().create(path, (short) 2);
+        final DataNodeFaultInjector injector = Mockito.mock
+            (DataNodeFaultInjector.class);
+        Mockito.doThrow(new IOException("mock IOException")).
+            when(injector).
+            writeBlockAfterFlush();
+        DataNodeFaultInjector.set(injector);
+        streams.add(out);
+        out.writeBytes("old gs data\n");
+        out.hflush();
+      }
+      /* Test the metric. */
+      final MetricsRecordBuilder dnMetrics =
+          getMetrics(cluster.getDataNodes().get(0).getMetrics().name());
+      //assertCounter("DatanodeNetworkErrors", 1L, dnMetrics);
+      assertCounterGt("DatanodeNetworkErrors", 1L, dnMetrics);
+
+      /* Test JMX datanode network counts. */
+      final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+      final ObjectName mxbeanName =
+          new ObjectName("Hadoop:service=DataNode,name=DataNodeInfo");
+      final Object dnc =
+          mbs.getAttribute(mxbeanName, "DatanodeNetworkCounts");
+      final String allDnc = dnc.toString();
+      assertTrue("expected to see loopback address",
+          allDnc.indexOf("127.0.0.1") >= 0);
+      assertTrue("expected to see networkErrors",
+          allDnc.indexOf("networkErrors") >= 0);
+    } finally {
+      IOUtils.cleanupWithLogger(LOG, streams.toArray(new Closeable[0]));
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+      DataNodeFaultInjector.set(oldInjector);
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
@@ -88,9 +88,9 @@ public class TestDataNodeMetrics {
     MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).build();
     try {
       FileSystem fs = cluster.getFileSystem();
-      final long LONG_FILE_LEN = Integer.MAX_VALUE + 1L;
+      final long LONG_FILE_LEN = Integer.MAX_VALUE+1L; 
       DFSTestUtil.createFile(fs, new Path("/tmp.txt"),
-          LONG_FILE_LEN, (short) 1, 1L);
+          LONG_FILE_LEN, (short)1, 1L);
       List<DataNode> datanodes = cluster.getDataNodes();
       assertEquals(datanodes.size(), 1);
       DataNode datanode = datanodes.get(0);
@@ -99,9 +99,7 @@ public class TestDataNodeMetrics {
       assertTrue("Expected non-zero number of incremental block reports",
           getLongCounter("IncrementalBlockReportsNumOps", rb) > 0);
     } finally {
-      if (cluster != null) {
-        cluster.shutdown();
-      }
+      if (cluster != null) {cluster.shutdown();}
     }
   }
 
@@ -116,7 +114,7 @@ public class TestDataNodeMetrics {
       // Create and read a 1 byte file
       Path tmpfile = new Path("/tmp.txt");
       DFSTestUtil.createFile(fs, tmpfile,
-          (long) 1, (short) 1, 1L);
+          (long)1, (short)1, 1L);
       DFSTestUtil.readFile(fs, tmpfile);
       List<DataNode> datanodes = cluster.getDataNodes();
       assertEquals(datanodes.size(), 1);
@@ -124,8 +122,8 @@ public class TestDataNodeMetrics {
       MetricsRecordBuilder rb = getMetrics(datanode.getMetrics().name());
       // Expect 2 packets, 1 for the 1 byte read, 1 for the empty packet
       // signaling the end of the block
-      assertCounter("SendDataPacketTransferNanosNumOps", (long) 2, rb);
-      assertCounter("SendDataPacketBlockedOnNetworkNanosNumOps", (long) 2, rb);
+      assertCounter("SendDataPacketTransferNanosNumOps", (long)2, rb);
+      assertCounter("SendDataPacketBlockedOnNetworkNanosNumOps", (long)2, rb);
       // Wait for at least 1 rollover
       Thread.sleep((interval + 1) * 1000);
       // Check that the sendPacket percentiles rolled to non-zero values
@@ -133,9 +131,7 @@ public class TestDataNodeMetrics {
       assertQuantileGauges("SendDataPacketBlockedOnNetworkNanos" + sec, rb);
       assertQuantileGauges("SendDataPacketTransferNanos" + sec, rb);
     } finally {
-      if (cluster != null) {
-        cluster.shutdown();
-      }
+      if (cluster != null) {cluster.shutdown();}
     }
   }
 
@@ -169,9 +165,7 @@ public class TestDataNodeMetrics {
       assertQuantileGauges("FlushNanos" + sec, dnMetrics);
       assertQuantileGauges("FsyncNanos" + sec, dnMetrics);
     } finally {
-      if (cluster != null) {
-        cluster.shutdown();
-      }
+      if (cluster != null) {cluster.shutdown();}
     }
   }
 
@@ -276,8 +270,8 @@ public class TestDataNodeMetrics {
   }
 
   /**
-   * Tests that round-trip acks in a datanode write pipeline are correctly
-   * measured.
+   * Tests that round-trip acks in a datanode write pipeline are correctly 
+   * measured. 
    */
   @Test
   public void testRoundTripAckMetric() throws Exception {
@@ -315,14 +309,14 @@ public class TestDataNodeMetrics {
           break;
         }
       }
-      assertNotNull("Could not find the head of the datanode write pipeline",
+      assertNotNull("Could not find the head of the datanode write pipeline", 
           headNode);
       // Close the file and wait for the metrics to rollover
       Thread.sleep((interval + 1) * 1000);
       // Check the ack was received
       MetricsRecordBuilder dnMetrics = getMetrics(headNode.getMetrics()
           .name());
-      assertTrue("Expected non-zero number of acks",
+      assertTrue("Expected non-zero number of acks", 
           getLongCounter("PacketAckRoundTripTimeNanosNumOps", dnMetrics) > 0);
       assertQuantileGauges("PacketAckRoundTripTimeNanos" + interval
           + "s", dnMetrics);
@@ -333,7 +327,7 @@ public class TestDataNodeMetrics {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test(timeout=60000)
   public void testTimeoutMetric() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     final Path path = new Path("/test");
@@ -384,10 +378,9 @@ public class TestDataNodeMetrics {
   /**
    * This function ensures that writing causes TotalWritetime to increment
    * and reading causes totalReadTime to move.
-   *
    * @throws Exception
    */
-  @Test(timeout = 120000)
+  @Test(timeout=120000)
   public void testDataNodeTimeSpend() throws Exception {
     Configuration conf = new HdfsConfiguration();
     conf.set(DFSConfigKeys.DFS_METRICS_PERCENTILES_INTERVALS_KEY, "" + 60);
@@ -477,16 +470,16 @@ public class TestDataNodeMetrics {
 
       MetricsRecordBuilder rb = getMetrics(datanode.getMetrics().name());
       long dataNodeActiveXceiversCount = MetricsAsserts.getIntGauge(
-          "DataNodeActiveXceiversCount", rb);
+              "DataNodeActiveXceiversCount", rb);
       assertEquals(dataNodeActiveXceiversCount, 0);
 
       Path path = new Path("/counter.txt");
       DFSTestUtil.createFile(fs, path, 204800000, (short) 3, Time
-          .monotonicNow());
+              .monotonicNow());
 
       MetricsRecordBuilder rbNew = getMetrics(datanode.getMetrics().name());
       dataNodeActiveXceiversCount = MetricsAsserts.getIntGauge(
-          "DataNodeActiveXceiversCount", rbNew);
+              "DataNodeActiveXceiversCount", rbNew);
       assertTrue(dataNodeActiveXceiversCount >= 0);
     } finally {
       if (cluster != null) {
@@ -573,12 +566,12 @@ public class TestDataNodeMetrics {
           fs.getClient().getLocatedBlocks(p.toString(), 0).get(0).getBlock();
       try {
         new BlockSender(b, 0, -1, false, true, true,
-            cluster.getDataNodes().get(0), null,
-            CachingStrategy.newDefaultStrategy());
+                cluster.getDataNodes().get(0), null,
+                CachingStrategy.newDefaultStrategy());
         fail("Must throw FileNotFoundException");
       } catch (FileNotFoundException fe) {
         assertTrue("Should throw too many open files",
-            fe.getMessage().contains("Too many open files"));
+                fe.getMessage().contains("Too many open files"));
       }
       cluster.triggerHeartbeats(); // IBR delete ack
       //After DN throws too many open files
@@ -593,7 +586,7 @@ public class TestDataNodeMetrics {
   }
 
   private void verifyBlockLocations(DistributedFileSystem fs, Path p,
-                                    int expected) throws IOException, TimeoutException, InterruptedException {
+      int expected) throws IOException, TimeoutException, InterruptedException {
     final LocatedBlock lb =
         fs.getClient().getLocatedBlocks(p.toString(), 0).get(0);
     GenericTestUtils.waitFor(new Supplier<Boolean>() {
@@ -617,12 +610,10 @@ public class TestDataNodeMetrics {
     MetricsRecordBuilder rb = getMetrics(dn.getMetrics().name());
     assertCounter("HeartbeatsNumOps", 1L, rb);
   }
-
   @Test(timeout = 60000)
   public void testSlowMetrics() throws Exception {
     DataNodeFaultInjector dnFaultInjector = new DataNodeFaultInjector() {
-      @Override
-      public void delay() {
+      @Override public void delay() {
         try {
           Thread.sleep(310);
         } catch (InterruptedException e) {
@@ -649,8 +640,7 @@ public class TestDataNodeMetrics {
       final AtomicInteger x = new AtomicInteger(0);
 
       GenericTestUtils.waitFor(new Supplier<Boolean>() {
-        @Override
-        public Boolean get() {
+        @Override public Boolean get() {
           x.getAndIncrement();
           try {
             DFSTestUtil
@@ -745,7 +735,7 @@ public class TestDataNodeMetrics {
       cluster.waitActive();
       FileSystem fs = cluster.getFileSystem();
       Path testFile = new Path("/testNodeLocalMetrics.txt");
-      DFSTestUtil.createFile(fs, testFile, 10L, (short) 1, 1L);
+      DFSTestUtil.createFile(fs, testFile, 10L, (short)1, 1L);
       DFSTestUtil.readFile(fs, testFile);
       List<DataNode> datanodes = cluster.getDataNodes();
       assertEquals(1, datanodes.size());
@@ -827,4 +817,3 @@ public class TestDataNodeMetrics {
     }
   }
 }
-

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeNetworkErrorsWithDefaultConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeNetworkErrorsWithDefaultConf.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.hdfs.server.datanode;
 
 import org.apache.hadoop.conf.Configuration;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeNetworkErrorsWithDefaultConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeNetworkErrorsWithDefaultConf.java
@@ -1,0 +1,92 @@
+package org.apache.hadoop.hdfs.server.datanode;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.util.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
+import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
+
+public class TestDataNodeNetworkErrorsWithDefaultConf {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestDataNodeNetworkErrorsWithDefaultConf.class);
+
+  @Test(timeout = 60000)
+  public void testDatanodeNetworkErrorsMetricDefaultConf() throws Exception {
+    final Configuration conf = new HdfsConfiguration();
+    final MiniDFSCluster cluster =
+        new MiniDFSCluster.Builder(conf).numDataNodes(6).build();
+    cluster.waitActive();
+    final List<FSDataOutputStream> streams = Lists.newArrayList();
+    DataNodeFaultInjector oldInjector = DataNodeFaultInjector.get();
+    DataNodeFaultInjector newInjector = new DataNodeFaultInjector() {
+      public void incrementDatanodeNetworkErrors(DataXceiver dataXceiver) {
+        dataXceiver.incrDatanodeNetworkErrorsWithPort();
+      }
+    };
+    DataNodeFaultInjector.set(newInjector);
+    try {
+      GenericTestUtils.waitFor(new Supplier<Boolean>() {
+        @Override
+        public Boolean get() {
+          try {
+            for (int i = 0; i < 100; i++) {
+              final Path path = new Path("/test" + i);
+              final FSDataOutputStream out =
+                  cluster.getFileSystem().create(path, (short) 3);
+              streams.add(out);
+              out.writeBytes("old gs data\n");
+              out.hflush();
+            }
+          } catch (IOException e) {
+            e.printStackTrace();
+          }
+
+          final MetricsRecordBuilder dnMetrics =
+              getMetrics(cluster.getDataNodes().get(0).getMetrics().name());
+          long datanodeNetworkErrors = getLongCounter("DatanodeNetworkErrors", dnMetrics);
+          return datanodeNetworkErrors > 10;
+        }
+      }, 1000, 60000);
+
+      final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+      final ObjectName mxbeanName =
+          new ObjectName("Hadoop:service=DataNode,name=DataNodeInfo");
+      final Object dnc =
+          mbs.getAttribute(mxbeanName, "DatanodeNetworkCounts");
+      // Compute number of DatanodeNetworkCounts.
+      final String allDnc = dnc.toString();
+      int oldStringLength = allDnc.length();
+      String keyword = "key=networkErrors, value";
+      int newStringLength = allDnc.replace(keyword, "").length();
+      int networkErrorsCount = (oldStringLength - newStringLength) / keyword.length();
+      final MetricsRecordBuilder dnMetrics =
+          getMetrics(cluster.getDataNodes().get(0).getMetrics().name());
+      long datanodeNetworkErrors = getLongCounter("DatanodeNetworkErrors", dnMetrics);
+      Assert.assertEquals(datanodeNetworkErrors, networkErrorsCount);
+    } finally {
+      IOUtils.cleanupWithLogger(LOG, streams.toArray(new Closeable[0]));
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+      DataNodeFaultInjector.set(oldInjector);
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeNetworkErrorsWithTopNConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeNetworkErrorsWithTopNConf.java
@@ -1,0 +1,91 @@
+package org.apache.hadoop.hdfs.server.datanode;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.util.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
+import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
+
+public class TestDataNodeNetworkErrorsWithTopNConf {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestDataNodeNetworkErrorsWithTopNConf.class);
+
+  @Test(timeout=60000)
+  public void testDatanodeNetworkErrorsMetricTopN() throws Exception {
+    final Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFSConfigKeys.DFS_DATANODE_NETWORKERRORS_DISPLAY_TOPCOUNT, 2);
+    final MiniDFSCluster cluster =
+        new MiniDFSCluster.Builder(conf).numDataNodes(6).build();
+    cluster.waitActive();
+    final List<FSDataOutputStream> streams = Lists.newArrayList();
+    DataNodeFaultInjector oldInjector = DataNodeFaultInjector.get();
+    DataNodeFaultInjector newInjector = new DataNodeFaultInjector() {
+      public void incrementDatanodeNetworkErrors(DataXceiver dataXceiver) {
+        dataXceiver.incrDatanodeNetworkErrorsWithPort();
+      }
+    };
+    DataNodeFaultInjector.set(newInjector);
+    try {
+      GenericTestUtils.waitFor(new Supplier<Boolean>() {
+        @Override
+        public Boolean get() {
+          try {
+            for (int i = 0; i < 100; i++) {
+              final Path path = new Path("/test" + i);
+              final FSDataOutputStream out =
+                  cluster.getFileSystem().create(path, (short) 3);
+              streams.add(out);
+              out.writeBytes("old gs data\n");
+              out.hflush();
+            }
+          } catch (IOException e) {
+            e.printStackTrace();
+          }
+
+          final MetricsRecordBuilder dnMetrics =
+              getMetrics(cluster.getDataNodes().get(0).getMetrics().name());
+          long datanodeNetworkErrors = getLongCounter("DatanodeNetworkErrors", dnMetrics);
+          return datanodeNetworkErrors > 10;
+        }
+      }, 1000, 60000);
+      final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+      final ObjectName mxbeanName =
+          new ObjectName("Hadoop:service=DataNode,name=DataNodeInfo");
+      final Object dnc =
+          mbs.getAttribute(mxbeanName, "DatanodeNetworkCounts");
+      // Compute number of DatanodeNetworkCounts.
+      final String allDnc = dnc.toString();
+      int oldStringLength = allDnc.length();
+      String keyword = "key=networkErrors, value";
+      int newStringLength = allDnc.replace(keyword, "").length();
+      int networkErrorsCount = (oldStringLength - newStringLength) / keyword.length();
+      Assert.assertEquals(2, networkErrorsCount);
+    } finally {
+      IOUtils.cleanupWithLogger(LOG, streams.toArray(new Closeable[0]));
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+      DataNodeFaultInjector.set(oldInjector);
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeNetworkErrorsWithTopNConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeNetworkErrorsWithTopNConf.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.hdfs.server.datanode;
 
 import org.apache.hadoop.conf.Configuration;


### PR DESCRIPTION
### Description of PR
In our prod environment, we try to collect datanode metrics every 15s through jmx_exporter.  we found the datanodenetworkerror metric generates a lot.

for example, if we have a cluster with 1000 datanodes, every datanode may generate 999 or more(from client) datanodenetworkerror metrics, and overall datanodes will generate 1000 multiple 999 = 999000 metrics. This is a very expensive operation. In most scenarios, we only need the topN of it.

![image](https://github.com/user-attachments/assets/9d030e96-3e81-46ae-a6d3-61ea0b537ca7)

### How was this patch tested?
no need extra UT,  TestDataNodeMetrics#testTimeoutMetric has done it.


