### PR TITLE
YARN-11476. Add  NodeManager metric for event queue size of dispatcher

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeManager.java
@@ -506,8 +506,8 @@ public class NodeManager extends CompositeService
     context.getContainerExecutor().start();
 
     eventQueueMetricExecutor = new ScheduledThreadPoolExecutor(1,
-        new ThreadFactoryBuilder().setDaemon(true)
-            .setNameFormat("EventQueueSizeMetricThread").build());
+         new ThreadFactoryBuilder().setDaemon(true)
+         .setNameFormat("EventQueueSizeMetricThread").build());
     eventQueueMetricExecutor.scheduleAtFixedRate(() -> {
       metrics.setNmDispatcherEventQueueSize(dispatcher.getEventQueueSize());
       metrics.setSchedulerEventQueueSize(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/metrics/NodeManagerMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/metrics/NodeManagerMetrics.java
@@ -118,6 +118,11 @@ public class NodeManagerMetrics {
   @Metric("Container localization time in milliseconds")
       MutableRate localizationDurationMillis;
 
+  @Metric("# of nm dispatcher event queue size")
+  MutableGaugeInt nmDispatcherEventQueueSize;
+  @Metric("# of scheduler dispatcher event queue size")
+  MutableGaugeInt schedulerDispatcherEventQueueSize;
+
   // CHECKSTYLE:ON:VisibilityModifier
 
   private JvmMetrics jvmMetrics = null;
@@ -480,5 +485,21 @@ public class NodeManagerMetrics {
 
   public void localizationComplete(long downloadMillis) {
     localizationDurationMillis.add(downloadMillis);
+  }
+
+  public int getNmDispatcherEventQueueSize() {
+    return nmDispatcherEventQueueSize.value();
+  }
+
+  public void setNmDispatcherEventQueueSize(int nmDispatcherEventQueueSize) {
+    this.nmDispatcherEventQueueSize.set(nmDispatcherEventQueueSize);
+  }
+
+  public int getSchedulerEventQueueSize() {
+    return schedulerDispatcherEventQueueSize.value();
+  }
+
+  public void setSchedulerEventQueueSize(int schedulerEventQueueSize) {
+    this.schedulerDispatcherEventQueueSize.set(schedulerEventQueueSize);
   }
 }


### PR DESCRIPTION
### Description of PR
NodeManager has two dispatchers, we can add metrics to observe the dispatcher queue size.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

