### PR TITLE
HADOOP-18751. Fix incorrect output path in javadoc build phase

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/ClassLoaderCheck.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/ClassLoaderCheck.java
@@ -31,4 +31,3 @@ public class ClassLoaderCheck {
     }
   }
 }
-

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/ClassLoaderCheck.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/ClassLoaderCheck.java
@@ -31,3 +31,4 @@ public class ClassLoaderCheck {
     }
   }
 }
+

--- a/hadoop-project-dist/pom.xml
+++ b/hadoop-project-dist/pom.xml
@@ -106,7 +106,7 @@
           <source>${maven.compile.source}</source>
           <charset>${maven.compile.encoding}</charset>
           <reportOutputDirectory>${project.build.directory}/site</reportOutputDirectory>
-          <destDir>${project.build.directory}/api</destDir>
+          <destDir>api</destDir>
           <groups>
             <group>
               <title>${project.name} API</title>

--- a/hadoop-project-dist/pom.xml
+++ b/hadoop-project-dist/pom.xml
@@ -216,6 +216,18 @@
                 <configuration>
                   <exportAntProperties>true</exportAntProperties>
                   <target>
+                    <!-- destDirPath is where the generated Javadocs will be located.
+                     The value of destDirPath obtained below is used for the "destDir" attribute
+                     in the maven-javadoc-plugin in this pom.xml.
+                     As per HADOOP-8500 and HADOOP-13784, we wanted to dump the javadoc into an
+                     "api" directory that was outside the "site" directory.
+                     Unfortunately, maven-javadoc-plugin doesn't give us a way to do that since
+                     "destDir" is always appended to "reportOutputDirectory". While we can achieve
+                     this using the relative path "../api", it only works for Windows. But it fails
+                     on Linux since the parent directory of "../api" wouldn't yet exist and the
+                     path resolution fails.
+                     Thus, we're going to leverage this approach for Windows and leave the
+                     behaviour on Linux intact.-->
                     <condition property="destDirPath" value="../api" else="${project.build.directory}/api">
                       <and>
                         <os family="windows"/>

--- a/hadoop-project-dist/pom.xml
+++ b/hadoop-project-dist/pom.xml
@@ -106,7 +106,7 @@
           <source>${maven.compile.source}</source>
           <charset>${maven.compile.encoding}</charset>
           <reportOutputDirectory>${project.build.directory}/site</reportOutputDirectory>
-          <destDir>api</destDir>
+          <destDir>../api</destDir>
           <groups>
             <group>
               <title>${project.name} API</title>

--- a/hadoop-project-dist/pom.xml
+++ b/hadoop-project-dist/pom.xml
@@ -106,7 +106,7 @@
           <source>${maven.compile.source}</source>
           <charset>${maven.compile.encoding}</charset>
           <reportOutputDirectory>${project.build.directory}/site</reportOutputDirectory>
-          <destDir>../api</destDir>
+          <destDir>${destDirPath}</destDir>
           <groups>
             <group>
               <title>${project.name} API</title>
@@ -207,6 +207,24 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
+              <execution>
+                <id>choose-javadoc-dest-dir</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <exportAntProperties>true</exportAntProperties>
+                  <target>
+                    <condition property="destDirPath" value="../api" else="${project.build.directory}/api">
+                      <and>
+                        <os family="windows"/>
+                      </and>
+                    </condition>
+                    <echo>destDirPath to use for maven-javadoc-plugin = ${destDirPath}</echo>
+                  </target>
+                </configuration>
+              </execution>
 
               <!-- Pre site -->
               <execution>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

The javadoc build phase fails with the following error -

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.1:javadoc-no-fork (default-cli) on project hadoop-common:
An error has occurred in Javadoc report generation:
Unable to write 'options' temporary file for command execution:
H:\hadoop-common-project\hadoop-common\target\site\H:\hadoop-common-project\hadoop-common\target\api\options
(The filename, directory name, or volume label syntax is incorrect) -> [Help 1]
```

As called out by the error message the path `H:\hadoop-common-project\hadoop-common\target\site\H:\hadoop-common-project\hadoop-common\target\api\options` is invalid.

The culprit being - https://github.com/apache/hadoop/blob/e9740cb17aef157a615dc36ae08cd224ce1672f0/hadoop-project-dist/pom.xml#L109

As per the [docs from maven-javadoc-plugin](https://maven.apache.org/plugins/maven-javadoc-plugin/examples/output-configuration.html), `destDir` attribute's value gets appended to that of `reportOutputDirectory`. This implies that `destDir` must be a relative path, although not called out in the documentation. Since this isn't the case here,
1. In Linux, this yields an unintended path (albeit a valid one) and doesn't fail.
2. In Windows, it yields an incorrect path and thus fails since there's a colon ( : ) for the drive letter in the middle of the incorrectly concatenated path -
H:\hadoop-common-project\hadoop-common\target\site\H`:`\hadoop-common-project\hadoop-common\target\api\options

Thus, fixing this would fix the build failure on Windows and put the docs in the appropriate directory in Linux.

### How was this patch tested?
Jenkins CI validation.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

