### PR TITLE
YARN-11463. Node Labels root directory creation doesn't have a retry logic - addendum

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/store/AbstractFSNodeStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/store/AbstractFSNodeStore.java
@@ -69,9 +69,9 @@ public abstract class AbstractFSNodeStore<M> {
     int maxRetries = conf.getInt(YarnConfiguration.NODE_STORE_ROOT_DIR_NUM_RETRIES,
         YarnConfiguration.NODE_STORE_ROOT_DIR_NUM_DEFAULT_RETRIES);
     int retryCount = 0;
-    boolean success = fs.mkdirs(fsWorkingPath);
+    boolean success = false;
 
-    while (!success && retryCount < maxRetries) {
+    while (!success && retryCount <= maxRetries) {
       try {
         if (!fs.exists(fsWorkingPath)) {
           success = fs.mkdirs(fsWorkingPath);
@@ -80,7 +80,7 @@ public abstract class AbstractFSNodeStore<M> {
         }
       } catch (IOException e) {
         retryCount++;
-        if (retryCount >= maxRetries) {
+        if (retryCount > maxRetries) {
           throw e;
         }
         try {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/TestFileSystemNodeLabelsStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/TestFileSystemNodeLabelsStore.java
@@ -348,24 +348,56 @@ public class TestFileSystemNodeLabelsStore extends NodeLabelTestBase {
 
   @MethodSource("getParameters")
   @ParameterizedTest
-  void testRootMkdirOnInitStore(String className) throws Exception {
+  void testRootMkdirOnInitStoreWhenRootDirectoryAlreadyExists(String className) throws Exception {
     initTestFileSystemNodeLabelsStore(className);
     final FileSystem mockFs = Mockito.mock(FileSystem.class);
+    final FileSystemNodeLabelsStore mockStore = createMockNodeLabelsStore(mockFs);
+    final int expectedMkdirsCount = 0;
+
+    Mockito.when(mockStore.getFs().exists(Mockito.any(Path.class)))
+        .thenReturn(true);
+    verifyMkdirsCount(mockStore, expectedMkdirsCount);
+  }
+
+  @MethodSource("getParameters")
+  @ParameterizedTest
+  void testRootMkdirOnInitStoreWhenRootDirectoryNotExists(String className) throws Exception {
+    initTestFileSystemNodeLabelsStore(className);
+    final FileSystem mockFs = Mockito.mock(FileSystem.class);
+    final FileSystemNodeLabelsStore mockStore = createMockNodeLabelsStore(mockFs);
+    final int expectedMkdirsCount = 1;
+
+    Mockito.when(mockStore.getFs().exists(Mockito.any(Path.class)))
+        .thenReturn(false).thenReturn(true);
+    verifyMkdirsCount(mockStore, expectedMkdirsCount);
+  }
+
+  @MethodSource("getParameters")
+  @ParameterizedTest
+  void testRootMkdirOnInitStoreRetryLogic(String className) throws Exception {
+    initTestFileSystemNodeLabelsStore(className);
+    final FileSystem mockFs = Mockito.mock(FileSystem.class);
+    final FileSystemNodeLabelsStore mockStore = createMockNodeLabelsStore(mockFs);
+    final int expectedMkdirsCount = 2;
+
+    Mockito.when(mockStore.getFs().exists(Mockito.any(Path.class)))
+        .thenReturn(false).thenReturn(false).thenReturn(true);
+    verifyMkdirsCount(mockStore, expectedMkdirsCount);
+  }
+
+  private FileSystemNodeLabelsStore createMockNodeLabelsStore(FileSystem mockFs) {
     FileSystemNodeLabelsStore mockStore = new FileSystemNodeLabelsStore() {
       public void initFileSystem(Configuration config) throws IOException {
         setFs(mockFs);
       }
     };
-
     mockStore.setFs(mockFs);
-    verifyMkdirsCount(mockStore, true, 1);
+    return mockStore;
   }
 
   private void verifyMkdirsCount(FileSystemNodeLabelsStore store,
-      boolean existsRetVal, int expectedNumOfCalls)
+      int expectedNumOfCalls)
       throws Exception {
-    Mockito.when(store.getFs().exists(Mockito.any(
-        Path.class))).thenReturn(existsRetVal);
     store.init(conf, mgr);
     Mockito.verify(store.getFs(), Mockito.times(
         expectedNumOfCalls)).mkdirs(Mockito.any(Path


### PR DESCRIPTION
Change-Id: Ice44690b47e6850f33a0ff0dd109b1d3a48c5a16

### Description of PR
The original change for retry logic called mkdirs first time outside of the try-catch block, and if an exception occurred, the retry didn't happened. Addressing this problem by moving all mkdirs command into the try-catch block.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

