### PR TITLE
HADOOP-18739: Parallelize concatenation of distcp chunks of separate files

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
@@ -88,6 +88,8 @@ public final class DistCpConstants {
   public static final String CONF_LABEL_DIRECT_WRITE = "distcp.direct.write";
   public static final String CONF_LABEL_UPDATE_ROOT =
           "distcp.update.root.attributes";
+  public static final String CONF_LABEL_CHUNK_CONCAT_THREAD_POOL_SIZE =
+      "distcp.chunk.concat.thread.pool.size";
 
   /* Total bytes to be copied. Updated by copylisting. Unfiltered count */
   public static final String CONF_LABEL_TOTAL_BYTES_TO_BE_COPIED = "mapred.total.bytes.expected";


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
While copying a folder containing large files consisting of multiple distcp chunks, copy committer synchronously picks chunks of each file and concatenates them. This is very slow.
As part of this PR, we are parallelising the concatenation of distcp chunks of separate files with a default thread pool of size 10.

### How was this patch tested?
* Existing unit tests are passing which are testing both failure and success scenarios.
* Added a unit test to check against a folder containing different file sizes and nested folders. This scenario was failing initially for the PR.
* Tested the patch on distributed cloud setup by running a distcp job for copying a folder of size 100GB having 20 files of size 5GB from one cluster to another. Noticed an improvement of 2 mins in latency.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

