### PR TITLE
HADOOP-18729. Fix mvnsite on Windows 10

### DIFF
--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -652,9 +652,10 @@
                     <goal>exec</goal>
                 </goals>
                 <configuration>
-                    <executable>${basedir}/../../dev-support/bin/shelldocs</executable>
+                    <executable>${shell-executable}</executable>
                     <workingDirectory>src/site/markdown</workingDirectory>
                     <arguments>
+                        <argument>${basedir}/../../dev-support/bin/shelldocs</argument>
                         <argument>--skipprnorep</argument>
                         <argument>--output</argument>
                         <argument>${basedir}/src/site/markdown/UnixShellAPI.md</argument>

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/cli/CLITestHelper.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/cli/CLITestHelper.java
@@ -461,4 +461,5 @@ public class CLITestHelper {
       charString += s;
     }
   }
+
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/cli/CLITestHelper.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/cli/CLITestHelper.java
@@ -47,20 +47,20 @@ public class CLITestHelper {
       .class);
 
   // In this mode, it runs the command and compares the actual output
-  // with the expected output
+  // with the expected output  
   public static final String TESTMODE_TEST = "test"; // Run the tests
-
+  
   // If it is set to nocompare, run the command and do not compare.
   // This can be useful populate the testConfig.xml file the first time
   // a new command is added
   public static final String TESTMODE_NOCOMPARE = "nocompare";
   public static final String TEST_CACHE_DATA_DIR =
     System.getProperty("test.cache.data", "build/test/cache");
-
+  
   //By default, run the tests. The other mode is to run the commands and not
   // compare the output
   protected String testMode = TESTMODE_TEST;
-
+  
   // Storage for tests read in from the config file
   protected ArrayList<CLITestData> testsFromConfigFile = null;
   protected ArrayList<ComparatorData> testComparators = null;
@@ -104,29 +104,29 @@ public class CLITestHelper {
   protected String getTestFile() {
     return "";
   }
-
+  
   /*
    * Setup
    */
   public void setUp() throws Exception {
     // Read the testConfig.xml file
     readTestConfigFile();
-
+    
     conf = new Configuration();
-    conf.setBoolean(CommonConfigurationKeys.HADOOP_SECURITY_AUTHORIZATION,
+    conf.setBoolean(CommonConfigurationKeys.HADOOP_SECURITY_AUTHORIZATION, 
                     true);
 
     clitestDataDir = new File(TEST_CACHE_DATA_DIR).
     toURI().toString().replace(' ', '+');
   }
-
+  
   /**
    * Tear down
    */
   public void tearDown() throws Exception {
     displayResults();
   }
-
+  
   /**
    * Expand the commands from the test config xml file
    * @param cmd
@@ -136,22 +136,22 @@ public class CLITestHelper {
     String expCmd = cmd;
     expCmd = expCmd.replaceAll("CLITEST_DATA", clitestDataDir);
     expCmd = expCmd.replaceAll("USERNAME", username);
-
+    
     return expCmd;
   }
-
+  
   /**
    * Display the summarized results
    */
   private void displayResults() {
     LOG.info("Detailed results:");
     LOG.info("----------------------------------\n");
-
+    
     for (int i = 0; i < testsFromConfigFile.size(); i++) {
       CLITestData td = testsFromConfigFile.get(i);
-
+      
       boolean testResult = td.getTestResult();
-
+      
       // Display the details only if there is a failure
       if (!testResult) {
         LOG.info("-------------------------------------------");
@@ -161,7 +161,7 @@ public class CLITestHelper {
 
         ArrayList<CLICommand> testCommands = td.getTestCommands();
         for (CLICommand cmd : testCommands) {
-          LOG.info("              Test Commands: [" +
+          LOG.info("              Test Commands: [" + 
                    expandCommand(cmd.getCmd()) + "]");
         }
 
@@ -176,29 +176,29 @@ public class CLITestHelper {
         ArrayList<ComparatorData> compdata = td.getComparatorData();
         for (ComparatorData cd : compdata) {
           boolean resultBoolean = cd.getTestResult();
-          LOG.info("                 Comparator: [" +
+          LOG.info("                 Comparator: [" + 
                    cd.getComparatorType() + "]");
-          LOG.info("         Comparision result:   [" +
+          LOG.info("         Comparision result:   [" + 
                    (resultBoolean ? "pass" : "fail") + "]");
-          LOG.info("            Expected output:   [" +
+          LOG.info("            Expected output:   [" + 
                    expandCommand(cd.getExpectedOutput()) + "]");
-          LOG.info("              Actual output:   [" +
+          LOG.info("              Actual output:   [" + 
                    cd.getActualOutput() + "]");
         }
         LOG.info("");
       }
     }
-
+    
     LOG.info("Summary results:");
     LOG.info("----------------------------------\n");
-
+    
     boolean overallResults = true;
     int totalPass = 0;
     int totalFail = 0;
     int totalComparators = 0;
     for (int i = 0; i < testsFromConfigFile.size(); i++) {
       CLITestData td = testsFromConfigFile.get(i);
-      totalComparators +=
+      totalComparators += 
     	  testsFromConfigFile.get(i).getComparatorData().size();
       boolean resultBoolean = td.getTestResult();
       if (resultBoolean) {
@@ -208,27 +208,27 @@ public class CLITestHelper {
       }
       overallResults &= resultBoolean;
     }
-
-
+    
+    
     LOG.info("               Testing mode: " + testMode);
     LOG.info("");
-    LOG.info("             Overall result: " +
+    LOG.info("             Overall result: " + 
     		(overallResults ? "+++ PASS +++" : "--- FAIL ---"));
     if ((totalPass + totalFail) == 0) {
       LOG.info("               # Tests pass: " + 0);
       LOG.info("               # Tests fail: " + 0);
     }
-    else
+    else 
     {
       LOG.info("               # Tests pass: " + totalPass +
           " (" + (100 * totalPass / (totalPass + totalFail)) + "%)");
-      LOG.info("               # Tests fail: " + totalFail +
+      LOG.info("               # Tests fail: " + totalFail + 
           " (" + (100 * totalFail / (totalPass + totalFail)) + "%)");
     }
-
-    LOG.info("         # Validations done: " + totalComparators +
+    
+    LOG.info("         # Validations done: " + totalComparators + 
     		" (each test may do multiple validations)");
-
+    
     LOG.info("");
     LOG.info("Failing tests:");
     LOG.info("--------------");
@@ -237,7 +237,7 @@ public class CLITestHelper {
     for (i = 0; i < testsFromConfigFile.size(); i++) {
       boolean resultBoolean = testsFromConfigFile.get(i).getTestResult();
       if (!resultBoolean) {
-        LOG.info((i + 1) + ": " +
+        LOG.info((i + 1) + ": " + 
         		testsFromConfigFile.get(i).getTestDesc());
         foundTests = true;
       }
@@ -245,7 +245,7 @@ public class CLITestHelper {
     if (!foundTests) {
     	LOG.info("NONE");
     }
-
+    
     foundTests = false;
     LOG.info("");
     LOG.info("Passing tests:");
@@ -253,7 +253,7 @@ public class CLITestHelper {
     for (i = 0; i < testsFromConfigFile.size(); i++) {
       boolean resultBoolean = testsFromConfigFile.get(i).getTestResult();
       if (resultBoolean) {
-        LOG.info((i + 1) + ": " +
+        LOG.info((i + 1) + ": " + 
         		testsFromConfigFile.get(i).getTestDesc());
         foundTests = true;
       }
@@ -265,9 +265,9 @@ public class CLITestHelper {
     assertTrue("One of the tests failed. " +
     		"See the Detailed results to identify " +
     		"the command that failed", overallResults);
-
+    
   }
-
+  
   /**
    * Compare the actual output with the expected output
    * @param compdata
@@ -277,26 +277,26 @@ public class CLITestHelper {
     // Compare the output based on the comparator
     String comparatorType = compdata.getComparatorType();
     Class<?> comparatorClass = null;
-
+    
     // If testMode is "test", then run the command and compare the output
     // If testMode is "nocompare", then run the command and dump the output.
     // Do not compare
-
+    
     boolean compareOutput = false;
-
+    
     if (testMode.equals(TESTMODE_TEST)) {
       try {
     	// Initialize the comparator class and run its compare method
-        comparatorClass = Class.forName("org.apache.hadoop.cli.util." +
+        comparatorClass = Class.forName("org.apache.hadoop.cli.util." + 
           comparatorType);
         ComparatorBase comp = (ComparatorBase) comparatorClass.newInstance();
-        compareOutput = comp.compare(cmdResult.getCommandOutput(),
+        compareOutput = comp.compare(cmdResult.getCommandOutput(), 
           expandCommand(compdata.getExpectedOutput()));
       } catch (Exception e) {
         LOG.info("Error in instantiating the comparator" + e);
       }
     }
-
+    
     return compareOutput;
   }
 
@@ -304,20 +304,20 @@ public class CLITestHelper {
       Result cmdResult) {
     return compdata.getExitCode() == cmdResult.getExitCode();
   }
-
+  
   /***********************************
    ************* TESTS RUNNER
    *********************************/
-
+  
   public void testAll() {
     assertTrue("Number of tests has to be greater then zero",
       testsFromConfigFile.size() > 0);
     LOG.info("TestAll");
     // Run the tests defined in the testConf.xml config file.
     for (int index = 0; index < testsFromConfigFile.size(); index++) {
-
+      
       CLITestData testdata = testsFromConfigFile.get(index);
-
+   
       // Execute the test commands
       ArrayList<CLICommand> testCommands = testdata.getTestCommands();
       Result cmdResult = null;
@@ -328,16 +328,16 @@ public class CLITestHelper {
         fail(StringUtils.stringifyException(e));
       }
       }
-
+      
       boolean overallTCResult = true;
       // Run comparators
       ArrayList<ComparatorData> compdata = testdata.getComparatorData();
       for (ComparatorData cd : compdata) {
         final String comptype = cd.getComparatorType();
-
+        
         boolean compareOutput = false;
         boolean compareExitCode = false;
-
+        
         if (! comptype.equalsIgnoreCase("none")) {
           compareOutput = compareTestOutput(cd, cmdResult);
           if (cd.getExitCode() == -1) {
@@ -348,17 +348,17 @@ public class CLITestHelper {
           }
           overallTCResult &= (compareOutput & compareExitCode);
         }
-
+        
         cd.setExitCode(cmdResult.getExitCode());
         cd.setActualOutput(cmdResult.getCommandOutput());
         cd.setTestResult(compareOutput);
       }
       testdata.setTestResult(overallTCResult);
-
+      
       // Execute the cleanup commands
       ArrayList<CLICommand> cleanupCommands = testdata.getCleanupCommands();
       for (CLICommand cmd : cleanupCommands) {
-      try {
+      try { 
         execute(cmd);
       } catch (Exception e) {
         fail(StringUtils.stringifyException(e));
@@ -373,7 +373,7 @@ public class CLITestHelper {
   protected CommandExecutor.Result execute(CLICommand cmd) throws Exception {
     throw new Exception("Unknown type of test command:"+ cmd.getType());
   }
-
+  
   /*
    * Parser class for the test config xml file
    */
@@ -383,16 +383,16 @@ public class CLITestHelper {
     ArrayList<CLICommand> testCommands = null;
     ArrayList<CLICommand> cleanupCommands = null;
     boolean runOnWindows = true;
-
+    
     @Override
     public void startDocument() throws SAXException {
       testsFromConfigFile = new ArrayList<CLITestData>();
     }
-
+    
     @Override
-    public void startElement(String uri,
-    		String localName,
-    		String qName,
+    public void startElement(String uri, 
+    		String localName, 
+    		String qName, 
     		Attributes attributes) throws SAXException {
       if (qName.equals("test")) {
         td = new CLITestData();
@@ -408,7 +408,7 @@ public class CLITestHelper {
       }
       charString = "";
     }
-
+    
     @Override
     public void endElement(String uri, String localName,String qName)
         throws SAXException {
@@ -452,14 +452,13 @@ public class CLITestHelper {
         }
       }
     }
-
+    
     @Override
-    public void characters(char[] ch,
-    		int start,
+    public void characters(char[] ch, 
+    		int start, 
     		int length) throws SAXException {
       String s = new String(ch, start, length);
       charString += s;
     }
-
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/cli/CLITestHelper.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/cli/CLITestHelper.java
@@ -47,20 +47,20 @@ public class CLITestHelper {
       .class);
 
   // In this mode, it runs the command and compares the actual output
-  // with the expected output  
+  // with the expected output
   public static final String TESTMODE_TEST = "test"; // Run the tests
-  
+
   // If it is set to nocompare, run the command and do not compare.
   // This can be useful populate the testConfig.xml file the first time
   // a new command is added
   public static final String TESTMODE_NOCOMPARE = "nocompare";
   public static final String TEST_CACHE_DATA_DIR =
     System.getProperty("test.cache.data", "build/test/cache");
-  
+
   //By default, run the tests. The other mode is to run the commands and not
   // compare the output
   protected String testMode = TESTMODE_TEST;
-  
+
   // Storage for tests read in from the config file
   protected ArrayList<CLITestData> testsFromConfigFile = null;
   protected ArrayList<ComparatorData> testComparators = null;
@@ -104,29 +104,29 @@ public class CLITestHelper {
   protected String getTestFile() {
     return "";
   }
-  
+
   /*
    * Setup
    */
   public void setUp() throws Exception {
     // Read the testConfig.xml file
     readTestConfigFile();
-    
+
     conf = new Configuration();
-    conf.setBoolean(CommonConfigurationKeys.HADOOP_SECURITY_AUTHORIZATION, 
+    conf.setBoolean(CommonConfigurationKeys.HADOOP_SECURITY_AUTHORIZATION,
                     true);
 
     clitestDataDir = new File(TEST_CACHE_DATA_DIR).
     toURI().toString().replace(' ', '+');
   }
-  
+
   /**
    * Tear down
    */
   public void tearDown() throws Exception {
     displayResults();
   }
-  
+
   /**
    * Expand the commands from the test config xml file
    * @param cmd
@@ -136,22 +136,22 @@ public class CLITestHelper {
     String expCmd = cmd;
     expCmd = expCmd.replaceAll("CLITEST_DATA", clitestDataDir);
     expCmd = expCmd.replaceAll("USERNAME", username);
-    
+
     return expCmd;
   }
-  
+
   /**
    * Display the summarized results
    */
   private void displayResults() {
     LOG.info("Detailed results:");
     LOG.info("----------------------------------\n");
-    
+
     for (int i = 0; i < testsFromConfigFile.size(); i++) {
       CLITestData td = testsFromConfigFile.get(i);
-      
+
       boolean testResult = td.getTestResult();
-      
+
       // Display the details only if there is a failure
       if (!testResult) {
         LOG.info("-------------------------------------------");
@@ -161,7 +161,7 @@ public class CLITestHelper {
 
         ArrayList<CLICommand> testCommands = td.getTestCommands();
         for (CLICommand cmd : testCommands) {
-          LOG.info("              Test Commands: [" + 
+          LOG.info("              Test Commands: [" +
                    expandCommand(cmd.getCmd()) + "]");
         }
 
@@ -176,29 +176,29 @@ public class CLITestHelper {
         ArrayList<ComparatorData> compdata = td.getComparatorData();
         for (ComparatorData cd : compdata) {
           boolean resultBoolean = cd.getTestResult();
-          LOG.info("                 Comparator: [" + 
+          LOG.info("                 Comparator: [" +
                    cd.getComparatorType() + "]");
-          LOG.info("         Comparision result:   [" + 
+          LOG.info("         Comparision result:   [" +
                    (resultBoolean ? "pass" : "fail") + "]");
-          LOG.info("            Expected output:   [" + 
+          LOG.info("            Expected output:   [" +
                    expandCommand(cd.getExpectedOutput()) + "]");
-          LOG.info("              Actual output:   [" + 
+          LOG.info("              Actual output:   [" +
                    cd.getActualOutput() + "]");
         }
         LOG.info("");
       }
     }
-    
+
     LOG.info("Summary results:");
     LOG.info("----------------------------------\n");
-    
+
     boolean overallResults = true;
     int totalPass = 0;
     int totalFail = 0;
     int totalComparators = 0;
     for (int i = 0; i < testsFromConfigFile.size(); i++) {
       CLITestData td = testsFromConfigFile.get(i);
-      totalComparators += 
+      totalComparators +=
     	  testsFromConfigFile.get(i).getComparatorData().size();
       boolean resultBoolean = td.getTestResult();
       if (resultBoolean) {
@@ -208,27 +208,27 @@ public class CLITestHelper {
       }
       overallResults &= resultBoolean;
     }
-    
-    
+
+
     LOG.info("               Testing mode: " + testMode);
     LOG.info("");
-    LOG.info("             Overall result: " + 
+    LOG.info("             Overall result: " +
     		(overallResults ? "+++ PASS +++" : "--- FAIL ---"));
     if ((totalPass + totalFail) == 0) {
       LOG.info("               # Tests pass: " + 0);
       LOG.info("               # Tests fail: " + 0);
     }
-    else 
+    else
     {
       LOG.info("               # Tests pass: " + totalPass +
           " (" + (100 * totalPass / (totalPass + totalFail)) + "%)");
-      LOG.info("               # Tests fail: " + totalFail + 
+      LOG.info("               # Tests fail: " + totalFail +
           " (" + (100 * totalFail / (totalPass + totalFail)) + "%)");
     }
-    
-    LOG.info("         # Validations done: " + totalComparators + 
+
+    LOG.info("         # Validations done: " + totalComparators +
     		" (each test may do multiple validations)");
-    
+
     LOG.info("");
     LOG.info("Failing tests:");
     LOG.info("--------------");
@@ -237,7 +237,7 @@ public class CLITestHelper {
     for (i = 0; i < testsFromConfigFile.size(); i++) {
       boolean resultBoolean = testsFromConfigFile.get(i).getTestResult();
       if (!resultBoolean) {
-        LOG.info((i + 1) + ": " + 
+        LOG.info((i + 1) + ": " +
         		testsFromConfigFile.get(i).getTestDesc());
         foundTests = true;
       }
@@ -245,7 +245,7 @@ public class CLITestHelper {
     if (!foundTests) {
     	LOG.info("NONE");
     }
-    
+
     foundTests = false;
     LOG.info("");
     LOG.info("Passing tests:");
@@ -253,7 +253,7 @@ public class CLITestHelper {
     for (i = 0; i < testsFromConfigFile.size(); i++) {
       boolean resultBoolean = testsFromConfigFile.get(i).getTestResult();
       if (resultBoolean) {
-        LOG.info((i + 1) + ": " + 
+        LOG.info((i + 1) + ": " +
         		testsFromConfigFile.get(i).getTestDesc());
         foundTests = true;
       }
@@ -265,9 +265,9 @@ public class CLITestHelper {
     assertTrue("One of the tests failed. " +
     		"See the Detailed results to identify " +
     		"the command that failed", overallResults);
-    
+
   }
-  
+
   /**
    * Compare the actual output with the expected output
    * @param compdata
@@ -277,26 +277,26 @@ public class CLITestHelper {
     // Compare the output based on the comparator
     String comparatorType = compdata.getComparatorType();
     Class<?> comparatorClass = null;
-    
+
     // If testMode is "test", then run the command and compare the output
     // If testMode is "nocompare", then run the command and dump the output.
     // Do not compare
-    
+
     boolean compareOutput = false;
-    
+
     if (testMode.equals(TESTMODE_TEST)) {
       try {
     	// Initialize the comparator class and run its compare method
-        comparatorClass = Class.forName("org.apache.hadoop.cli.util." + 
+        comparatorClass = Class.forName("org.apache.hadoop.cli.util." +
           comparatorType);
         ComparatorBase comp = (ComparatorBase) comparatorClass.newInstance();
-        compareOutput = comp.compare(cmdResult.getCommandOutput(), 
+        compareOutput = comp.compare(cmdResult.getCommandOutput(),
           expandCommand(compdata.getExpectedOutput()));
       } catch (Exception e) {
         LOG.info("Error in instantiating the comparator" + e);
       }
     }
-    
+
     return compareOutput;
   }
 
@@ -304,20 +304,20 @@ public class CLITestHelper {
       Result cmdResult) {
     return compdata.getExitCode() == cmdResult.getExitCode();
   }
-  
+
   /***********************************
    ************* TESTS RUNNER
    *********************************/
-  
+
   public void testAll() {
     assertTrue("Number of tests has to be greater then zero",
       testsFromConfigFile.size() > 0);
     LOG.info("TestAll");
     // Run the tests defined in the testConf.xml config file.
     for (int index = 0; index < testsFromConfigFile.size(); index++) {
-      
+
       CLITestData testdata = testsFromConfigFile.get(index);
-   
+
       // Execute the test commands
       ArrayList<CLICommand> testCommands = testdata.getTestCommands();
       Result cmdResult = null;
@@ -328,16 +328,16 @@ public class CLITestHelper {
         fail(StringUtils.stringifyException(e));
       }
       }
-      
+
       boolean overallTCResult = true;
       // Run comparators
       ArrayList<ComparatorData> compdata = testdata.getComparatorData();
       for (ComparatorData cd : compdata) {
         final String comptype = cd.getComparatorType();
-        
+
         boolean compareOutput = false;
         boolean compareExitCode = false;
-        
+
         if (! comptype.equalsIgnoreCase("none")) {
           compareOutput = compareTestOutput(cd, cmdResult);
           if (cd.getExitCode() == -1) {
@@ -348,17 +348,17 @@ public class CLITestHelper {
           }
           overallTCResult &= (compareOutput & compareExitCode);
         }
-        
+
         cd.setExitCode(cmdResult.getExitCode());
         cd.setActualOutput(cmdResult.getCommandOutput());
         cd.setTestResult(compareOutput);
       }
       testdata.setTestResult(overallTCResult);
-      
+
       // Execute the cleanup commands
       ArrayList<CLICommand> cleanupCommands = testdata.getCleanupCommands();
       for (CLICommand cmd : cleanupCommands) {
-      try { 
+      try {
         execute(cmd);
       } catch (Exception e) {
         fail(StringUtils.stringifyException(e));
@@ -373,7 +373,7 @@ public class CLITestHelper {
   protected CommandExecutor.Result execute(CLICommand cmd) throws Exception {
     throw new Exception("Unknown type of test command:"+ cmd.getType());
   }
-  
+
   /*
    * Parser class for the test config xml file
    */
@@ -383,16 +383,16 @@ public class CLITestHelper {
     ArrayList<CLICommand> testCommands = null;
     ArrayList<CLICommand> cleanupCommands = null;
     boolean runOnWindows = true;
-    
+
     @Override
     public void startDocument() throws SAXException {
       testsFromConfigFile = new ArrayList<CLITestData>();
     }
-    
+
     @Override
-    public void startElement(String uri, 
-    		String localName, 
-    		String qName, 
+    public void startElement(String uri,
+    		String localName,
+    		String qName,
     		Attributes attributes) throws SAXException {
       if (qName.equals("test")) {
         td = new CLITestData();
@@ -408,7 +408,7 @@ public class CLITestHelper {
       }
       charString = "";
     }
-    
+
     @Override
     public void endElement(String uri, String localName,String qName)
         throws SAXException {
@@ -452,13 +452,14 @@ public class CLITestHelper {
         }
       }
     }
-    
+
     @Override
-    public void characters(char[] ch, 
-    		int start, 
+    public void characters(char[] ch,
+    		int start,
     		int length) throws SAXException {
       String s = new String(ch, start, length);
       charString += s;
     }
+
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/cli/CLITestHelper.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/cli/CLITestHelper.java
@@ -461,5 +461,4 @@ public class CLITestHelper {
       charString += s;
     }
   }
-
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

[HADOOP-18729](https://issues.apache.org/jira/browse/HADOOP-18729)

### Description of PR
* The mvnsite step invokes shelldocs script. This fails to run on Windows since this script is written in Bash, which Windows can't execute natively.
* Thus, we must run this script through Bash on Windows.

### How was this patch tested?
Jenkins CI validation.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

