### PR TITLE
HDFS-17026. RBF: NamenodeHeartbeatService should update JMX report with configurable frequency

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
@@ -21,8 +21,6 @@ import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HEALTH_MONITOR_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HEARTBEAT_INTERVAL_MS;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HEARTBEAT_INTERVAL_MS_DEFAULT;
-import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_ENABLED;
-import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS_DEFAULT;
 
@@ -112,8 +110,6 @@ public class NamenodeHeartbeatService extends PeriodicService {
   /** URL scheme to use for JMX calls. */
   private String scheme;
 
-  /** Whether to update JMX report. */
-  private boolean updateJmxEnabled;
   /** Frequency of updates to JMX report. */
   private long updateJmxIntervalMs;
   /** Timestamp of last attempt to update JMX report. */
@@ -249,8 +245,6 @@ public class NamenodeHeartbeatService extends PeriodicService {
       this.healthMonitorTimeoutMs = (int) timeoutMs;
     }
 
-    this.updateJmxEnabled = conf.getBoolean(DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_ENABLED,
-        DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_ENABLED_DEFAULT);
     this.updateJmxIntervalMs = conf.getLong(DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS,
         DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS_DEFAULT);
 
@@ -516,9 +510,9 @@ public class NamenodeHeartbeatService extends PeriodicService {
    *    configured interval (if any).
    */
   private boolean shouldUpdateJmx() {
-    return updateJmxEnabled
-        && (updateJmxIntervalMs < 0
-        || Time.monotonicNow() - lastJmxUpdateAttempt > updateJmxIntervalMs);
+    return updateJmxIntervalMs == 0
+        || (updateJmxIntervalMs > 0
+        && Time.monotonicNow() - lastJmxUpdateAttempt > updateJmxIntervalMs);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
@@ -510,8 +510,11 @@ public class NamenodeHeartbeatService extends PeriodicService {
    *    configured interval (if any).
    */
   private boolean shouldUpdateJmx() {
-    return this.updateJmxIntervalMs >= 0
-        && Time.monotonicNow() - this.lastJmxUpdateAttempt > this.updateJmxIntervalMs;
+    if (this.updateJmxIntervalMs < 0) {
+      return false;
+    }
+
+    return Time.monotonicNow() - this.lastJmxUpdateAttempt > this.updateJmxIntervalMs;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
@@ -21,6 +21,10 @@ import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HEALTH_MONITOR_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HEARTBEAT_INTERVAL_MS;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HEARTBEAT_INTERVAL_MS_DEFAULT;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_ENABLED;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_ENABLED_DEFAULT;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS_DEFAULT;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -47,6 +51,7 @@ import org.apache.hadoop.hdfs.tools.NNHAServiceTarget;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.SecurityUtil;
+import org.apache.hadoop.util.Time;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -106,6 +111,17 @@ public class NamenodeHeartbeatService extends PeriodicService {
   private URLConnectionFactory connectionFactory;
   /** URL scheme to use for JMX calls. */
   private String scheme;
+
+  /** Whether to update JMX report */
+  private boolean updateJmxEnabled;
+  /** Frequency of updates to JMX report */
+  private long updateJmxIntervalMs;
+  /** Timestamp of last attempt to update JMX report */
+  private long lastJmxUpdateAttempt;
+  /** Result of the last successful FsNamesystemMetrics report */
+  private JSONArray fsNamesystemMetrics;
+  /** Result of the last successful NamenodeInfoMetrics report */
+  private JSONArray namenodeInfoMetrics;
 
   private String resolvedHost;
   private String originalNnId;
@@ -232,6 +248,11 @@ public class NamenodeHeartbeatService extends PeriodicService {
     } else {
       this.healthMonitorTimeoutMs = (int) timeoutMs;
     }
+
+    this.updateJmxEnabled = conf.getBoolean(DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_ENABLED,
+        DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_ENABLED_DEFAULT);
+    this.updateJmxIntervalMs = conf.getLong(DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS,
+        DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS_DEFAULT);
 
     super.serviceInit(configuration);
   }
@@ -447,8 +468,13 @@ public class NamenodeHeartbeatService extends PeriodicService {
       String address, NamenodeStatusReport report) {
     try {
       // TODO part of this should be moved to its own utility
-      getFsNamesystemMetrics(address, report);
-      getNamenodeInfoMetrics(address, report);
+      if (shouldUpdateJmx()) {
+        lastJmxUpdateAttempt = Time.monotonicNow();
+        getFsNamesystemMetrics(address);
+        getNamenodeInfoMetrics(address);
+      }
+      populateFsNamesystemMetrics(fsNamesystemMetrics, report);
+      populateNamenodeInfoMetrics(namenodeInfoMetrics, report);
     } catch (Exception e) {
       LOG.error("Cannot get stat from {} using JMX", getNamenodeDesc(), e);
     }
@@ -483,16 +509,35 @@ public class NamenodeHeartbeatService extends PeriodicService {
   }
 
   /**
+   * Evaluates whether the JMX report should be refreshed by
+   * calling the Namenode, based on the following conditions:
+   * 1. JMX Updates must be enabled.
+   * 2. The last attempt to update JMX occurred before the
+   *    configured interval (if any).
+   */
+  private boolean shouldUpdateJmx() {
+    return updateJmxEnabled
+        && (updateJmxIntervalMs < 0
+        || Time.monotonicNow() - lastJmxUpdateAttempt > updateJmxIntervalMs);
+  }
+
+  /**
    * Fetches NamenodeInfo metrics from namenode.
    * @param address Web interface of the Namenode to monitor.
-   * @param report Namenode status report to update with JMX data.
-   * @throws JSONException
    */
-  private void getNamenodeInfoMetrics(String address,
-      NamenodeStatusReport report) throws JSONException {
+  private void getNamenodeInfoMetrics(String address) {
     String query = "Hadoop:service=NameNode,name=NameNodeInfo";
-    JSONArray aux =
-        FederationUtil.getJmx(query, address, connectionFactory, scheme);
+    namenodeInfoMetrics = FederationUtil.getJmx(query, address, connectionFactory, scheme);
+  }
+
+  /**
+   * Populates NamenodeInfo metrics into report.
+   * @param aux NamenodeInfo metrics from namenode.
+   * @param report Namenode status report to update with JMX data.
+   * @throws JSONException When an invalid JSONObject is found
+   */
+  private void populateNamenodeInfoMetrics(JSONArray aux, NamenodeStatusReport report)
+      throws JSONException {
     if (aux != null && aux.length() > 0) {
       JSONObject jsonObject = aux.getJSONObject(0);
       String name = jsonObject.getString("name");
@@ -510,14 +555,20 @@ public class NamenodeHeartbeatService extends PeriodicService {
   /**
    * Fetches FSNamesystem* metrics from namenode.
    * @param address Web interface of the Namenode to monitor.
-   * @param report Namenode status report to update with JMX data.
-   * @throws JSONException
    */
-  private void getFsNamesystemMetrics(String address,
-      NamenodeStatusReport report) throws JSONException {
+  private void getFsNamesystemMetrics(String address) {
     String query = "Hadoop:service=NameNode,name=FSNamesystem*";
-    JSONArray aux = FederationUtil.getJmx(
-        query, address, connectionFactory, scheme);
+    fsNamesystemMetrics = FederationUtil.getJmx(query, address, connectionFactory, scheme);
+  }
+
+  /**
+   * Populates FSNamesystem* metrics into report.
+   * @param aux FSNamesystem* metrics from namenode.
+   * @param report Namenode status report to update with JMX data.
+   * @throws JSONException When invalid JSONObject is found.
+   */
+  private void populateFsNamesystemMetrics(JSONArray aux, NamenodeStatusReport report)
+      throws JSONException {
     if (aux != null) {
       for (int i = 0; i < aux.length(); i++) {
         JSONObject jsonObject = aux.getJSONObject(i);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
@@ -112,15 +112,15 @@ public class NamenodeHeartbeatService extends PeriodicService {
   /** URL scheme to use for JMX calls. */
   private String scheme;
 
-  /** Whether to update JMX report */
+  /** Whether to update JMX report. */
   private boolean updateJmxEnabled;
-  /** Frequency of updates to JMX report */
+  /** Frequency of updates to JMX report. */
   private long updateJmxIntervalMs;
-  /** Timestamp of last attempt to update JMX report */
+  /** Timestamp of last attempt to update JMX report. */
   private long lastJmxUpdateAttempt;
-  /** Result of the last successful FsNamesystemMetrics report */
+  /** Result of the last successful FsNamesystemMetrics report. */
   private JSONArray fsNamesystemMetrics;
-  /** Result of the last successful NamenodeInfoMetrics report */
+  /** Result of the last successful NamenodeInfoMetrics report. */
   private JSONArray namenodeInfoMetrics;
 
   private String resolvedHost;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
@@ -510,9 +510,8 @@ public class NamenodeHeartbeatService extends PeriodicService {
    *    configured interval (if any).
    */
   private boolean shouldUpdateJmx() {
-    return updateJmxIntervalMs == 0
-        || (updateJmxIntervalMs > 0
-        && Time.monotonicNow() - lastJmxUpdateAttempt > updateJmxIntervalMs);
+    return updateJmxIntervalMs >= 0
+        && Time.monotonicNow() - lastJmxUpdateAttempt > updateJmxIntervalMs;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
@@ -245,8 +245,8 @@ public class NamenodeHeartbeatService extends PeriodicService {
       this.healthMonitorTimeoutMs = (int) timeoutMs;
     }
 
-    this.updateJmxIntervalMs = conf.getLong(DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS,
-        DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS_DEFAULT);
+    this.updateJmxIntervalMs = conf.getTimeDuration(DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS,
+        DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS_DEFAULT, TimeUnit.MILLISECONDS);
 
     super.serviceInit(configuration);
   }
@@ -463,12 +463,12 @@ public class NamenodeHeartbeatService extends PeriodicService {
     try {
       // TODO part of this should be moved to its own utility
       if (shouldUpdateJmx()) {
-        lastJmxUpdateAttempt = Time.monotonicNow();
+        this.lastJmxUpdateAttempt = Time.monotonicNow();
         getFsNamesystemMetrics(address);
         getNamenodeInfoMetrics(address);
       }
-      populateFsNamesystemMetrics(fsNamesystemMetrics, report);
-      populateNamenodeInfoMetrics(namenodeInfoMetrics, report);
+      populateFsNamesystemMetrics(this.fsNamesystemMetrics, report);
+      populateNamenodeInfoMetrics(this.namenodeInfoMetrics, report);
     } catch (Exception e) {
       LOG.error("Cannot get stat from {} using JMX", getNamenodeDesc(), e);
     }
@@ -510,8 +510,8 @@ public class NamenodeHeartbeatService extends PeriodicService {
    *    configured interval (if any).
    */
   private boolean shouldUpdateJmx() {
-    return updateJmxIntervalMs >= 0
-        && Time.monotonicNow() - lastJmxUpdateAttempt > updateJmxIntervalMs;
+    return this.updateJmxIntervalMs >= 0
+        && Time.monotonicNow() - this.lastJmxUpdateAttempt > this.updateJmxIntervalMs;
   }
 
   /**
@@ -520,7 +520,7 @@ public class NamenodeHeartbeatService extends PeriodicService {
    */
   private void getNamenodeInfoMetrics(String address) {
     String query = "Hadoop:service=NameNode,name=NameNodeInfo";
-    namenodeInfoMetrics = FederationUtil.getJmx(query, address, connectionFactory, scheme);
+    this.namenodeInfoMetrics = FederationUtil.getJmx(query, address, connectionFactory, scheme);
   }
 
   /**
@@ -551,7 +551,7 @@ public class NamenodeHeartbeatService extends PeriodicService {
    */
   private void getFsNamesystemMetrics(String address) {
     String query = "Hadoop:service=NameNode,name=FSNamesystem*";
-    fsNamesystemMetrics = FederationUtil.getJmx(query, address, connectionFactory, scheme);
+    this.fsNamesystemMetrics = FederationUtil.getJmx(query, address, connectionFactory, scheme);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -115,12 +115,9 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
       FEDERATION_ROUTER_PREFIX + "heartbeat-state.interval";
   public static final long DFS_ROUTER_HEARTBEAT_STATE_INTERVAL_MS_DEFAULT =
       TimeUnit.SECONDS.toMillis(5);
-  public static final String DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_ENABLED =
-      FEDERATION_ROUTER_PREFIX + "namenode.heartbeat.jmx.enable";
-  public static final boolean DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_ENABLED_DEFAULT = true;
   public static final String DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS =
       FEDERATION_ROUTER_PREFIX + "namenode.heartbeat.jmx.interval";
-  public static final long DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS_DEFAULT = -1;
+  public static final long DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS_DEFAULT = 0;
 
   // HDFS Router NN client
   public static final String

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -115,6 +115,12 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
       FEDERATION_ROUTER_PREFIX + "heartbeat-state.interval";
   public static final long DFS_ROUTER_HEARTBEAT_STATE_INTERVAL_MS_DEFAULT =
       TimeUnit.SECONDS.toMillis(5);
+  public static final String DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_ENABLED =
+      FEDERATION_ROUTER_PREFIX + "namenode.heartbeat.jmx.enable";
+  public static final boolean DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_ENABLED_DEFAULT = true;
+  public static final String DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS =
+      FEDERATION_ROUTER_PREFIX + "namenode.heartbeat.jmx.interval";
+  public static final long DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS_DEFAULT = -1;
 
   // HDFS Router NN client
   public static final String

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -472,20 +472,12 @@
   </property>
 
   <property>
-    <name>dfs.federation.router.namenode.heartbeat.jmx.enable</name>
-    <value>true</value>
-    <description>
-      If true, the Router requests JMX reports from the Namenode.
-    </description>
-  </property>
-
-  <property>
     <name>dfs.federation.router.namenode.heartbeat.jmx.interval</name>
-    <value>-1</value>
+    <value>0</value>
     <description>
       How often the Router should request JMX reports from the Namenode in miliseconds.
-      If this value is negative, it will request JMX reports every time a Namenode
-      report is requested.
+      If this value is 0, it will request JMX reports every time a Namenode report is requested.
+      If this value is negative, it will disable JMX reports from the Namenode.
     </description>
   </property>
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -472,6 +472,24 @@
   </property>
 
   <property>
+    <name>dfs.federation.router.namenode.heartbeat.jmx.enable</name>
+    <value>true</value>
+    <description>
+      If true, the Router requests JMX reports from the Namenode.
+    </description>
+  </property>
+
+  <property>
+    <name>dfs.federation.router.namenode.heartbeat.jmx.interval</name>
+    <value>-1</value>
+    <description>
+      How often the Router should request JMX reports from the Namenode in miliseconds.
+      If this value is negative, it will request JMX reports every time a Namenode
+      report is requested.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.federation.router.store.router.expiration</name>
     <value>5m</value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeMonitoring.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeMonitoring.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
@@ -293,7 +294,32 @@ public class TestRouterNamenodeMonitoring {
     verifyUrlSchemes(HttpConfig.Policy.HTTPS_ONLY.name());
   }
 
+  @Test
+  public void testJmxRequestFrequency() {
+    // Disable JMX requests
+    Configuration conf = getNamenodesConfig();
+    conf.setBoolean(RBFConfigKeys.DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_ENABLED, false);
+    verifyUrlSchemes(HttpConfig.Policy.HTTPS_ONLY.name(), conf, 0, 0, 1);
+
+    // Set JMX requests to lower frequency
+    conf = getNamenodesConfig();
+    conf.setLong(RBFConfigKeys.DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS,
+        TimeUnit.MINUTES.toMillis(5));
+    verifyUrlSchemes(HttpConfig.Policy.HTTPS_ONLY.name(), conf, 0, 1, 2);
+
+    // Set JMX requests to default frequency
+    conf = getNamenodesConfig();
+    verifyUrlSchemes(HttpConfig.Policy.HTTPS_ONLY.name(), conf, 0, 2, 2);
+  }
+
   private void verifyUrlSchemes(String scheme) {
+    int httpRequests = HttpConfig.Policy.HTTP_ONLY.name().equals(scheme) ? 1 : 0;
+    int httpsRequests = HttpConfig.Policy.HTTPS_ONLY.name().equals(scheme) ? 1 : 0;
+    verifyUrlSchemes(scheme, getNamenodesConfig(), httpRequests, httpsRequests, 1);
+  }
+
+  private void verifyUrlSchemes(String scheme, Configuration conf, int httpRequests,
+      int httpsRequests, int requestsPerService) {
 
     // Attach our own log appender so we can verify output
     final LogVerificationAppender appender =
@@ -304,7 +330,6 @@ public class TestRouterNamenodeMonitoring {
     GenericTestUtils.setRootLogLevel(Level.DEBUG);
 
     // Setup and start the Router
-    Configuration conf = getNamenodesConfig();
     conf.set(DFSConfigKeys.DFS_HTTP_POLICY_KEY, scheme);
     Configuration routerConf = new RouterConfigBuilder(conf)
         .heartbeat(true)
@@ -318,15 +343,12 @@ public class TestRouterNamenodeMonitoring {
     Collection<NamenodeHeartbeatService> heartbeatServices =
         router.getNamenodeHeartbeatServices();
     for (NamenodeHeartbeatService heartbeatService : heartbeatServices) {
-      heartbeatService.getNamenodeStatusReport();
+      for (int request = 0; request < requestsPerService; request++) {
+        heartbeatService.getNamenodeStatusReport();
+      }
     }
-    if (HttpConfig.Policy.HTTPS_ONLY.name().equals(scheme)) {
-      assertEquals(2, appender.countLinesWithMessage("JMX URL: https://"));
-      assertEquals(0, appender.countLinesWithMessage("JMX URL: http://"));
-    } else {
-      assertEquals(2, appender.countLinesWithMessage("JMX URL: http://"));
-      assertEquals(0, appender.countLinesWithMessage("JMX URL: https://"));
-    }
+    assertEquals(httpsRequests * 2, appender.countLinesWithMessage("JMX URL: https://"));
+    assertEquals(httpRequests * 2, appender.countLinesWithMessage("JMX URL: http://"));
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeMonitoring.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeMonitoring.java
@@ -298,7 +298,7 @@ public class TestRouterNamenodeMonitoring {
   public void testJmxRequestFrequency() {
     // Disable JMX requests
     Configuration conf = getNamenodesConfig();
-    conf.setBoolean(RBFConfigKeys.DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_ENABLED, false);
+    conf.setLong(RBFConfigKeys.DFS_ROUTER_NAMENODE_HEARTBEAT_JMX_INTERVAL_MS, -1);
     verifyUrlSchemes(HttpConfig.Policy.HTTPS_ONLY.name(), conf, 0, 0, 1);
 
     // Set JMX requests to lower frequency


### PR DESCRIPTION
…er frequency

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Changes to the NamenodeHeartbeatService to update JMX reports on a configurable frequency or to disable JMX updates altogether, as opposed to updating it every time the service wakes up. This will help reduce the load on Namenodes in clusters with a high number of routers.
With these changes, we expect the NamenodeStatusReport to contain slightly outdated Namenode information, which should not impact critical paths for routers.

### How was this patch tested?
Added unit test on TestRouterNamenodeMonitoring#testJmxRequestFrequency that tests the following configurations:
1. Default configuration which should update JMX every time the report is generated.
2. Configuration with JMX updates disabled, which should never update JMX
3. Configuration with a high JMX update interval, which should not update JMX every time the report is generated.


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

