### PR TITLE
HADOOP-18734. Create qbt.sh symlink on Windows

### DIFF
--- a/dev-support/bin/yetus-wrapper
+++ b/dev-support/bin/yetus-wrapper
@@ -171,7 +171,12 @@ if [[ -n "${GPGBIN}" && ! "${HADOOP_SKIP_YETUS_VERIFICATION}" = true ]]; then
    fi
 fi
 
-if ! (gunzip -c "${TARBALL}.gz" | tar xpf -); then
+if [[ "$IS_WINDOWS" && "$IS_WINDOWS" == 1 ]]; then
+  UNZIP_FAILURE=$(gunzip -c "${TARBALL}.gz" | tar xpf - 2>&1)
+  YETUS_PRECOMMIT_DIR="${YETUS_PREFIX}-${HADOOP_YETUS_VERSION}/lib/precommit"
+  ln -s "${YETUS_PRECOMMIT_DIR}/test-patch.sh" qbt.sh
+  mv qbt.sh "${YETUS_PRECOMMIT_DIR}"
+elif ! (gunzip -c "${TARBALL}.gz" | tar xpf -); then
   yetus_error "ERROR: ${TARBALL}.gz is corrupt. Investigate and then remove ${HADOOP_PATCHPROCESS} to try again."
   exit 1
 fi

--- a/dev-support/bin/yetus-wrapper
+++ b/dev-support/bin/yetus-wrapper
@@ -172,7 +172,12 @@ if [[ -n "${GPGBIN}" && ! "${HADOOP_SKIP_YETUS_VERIFICATION}" = true ]]; then
 fi
 
 if [[ "$IS_WINDOWS" && "$IS_WINDOWS" == 1 ]]; then
-  UNZIP_FAILURE=$(gunzip -c "${TARBALL}.gz" | tar xpf - 2>&1)
+  gunzip -c "${TARBALL}.gz" | tar xpf -
+
+  # One of the entries in the Yetus tarball unzips a symlink qbt.sh.
+  # The symlink creation fails on Windows, unless this CI is run as Admin or Developer mode is
+  # enabled.
+  # Thus, we create the qbt.sh symlink ourselves and move it to the target.
   YETUS_PRECOMMIT_DIR="${YETUS_PREFIX}-${HADOOP_YETUS_VERSION}/lib/precommit"
   ln -s "${YETUS_PRECOMMIT_DIR}/test-patch.sh" qbt.sh
   mv qbt.sh "${YETUS_PRECOMMIT_DIR}"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

[HADOOP-18734](https://issues.apache.org/jira/browse/HADOOP-18734)

The hadoop-common project fails when mvnsite is built while running the shelldocs plugin on Windows 10 -

```
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.3.1:exec (shelldocs) on project hadoop-common: Command execution failed. Process exited with an error: 1 (Exit value: 1) -> [Help 1]
```

This being the reason -

```
[INFO] --- exec-maven-plugin:1.3.1:exec (shelldocs) @ hadoop-common ---
tar: apache-yetus-0.14.0/lib/precommit/qbt.sh: Cannot create symlink to 'test-patch.sh': No such file or directory
tar: Exiting with failure status due to previous errors
ERROR: apache-yetus-0.14.0-bin.tar.gz is corrupt. Investigate and then remove /c/hadoop/patchprocess to try again.
```

The apache-yetus-0.14.0 tarball contains a symlink qbt.sh. Unzipping this tarball fails to create the qbt.sh symlink since the creation of symlink is limited to Admin or when the developer mode is enabled.

The solution here is to use the ln command to create the symlink and move it to the required target location.

### How was this patch tested?
Jenkins CI validation.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

