### PR TITLE
HDFS-16998. RBF: Add ops metrics for getSlowDatanodeReport in RouterClientActivity

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientMetrics.java
@@ -147,6 +147,7 @@ public class RouterClientMetrics {
   @Metric private MutableCounterLong satisfyStoragePolicyOps;
   @Metric private MutableCounterLong getHAServiceStateOps;
   @Metric private MutableCounterLong otherOps;
+  @Metric private MutableCounterLong getSlowDatanodeReportOps;
 
   // private ConcurrentOps
   @Metric private MutableCounterLong concurrentSetReplicationOps;
@@ -184,6 +185,7 @@ public class RouterClientMetrics {
   @Metric private MutableCounterLong concurrentSetQuotaOps;
   @Metric private MutableCounterLong concurrentGetQuotaUsageOps;
   @Metric private MutableCounterLong concurrentOtherOps;
+  @Metric private MutableCounterLong concurrentGetSlowDatanodeReportOps;
 
   RouterClientMetrics(String processName, String sessionId) {
     registry.tag(ProcessName, processName).tag(SessionId, sessionId);
@@ -525,6 +527,9 @@ public class RouterClientMetrics {
     case "getHAServiceState":
       getHAServiceStateOps.incr();
       break;
+    case "getSlowDatanodeReport":
+      getSlowDatanodeReportOps.incr();
+      break;
     default:
       otherOps.incr();
     }
@@ -637,6 +642,9 @@ public class RouterClientMetrics {
       break;
     case "getQuotaUsage":
       concurrentGetQuotaUsageOps.incr();
+      break;
+    case "getSlowDatanodeReport":
+      concurrentGetSlowDatanodeReportOps.incr();
       break;
     default :
       concurrentOtherOps.incr();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/metrics/TestRouterClientMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/metrics/TestRouterClientMetrics.java
@@ -170,5 +170,12 @@ public class TestRouterClientMetrics {
         getMetrics(ROUTER_METRICS));
   }
 
+  @Test
+  public void testGetSlowDatanodeReport() throws Exception {
+    router.getRpcServer().getSlowDatanodeReport();
+    assertCounter("GetSlowDatanodeReportOps", 2L, getMetrics(ROUTER_METRICS));
+    assertCounter("ConcurrentGetSlowDatanodeReportOps", 1L, getMetrics(ROUTER_METRICS));
+  }
+
 }
 


### PR DESCRIPTION
[HDFS-16998](https://issues.apache.org/jira/browse/HDFS-16998)