### PR TITLE
HDFS-17000. Fix faulty loop condition in TestDFSStripedOutputStreamUpdatePipeline

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedOutputStreamUpdatePipeline.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedOutputStreamUpdatePipeline.java
@@ -45,7 +45,7 @@ public class TestDFSStripedOutputStreamUpdatePipeline {
       Path filePath = new Path("/test/file");
       FSDataOutputStream out = dfs.create(filePath);
       try {
-        for (int i = 0; i < Long.MAX_VALUE; i++) {
+        for (int i = 0; i < Integer.MAX_VALUE; i++) {
           out.write(i);
           if (i == 1024 * 1024 * 5) {
             cluster.stopDataNode(0);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The loop iterates over an int but previously compared the value against `Long.MAX_VALUE`, so it would have overflown before having reached that value, and the loop would never have terminated normally.

However, as mentioned in the comments of HDFS-17000 eventually an (expected) exception would have occurred so the loop would have terminated at some point.

Either way, this commit fixes the loop condition to be on the safe side.

### How was this patch tested?
Not tested

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
