### PR TITLE
YARN-11487. WebAppProxyServlet log output request ip

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
@@ -396,6 +396,8 @@ public class WebAppProxyServlet extends HttpServlet {
       boolean isRedirect = false;
       String pathInfo = req.getPathInfo();
       final String remoteUser = req.getRemoteUser();
+      final String remoteUserWithIPAddress =
+          remoteUser + "/" + req.getRemoteAddr();
 
       String[] parts = null;
 
@@ -411,7 +413,7 @@ public class WebAppProxyServlet extends HttpServlet {
       }
 
       if ((parts == null) || (parts.length < 2)) {
-        LOG.warn("{} gave an invalid proxy path {}", remoteUser,  pathInfo);
+        LOG.warn("{} gave an invalid proxy path {}", remoteUserWithIPAddress,  pathInfo);
         notFound(resp, "Your path appears to be formatted incorrectly.");
         return;
       }
@@ -423,7 +425,7 @@ public class WebAppProxyServlet extends HttpServlet {
 
       if (id == null) {
         LOG.warn("{} attempting to access {} that is invalid",
-            remoteUser, appId);
+            remoteUserWithIPAddress, appId);
         notFound(resp, appId + " appears to be formatted incorrectly.");
         return;
       }
@@ -467,7 +469,7 @@ public class WebAppProxyServlet extends HttpServlet {
 
       if (applicationReport == null) {
         LOG.warn("{} attempting to access {} that was not found",
-            remoteUser, id);
+            remoteUserWithIPAddress, id);
 
         URI toFetch =
             ProxyUriUtils
@@ -500,7 +502,7 @@ public class WebAppProxyServlet extends HttpServlet {
       if (checkUser && !runningUser.equals(remoteUser)) {
         LOG.info("Asking {} if they want to connect to the "
             + "app master GUI of {} owned by {}",
-            remoteUser, appId, runningUser);
+            remoteUserWithIPAddress, appId, runningUser);
         warnUserPage(resp, ProxyUriUtils.getPathAndQuery(id, rest, 
             req.getQueryString(), true), runningUser, id);
 
@@ -513,7 +515,7 @@ public class WebAppProxyServlet extends HttpServlet {
 
       LOG.info("{} is accessing unchecked {}"
           + " which is the app master GUI of {} owned by {}",
-          remoteUser, toFetch, appId, runningUser);
+          remoteUserWithIPAddress, toFetch, appId, runningUser);
 
       switch (applicationReport.getYarnApplicationState()) {
         case KILLED:


### PR DESCRIPTION
### Description of PR
Output the request ip of `WebAppProxyServlet` in the log.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

