### PR TITLE
HADOOP-18748 Optimize Configuration.handleDeprecation

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -752,13 +752,15 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
     if (!overlayProps.isEmpty()) {
       for (String nk : names) {
         String k = map.get(nk);
-        if (k != null && !overlayProps.containsKey(nk)) {
-          String v = overlayProps.getProperty(k);
-          if (v != null) {
+        if (k != null) {
+          overlayProps.computeIfAbsent(nk, (x) -> {
+            String v = overlayProps.getProperty(k);
             // Update both properties and overlays.
-            getProps().setProperty(nk, v);
-            overlayProps.setProperty(nk, v);
-          }
+            if (v != null) {
+              getProps().setProperty(nk, v);
+            }
+            return v;
+          });
         }
       }
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -724,54 +724,51 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
     if (null != name) {
       name = name.trim();
     }
-    // Initialize the return value with requested name
-    String[] names = new String[]{name};
-    // Deprecated keys are logged once and an updated names are returned
-    DeprecatedKeyInfo keyInfo = deprecations.getDeprecatedKeyMap().get(name);
-    if (keyInfo != null) {
+
+    final DeprecatedKeyInfo keyInfo = deprecations.getDeprecatedKeyMap().get(name);
+    final String[] names;
+    if (keyInfo == null) {
+      names = new String[]{name};
+      // Handling deprecations is rare so bail out early for the common case.
+      if (deprecations.getReverseDeprecatedKeyMap().get(name) == null) {
+        return names;
+      }
+    } else {
+      names = keyInfo.newKeys;
       if (!keyInfo.getAndSetAccessed()) {
         logDeprecation(keyInfo.getWarningMessage(name));
       }
-      // Override return value for deprecated keys
-      names = keyInfo.newKeys;
     }
 
-    // Update properties with deprecated key if already loaded and new
-    // deprecation has been added
-    updatePropertiesWithDeprecatedKeys(deprecations, names);
-
-    // If there are no overlay values we can return early
-    Properties overlayProperties = getOverlay();
-    if (overlayProperties.isEmpty()) {
-      return names;
-    }
-    // Update properties and overlays with reverse lookup values
-    for (String n : names) {
-      String deprecatedKey = deprecations.getReverseDeprecatedKeyMap().get(n);
-      if (deprecatedKey != null && !overlayProperties.containsKey(n)) {
-        String deprecatedValue = overlayProperties.getProperty(deprecatedKey);
-        if (deprecatedValue != null) {
-          getProps().setProperty(n, deprecatedValue);
-          overlayProperties.setProperty(n, deprecatedValue);
+    final Map<String, String> map = deprecations.getReverseDeprecatedKeyMap();
+    for (String nk : names) {
+      String k = map.get(nk);
+      if (k != null && !getProps().containsKey(nk)) {
+        String v = getProps().getProperty(k);
+        if (v != null) {
+          getProps().setProperty(nk, v);
         }
       }
     }
+
+    Properties overlayProps = getOverlay();
+    if (!overlayProps.isEmpty()) {
+      for (String nk : names) {
+        String k = map.get(nk);
+        if (k != null && !overlayProps.containsKey(nk)) {
+          String v = overlayProps.getProperty(k);
+          if (v != null) {
+            // Update both properties and overlays.
+            getProps().setProperty(nk, v);
+            overlayProps.setProperty(nk, v);
+          }
+        }
+      }
+    }
+
     return names;
   }
 
-  private void updatePropertiesWithDeprecatedKeys(
-      DeprecationContext deprecations, String[] newNames) {
-    for (String newName : newNames) {
-      String deprecatedKey = deprecations.getReverseDeprecatedKeyMap().get(newName);
-      if (deprecatedKey != null && !getProps().containsKey(newName)) {
-        String deprecatedValue = getProps().getProperty(deprecatedKey);
-        if (deprecatedValue != null) {
-          getProps().setProperty(newName, deprecatedValue);
-        }
-      }
-    }
-  }
- 
   private void handleDeprecation() {
     LOG.debug("Handling deprecation for all properties in config...");
     DeprecationContext deprecations = deprecationContext.get();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -743,11 +743,8 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
     final Map<String, String> map = deprecations.getReverseDeprecatedKeyMap();
     for (String nk : names) {
       String k = map.get(nk);
-      if (k != null && !getProps().containsKey(nk)) {
-        String v = getProps().getProperty(k);
-        if (v != null) {
-          getProps().setProperty(nk, v);
-        }
+      if (k != null) {
+        getProps().computeIfAbsent(nk, (x) -> getProps().getProperty(k));
       }
     }
 


### PR DESCRIPTION
### Description of PR
Optimize `Configuration.handleDeprecation` by adding a fastpath for when a property is not deprecated. While at it factor out property propagation so that it can be reused by both main and overlay properties.


### How was this patch tested?
Existing tests:
- https://github.com/apache/hadoop/blob/trunk/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfigurationDeprecation.java
- https://github.com/apache/hadoop/blob/trunk/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestDeprecatedKeys.java

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

