### PR TITLE
YARN-11470. FederationStateStoreFacade Cache Support Guava Cache.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -4015,7 +4015,7 @@ public class YarnConfiguration extends Configuration {
           + "DefaultSubClusterResolverImpl";
 
   public static final String FEDERATION_FACADE_CACHE_CLASS =
-      FEDERATION_PREFIX + "facade.cache.class";
+      FEDERATION_PREFIX + "cache.class";
   public static final String DEFAULT_FEDERATION_FACADE_CACHE_CLASS =
       "org.apache.hadoop.yarn.server.federation.cache.FederationJCache";
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -4014,6 +4014,11 @@ public class YarnConfiguration extends Configuration {
       "org.apache.hadoop.yarn.server.federation.resolver."
           + "DefaultSubClusterResolverImpl";
 
+  public static final String FEDERATION_FACADE_CACHE_CLASS =
+      FEDERATION_PREFIX + "facade.cache.class";
+  public static final String DEFAULT_FEDERATION_FACADE_CACHE_CLASS =
+      "org.apache.hadoop.yarn.server.federation.cache.FederationJCache";
+
   // the maximum wait time for the first async heartbeat response
   public static final String FEDERATION_AMRMPROXY_HB_MAX_WAIT_MS =
       FEDERATION_PREFIX + "amrmproxy.hb.maximum.wait.ms";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -5198,7 +5198,7 @@
       Specifies the class name of the cache implementation in YARN FederationCache.
       By default, this property is org.apache.hadoop.yarn.server.federation.cache.FederationJCache.
     </description>
-    <name>yarn.federation.facade.cache.class</name>
+    <name>yarn.federation.cache.class</name>
     <value>org.apache.hadoop.yarn.server.federation.cache.FederationJCache</value>
   </property>
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -5193,4 +5193,13 @@
     <value>1000</value>
   </property>
 
+  <property>
+    <description>
+      Specifies the class name of the cache implementation in YARN FederationCache.
+      By default, this property is org.apache.hadoop.yarn.server.federation.cache.FederationJCache.
+    </description>
+    <name>yarn.federation.facade.cache.class</name>
+    <value>org.apache.hadoop.yarn.server.federation.cache.FederationJCache</value>
+  </property>
+
 </configuration>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/cache/FederationGuavaCache.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/cache/FederationGuavaCache.java
@@ -71,9 +71,10 @@ public class FederationGuavaCache extends FederationCache {
   }
 
   @Override
-  public Map<SubClusterId, SubClusterInfo> getSubClusters(boolean filterInactiveSubClusters) throws YarnException {
+  public Map<SubClusterId, SubClusterInfo> getSubClusters(boolean filterInactiveSubClusters)
+      throws YarnException {
     final String cacheKey = buildCacheKey(className, GET_SUBCLUSTERS_CACHEID,
-       Boolean.toString(filterInactiveSubClusters));
+        Boolean.toString(filterInactiveSubClusters));
     CacheRequest<String, ?> cacheRequest = cache.getIfPresent(cacheKey);
     if (cacheRequest == null) {
       cacheRequest = buildGetSubClustersCacheRequest(className, filterInactiveSubClusters);
@@ -96,7 +97,7 @@ public class FederationGuavaCache extends FederationCache {
   @Override
   public SubClusterId getApplicationHomeSubCluster(ApplicationId appId) throws Exception {
     final String cacheKey = buildCacheKey(className, GET_APPLICATION_HOME_SUBCLUSTER_CACHEID,
-       appId.toString());
+        appId.toString());
     CacheRequest<String, ?> cacheRequest = cache.getIfPresent(cacheKey);
     if (cacheRequest == null) {
       cacheRequest = buildGetApplicationHomeSubClusterRequest(className, appId);
@@ -110,7 +111,7 @@ public class FederationGuavaCache extends FederationCache {
   @Override
   public void removeSubCluster(boolean flushCache) {
     final String cacheKey = buildCacheKey(className, GET_SUBCLUSTERS_CACHEID,
-       Boolean.toString(flushCache));
+        Boolean.toString(flushCache));
     cache.invalidate(cacheKey);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/cache/FederationGuavaCache.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/cache/FederationGuavaCache.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.yarn.server.federation.cache;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.thirdparty.com.google.common.cache.Cache;
+import org.apache.hadoop.thirdparty.com.google.common.cache.CacheBuilder;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.server.federation.store.FederationStateStore;
+import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
+import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;
+import org.apache.hadoop.yarn.server.federation.store.records.SubClusterPolicyConfiguration;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class FederationGuavaCache extends FederationCache {
+
+  private Cache<String, CacheRequest<String, ?>> cache;
+
+  private int cacheTimeToLive;
+
+  private String className = this.getClass().getSimpleName();
+
+  private boolean isCachingEnabled = false;
+
+  @Override
+  public boolean isCachingEnabled() {
+    return isCachingEnabled;
+  }
+
+  @Override
+  public void initCache(Configuration pConf, FederationStateStore pStateStore) {
+    // Picking the JCache provider from classpath, need to make sure there's
+    // no conflict or pick up a specific one in the future.
+    cacheTimeToLive = pConf.getInt(YarnConfiguration.FEDERATION_CACHE_TIME_TO_LIVE_SECS,
+        YarnConfiguration.DEFAULT_FEDERATION_CACHE_TIME_TO_LIVE_SECS);
+    if (cacheTimeToLive <= 0) {
+      isCachingEnabled = false;
+      return;
+    }
+    this.setStateStore(pStateStore);
+
+    // Initialize Cache.
+    cache = CacheBuilder.newBuilder().expireAfterWrite(cacheTimeToLive,
+        TimeUnit.MILLISECONDS).build();
+    isCachingEnabled = true;
+  }
+
+  @Override
+  public void clearCache() {
+    cache.invalidateAll();
+    cache = null;
+  }
+
+  @Override
+  public Map<SubClusterId, SubClusterInfo> getSubClusters(boolean filterInactiveSubClusters) throws YarnException {
+    final String cacheKey = buildCacheKey(className, GET_SUBCLUSTERS_CACHEID,
+       Boolean.toString(filterInactiveSubClusters));
+    CacheRequest<String, ?> cacheRequest = cache.getIfPresent(cacheKey);
+    if (cacheRequest == null) {
+      cacheRequest = buildGetSubClustersCacheRequest(className, filterInactiveSubClusters);
+      cache.put(cacheKey, cacheRequest);
+    }
+    return buildSubClusterInfoMap(cacheRequest);
+  }
+
+  @Override
+  public Map<String, SubClusterPolicyConfiguration> getPoliciesConfigurations() throws Exception {
+    final String cacheKey = buildCacheKey(className, GET_POLICIES_CONFIGURATIONS_CACHEID);
+    CacheRequest<String, ?> cacheRequest = cache.getIfPresent(cacheKey);
+    if(cacheRequest == null){
+      cacheRequest = buildGetPoliciesConfigurationsCacheRequest(className);
+      cache.put(cacheKey, cacheRequest);
+    }
+    return buildPolicyConfigMap(cacheRequest);
+  }
+
+  @Override
+  public SubClusterId getApplicationHomeSubCluster(ApplicationId appId) throws Exception {
+    final String cacheKey = buildCacheKey(className, GET_APPLICATION_HOME_SUBCLUSTER_CACHEID,
+       appId.toString());
+    CacheRequest<String, ?> cacheRequest = cache.getIfPresent(cacheKey);
+    if (cacheRequest == null) {
+      cacheRequest = buildGetApplicationHomeSubClusterRequest(className, appId);
+      cache.put(cacheKey, cacheRequest);
+    }
+    CacheResponse<SubClusterId> response =
+        ApplicationHomeSubClusterCacheResponse.class.cast(cacheRequest.getValue());
+    return response.getItem();
+  }
+
+  @Override
+  public void removeSubCluster(boolean flushCache) {
+    final String cacheKey = buildCacheKey(className, GET_SUBCLUSTERS_CACHEID,
+       Boolean.toString(flushCache));
+    cache.invalidate(cacheKey);
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
@@ -132,8 +132,11 @@ public final class FederationStateStoreFacade {
           SubClusterResolver.class);
       this.subclusterResolver.load();
 
-      federationCache = new FederationJCache();
-      federationCache.initCache(config, stateStore);
+      this.federationCache = createInstance(conf,
+          YarnConfiguration.FEDERATION_FACADE_CACHE_CLASS,
+          YarnConfiguration.DEFAULT_FEDERATION_FACADE_CACHE_CLASS,
+          FederationCache.class);
+      this.federationCache.initCache(config, stateStore);
 
     } catch (YarnException ex) {
       LOG.error("Failed to initialize the FederationStateStoreFacade object", ex);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.server.federation.cache.FederationCache;
-import org.apache.hadoop.yarn.server.federation.cache.FederationJCache;
 import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyUtils;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
 import org.apache.hadoop.yarn.server.federation.resolver.SubClusterResolver;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
@@ -133,7 +133,6 @@ public final class FederationStateStoreFacade {
 
       // We check the configuration of Cache,
       // if the configuration is null, set it to FederationJCache
-
       this.federationCache = createInstance(conf,
           YarnConfiguration.FEDERATION_FACADE_CACHE_CLASS,
           YarnConfiguration.DEFAULT_FEDERATION_FACADE_CACHE_CLASS,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
@@ -131,6 +131,9 @@ public final class FederationStateStoreFacade {
           SubClusterResolver.class);
       this.subclusterResolver.load();
 
+      // We check the configuration of Cache,
+      // if the configuration is null, set it to FederationJCache
+
       this.federationCache = createInstance(conf,
           YarnConfiguration.FEDERATION_FACADE_CACHE_CLASS,
           YarnConfiguration.DEFAULT_FEDERATION_FACADE_CACHE_CLASS,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/cache/TestFederationCache.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/cache/TestFederationCache.java
@@ -49,9 +49,9 @@ public class TestFederationCache {
 
   @Parameterized.Parameters
   public static Collection<String[]> getParameters() {
-    return Arrays.asList(
-        new String[][] { {"org.apache.hadoop.yarn.server.federation.cache.FederationGuavaCache"},
-        {"org.apache.hadoop.yarn.server.federation.cache.FederationJCache"} });
+    String federationGuavaCacheClass = FederationGuavaCache.class.getName();
+    String federationJCacheClass = FederationJCache.class.getName();
+    return Arrays.asList(new String[][] {{federationGuavaCacheClass}, {federationJCacheClass}});
   }
 
   private final long clusterTs = System.currentTimeMillis();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/cache/TestFederationCache.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/cache/TestFederationCache.java
@@ -48,10 +48,8 @@ import static org.junit.Assert.assertEquals;
 public class TestFederationCache {
 
   @Parameterized.Parameters
-  public static Collection<String[]> getParameters() {
-    String federationGuavaCacheClass = FederationGuavaCache.class.getName();
-    String federationJCacheClass = FederationJCache.class.getName();
-    return Arrays.asList(new String[][] {{federationGuavaCacheClass}, {federationJCacheClass}});
+  public static Collection<Class[]> getParameters() {
+    return Arrays.asList(new Class[][] {{FederationGuavaCache.class}, {FederationJCache.class}});
   }
 
   private final long clusterTs = System.currentTimeMillis();
@@ -64,10 +62,11 @@ public class TestFederationCache {
   private FederationStateStoreTestUtil stateStoreTestUtil;
   private FederationStateStoreFacade facade = FederationStateStoreFacade.getInstance();
 
-  public TestFederationCache(String cacheClassName) {
+  public TestFederationCache(Class cacheClassName) {
     conf = new Configuration();
     conf.setInt(YarnConfiguration.FEDERATION_CACHE_TIME_TO_LIVE_SECS, 1);
-    conf.set(YarnConfiguration.FEDERATION_FACADE_CACHE_CLASS, cacheClassName);
+    conf.setClass(YarnConfiguration.FEDERATION_FACADE_CACHE_CLASS,
+        cacheClassName, FederationCache.class);
   }
 
   @Before

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/cache/TestFederationCache.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/cache/TestFederationCache.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.yarn.server.federation.cache;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.server.federation.store.FederationStateStore;
+import org.apache.hadoop.yarn.server.federation.store.impl.MemoryFederationStateStore;
+import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
+import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;
+import org.apache.hadoop.yarn.server.federation.store.records.SubClusterPolicyConfiguration;
+import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
+import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreTestUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for FederationCache.
+ */
+@RunWith(Parameterized.class)
+public class TestFederationCache {
+
+  @Parameterized.Parameters
+  public static Collection<String[]> getParameters() {
+    return Arrays.asList(
+        new String[][] { { "org.apache.hadoop.yarn.server.federation.cache.FederationGuavaCache" },
+        { "org.apache.hadoop.yarn.server.federation.cache.FederationJCache" } });
+  }
+
+  private final long clusterTs = System.currentTimeMillis();
+  private final int numSubClusters = 3;
+  private final int numApps = 5;
+  private final int numQueues = 2;
+
+  private Configuration conf;
+  private FederationStateStore stateStore;
+  private FederationStateStoreTestUtil stateStoreTestUtil;
+  private FederationStateStoreFacade facade = FederationStateStoreFacade.getInstance();
+
+  public TestFederationCache(String cacheClassName) {
+    conf = new Configuration();
+    conf.setInt(YarnConfiguration.FEDERATION_CACHE_TIME_TO_LIVE_SECS, 1);
+    conf.set(YarnConfiguration.FEDERATION_FACADE_CACHE_CLASS, cacheClassName);
+  }
+
+  @Before
+  public void setUp() throws IOException, YarnException {
+    stateStore = new MemoryFederationStateStore();
+    stateStore.init(conf);
+    facade.reinitialize(stateStore, conf);
+    // hydrate the store
+    stateStoreTestUtil = new FederationStateStoreTestUtil(stateStore);
+    stateStoreTestUtil.registerSubClusters(numSubClusters);
+    stateStoreTestUtil.addAppsHomeSC(clusterTs, numApps);
+    stateStoreTestUtil.addPolicyConfigs(numQueues);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    stateStore.close();
+    stateStore = null;
+  }
+
+  @Test
+  public void testGetSubCluster() throws YarnException {
+    for (int i = 0; i < numSubClusters; i++) {
+        SubClusterId subClusterId =
+            SubClusterId.newInstance(FederationStateStoreTestUtil.SC_PREFIX + i);
+        SubClusterInfo expectedSubCluster = stateStoreTestUtil.querySubClusterInfo(subClusterId);
+        SubClusterInfo cachedSubCluster = facade.getSubCluster(subClusterId);
+        assertEquals(expectedSubCluster, cachedSubCluster);
+    }
+  }
+
+  @Test
+  public void testGetPoliciesConfigurations() throws YarnException {
+    Map<String, SubClusterPolicyConfiguration> queuePolicies =
+        facade.getPoliciesConfigurations();
+    for (String queue : queuePolicies.keySet()) {
+        SubClusterPolicyConfiguration expectedPC = stateStoreTestUtil.queryPolicyConfiguration(queue);
+        SubClusterPolicyConfiguration cachedPC = queuePolicies.get(queue);
+        assertEquals(expectedPC, cachedPC);
+    }
+  }
+
+  @Test
+  public void testGetHomeSubClusterForApp() throws YarnException {
+    for (int i = 0; i < numApps; i++) {
+       ApplicationId appId = ApplicationId.newInstance(clusterTs, i);
+       SubClusterId expectedSC = stateStoreTestUtil.queryApplicationHomeSC(appId);
+       SubClusterId cachedPC = facade.getApplicationHomeSubCluster(appId);
+       assertEquals(expectedSC, cachedPC);
+    }
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/cache/TestFederationCache.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/cache/TestFederationCache.java
@@ -50,8 +50,8 @@ public class TestFederationCache {
   @Parameterized.Parameters
   public static Collection<String[]> getParameters() {
     return Arrays.asList(
-        new String[][] { { "org.apache.hadoop.yarn.server.federation.cache.FederationGuavaCache" },
-        { "org.apache.hadoop.yarn.server.federation.cache.FederationJCache" } });
+        new String[][] { {"org.apache.hadoop.yarn.server.federation.cache.FederationGuavaCache"},
+        {"org.apache.hadoop.yarn.server.federation.cache.FederationJCache"} });
   }
 
   private final long clusterTs = System.currentTimeMillis();
@@ -91,11 +91,11 @@ public class TestFederationCache {
   @Test
   public void testGetSubCluster() throws YarnException {
     for (int i = 0; i < numSubClusters; i++) {
-        SubClusterId subClusterId =
-            SubClusterId.newInstance(FederationStateStoreTestUtil.SC_PREFIX + i);
-        SubClusterInfo expectedSubCluster = stateStoreTestUtil.querySubClusterInfo(subClusterId);
-        SubClusterInfo cachedSubCluster = facade.getSubCluster(subClusterId);
-        assertEquals(expectedSubCluster, cachedSubCluster);
+      SubClusterId subClusterId =
+          SubClusterId.newInstance(FederationStateStoreTestUtil.SC_PREFIX + i);
+      SubClusterInfo expectedSubCluster = stateStoreTestUtil.querySubClusterInfo(subClusterId);
+      SubClusterInfo cachedSubCluster = facade.getSubCluster(subClusterId);
+      assertEquals(expectedSubCluster, cachedSubCluster);
     }
   }
 
@@ -104,19 +104,19 @@ public class TestFederationCache {
     Map<String, SubClusterPolicyConfiguration> queuePolicies =
         facade.getPoliciesConfigurations();
     for (String queue : queuePolicies.keySet()) {
-        SubClusterPolicyConfiguration expectedPC = stateStoreTestUtil.queryPolicyConfiguration(queue);
-        SubClusterPolicyConfiguration cachedPC = queuePolicies.get(queue);
-        assertEquals(expectedPC, cachedPC);
+      SubClusterPolicyConfiguration expectedPC = stateStoreTestUtil.queryPolicyConfiguration(queue);
+      SubClusterPolicyConfiguration cachedPC = queuePolicies.get(queue);
+      assertEquals(expectedPC, cachedPC);
     }
   }
 
   @Test
   public void testGetHomeSubClusterForApp() throws YarnException {
     for (int i = 0; i < numApps; i++) {
-       ApplicationId appId = ApplicationId.newInstance(clusterTs, i);
-       SubClusterId expectedSC = stateStoreTestUtil.queryApplicationHomeSC(appId);
-       SubClusterId cachedPC = facade.getApplicationHomeSubCluster(appId);
-       assertEquals(expectedSC, cachedPC);
+      ApplicationId appId = ApplicationId.newInstance(clusterTs, i);
+      SubClusterId expectedSC = stateStoreTestUtil.queryApplicationHomeSC(appId);
+      SubClusterId cachedPC = facade.getApplicationHomeSubCluster(appId);
+      assertEquals(expectedSC, cachedPC);
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
@@ -316,7 +316,7 @@ To enable cross-origin support (CORS) for the Yarn Router, please set the follow
 
 Cache:
 
-Cache is not enabled by default. When we set the `yarn.federation.cache-ttl.secs` parameter and its value is greater than 0, Cache will be enabled. 
+Cache is not enabled by default. When we set the `yarn.federation.cache-ttl.secs` parameter and its value is greater than 0, Cache will be enabled.
 We currently provide two Cache implementations: `JCache` and `GuavaCache`.
 
 > JCache

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
@@ -292,6 +292,7 @@ Optional:
 |`yarn.router.submit.interval.time` | `10ms` | The interval between two retry, the default value is 10ms. |
 |`yarn.federation.statestore.max-connections` | `10` | This is the maximum number of parallel connections each Router makes to the state-store. |
 |`yarn.federation.cache-ttl.secs` | `60` | The Router caches informations, and this is the time to leave before the cache is invalidated. |
+|`yarn.federation.cache.class` | `org.apache.hadoop.yarn.server.federation.cache.FederationJCache` | The Router caches informations, We can configure the Cache implementation and the default implementation is FederationJCache.|
 |`yarn.router.webapp.interceptor-class.pipeline` | `org.apache.hadoop.yarn.server.router.webapp.FederationInterceptorREST` | A comma-separated list of interceptor classes to be run at the router when interfacing with the client via REST interface. The last step of this pipeline must be the Federation Interceptor REST. |
 
 Security:
@@ -313,6 +314,22 @@ To enable cross-origin support (CORS) for the Yarn Router, please set the follow
 | `hadoop.http.filter.initializers`         | `org.apache.hadoop.security.HttpCrossOriginFilterInitializer` | Optional. Set the filter to HttpCrossOriginFilterInitializer, Configure this parameter in core-site.xml. |
 | `yarn.router.webapp.cross-origin.enabled` | `true`                                                       | Optional. Enable/disable CORS filter.Configure this parameter in yarn-site.xml. |
 
+Cache:
+
+Cache is not enabled by default. When we set the `yarn.federation.cache-ttl.secs` parameter and its value is greater than 0, Cache will be enabled. 
+We currently provide two Cache implementations: `JCache` and `GuavaCache`.
+
+> JCache
+
+  We used `geronimo-jcache`,`geronimo-jcache` is an implementation of the Java Caching API (JSR-107) specification provided by the Apache Geronimo project. 
+  It defines a standardized implementation of the JCache API, allowing developers to use the same API to access different caching implementations.
+  In YARN Federation we use a combination of `geronimo-jcache` and `Ehcache`. 
+  If we want to use JCache, we can configure `yarn.federation.cache.class` to `org.apache.hadoop.yarn.server.federation.cache.FederationJCache`.
+
+> GuavaCache
+
+  This is a Cache implemented based on the Guava framework. 
+  If we want to use it, we can configure `yarn.federation.cache.class` to `org.apache.hadoop.yarn.server.federation.cache.FederationGuavaCache`.
 
 ###ON NMs:
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
@@ -321,15 +321,15 @@ We currently provide two Cache implementations: `JCache` and `GuavaCache`.
 
 > JCache
 
-  We used `geronimo-jcache`,`geronimo-jcache` is an implementation of the Java Caching API (JSR-107) specification provided by the Apache Geronimo project. 
-  It defines a standardized implementation of the JCache API, allowing developers to use the same API to access different caching implementations.
-  In YARN Federation we use a combination of `geronimo-jcache` and `Ehcache`. 
-  If we want to use JCache, we can configure `yarn.federation.cache.class` to `org.apache.hadoop.yarn.server.federation.cache.FederationJCache`.
+We used `geronimo-jcache`,`geronimo-jcache` is an implementation of the Java Caching API (JSR-107) specification provided by the Apache Geronimo project.
+It defines a standardized implementation of the JCache API, allowing developers to use the same API to access different caching implementations.
+In YARN Federation we use a combination of `geronimo-jcache` and `Ehcache`.
+If we want to use JCache, we can configure `yarn.federation.cache.class` to `org.apache.hadoop.yarn.server.federation.cache.FederationJCache`.
 
 > GuavaCache
 
-  This is a Cache implemented based on the Guava framework. 
-  If we want to use it, we can configure `yarn.federation.cache.class` to `org.apache.hadoop.yarn.server.federation.cache.FederationGuavaCache`.
+This is a Cache implemented based on the Guava framework.
+If we want to use it, we can configure `yarn.federation.cache.class` to `org.apache.hadoop.yarn.server.federation.cache.FederationGuavaCache`.
 
 ###ON NMs:
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11470. FederationStateStoreFacade Cache Support Guava Cache.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

