### PR TITLE
HDFS-17030. Limit wait time for getHAServiceState in ObserverReaderProxy

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
@@ -373,12 +373,14 @@ public class ObserverReadProxyProvider<T>
       LOG.debug("HA State for {} is {}", proxyInfo.proxyInfo, state);
     } catch (TimeoutException e) {
       // Cancel the task on timeout
-      LOG.warn("Cancel NN probe task due to timeout for {}: {}", proxyInfo.proxyInfo, e);
+      String msg = String.format("Cancel NN probe task due to timeout for %s", proxyInfo.proxyInfo);
+      LOG.warn(msg, e);
       if (task != null) {
         task.cancel(true);
       }
     } catch (InterruptedException|ExecutionException e) {
-      LOG.warn("Exception in NN probe task for {}: {}", proxyInfo.proxyInfo, e);
+      String msg = String.format("Exception in NN probe task for %s", proxyInfo.proxyInfo);
+      LOG.warn(msg, e);
     }
 
     return state;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
@@ -244,6 +244,10 @@ public class ObserverReadProxyProvider<T>
     namenodeHAStateProbeTimeoutSec = conf.getTimeDuration(
         NAMENODE_HA_STATE_PROBE_TIMEOUT,
         NAMENODE_HA_STATE_PROBE_TIMEOUT_DEFAULT, TimeUnit.SECONDS);
+    // Disallow negative values for namenodeHAStateProbeTimeoutSec
+    if (namenodeHAStateProbeTimeoutSec < 0) {
+      namenodeHAStateProbeTimeoutSec = NAMENODE_HA_STATE_PROBE_TIMEOUT_DEFAULT;
+    }
 
     if (wrappedProxy instanceof ClientProtocol) {
       this.observerReadEnabled = true;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
@@ -96,15 +96,16 @@ public class ObserverReadProxyProvider<T>
   /** Observer probe retry period default to 10 min. */
   static final long OBSERVER_PROBE_RETRY_PERIOD_DEFAULT = 60 * 10 * 1000;
 
-  /** Timeout in ms to cancel the ha-state probe rpc request for an namenode. */
+  /**
+   * Timeout in ms to cancel the ha-state probe rpc request for an namenode.
+   * To disable timeout, set it to 0 or a negative value.
+   */
   static final String NAMENODE_HA_STATE_PROBE_TIMEOUT =
       HdfsClientConfigKeys.Failover.PREFIX + "namenode.ha-state.probe.timeout";
   /**
-   * Namenode ha-state probe timeout default to 25 sec.
-   * ipc.client.connect.timeout defaults to be 20 seconds. So, in 25 seconds,
-   * we can try twice to connect to an NN.
+   * Default to disable namenode ha-state probe timeout.
    */
-  static final long NAMENODE_HA_STATE_PROBE_TIMEOUT_DEFAULT = 25000;  // 25 secs
+  static final long NAMENODE_HA_STATE_PROBE_TIMEOUT_DEFAULT = 0;
 
   /** The inner proxy provider used for active/standby failover. */
   private final AbstractNNFailoverProxyProvider<T> failoverProxy;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
@@ -99,8 +99,12 @@ public class ObserverReadProxyProvider<T>
   /** Timeout to cancel the ha-state probe rpc request for an namenode. */
   static final String NAMENODE_HA_STATE_PROBE_TIMEOUT =
       "dfs.client.namenode.ha-state.probe.timeout";
-  /** Namenode ha-state probe timeout default to 5 sec. */
-  static final long NAMENODE_HA_STATE_PROBE_TIMEOUT_DEFAULT = 5;
+  /**
+   * Namenode ha-state probe timeout default to 25 sec.
+   * ipc.client.connect.timeout defaults to be 20 seconds. So, in 25 seconds,
+   * we can try twice to connect to an NN.
+   */
+  static final long NAMENODE_HA_STATE_PROBE_TIMEOUT_DEFAULT = 25;
 
   /** The inner proxy provider used for active/standby failover. */
   private final AbstractNNFailoverProxyProvider<T> failoverProxy;
@@ -182,7 +186,7 @@ public class ObserverReadProxyProvider<T>
   private long lastObserverProbeTime;
 
   private final ExecutorService nnProbingThreadPool =
-      new ThreadPoolExecutor(4, 4, 0L, TimeUnit.MILLISECONDS,
+      new ThreadPoolExecutor(1, 4, 60000L, TimeUnit.MILLISECONDS,
           new ArrayBlockingQueue<Runnable>(1024));
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
@@ -177,7 +177,7 @@ public class ObserverReadProxyProvider<T>
    * Timeout in ms when we try to get the HA state of a namenode.
    */
   @VisibleForTesting
-  private long namenodeHAStateProbeTimeoutMs;
+  protected long namenodeHAStateProbeTimeoutMs;
 
   /**
    * The previous time where zero observer were found. If there was observer,

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
@@ -335,7 +335,6 @@ public class ObserverReadProxyProvider<T>
    * the second function.
    */
   HAServiceState getHAServiceStateWithTimeout(final NNProxyInfo<T> proxyInfo) {
-
     Callable<HAServiceState> getHAServiceStateTask = () -> getHAServiceState(proxyInfo);
 
     try {
@@ -364,12 +363,12 @@ public class ObserverReadProxyProvider<T>
       LOG.debug("HA State for {} is {}", proxyInfo.proxyInfo, state);
     } catch (TimeoutException e) {
       // Cancel the task on timeout
-      LOG.debug("Cancel NN probe task due to timeout for {}: {}", proxyInfo.proxyInfo, e);
+      LOG.warn("Cancel NN probe task due to timeout for {}: {}", proxyInfo.proxyInfo, e);
       if (task != null) {
         task.cancel(true);
       }
     } catch (InterruptedException|ExecutionException e) {
-      LOG.debug("Exception in NN probe task for {}: {}", proxyInfo.proxyInfo, e);
+      LOG.warn("Exception in NN probe task for {}: {}", proxyInfo.proxyInfo, e);
     }
 
     return state;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
@@ -185,6 +185,17 @@ public class ObserverReadProxyProvider<T>
    */
   private long lastObserverProbeTime;
 
+  /**
+   * Threadpool to send the getHAServiceState requests.
+   *
+   * One thread running all the time, with up to 4 threads. Idle threads will be killed after
+   * 1 minute. At most 1024 requests can be submitted before they start to be rejected.
+   *
+   * Each hdfs client will have its own ObserverReadProxyProvider. Thus,
+   * having 1 thread running should be sufficient in most cases.
+   * We are not expecting to receive a lot of outstanding RPC calls
+   * from a single hdfs client, thus setting the queue size to 1024.
+   */
   private final ExecutorService nnProbingThreadPool =
       new ThreadPoolExecutor(1, 4, 1L, TimeUnit.MINUTES,
           new ArrayBlockingQueue<Runnable>(1024));

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
@@ -342,7 +342,7 @@ public class ObserverReadProxyProvider<T>
           nnProbingThreadPool.submit(getHAServiceStateTask);
       return getHAServiceStateWithTimeout(proxyInfo, task);
     } catch (RejectedExecutionException e) {
-      LOG.debug("Run out of threads to submit the request to query HA state. "
+      LOG.warn("Run out of threads to submit the request to query HA state. "
           + "Ok to return null and we will fallback to use active NN to serve "
           + "this request.");
       return null;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
@@ -177,8 +177,7 @@ public class ObserverReadProxyProvider<T>
   /**
    * Timeout in ms when we try to get the HA state of a namenode.
    */
-  @VisibleForTesting
-  protected long namenodeHAStateProbeTimeoutMs;
+  private long namenodeHAStateProbeTimeoutMs;
 
   /**
    * The previous time where zero observer were found. If there was observer,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -57,6 +57,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.startsWith;
@@ -369,80 +370,69 @@ public class TestObserverReadProxyProvider {
     Future<HAServiceState> task = mock(Future.class);
     when(task.get(anyLong(), any(TimeUnit.class))).thenReturn(state);
 
-    HAServiceState state2 =
-        proxyProvider.getHAServiceStateWithTimeout(dummyNNProxyInfo, task);
+    HAServiceState state2 = proxyProvider.getHAServiceStateWithTimeout(dummyNNProxyInfo, task);
     assertEquals(state, state2);
     verify(task).get(anyLong(), any(TimeUnit.class));
     verifyNoMoreInteractions(task);
-    verify(logger).debug(startsWith("HA State for"));
+    verify(logger).debug(eq("HA State for {} is {}"), eq(null), eq(state));
   }
 
   /**
    * Test TimeoutException for GetHAServiceStateWithTimeout.
    */
   @Test
-  public void testTimeoutExceptionGetHAServiceStateWithTimeout()
-      throws Exception {
+  public void testTimeoutExceptionGetHAServiceStateWithTimeout() throws Exception {
     setupProxyProvider(1);
     NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
         (NNProxyInfo<ClientProtocol>) Mockito.mock(NNProxyInfo.class);
     Future<HAServiceState> task = mock(Future.class);
-    when(task.get(anyLong(), any(TimeUnit.class))).thenThrow(
-        new TimeoutException("Timeout"));
+    TimeoutException e = new TimeoutException("Timeout");
+    when(task.get(anyLong(), any(TimeUnit.class))).thenThrow(e);
 
-    HAServiceState state =
-        proxyProvider.getHAServiceStateWithTimeout(dummyNNProxyInfo, task);
+    HAServiceState state = proxyProvider.getHAServiceStateWithTimeout(dummyNNProxyInfo, task);
     assertNull(state);
     verify(task).get(anyLong(), any(TimeUnit.class));
     verify(task).cancel(true);
     verifyNoMoreInteractions(task);
-    verify(logger).debug(startsWith("Cancel NN probe task due to timeout for"));
+    verify(logger).debug(eq("Cancel NN probe task due to timeout for {}: {}"), eq(null), eq(e));
   }
 
   /**
    * Test InterruptedException for GetHAServiceStateWithTimeout.
-   * Tests for the other two exceptions are the same and thus left out.
    */
   @Test
-  public void testInterruptedExceptionGetHAServiceStateWithTimeout()
-      throws Exception {
+  public void testInterruptedExceptionGetHAServiceStateWithTimeout() throws Exception {
     setupProxyProvider(1);
     NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
         (NNProxyInfo<ClientProtocol>) Mockito.mock(NNProxyInfo.class);
     Future<HAServiceState> task = mock(Future.class);
-    when(task.get(anyLong(), any(TimeUnit.class))).thenThrow(
-        new InterruptedException("Interrupted"));
+    InterruptedException e = new InterruptedException("Interrupted");
+    when(task.get(anyLong(), any(TimeUnit.class))).thenThrow(e);
 
-    HAServiceState state =
-        proxyProvider.getHAServiceStateWithTimeout(dummyNNProxyInfo, task);
+    HAServiceState state = proxyProvider.getHAServiceStateWithTimeout(dummyNNProxyInfo, task);
     assertNull(state);
     verify(task).get(anyLong(), any(TimeUnit.class));
     verifyNoMoreInteractions(task);
-    verify(logger).debug(
-        startsWith("Interrupted exception in NN probe task for"));
+    verify(logger).debug(eq("Exception in NN probe task for {}: {}"), eq(null), eq(e));
   }
 
   /**
-   * Test InterruptedException for GetHAServiceStateWithTimeout.
-   * Tests for the other two exceptions are the same and thus left out.
+   * Test ExecutionException for GetHAServiceStateWithTimeout.
    */
   @Test
-  public void testExecutionExceptionGetHAServiceStateWithTimeout()
-      throws Exception {
+  public void testExecutionExceptionGetHAServiceStateWithTimeout() throws Exception {
     setupProxyProvider(1);
     NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
         (NNProxyInfo<ClientProtocol>) Mockito.mock(NNProxyInfo.class);
     Future<HAServiceState> task = mock(Future.class);
-    when(task.get(anyLong(), any(TimeUnit.class))).thenThrow(
-        new ExecutionException(new InterruptedException("Interrupted")));
+    Exception e = new ExecutionException(new InterruptedException("Interrupted"));
+    when(task.get(anyLong(), any(TimeUnit.class))).thenThrow(e);
 
-    HAServiceState state =
-        proxyProvider.getHAServiceStateWithTimeout(dummyNNProxyInfo, task);
+    HAServiceState state = proxyProvider.getHAServiceStateWithTimeout(dummyNNProxyInfo, task);
     assertNull(state);
     verify(task).get(anyLong(), any(TimeUnit.class));
     verifyNoMoreInteractions(task);
-    verify(logger).debug(
-        startsWith("Execution exception in NN probe task for "));
+    verify(logger).debug(eq("Exception in NN probe task for {}: {}"), eq(null), eq(e));
   }
 
   private void doRead() throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -101,7 +101,8 @@ public class TestObserverReadProxyProvider {
   /**
    * Replace LOG in ObserverReadProxy with a mocked logger.
    */
-  private void setupMockLoggerForProxyProvider() throws NoSuchFieldException, IllegalAccessException {
+  private void setupMockLoggerForProxyProvider()
+      throws NoSuchFieldException, IllegalAccessException {
     Field field = ObserverReadProxyProvider.class.getDeclaredField("LOG");
     field.setAccessible(true);
     // remove final modifier

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -84,7 +84,6 @@ public class TestObserverReadProxyProvider {
   private URI nnURI;
 
   private ObserverReadProxyProvider<ClientProtocol> proxyProvider;
-
   private NameNodeAnswer[] namenodeAnswers;
   private String[] namenodeAddrs;
 
@@ -97,8 +96,6 @@ public class TestObserverReadProxyProvider {
   public void setup() throws Exception {
     ns = "testcluster";
     nnURI = URI.create("hdfs://" + ns);
-
-    MockitoAnnotations.initMocks(this);
   }
 
   private void setupProxyProvider(int namenodeCount) throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -60,7 +60,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -74,9 +74,9 @@ import static org.mockito.Mockito.verify;
  * NameNode to communicate with.
  */
 public class TestObserverReadProxyProvider {
-  private final static int SLOW_RESPONSE_SLEEP_TIME = 5000; // 5 s
-  private final static int NAMENODE_HA_STATE_PROBE_TIMEOUT_SHORT = 2000; // 2s
-  private final static int NAMENODE_HA_STATE_PROBE_TIMEOUT_LONG = 25000; // 25s
+  private final static long SLOW_RESPONSE_SLEEP_TIME = TimeUnit.SECONDS.toMillis(5); // 5 s
+  private final static long NAMENODE_HA_STATE_PROBE_TIMEOUT_SHORT = TimeUnit.SECONDS.toMillis(2);
+  private final static long NAMENODE_HA_STATE_PROBE_TIMEOUT_LONG = TimeUnit.SECONDS.toMillis(25);
 
   private static final LocatedBlock[] EMPTY_BLOCKS = new LocatedBlock[0];
   private String ns;
@@ -114,9 +114,9 @@ public class TestObserverReadProxyProvider {
     setupProxyProvider(namenodeCount, new Configuration());
   }
 
-  private void setupProxyProvider(int namenodeCount, int nnHAStateProbeTimeout) throws Exception {
+  private void setupProxyProvider(int namenodeCount, long nnHAStateProbeTimeout) throws Exception {
     Configuration conf = new Configuration();
-    conf.setInt(NAMENODE_HA_STATE_PROBE_TIMEOUT, nnHAStateProbeTimeout);
+    conf.setLong(NAMENODE_HA_STATE_PROBE_TIMEOUT, nnHAStateProbeTimeout);
     setupProxyProvider(namenodeCount, conf);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -439,10 +439,7 @@ public class TestObserverReadProxyProvider {
   }
 
   /**
-   * Test getHAServiceState when we have a slow NN, using the default timeout (25s).
-   * This is to verify the old behavior without being able to fast-fail (we can also set
-   * namenodeHAStateProbeTimeoutMs to 0 or a negative value and the rest of the test can stay
-   * the same).
+   * Test the default getHAServiceState with no timeout, when we have a slow NN.
    *
    * 5-second (SLOW_RESPONSE_SLEEP_TIME) latency is introduced and we expect that latency is added
    * to the READ operation.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -439,8 +439,13 @@ public class TestObserverReadProxyProvider {
   }
 
   /**
-   * Test default (no timeout) getHAServiceState when we have a slow NN.
-   * Expect the response to take longer than SLOW_RESPONSE_SLEEP_TIME.
+   * Test getHAServiceState when we have a slow NN, using the default timeout (25s).
+   * This is to verify the old behavior without being able to fast-fail (we can also set
+   * namenodeHAStateProbeTimeoutMs to 0 or a negative value and the rest of the test can stay
+   * the same).
+   *
+   * 5-second (SLOW_RESPONSE_SLEEP_TIME) latency is introduced and we expect that latency is added
+   * to the READ operation.
    */
   @Test
   public void testStandbyGetHAServiceStateNoTimeout() throws Exception {
@@ -453,7 +458,7 @@ public class TestObserverReadProxyProvider {
     watch.start();
     doRead();
     long runtime = watch.now(TimeUnit.MILLISECONDS);
-    assertTrue("Read operation finishes earlier than we expected",
+    assertTrue("Read operation finished earlier than we expected",
         runtime > SLOW_RESPONSE_SLEEP_TIME);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -452,7 +452,7 @@ public class TestObserverReadProxyProvider {
   }
 
   /**
-   * Test GetHAServiceState when timeout is disabled.
+   * Test GetHAServiceState when timeout is disabled (test the else { task.get() } code path)
    */
   @Test
   public void testGetHAServiceStateWithoutTimeout() throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -407,7 +407,7 @@ public class TestObserverReadProxyProvider {
     verify(task).get(anyLong(), any(TimeUnit.class));
     verify(task).cancel(true);
     verifyNoMoreInteractions(task);
-    verify(logger).debug(eq("Cancel NN probe task due to timeout for {}: {}"), eq(null), eq(e));
+    verify(logger).warn(eq("Cancel NN probe task due to timeout for {}: {}"), eq(null), eq(e));
   }
 
   /**
@@ -426,7 +426,7 @@ public class TestObserverReadProxyProvider {
     assertNull(state);
     verify(task).get(anyLong(), any(TimeUnit.class));
     verifyNoMoreInteractions(task);
-    verify(logger).debug(eq("Exception in NN probe task for {}: {}"), eq(null), eq(e));
+    verify(logger).warn(eq("Exception in NN probe task for {}: {}"), eq(null), eq(e));
   }
 
   /**
@@ -445,7 +445,7 @@ public class TestObserverReadProxyProvider {
     assertNull(state);
     verify(task).get(anyLong(), any(TimeUnit.class));
     verifyNoMoreInteractions(task);
-    verify(logger).debug(eq("Exception in NN probe task for {}: {}"), eq(null), eq(e));
+    verify(logger).warn(eq("Exception in NN probe task for {}: {}"), eq(null), eq(e));
   }
 
   /**


### PR DESCRIPTION
### Description of PR
Added support to fail fast when detecting unreachable/irresponsible standby NN in ObserverReaderProxy

`ObserverReadProxyProvider.getHAServiceState()`, `Client.getConnection()` and `SocketIOWithTimeout$SelectorPool.select()` are all done by the same nnProbe thread. And `SocketIOWithTimeout$SelectorPool.select()` checks whether the current thread is interrupted in its `while(true)` loop. So, when we call `task.cancel()` on timeout from the main thread, this probe task will be interrupted and cancelled earlier.

```
23/12/24 06:25:28 DEBUG ha.ObserverReadProxyProvider: getHAServiceState: current thread: Thread[nn-ha-state-probing-pool1-t3,5,main], id=35
23/12/24 06:25:28 DEBUG ipc.Client: getConnection: current thread: Thread[nn-ha-state-probing-pool1-t3,5,main], id=35
23/12/24 06:25:33 DEBUG ha.ObserverReadProxyProvider: getHAServiceStateWithTimeout: current thread: Thread[main,5,main], id=1 sent cancel command.
23/12/24 06:25:33 DEBUG net.SocketIOWithTimeout: in select: captured interrupt. current thread Thread[nn-ha-state-probing-pool1-t3,5,main], id = 35
```


### How was this patch tested?
* Unit tests
```
~/p/h/t/hadoop-hdfs-project (HDFS-17030)> mvn test -Dtest="TestObserverReadProxyProvider.java"
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.hdfs.server.namenode.ha.TestObserverReadProxyProvider
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.136 s - in org.apache.hadoop.hdfs.server.namenode.ha.TestObserverReadProxyProvider
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
```
* Tested in a testing cluster
    + We take a heap dump at a standby NN.
        ```
        bash-4.2$ jmap -F -dump:format=b,file=heapdump-25801.hprof 25801
        Attaching to process ID 25801, please wait...
        Debugger attached successfully.
        Server compiler detected.
        JVM version is 25.172-b11
        Dumping heap to heapdump-25801.hprof ... 
        ```

    + Existing hadoop-binary took more than 2 mins to complete the List operation, because we set _ipc.client.rpc-timeout.ms_ to 2 mins.
        ```
        [xinglin@ltx1-hcl14866 ~]$ time hdfs dfs -ls /tmp/testFile.txt
        23/05/24 23:07:05 INFO fs.FileBasedMountTableLoader: TID: 1 - Loading mount table from hdfs://ltx1-yugiohnn01.grid.linkedin.com:9000/mounttable/linkfs/ltx1-yugioh-router-mountpoints.json.
        -rw-r--r--   3 xinglin user      15841 2023-05-18 22:18 /tmp/testFile.txt
        real	2m4.161s
        user	0m5.052s
        sys	0m0.322s
        ```
    + New binary completed the List operation in under 10 seconds. 
        ```
        [xinglin@ltx1-hcl14866 hadoop-bin_2100506]$ time hdfs dfs -ls /tmp/testFile.txt 2>log2.txt 1>&1
        -rw-r--r--   3 xinglin user      15841 2023-05-18 22:18 /tmp/testFile.txt
        real	0m7.399s
        user	0m5.091s
        sys	0m0.274s
        ```
    + Relevant log lines. Note the 5 second delay (07:12 -> 07:17). Default timeout for fast-fail has been increased from 5 seconds to 25 seconds.
        ```
        23/05/24 23:07:12 DEBUG ha.ObserverReadProxyProvider: HA State for ltx1-yugiohnn01-ha1.grid.linkedin.com/10.150.1.132:9000 is active
        23/05/24 23:07:12 DEBUG ha.ObserverReadProxyProvider: Changed current proxy from none to ltx1-yugiohnn01-ha1.grid.linkedin.com/10.150.1.132:9000
        23/05/24 23:07:12 DEBUG ha.ObserverReadProxyProvider: Skipping proxy ltx1-yugiohnn01-ha1.grid.linkedin.com/10.150.1.132:9000 for getBlockLocations because it is in state active
        23/05/24 23:07:12 DEBUG ha.ObserverReadProxyProvider: HA State for ltx1-yugiohnn01-ha2.grid.linkedin.com/10.150.1.133:9000 is standby
        23/05/24 23:07:12 DEBUG ha.ObserverReadProxyProvider: Changed current proxy from ltx1-yugiohnn01-ha1.grid.linkedin.com/10.150.1.132:9000 to ltx1-yugiohnn01-ha2.grid.linkedin.com/10.150.1.133:9000
        23/05/24 23:07:12 DEBUG ha.ObserverReadProxyProvider: Skipping proxy ltx1-yugiohnn01-ha2.grid.linkedin.com/10.150.1.133:9000 for getBlockLocations because it is in state standby
        23/05/24 23:07:17 DEBUG ha.ObserverReadProxyProvider: Cancel NN probe task due to timeout for ltx1-yugiohnn01-ha3.grid.linkedin.com/10.150.1.245:9000
        23/05/24 23:07:17 DEBUG ha.ObserverReadProxyProvider: Changed current proxy from ltx1-yugiohnn01-ha2.grid.linkedin.com/10.150.1.133:9000 to ltx1-yugiohnn01-ha3.grid.linkedin.com/10.150.1.245:9000
        23/05/24 23:07:17 DEBUG ha.ObserverReadProxyProvider: Skipping proxy ltx1-yugiohnn01-ha3.grid.linkedin.com/10.150.1.245:9000 for getBlockLocations because it is in state unreachable
        23/05/24 23:07:17 DEBUG ha.ObserverReadProxyProvider: HA State for ltx1-yugiohnn01-ha4.grid.linkedin.com/10.150.1.147:9000 is observer
        23/05/24 23:07:17 DEBUG ha.ObserverReadProxyProvider: Changed current proxy from ltx1-yugiohnn01-ha3.grid.linkedin.com/10.150.1.245:9000 to ltx1-yugiohnn01-ha4.grid.linkedin.com/10.150.1.147:9000
        23/05/24 23:07:17 DEBUG ha.ObserverReadProxyProvider: Attempting to service getBlockLocations using proxy ltx1-yugiohnn01-ha4.grid.linkedin.com/10.150.1.147:9000
        23/05/24 23:07:17 DEBUG ha.ObserverReadProxyProvider: Invocation of getBlockLocations using ltx1-yugiohnn01-ha4.grid.linkedin.com/10.150.1.147:9000 was successful
        23/05/24 23:07:17 DEBUG ha.ObserverReadProxyProvider: Attempting to service getServerDefaults using proxy ltx1-yugiohnn01-ha4.grid.linkedin.com/10.150.1.147:9000
        23/05/24 23:07:17 DEBUG ha.ObserverReadProxyProvider: Invocation of getServerDefaults using ltx1-yugiohnn01-ha4.grid.linkedin.com/10.150.1.147:9000 was successful
        ```

