### PR TITLE
HDFS-17007.  TestPendingReconstruction.testProcessPendingReconstructions verify HDFS-11960 test case is wrong

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingReconstruction.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingReconstruction.java
@@ -276,13 +276,14 @@ public class TestPendingReconstruction {
       // Stop the replication/redundancy monitor
       BlockManagerTestUtil.stopRedundancyThread(blkManager);
       pendingReconstruction.clear();
+      pendingReconstruction.stop();
       // Pick a real node
       DatanodeDescriptor desc[] = { blkManager.getDatanodeManager().
           getDatanodes().iterator().next() };
 
       // Add a stored block to the pendingReconstruction.
-      pendingReconstruction.increment(blockInfo,
-          DFSTestUtil.createDatanodeStorageInfos(1));
+      pendingReconstruction.increment(storedBlock,
+          desc[0].getStorageInfos()[0]);
       assertEquals("Size of pendingReconstructions ", 1,
           pendingReconstruction.size());
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingReconstruction.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingReconstruction.java
@@ -276,7 +276,6 @@ public class TestPendingReconstruction {
       // Stop the replication/redundancy monitor
       BlockManagerTestUtil.stopRedundancyThread(blkManager);
       pendingReconstruction.clear();
-      pendingReconstruction.stop();
       // Pick a real node
       DatanodeDescriptor desc[] = { blkManager.getDatanodeManager().
           getDatanodes().iterator().next() };
@@ -311,9 +310,6 @@ public class TestPendingReconstruction {
       } finally {
         fsn.writeUnlock();
       }
-
-      GenericTestUtils.waitFor(() -> pendingReconstruction.size() == 0, 500,
-          10000);
       // The pending queue should be empty.
       assertEquals("Size of pendingReconstructions ", 0,
           pendingReconstruction.size());


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
TestPendingReconstruction.testProcessPendingReconstructions() verify [HDFS-11960](https://issues.apache.org/jira/browse/HDFS-11960) is wrong.

(1) It does not  stop PendingReconstructionMonitor. The blockid will into timeouts queue because of timout duration is 3s.

(2) Test blockid should be blk_1_1 with different genstamp.  

(3) The blk_1_1 should test with the same DatanodeDescriptor

### How was this patch tested?
It is a tested case bug.

