### PR TITLE
HDFS-16946. Fix getTopTokenRealOwners to return String

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
@@ -721,8 +721,7 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
         List<Metrics2Util.NameValuePair> topOwners = mgr.getSecretManager()
                 .getTopTokenRealOwners(this.topTokenRealOwners);
         topTokenRealOwnersString = JsonUtil.toJsonString(topOwners);
-      }
-      catch (Exception e) {
+      } catch (Exception e) {
         LOG.error("Unable to fetch the top token real owners as string {}", e.getMessage());
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
@@ -50,8 +50,6 @@ import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
 import javax.management.StandardMBean;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/security/TestRouterSecurityManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/security/TestRouterSecurityManager.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.hdfs.server.federation.router.security.RouterSecurityMa
 import org.apache.hadoop.hdfs.server.federation.router.Router;
 import org.apache.hadoop.hdfs.server.federation.router.security.token.ZKDelegationTokenSecretManagerImpl;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.metrics2.MetricsException;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.util.Metrics2Util.NameValuePair;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -82,6 +82,7 @@ public class TestRouterSecurityManager {
     mockDelegationTokenSecretManager.startThreads();
     securityManager =
         new RouterSecurityManager(mockDelegationTokenSecretManager);
+    DefaultMetricsSystem.setMiniClusterMode(true);
   }
 
   @Rule
@@ -89,13 +90,8 @@ public class TestRouterSecurityManager {
 
   private Router initializeAndStartRouter(Configuration configuration) {
     Router router = new Router();
-    try {
-      router.init(configuration);
-      router.start();
-    } catch (MetricsException e) {
-      //do nothing
-      LOG.info("Metrics source already exists: {}", e.getMessage());
-    }
+    router.init(configuration);
+    router.start();
     return router;
   }
 
@@ -305,6 +301,8 @@ public class TestRouterSecurityManager {
     JsonNode topTokenRealOwnersList = new ObjectMapper().readTree(topTokenRealOwners);
     assertEquals("The key:name contains incorrect value " + topTokenRealOwners, expectedOwner,
         topTokenRealOwnersList.get(0).get("name").asText());
+    // Destroy the cluster
+    RouterHDFSContract.destroyCluster();
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/security/TestRouterSecurityManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/security/TestRouterSecurityManager.java
@@ -286,8 +286,9 @@ public class TestRouterSecurityManager {
     Router router = initializeAndStartRouter(conf);
 
     // Create credentials
-    UserGroupInformation ugi = UserGroupInformation.createUserForTesting("router", getUserGroupForTesting());
-    Credentials creds = RouterSecurityManager.createCredentials(router, ugi, "some_renewer");
+    UserGroupInformation ugi =
+            UserGroupInformation.createUserForTesting("router", getUserGroupForTesting());
+    RouterSecurityManager.createCredentials(router, ugi, "some_renewer");
 
     String host = Path.WINDOWS ? "127.0.0.1" : "localhost";
     String expectedOwner = "router/" + host + "@EXAMPLE.COM";


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
getTopTokenRealOwners can't be parsed as json string. And was returning the following "org.apache.hadoop.metrics2.util.Metrics2Util$NameValuePair@1"
Fixed this to convert the List to string

### How was this patch tested?
Tested the patch by intercepting TestRouterSecurityManager.testDelgationTokenTopOwners() and converting the output to string.
Tried to add a test in TestRBFMetrics, but `this.router.getRpcServer()`, is failing with NullPointerException

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

