### PR TITLE
HDFS-16999. Fix wrong use of processFirstBlockReport().

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -2913,7 +2913,7 @@ public class BlockManager implements BlockStatsMXBean {
         return !node.hasStaleStorages();
       }
 
-      if (storageInfo.getBlockReportCount() == 0) {
+      if (!storageInfo.hasReceivedBlockReport()) {
         // The first block report can be processed a lot more efficiently than
         // ordinary block reports.  This shortens restart times.
         blockLog.info("BLOCK* processReport 0x{} with lease ID 0x{}: Processing first "

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeStorageInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeStorageInfo.java
@@ -128,6 +128,10 @@ public class DatanodeStorageInfo {
   /** The number of block reports received */
   private int blockReportCount = 0;
 
+  /** Whether the NameNode has received block reports for this storage since it
+   * was started.*/
+  private boolean hasReceivedBlockReport = false;
+
   /**
    * Set to false on any NN failover, and reset to true
    * whenever a block report is received.
@@ -160,6 +164,10 @@ public class DatanodeStorageInfo {
     return blockReportCount;
   }
 
+  boolean hasReceivedBlockReport() {
+    return hasReceivedBlockReport;
+  }
+
   void setBlockReportCount(int blockReportCount) {
     this.blockReportCount = blockReportCount;
   }
@@ -188,6 +196,7 @@ public class DatanodeStorageInfo {
       blockContentsStale = false;
     }
     blockReportCount++;
+    hasReceivedBlockReport = true;
   }
 
   @VisibleForTesting

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
@@ -350,7 +350,7 @@ public class FsVolumeImpl implements FsVolumeSpi {
   }
 
   @VisibleForTesting
-  File getCurrentDir() {
+  public File getCurrentDir() {
     return currentDir;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
@@ -2077,9 +2077,8 @@ public class TestBlockManager {
   @Test
   public void testBlockReportAfterDataNodeRestart() throws Exception {
     Configuration conf = new HdfsConfiguration();
-    try (final MiniDFSCluster cluster =
-             new MiniDFSCluster.Builder(conf).numDataNodes(3)
-                 .storagesPerDatanode(1).build()) {
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+           .numDataNodes(3).storagesPerDatanode(1).build()) {
       cluster.waitActive();
       BlockManager blockManager = cluster.getNamesystem().getBlockManager();
       DistributedFileSystem fs = cluster.getFileSystem();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.thirdparty.com.google.common.collect.LinkedListMultimap;
@@ -2065,5 +2068,57 @@ public class TestBlockManager {
     assertFalse(bm.validateReconstructionWork(work));
     // validateReconstructionWork return false, need to perform resetTargets().
     assertNull(work.getTargets());
+  }
+
+  /**
+   * Test whether the first block report after DataNode restart is completely
+   * processed.
+   */
+  @Test
+  public void testBlockReportAfterDataNodeRestart() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    try (final MiniDFSCluster cluster =
+             new MiniDFSCluster.Builder(conf).numDataNodes(3)
+                 .storagesPerDatanode(1).build()) {
+      cluster.waitActive();
+      BlockManager blockManager = cluster.getNamesystem().getBlockManager();
+      DistributedFileSystem fs = cluster.getFileSystem();
+      final Path filePath = new Path("/tmp.txt");
+      final long fileLen = 1L;
+      DFSTestUtil.createFile(fs, filePath, fileLen, (short) 3, 1L);
+      DFSTestUtil.waitForReplication(fs, filePath, (short) 3, 60000);
+      ArrayList<DataNode> datanodes = cluster.getDataNodes();
+      assertEquals(datanodes.size(), 3);
+
+      // Stop RedundancyMonitor.
+      blockManager.setInitializedReplQueues(false);
+
+      // Delete the replica on the first datanode.
+      File dnDir =
+          datanodes.get(0).getFSDataset().getVolumeList().get(0)
+              .getCurrentDir();
+      String[] children = FileUtil.list(dnDir);
+      for (String s : children) {
+        if (!s.equals("VERSION")) {
+          FileUtil.fullyDeleteContents(new File(dnDir, s));
+        }
+      }
+
+      // The number of replicas is still 3 because the datanode has not sent
+      // a new block report.
+      FileStatus stat = fs.getFileStatus(filePath);
+      BlockLocation[] locs = fs.getFileBlockLocations(stat, 0, stat.getLen());
+      assertEquals(3, locs[0].getHosts().length);
+
+      // Restart the first datanode.
+      cluster.restartDataNode(0, true);
+
+      // Wait for the block report to be processed.
+      Thread.sleep(5000);
+
+      // The replica num should be 2.
+      locs = fs.getFileBlockLocations(stat, 0, stat.getLen());
+      assertEquals(2, locs[0].getHosts().length);
+    }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
@@ -2093,9 +2093,9 @@ public class TestBlockManager {
       blockManager.setInitializedReplQueues(false);
 
       // Delete the replica on the first datanode.
-      File dnDir =
-          datanodes.get(0).getFSDataset().getVolumeList().get(0)
-              .getCurrentDir();
+      DataNode dn = datanodes.get(0);
+      int dnIpcPort = dn.getIpcPort();
+      File dnDir = dn.getFSDataset().getVolumeList().get(0).getCurrentDir();
       String[] children = FileUtil.list(dnDir);
       for (String s : children) {
         if (!s.equals("VERSION")) {
@@ -2113,7 +2113,8 @@ public class TestBlockManager {
       cluster.restartDataNode(0, true);
 
       // Wait for the block report to be processed.
-      Thread.sleep(5000);
+      cluster.waitDatanodeFullyStarted(cluster.getDataNode(dnIpcPort), 10000);
+      cluster.waitFirstBRCompleted(0, 10000);
 
       // The replica num should be 2.
       locs = fs.getFileBlockLocations(stat, 0, stat.getLen());


### PR DESCRIPTION
### Description of PR
`processFirstBlockReport()` is used to process first block report from datanode. It does not calculating `toRemove` list because it believes that there is no metadata about the datanode in the namenode. However, If a datanode is re registered after restarting, its `blockReportCount` will be updated to 0. 
https://github.com/apache/hadoop/blob/c7699d3dcd4f8feaf2c5ae5943b8a4cec738e95d/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java#L1007-L1012
That is to say, the first block report after a datanode restarts will be processed by `processFirstBlockReport()`. 
https://github.com/apache/hadoop/blob/c7699d3dcd4f8feaf2c5ae5943b8a4cec738e95d/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java#L2916-L2925
This is unreasonable because the metadata of the datanode already exists in namenode at this time, and if redundant replica metadata is not removed in time, the blocks with insufficient replicas cannot be reconstruct in time, which increases the risk of missing block. In summary, `processFirstBlockReport()` should only be used when the namenode restarts, not when the datanode restarts.
### How was this patch tested?
Add a new unit test.
