### PR TITLE
HDFS-17035. FsVolumeImpl#getActualNonDfsUsed may return negative value.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
@@ -511,7 +511,7 @@ public class FsVolumeImpl implements FsVolumeSpi {
   }
 
   private long getRemainingReserved() throws IOException {
-    long actualNonDfsUsed = getActualNonDfsUsed();
+    long actualNonDfsUsed = Math.max(getActualNonDfsUsed(), 0L);
     long actualReserved = getReserved();
     if (actualNonDfsUsed < actualReserved) {
       return actualReserved - actualNonDfsUsed;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
@@ -499,7 +499,7 @@ public class FsVolumeImpl implements FsVolumeSpi {
         return used;
       }
     }
-    return getDfUsed() - getDfsUsed();
+    return Math.max(getDfUsed() - getDfsUsed(), 0);
   }
 
   /**
@@ -511,7 +511,7 @@ public class FsVolumeImpl implements FsVolumeSpi {
   }
 
   private long getRemainingReserved() throws IOException {
-    long actualNonDfsUsed = Math.max(getActualNonDfsUsed(), 0L);
+    long actualNonDfsUsed = getActualNonDfsUsed();
     long actualReserved = getReserved();
     if (actualNonDfsUsed < actualReserved) {
       return actualReserved - actualNonDfsUsed;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
@@ -499,7 +499,7 @@ public class FsVolumeImpl implements FsVolumeSpi {
         return used;
       }
     }
-    return Math.max(getDfUsed() - getDfsUsed(), 0);
+    return Math.max(getDfUsed() - getDfsUsed(), 0L);
   }
 
   /**


### PR DESCRIPTION
### Description of PR

Currently, method getActualNonDfsUsed may return negative value, which can cause getRemainingReserved computed inaccurately.

The reason is FsVolumeImpl#getDfsUsed use GetSpaceUsed to compute the usage periodically, not in time.

### How was this patch tested?
TestFsVolumeList
TestRoundRobinVolumeChoosingPolicy
TestAvailableSpaceVolumeChoosingPolicy
TestDatanodeReport
TestStorageBlockPoolUsageStdDev

