### PR TITLE
HDFS-16995. Remove unused parameters at NameNodeHttpServer#initWebHdfs

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterHttpServer.java
@@ -88,10 +88,8 @@ public class RouterHttpServer extends AbstractService {
 
     this.httpServer = builder.build();
 
-    String httpKeytab = conf.get(DFSUtil.getSpnegoKeytabKey(conf,
-        RBFConfigKeys.DFS_ROUTER_KEYTAB_FILE_KEY));
-    NameNodeHttpServer.initWebHdfs(conf, httpAddress.getHostName(), httpKeytab,
-        httpServer, RouterWebHdfsMethods.class.getPackage().getName());
+    NameNodeHttpServer.initWebHdfs(conf, httpServer,
+            RouterWebHdfsMethods.class.getPackage().getName());
 
     this.httpServer.setAttribute(NAMENODE_ATTRIBUTE_KEY, this.router);
     this.httpServer.setAttribute(JspHelper.CURRENT_CONF, this.conf);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterHttpServer.java
@@ -89,7 +89,7 @@ public class RouterHttpServer extends AbstractService {
     this.httpServer = builder.build();
 
     NameNodeHttpServer.initWebHdfs(conf, httpServer,
-            RouterWebHdfsMethods.class.getPackage().getName());
+        RouterWebHdfsMethods.class.getPackage().getName());
 
     this.httpServer.setAttribute(NAMENODE_ATTRIBUTE_KEY, this.router);
     this.httpServer.setAttribute(JspHelper.CURRENT_CONF, this.conf);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeHttpServer.java
@@ -76,10 +76,9 @@ public class NameNodeHttpServer {
     this.bindAddress = bindAddress;
   }
 
-  public static void initWebHdfs(Configuration conf, String hostname,
-      String httpKeytab,
-      HttpServer2 httpServer2, String jerseyResourcePackage)
-      throws IOException {
+  public static void initWebHdfs(Configuration conf, HttpServer2 httpServer2,
+                                 String jerseyResourcePackage)
+          throws IOException {
     // set user pattern based on configuration file
     UserParam.setUserPattern(conf.get(
         HdfsClientConfigKeys.DFS_WEBHDFS_USER_PATTERN_KEY,
@@ -159,9 +158,8 @@ public class NameNodeHttpServer {
       httpServer.setAttribute(DFSConfigKeys.DFS_DATANODE_HTTPS_PORT_KEY,
           datanodeSslPort.getPort());
     }
-    String httpKeytab = conf.get(DFSUtil.getSpnegoKeytabKey(conf,
-        DFSConfigKeys.DFS_NAMENODE_KEYTAB_FILE_KEY));
-    initWebHdfs(conf, bindAddress.getHostName(), httpKeytab, httpServer,
+
+    initWebHdfs(conf, httpServer,
         NamenodeWebHdfsMethods.class.getPackage().getName());
 
     httpServer.setAttribute(NAMENODE_ATTRIBUTE_KEY, nn);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeHttpServer.java
@@ -77,8 +77,7 @@ public class NameNodeHttpServer {
   }
 
   public static void initWebHdfs(Configuration conf, HttpServer2 httpServer2,
-                                 String jerseyResourcePackage)
-          throws IOException {
+      String jerseyResourcePackage) throws IOException {
     // set user pattern based on configuration file
     UserParam.setUserPattern(conf.get(
         HdfsClientConfigKeys.DFS_WEBHDFS_USER_PATTERN_KEY,
@@ -159,8 +158,7 @@ public class NameNodeHttpServer {
           datanodeSslPort.getPort());
     }
 
-    initWebHdfs(conf, httpServer,
-        NamenodeWebHdfsMethods.class.getPackage().getName());
+    initWebHdfs(conf, httpServer, NamenodeWebHdfsMethods.class.getPackage().getName());
 
     httpServer.setAttribute(NAMENODE_ATTRIBUTE_KEY, nn);
     httpServer.setAttribute(JspHelper.CURRENT_CONF, conf);


### PR DESCRIPTION


### Description of PR
Parameters of keytab and hostname  was not used at `intWebHdfs`
So maybe is should remove it.
The related code was removed at [HADOOP-16354](https://issues.apache.org/jira/browse/HADOOP-16354)

### How was this patch tested?
The current UT can coverage this changes.

### For code changes:



