### PR TITLE
HDFS-17011. Fix the metric of  "HttpPort" at DataNodeInfo

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -3558,7 +3558,7 @@ public class DataNode extends ReconfigurableBase
 
   @Override // DataNodeMXBean
   public String getHttpPort(){
-    return this.getConf().get("dfs.datanode.info.port");
+    return String.valueOf(infoPort);
   }
 
   @Override // DataNodeMXBean

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMXBean.java
@@ -92,6 +92,7 @@ public class TestDataNodeMXBean extends SaslDataTransferTestCase {
       Assert.assertEquals(datanode.getRpcPort(),rpcPort);
       // get attribute "HttpPort"
       String httpPort = (String)mbs.getAttribute(mxbeanName, "HttpPort");
+      Assert.assertNotNull(httpPort);
       Assert.assertEquals(datanode.getHttpPort(),httpPort);
       // get attribute "NamenodeAddresses"
       String namenodeAddresses = (String)mbs.getAttribute(mxbeanName, 


### PR DESCRIPTION
### Description of PR
Now, the "HttpPort" metric was getting from the conf `dfs.datanode.info.port`

but the conf seem to be useless, and can be replaced by infoPort. InfoPort already assigned (#Line1373)

### How was this patch tested?
#### Before
![before](https://github.com/apache/hadoop/assets/32935220/600b869d-4cd5-481f-bedf-9cd918f05283)   
#### After
![after](https://github.com/apache/hadoop/assets/32935220/3b83e523-8a72-4f53-9f76-bd7ed0b7c930)   


issue: https://issues.apache.org/jira/browse/HDFS-17011


