### PR TITLE
YARN-11491. [Federation] Use ZookeeperFederationStateStore as the DefaultStateStore.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -4001,7 +4001,7 @@ public class YarnConfiguration extends Configuration {
       FEDERATION_PREFIX + "state-store.class";
 
   public static final String DEFAULT_FEDERATION_STATESTORE_CLIENT_CLASS =
-      "org.apache.hadoop.yarn.server.federation.store.impl.MemoryFederationStateStore";
+      "org.apache.hadoop.yarn.server.federation.store.impl.ZookeeperFederationStateStore";
 
   public static final String FEDERATION_CACHE_TIME_TO_LIVE_SECS =
       FEDERATION_PREFIX + "cache-ttl.secs";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -3727,10 +3727,11 @@
 
   <property>
     <description>
-      Store class name for federation state store
+      Store class name for federation state store,
+      Default is ZookeeperFederationStateStore.
     </description>
     <name>yarn.federation.state-store.class</name>
-    <value>org.apache.hadoop.yarn.server.federation.store.impl.MemoryFederationStateStore</value>
+    <value>org.apache.hadoop.yarn.server.federation.store.impl.ZookeeperFederationStateStore</value>
   </property>
 
   <property>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/conf/TestYarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/conf/TestYarnConfiguration.java
@@ -266,4 +266,14 @@ public class TestYarnConfiguration {
     assertTrue(NumberUtils.isDigits(rmAmExpiryIntervalMS1));
     assertEquals(600000, Long.parseLong(rmAmExpiryIntervalMS1));
   }
+
+  @Test
+  void testGetFederationStoreClass() throws Exception {
+    YarnConfiguration conf = new YarnConfiguration();
+    String defaultFedStateStoreClass = conf.get(
+        YarnConfiguration.FEDERATION_STATESTORE_CLIENT_CLASS,
+        YarnConfiguration.DEFAULT_FEDERATION_STATESTORE_CLIENT_CLASS);
+    assertEquals(YarnConfiguration.DEFAULT_FEDERATION_STATESTORE_CLIENT_CLASS,
+        defaultFedStateStoreClass);
+  }
 }


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: YARN-11491. [Federation] Use ZookeeperFederationStateStore as the DefaultStateStore.

We currently use `MemoryFederationStateStore` as the default StateStore, in the production environment, we should use `ZookeeperFederationStateStore` as the default StateStore.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

