### PR TITLE
HDFS-17017. Fix the issue of arguments number limit in report command in DFSAdmin

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
@@ -489,7 +489,11 @@ public class DFSAdmin extends FsShell {
   protected DistributedFileSystem getDFS() throws IOException {
     return AdminHelper.checkAndGetDFS(getFS(), getConf());
   }
-  
+
+  public static final String[] DFS_REPORT_ARGS =
+      new String[] {"-live", "-dead", "-decommissioning", "-enteringmaintenance",
+          "-inmaintenance", "-slownodes"};
+
   /**
    * Gives a report on how the FileSystem is doing.
    * @exception IOException if the filesystem does not exist.
@@ -581,17 +585,16 @@ public class DFSAdmin extends FsShell {
     List<String> args = Arrays.asList(argv);
     // Truncate already handled arguments before parsing report()-specific ones
     args = new ArrayList<String>(args.subList(i, args.size()));
-    final boolean listLive = StringUtils.popOption("-live", args);
-    final boolean listDead = StringUtils.popOption("-dead", args);
+    final boolean listLive = StringUtils.popOption(DFS_REPORT_ARGS[0], args);
+    final boolean listDead = StringUtils.popOption(DFS_REPORT_ARGS[1], args);
     final boolean listDecommissioning =
-        StringUtils.popOption("-decommissioning", args);
+        StringUtils.popOption(DFS_REPORT_ARGS[2], args);
     final boolean listEnteringMaintenance =
-        StringUtils.popOption("-enteringmaintenance", args);
+        StringUtils.popOption(DFS_REPORT_ARGS[3], args);
     final boolean listInMaintenance =
-        StringUtils.popOption("-inmaintenance", args);
+        StringUtils.popOption(DFS_REPORT_ARGS[4], args);
     final boolean listSlowNodes =
-        StringUtils.popOption("-slownodes", args);
-
+        StringUtils.popOption(DFS_REPORT_ARGS[5], args);
 
     // If no filter flags are found, then list all DN types
     boolean listAll = (!listLive && !listDead && !listDecommissioning
@@ -2399,7 +2402,7 @@ public class DFSAdmin extends FsShell {
         return exitCode;
       }
     } else if ("-report".equals(cmd)) {
-      if (argv.length > 7) {
+      if (argv.length > DFS_REPORT_ARGS.length + 1) {
         printUsage(cmd);
         return exitCode;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
@@ -2399,7 +2399,7 @@ public class DFSAdmin extends FsShell {
         return exitCode;
       }
     } else if ("-report".equals(cmd)) {
-      if (argv.length > 6) {
+      if (argv.length > 7) {
         printUsage(cmd);
         return exitCode;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -798,8 +798,11 @@ public class TestDFSAdmin {
 
       // verify report command for list all DN types
       resetStream();
-      assertEquals(0, ToolRunner.run(dfsAdmin, new String[] {"-report", "-live",
-          "-dead", "-decommissioning", "-enteringmaintenance", "-inmaintenance", "-slownodes"}));
+      String[] reportWithArg = new String[DFSAdmin.DFS_REPORT_ARGS.length + 1];
+      reportWithArg[0] = "-report";
+      System.arraycopy(DFSAdmin.DFS_REPORT_ARGS, 0, reportWithArg, 1,
+          DFSAdmin.DFS_REPORT_ARGS.length);
+      assertEquals(0, ToolRunner.run(dfsAdmin, reportWithArg));
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -795,6 +795,11 @@ public class TestDFSAdmin {
       resetStream();
       assertEquals(0, ToolRunner.run(dfsAdmin, new String[] {"-report"}));
       verifyNodesAndCorruptBlocks(numDn, numDn - 1, 1, 1, client, 0L, 0L);
+
+      // verify report command for list all DN types
+      resetStream();
+      assertEquals(0, ToolRunner.run(dfsAdmin, new String[] {"-report", "-live",
+          "-dead", "-decommissioning", "-enteringmaintenance", "-inmaintenance", "-slownodes"}));
     }
   }
 


### PR DESCRIPTION
### Description of PR

JIRA: [HDFS-17017](https://issues.apache.org/jira/browse/HDFS-17017)

Currently, the DFSAdmin report command should support a maximum number of arguments of 7， such as :

hdfs dfsadmin [-report] [-live] [-dead] [-decommissioning] [-enteringmaintenance] [-inmaintenance] [-slownodes]
