### PR TITLE
HDFS-17005: Update NameJournalStatus with new JN IP address on JN host change

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/IPCLoggerChannel.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/IPCLoggerChannel.java
@@ -18,10 +18,7 @@
 package org.apache.hadoop.hdfs.qjournal.client;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URL;
+import java.net.*;
 import java.security.PrivilegedExceptionAction;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -53,6 +50,7 @@ import org.apache.hadoop.hdfs.server.protocol.NamespaceInfo;
 import org.apache.hadoop.hdfs.server.protocol.RemoteEditLogManifest;
 import org.apache.hadoop.ipc.ProtobufRpcEngine2;
 import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.util.StopWatch;
 
@@ -149,7 +147,19 @@ public class IPCLoggerChannel implements AsyncLogger {
    * Stopwatch which starts counting on each heartbeat that is sent
    */
   private final StopWatch lastHeartbeatStopwatch = new StopWatch();
-  
+
+  /**
+   * Stopwatch which updates addr after every HOSTNAME_REFRESH_MILLIS
+   */
+  private final StopWatch lastHostNameRefresh = new StopWatch();
+
+  /**
+   * Need to use an extra field to store updatedAddr as addr is final.
+   */
+  protected InetAddress updatedAddr;
+
+  private long hostnameRefreshMillis = 60 * 1000;
+
   private static final long HEARTBEAT_INTERVAL_MILLIS = 1000;
 
   private static final long WARN_JOURNAL_MILLIS_THRESHOLD = 1000;
@@ -168,6 +178,8 @@ public class IPCLoggerChannel implements AsyncLogger {
     this.journalId = journalId;
     this.nameServiceId = nameServiceId;
     this.addr = addr;
+    this.updatedAddr = addr.getAddress();
+    
     this.queueSizeLimitBytes = 1024 * 1024 * conf.getInt(
         DFSConfigKeys.DFS_QJOURNAL_QUEUE_SIZE_LIMIT_KEY,
         DFSConfigKeys.DFS_QJOURNAL_QUEUE_SIZE_LIMIT_DEFAULT);
@@ -599,7 +611,28 @@ public class IPCLoggerChannel implements AsyncLogger {
 
   @Override
   public String toString() {
+    checkPeriodicHostUpdate();
     return InetAddresses.toAddrString(addr.getAddress()) + ':' + addr.getPort();
+  }
+
+  public void setHostnameRefreshMillis(long hostnameRefreshMillis) {
+    this.hostnameRefreshMillis = hostnameRefreshMillis;
+  }
+
+  protected void checkPeriodicHostUpdate() {
+    if (lastHostNameRefresh.isRunning()) {
+      if (lastHostNameRefresh.now(TimeUnit.MILLISECONDS) > hostnameRefreshMillis) {
+        InetSocketAddress newAddr = NetUtils.createSocketAddrForHost(addr.getHostName(), addr.getPort());
+        if (!newAddr.isUnresolved() && !updatedAddr.equals(newAddr.getAddress())) {
+          QuorumJournalManager.LOG.warn("Address change detected on QJM (Only for JMX purposes). Old: " +
+                  updatedAddr + " New: " + newAddr.getAddress());
+          updatedAddr = newAddr.getAddress();
+        }
+        lastHostNameRefresh.reset().start();
+      }
+    } else {
+      lastHostNameRefresh.start();
+    }
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/IPCLoggerChannel.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/IPCLoggerChannel.java
@@ -179,7 +179,6 @@ public class IPCLoggerChannel implements AsyncLogger {
     this.nameServiceId = nameServiceId;
     this.addr = addr;
     this.updatedAddr = addr.getAddress();
-    
     this.queueSizeLimitBytes = 1024 * 1024 * conf.getInt(
         DFSConfigKeys.DFS_QJOURNAL_QUEUE_SIZE_LIMIT_KEY,
         DFSConfigKeys.DFS_QJOURNAL_QUEUE_SIZE_LIMIT_DEFAULT);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestIPCLoggerChannel.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestIPCLoggerChannel.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdfs.qjournal.protocol.QJournalProtocol;
 import org.apache.hadoop.hdfs.qjournal.protocol.RequestInfo;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeLayoutVersion;
 import org.apache.hadoop.hdfs.server.protocol.NamespaceInfo;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.DelayAnswer;
 import org.junit.Before;
@@ -76,7 +77,27 @@ public class TestIPCLoggerChannel {
     
     ch.setEpoch(1);
   }
-  
+
+  @Test
+  public void testAddressUpdate() throws InterruptedException {
+    NetUtils.addStaticResolution("host", "127.0.0.1");
+    IPCLoggerChannel ch1 = new IPCLoggerChannel(conf, FAKE_NSINFO, JID, NetUtils.createSocketAddrForHost("host", 1));
+    assertEquals("127.0.0.1", ch1.updatedAddr.getHostAddress());
+
+    NetUtils.addStaticResolution("host", "222.0.0.2");
+    ch1.setHostnameRefreshMillis(1);
+    // Start the stopwatch
+    ch1.checkPeriodicHostUpdate();
+    // This should not trigger the refresh because refreshMs hasn't reached yet
+    ch1.checkPeriodicHostUpdate();
+    assertEquals("127.0.0.1", ch1.updatedAddr.getHostAddress());
+
+    Thread.sleep(2);
+    // This should trigger the refresh because sleepMs > refreshMs
+    ch1.checkPeriodicHostUpdate();
+    assertEquals("222.0.0.2", ch1.updatedAddr.getHostAddress());
+  }
+
   @Test
   public void testSimpleCall() throws Exception {
     ch.sendEdits(1, 1, 3, FAKE_DATA).get();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Update JMX JN IP address when JN host changes

### How was this patch tested?
Unit tests and manual deployment of build on clusters

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

