### PR TITLE
HDFS-17010. Add a subtree test to TestSnapshotDiffReport.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapRootDescendantDiff.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapRootDescendantDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,10 +19,13 @@ package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
 import static org.junit.Assert.fail;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
@@ -32,7 +35,19 @@ import org.junit.Test;
 /**
  * Test snapshot diff report for the snapshot root descendant directory.
  */
-public class TestSnapRootDescendantDiff extends TestSnapshotDiffReport {
+public class TestSnapRootDescendantDiff {
+  {
+    SnapshotTestHelper.disableLogs();
+  }
+
+  private final Path dir = new Path("/" + getClass().getSimpleName());
+  private final Path sub1 = new Path(dir, "sub1");
+
+  protected Configuration conf;
+  protected MiniDFSCluster cluster;
+  protected DistributedFileSystem hdfs;
+  private final Map<Path, Integer> snapshotNumberMap = new HashMap<>();
+
   @Before
   public void setUp() throws Exception {
     conf = new Configuration();
@@ -57,6 +72,25 @@ public class TestSnapRootDescendantDiff extends TestSnapshotDiffReport {
       cluster.shutdown();
       cluster = null;
     }
+  }
+
+  private Path getSnapRootDir() {
+    return sub1;
+  }
+
+  private String genSnapshotName(Path snapshotDir) {
+    int sNum = -1;
+    if (snapshotNumberMap.containsKey(snapshotDir)) {
+      sNum = snapshotNumberMap.get(snapshotDir);
+    }
+    snapshotNumberMap.put(snapshotDir, ++sNum);
+    return "s" + sNum;
+  }
+
+  void modifyAndCreateSnapshot(Path modifyDir, Path[] snapshotDirs)
+      throws Exception {
+    TestSnapshotDiffReport.modifyAndCreateSnapshot(
+        modifyDir, snapshotDirs, hdfs, this::genSnapshotName);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDiffReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDiffReport.java
@@ -86,9 +86,9 @@ public class TestSnapshotDiffReport {
   private final Path dir = new Path("/TestSnapshot");
   private final Path sub1 = new Path(dir, "sub1");
   
-  protected Configuration conf;
-  protected MiniDFSCluster cluster;
-  protected DistributedFileSystem hdfs;
+  private Configuration conf;
+  private MiniDFSCluster cluster;
+  private DistributedFileSystem hdfs;
   private final HashMap<Path, Integer> snapshotNumberMap = new HashMap<Path, Integer>();
 
   @Before

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDiffReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDiffReport.java
@@ -1638,7 +1638,8 @@ public class TestSnapshotDiffReport {
     }
   }
 
-  void assertDiff(Path root, Path foo, Path bar, String from, String to) throws Exception {
+  private void assertDiff(Path root, Path foo, Path bar,
+      String from, String to) throws Exception {
     final String barDiff = diff(bar, from, to);
     final String fooDiff = diff(foo, from, to);
     Assert.assertEquals(barDiff, fooDiff.replace("/bar", ""));
@@ -1648,7 +1649,7 @@ public class TestSnapshotDiffReport {
     Assert.assertEquals(barDiff, rootDiff.replace("/foo/bar", ""));
   }
 
-  String diff(Path path, String from, String to) throws Exception {
+  private String diff(Path path, String from, String to) throws Exception {
     final SnapshotDiffReport diff = hdfs.getSnapshotDiffReport(path, from, to);
     LOG.info("DIFF {} from {} to {}", path, from, to);
     LOG.info("{}", diff);


### PR DESCRIPTION
### Description of PR

Add a test for running SnapshotDiffReport over subtrees of a snapshottable directory.
See https://issues.apache.org/jira/browse/HDFS-17010

### How was this patch tested?

This is a test.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

