### PR TITLE
YARN-11482. Fix bug of DRF comparision DominantResourceFairnessComparator2 in fair scheduler.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/policies/DominantResourceFairnessPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/policies/DominantResourceFairnessPolicy.java
@@ -390,7 +390,7 @@ public class DominantResourceFairnessPolicy extends SchedulingPolicy {
       // share for that resource
       boolean s1Needy = resourceInfo1[dominant1].getValue() <
           minShareInfo1[dominant1].getValue();
-      boolean s2Needy = resourceInfo1[dominant2].getValue() <
+      boolean s2Needy = resourceInfo2[dominant2].getValue() <
           minShareInfo2[dominant2].getValue();
 
       int res;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
DominantResourceFairnessComparator2 was using wrong resource info to get if one queue is needy or not now. We should fix it.
```
      boolean s1Needy = resourceInfo1[dominant1].getValue() <
          minShareInfo1[dominant1].getValue();
      boolean s2Needy = resourceInfo1[dominant2].getValue() <
          minShareInfo2[dominant2].getValue();
```

### How was this patch tested?


### For code changes:

- [Y] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
