### PR TITLE
HADOOP-18723. Add detail logs if distcp checksum mismatch

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
@@ -592,12 +592,14 @@ public class DistCpUtils {
     // comparison that took place and return not compatible.
     // else if matched, return compatible with the matched result.
     if (sourceChecksum == null || targetChecksum == null) {
-      LOG.error("Checksum incompatible. Source checksum: {}, target checksum: {}", sourceChecksum, targetChecksum);
+      LOG.error("Checksum incompatible. Source checksum: {}, target checksum: {}",
+          sourceChecksum, targetChecksum);
       return CopyMapper.ChecksumComparison.INCOMPATIBLE;
     } else if (sourceChecksum.equals(targetChecksum)) {
       return CopyMapper.ChecksumComparison.TRUE;
     }
-    LOG.error("Checksum not equal. Source checksum: {}, target checksum: {}", sourceChecksum, targetChecksum);
+    LOG.error("Checksum not equal. Source checksum: {}, target checksum: {}",
+        sourceChecksum, targetChecksum);
     return CopyMapper.ChecksumComparison.FALSE;
   }
 

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
@@ -592,13 +592,11 @@ public class DistCpUtils {
     // comparison that took place and return not compatible.
     // else if matched, return compatible with the matched result.
     if (sourceChecksum == null || targetChecksum == null) {
-      LOG.error("Checksum incompatible. Source checksum: {}, target checksum: {}",
-          sourceChecksum, targetChecksum);
       return CopyMapper.ChecksumComparison.INCOMPATIBLE;
     } else if (sourceChecksum.equals(targetChecksum)) {
       return CopyMapper.ChecksumComparison.TRUE;
     }
-    LOG.error("Checksum not equal. Source checksum: {}, target checksum: {}",
+    LOG.info("Checksum not equal. Source checksum: {}, target checksum: {}",
         sourceChecksum, targetChecksum);
     return CopyMapper.ChecksumComparison.FALSE;
   }

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
@@ -596,8 +596,9 @@ public class DistCpUtils {
     } else if (sourceChecksum.equals(targetChecksum)) {
       return CopyMapper.ChecksumComparison.TRUE;
     }
-    LOG.info("Checksum not equal. Source checksum: {}, target checksum: {}",
-        sourceChecksum, targetChecksum);
+    LOG.info("Checksum not equal. Source path: {}, source checksum: {}, target path {}, " +
+            "target checksum: {}",
+        source, sourceChecksum, target, targetChecksum);
     return CopyMapper.ChecksumComparison.FALSE;
   }
 

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
@@ -592,10 +592,12 @@ public class DistCpUtils {
     // comparison that took place and return not compatible.
     // else if matched, return compatible with the matched result.
     if (sourceChecksum == null || targetChecksum == null) {
+      LOG.error("Checksum incompatible. Source checksum: {}, target checksum: {}", sourceChecksum, targetChecksum);
       return CopyMapper.ChecksumComparison.INCOMPATIBLE;
     } else if (sourceChecksum.equals(targetChecksum)) {
       return CopyMapper.ChecksumComparison.TRUE;
     }
+    LOG.error("Checksum not equal. Source checksum: {}, target checksum: {}", sourceChecksum, targetChecksum);
     return CopyMapper.ChecksumComparison.FALSE;
   }
 

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
@@ -58,6 +58,7 @@ import static org.apache.hadoop.tools.DistCpConstants.CONF_LABEL_TARGET_FINAL_PA
 import static org.apache.hadoop.tools.DistCpConstants.CONF_LABEL_TARGET_WORK_PATH;
 import static org.apache.hadoop.tools.util.TestDistCpUtils.*;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestCopyCommitter {
   private static final Logger LOG = LoggerFactory.getLogger(TestCopyCommitter.class);

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.tools.mapred;
 
 import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.assertj.core.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -57,8 +58,6 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
 import static org.apache.hadoop.tools.DistCpConstants.CONF_LABEL_TARGET_FINAL_PATH;
 import static org.apache.hadoop.tools.DistCpConstants.CONF_LABEL_TARGET_WORK_PATH;
 import static org.apache.hadoop.tools.util.TestDistCpUtils.*;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestCopyCommitter {
   private static final Logger LOG = LoggerFactory.getLogger(TestCopyCommitter.class);
@@ -572,7 +571,7 @@ public class TestCopyCommitter {
                 fs, new Path(sourceBase + srcFilename), null,
                 fs, new Path(targetBase + srcFilename),
                 sourceCurrStatus.getLen()));
-        assertThat(log.getOutput(), containsString("Checksum not equal"));
+        Assertions.assertThat(log.getOutput()).contains("Checksum not equal");
       } catch(IOException exception) {
         if (skipCrc) {
           LOG.error("Unexpected exception is found", exception);

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
@@ -19,8 +19,6 @@
 package org.apache.hadoop.tools.mapred;
 
 import org.apache.hadoop.fs.contract.ContractTestUtils;
-import org.apache.hadoop.hdfs.server.balancer.NameNodeConnector;
-import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
@@ -57,6 +57,7 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
 import static org.apache.hadoop.tools.DistCpConstants.CONF_LABEL_TARGET_FINAL_PATH;
 import static org.apache.hadoop.tools.DistCpConstants.CONF_LABEL_TARGET_WORK_PATH;
 import static org.apache.hadoop.tools.util.TestDistCpUtils.*;
+import static org.hamcrest.CoreMatchers.containsString;
 
 public class TestCopyCommitter {
   private static final Logger LOG = LoggerFactory.getLogger(TestCopyCommitter.class);
@@ -570,7 +571,7 @@ public class TestCopyCommitter {
                 fs, new Path(sourceBase + srcFilename), null,
                 fs, new Path(targetBase + srcFilename),
                 sourceCurrStatus.getLen()));
-        assertTrue(log.getOutput().contains("Checksum not equal"));
+        assertThat(log.getOutput(), containsString("Checksum not equal"));
       } catch(IOException exception) {
         if (skipCrc) {
           LOG.error("Unexpected exception is found", exception);

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestCopyCommitter.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.tools.mapred;
 
 import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.hdfs.server.balancer.NameNodeConnector;
+import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -513,7 +515,8 @@ public class TestCopyCommitter {
 
   private void testCommitWithChecksumMismatch(boolean skipCrc)
       throws IOException {
-
+    GenericTestUtils.LogCapturer log = GenericTestUtils.LogCapturer.captureLogs(
+            LoggerFactory.getLogger(DistCpUtils.class));
     TaskAttemptContext taskAttemptContext = getTaskAttemptContext(config);
     JobContext jobContext = new JobContextImpl(
         taskAttemptContext.getConfiguration(),
@@ -569,6 +572,7 @@ public class TestCopyCommitter {
                 fs, new Path(sourceBase + srcFilename), null,
                 fs, new Path(targetBase + srcFilename),
                 sourceCurrStatus.getLen()));
+        assertTrue(log.getOutput().contains("Checksum not equal"));
       } catch(IOException exception) {
         if (skipCrc) {
           LOG.error("Unexpected exception is found", exception);


### PR DESCRIPTION
### Description of PR

We encountered some errors of mismatch checksum during Distcp jobs. It took us some time to figure out that checksum type is different.

Adding error logs shall help us to figure out such problems faster.

### How was this patch tested?

Add unit test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

