### PR TITLE
HADOOP-18727. Fix `WriteOperations.listMultipartUploads` function description

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperations.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperations.java
@@ -192,7 +192,8 @@ public interface WriteOperations extends AuditSpanSource, Closeable {
       throws IOException;
 
   /**
-   * List in-progress multipart uploads under a path
+   * List in-progress multipart uploads under a path: limited to the first
+   * few hundred.
    * @param prefix prefix for uploads to list
    * @return a list of in-progress multipart uploads
    * @throws IOException on problems

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperations.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperations.java
@@ -192,11 +192,10 @@ public interface WriteOperations extends AuditSpanSource, Closeable {
       throws IOException;
 
   /**
-   * Abort multipart uploads under a path: limited to the first
-   * few hundred.
-   * @param prefix prefix for uploads to abort
-   * @return a count of aborts
-   * @throws IOException trouble; FileNotFoundExceptions are swallowed.
+   * List in-progress multipart uploads under a path
+   * @param prefix prefix for uploads to list
+   * @return a list of in-progress multipart uploads
+   * @throws IOException on problems
    */
   List<MultipartUpload> listMultipartUploads(String prefix)
       throws IOException;


### PR DESCRIPTION
### Description of PR

This PR aims to fix the function description of `WriteOperations.listMultipartUploads`.

### How was this patch tested?

Manual review.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

