### PR TITLE
YARN-11463. Node Labels root directory creation doesn't have a retry logic - 2nd addendum

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/store/AbstractFSNodeStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/store/AbstractFSNodeStore.java
@@ -65,6 +65,12 @@ public abstract class AbstractFSNodeStore<M> {
     this.fsWorkingPath = fsStorePath;
     this.manager = mgr;
     initFileSystem(conf);
+    initNodeStoreRootDirectory(conf);
+    this.replication = conf.getInt(YarnConfiguration.FS_STORE_FILE_REPLICATION,
+        YarnConfiguration.DEFAULT_FS_STORE_FILE_REPLICATION);
+  }
+
+  private void initNodeStoreRootDirectory(Configuration conf) throws IOException {
     // mkdir of root dir path with retry logic
     int maxRetries = conf.getInt(YarnConfiguration.NODE_STORE_ROOT_DIR_NUM_RETRIES,
         YarnConfiguration.NODE_STORE_ROOT_DIR_NUM_DEFAULT_RETRIES);
@@ -73,11 +79,7 @@ public abstract class AbstractFSNodeStore<M> {
 
     while (!success && retryCount <= maxRetries) {
       try {
-        if (!fs.exists(fsWorkingPath)) {
-          success = fs.mkdirs(fsWorkingPath);
-        } else {
-          success = true;
-        }
+        success = fs.mkdirs(fsWorkingPath);
       } catch (IOException e) {
         retryCount++;
         if (retryCount > maxRetries) {
@@ -91,8 +93,6 @@ public abstract class AbstractFSNodeStore<M> {
         }
       }
     }
-    this.replication = conf.getInt(YarnConfiguration.FS_STORE_FILE_REPLICATION,
-        YarnConfiguration.DEFAULT_FS_STORE_FILE_REPLICATION);
     LOG.info("Created store directory :" + fsWorkingPath);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/TestFileSystemNodeLabelsStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/TestFileSystemNodeLabelsStore.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
+import org.apache.hadoop.hdfs.server.namenode.SafeModeException;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Timeout;
@@ -348,27 +349,13 @@ public class TestFileSystemNodeLabelsStore extends NodeLabelTestBase {
 
   @MethodSource("getParameters")
   @ParameterizedTest
-  void testRootMkdirOnInitStoreWhenRootDirectoryAlreadyExists(String className) throws Exception {
-    initTestFileSystemNodeLabelsStore(className);
-    final FileSystem mockFs = Mockito.mock(FileSystem.class);
-    final FileSystemNodeLabelsStore mockStore = createMockNodeLabelsStore(mockFs);
-    final int expectedMkdirsCount = 0;
-
-    Mockito.when(mockStore.getFs().exists(Mockito.any(Path.class)))
-        .thenReturn(true);
-    verifyMkdirsCount(mockStore, expectedMkdirsCount);
-  }
-
-  @MethodSource("getParameters")
-  @ParameterizedTest
-  void testRootMkdirOnInitStoreWhenRootDirectoryNotExists(String className) throws Exception {
+  void testRootMkdirOnInitStore(String className) throws Exception {
     initTestFileSystemNodeLabelsStore(className);
     final FileSystem mockFs = Mockito.mock(FileSystem.class);
     final FileSystemNodeLabelsStore mockStore = createMockNodeLabelsStore(mockFs);
     final int expectedMkdirsCount = 1;
 
-    Mockito.when(mockStore.getFs().exists(Mockito.any(Path.class)))
-        .thenReturn(false).thenReturn(true);
+    Mockito.when(mockStore.getFs().mkdirs(Mockito.any(Path.class))).thenReturn(true);
     verifyMkdirsCount(mockStore, expectedMkdirsCount);
   }
 
@@ -378,10 +365,11 @@ public class TestFileSystemNodeLabelsStore extends NodeLabelTestBase {
     initTestFileSystemNodeLabelsStore(className);
     final FileSystem mockFs = Mockito.mock(FileSystem.class);
     final FileSystemNodeLabelsStore mockStore = createMockNodeLabelsStore(mockFs);
-    final int expectedMkdirsCount = 2;
+    final int expectedMkdirsCount = 3;
 
-    Mockito.when(mockStore.getFs().exists(Mockito.any(Path.class)))
-        .thenReturn(false).thenReturn(false).thenReturn(true);
+    Mockito.when(mockStore.getFs().mkdirs(Mockito.any(Path.class)))
+        .thenThrow(SafeModeException.class).thenThrow(SafeModeException.class)
+        .thenReturn(true);
     verifyMkdirsCount(mockStore, expectedMkdirsCount);
   }
 


### PR DESCRIPTION
Change-Id: I0bf3a80ad3eb3321a875da7e898459208a883551

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
- I tested the solution and I found a case when HDFS was in safe mode during the time that I restarted RM, and as the root directory already existed in this case, we didn't catch the SafeModeException. For that I left only the "mkdirs" command in the try block, similar to the original logic. This way my testing was successful, the RM waited until HDFS left the safe mode, then became active again
- Extracted the root directory creation logic to a separate method
- In the unit tests I also mocked the behaviour when SafeModeException occurs during the root directory creation

### How was this patch tested?
My testings in a cluster:
- manually enabled safe mode in HDFS to trigger SafeModeException
- restarted RM to trigger FS node store initialization
- RM waited in initializing state
- after I disabled safe mode, node store initialization finished and RM became active again

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

