### PR TITLE
YARN-11480.Exceptions in the Nodemanager module are not recorded.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeStatusUpdaterImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeStatusUpdaterImpl.java
@@ -1448,7 +1448,7 @@ public class NodeStatusUpdaterImpl extends AbstractService implements
             try {
               heartbeatMonitor.wait(nextHeartBeatInterval);
             } catch (InterruptedException e) {
-              // Do Nothing
+              LOG.debug("Update wait interrupted in status-updater", e);
             }
           }
         }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/AppLogAggregatorImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/AppLogAggregatorImpl.java
@@ -626,7 +626,7 @@ public class AppLogAggregatorImpl implements AppLogAggregator {
       try {
         wait(200);
       } catch (InterruptedException e) {
-        // Do Nothing
+        LOG.debug("Update wait interrupted in do outofBand log aggregation", e);
       }
     }
     LOG.info("Do OutOfBand log aggregation");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/ContainerLogsPage.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/ContainerLogsPage.java
@@ -127,7 +127,7 @@ public class ContainerLogsPage extends NMView {
             appId, $(APP_OWNER));
         foundAggregatedLogs = true;
       } catch (IOException fnf) {
-        // Do Nothing
+        LOG.debug("Log aggregation error in ContainerLogsPage-render", fnf);
       }
 
       try {


### PR DESCRIPTION
JIRA: YARN-11480.Exceptions in the Nodemanager module are not recorded.

I read the code and found that some exceptions were caught in the nodemanager but not logged