### PR TITLE
HDFS-16994. NumTimedOutPendingReconstructions metrics should not be accumulated

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingReconstructionBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingReconstructionBlocks.java
@@ -53,7 +53,7 @@ class PendingReconstructionBlocks {
   private final ArrayList<BlockInfo> timedOutItems;
   Daemon timerThread = null;
   private volatile boolean fsRunning = true;
-  private long timedOutCount = 0L;
+  private volatile long timedOutCount = 0L;
 
   //
   // It might take anywhere between 5 to 10 minutes before
@@ -176,7 +176,9 @@ class PendingReconstructionBlocks {
    */
   long getNumTimedOuts() {
     synchronized (timedOutItems) {
-      return timedOutCount + timedOutItems.size();
+      long numTimeOuts = timedOutCount + timedOutItems.size();
+      timedOutCount = 0;
+      return numTimeOuts;
     }
   }
 


### PR DESCRIPTION
### Description of PR
For now, the NumTimedOutPendingReconstructions metric is computed by below statement:
```java
timedOutCount + timedOutItems.size(); 
```

Therefore, its value would always be accumulated unless namenode failover happens. 

In fact, the NumTimedOutPendingReconstructions metric should not be accumulated, So, we should set it to zero after we execute getNumTimedOuts method.


### How was this patch tested?
The UT TestPendingReconstruction#testPendingReconstruction was passed.
