### PR TITLE
YARN-11489. Fix memory leak of DelegationTokenRenewer futures in Dele…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
@@ -123,8 +123,8 @@ public class DelegationTokenRenewer extends AbstractService {
   private long tokenRenewerThreadTimeout;
   private long tokenRenewerThreadRetryInterval;
   private int tokenRenewerThreadRetryMaxAttempts;
-  private final Map<DelegationTokenRenewerEvent, Future<?>> futures =
-      new ConcurrentHashMap<>();
+  private final LinkedBlockingQueue<DelegationTokenRenewerFuture> futures =
+      new LinkedBlockingQueue<>();
   private boolean delegationTokenRenewerPoolTrackerFlag = true;
 
   // this config is supposedly not used by end-users.
@@ -227,7 +227,7 @@ public class DelegationTokenRenewer extends AbstractService {
       if (isServiceStarted) {
         Future<?> future =
             renewerService.submit(new DelegationTokenRenewerRunnable(evt));
-        futures.put(evt, future);
+        futures.add(new DelegationTokenRenewerFuture(evt, future));
       } else {
         pendingEventQueue.add(evt);
         int qSize = pendingEventQueue.size();
@@ -996,33 +996,35 @@ public class DelegationTokenRenewer extends AbstractService {
     @Override
     public void run() {
       while (true) {
-        for (Map.Entry<DelegationTokenRenewerEvent, Future<?>> entry : futures
-            .entrySet()) {
-          DelegationTokenRenewerEvent evt = entry.getKey();
-          Future<?> future = entry.getValue();
-          try {
-            future.get(tokenRenewerThreadTimeout, TimeUnit.MILLISECONDS);
-          } catch (TimeoutException e) {
-
-            // Cancel thread and retry the same event in case of timeout
-            if (future != null && !future.isDone() && !future.isCancelled()) {
-              future.cancel(true);
-              futures.remove(evt);
-              if (evt.getAttempt() < tokenRenewerThreadRetryMaxAttempts) {
-                renewalTimer.schedule(
-                    getTimerTask((AbstractDelegationTokenRenewerAppEvent) evt),
-                    tokenRenewerThreadRetryInterval);
-              } else {
-                LOG.info(
-                    "Exhausted max retry attempts {} in token renewer "
-                        + "thread for {}",
-                    tokenRenewerThreadRetryMaxAttempts, evt.getApplicationId());
-              }
+        DelegationTokenRenewerFuture dtrf;
+        try {
+          dtrf = futures.take();
+        } catch (InterruptedException e) {
+          LOG.debug("DelegationTokenRenewer pool tracker interrupted");
+          return;
+        }
+        DelegationTokenRenewerEvent evt = dtrf.getEvt();
+        Future<?> future = dtrf.getFuture();
+        try {
+          future.get(tokenRenewerThreadTimeout, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+          // Cancel thread and retry the same event in case of timeout.
+          if (!future.isDone() && !future.isCancelled()) {
+            future.cancel(true);
+            if (evt.getAttempt() < tokenRenewerThreadRetryMaxAttempts) {
+              renewalTimer.schedule(
+                  getTimerTask((AbstractDelegationTokenRenewerAppEvent) evt),
+                  tokenRenewerThreadRetryInterval);
+            } else {
+              LOG.info(
+                  "Exhausted max retry attempts {} in token renewer "
+                      + "thread for {}",
+                  tokenRenewerThreadRetryMaxAttempts, evt.getApplicationId());
             }
-          } catch (Exception e) {
-            LOG.info("Problem in submitting renew tasks in token renewer "
-                + "thread.", e);
           }
+        } catch (Exception e) {
+          LOG.info("Problem in submitting renew tasks in token renewer "
+              + "thread.", e);
         }
       }
     }
@@ -1187,6 +1189,32 @@ public class DelegationTokenRenewer extends AbstractService {
 
     public void setAttempt(int attempt) {
       this.attempt = attempt;
+    }
+  }
+
+  private static class DelegationTokenRenewerFuture {
+    private DelegationTokenRenewerEvent evt;
+    private Future<?> future;
+    DelegationTokenRenewerFuture(DelegationTokenRenewerEvent evt,
+        Future<?> future) {
+      this.future = future;
+      this.evt = evt;
+    }
+
+    public DelegationTokenRenewerEvent getEvt() {
+      return evt;
+    }
+
+    public void setEvt(DelegationTokenRenewerEvent evt) {
+      this.evt = evt;
+    }
+
+    public Future<?> getFuture() {
+      return future;
+    }
+
+    public void setFuture(Future<?> future) {
+      this.future = future;
     }
   }
 


### PR DESCRIPTION
…gationTokenRenewerPoolTracker

The future of DelegationTokenRenewer runnable is not removed properly previously and a Queue struct is more suitable than a Map struct for storing the futures.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The future objects that don't timeout leaks in `futures` ConcurrentHashMap forever.  A queue struct is good enough than a map to store future objects as we only want to check each future object timeouts once.

### How was this patch tested?
The unit tests `testTokenThreadTimeout` and `testTokenThreadTimeoutWithoutDelay` already covers the process of renew token timeout and I think no more unit tests are needed.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

