### PR TITLE
Hadoop-18759. [ABFS][Backoff-Optimization] Have a Linear retry policy for connection timeout.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -146,6 +146,22 @@ public class AbfsConfiguration{
       DefaultValue = DEFAULT_MAX_BACKOFF_INTERVAL)
   private int maxBackoffInterval;
 
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = AZURE_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED,
+      DefaultValue = DEFAULT_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED)
+  private boolean linearRetryForConnectionTimeoutEnabled;
+
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT,
+      DefaultValue = DEFAULT_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT)
+  private int minBackoffIntervalForConnectionTimeout;
+
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_MAX_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT,
+      DefaultValue = DEFAULT_MAX_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT)
+  private int maxBackoffIntervalForConnectionTimeout;
+
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = AZURE_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED,
+      DefaultValue = DEFAULT_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED)
+  private boolean linearRetryDoubleStepUpEnabled;
+
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_BACKOFF_INTERVAL,
       DefaultValue = DEFAULT_BACKOFF_INTERVAL)
   private int backoffInterval;
@@ -440,7 +456,7 @@ public class AbfsConfiguration{
    * looks for an account-agnostic value.
    * @param key Account-agnostic configuration key
    * @return value in String form if one exists, else null
-   * @throws IOException
+   * @throws java.io.IOException
    */
   public String getPasswordString(String key) throws IOException {
     char[] passchars = rawConfig.getPassword(accountConf(key));
@@ -455,12 +471,12 @@ public class AbfsConfiguration{
 
   /**
    * Returns a value for the key if the value exists and is not null.
-   * Otherwise, throws {@link ConfigurationPropertyNotFoundException} with
+   * Otherwise, throws {@link org.apache.hadoop.fs.azurebfs.contracts.exceptions.ConfigurationPropertyNotFoundException} with
    * key name.
    *
    * @param key Account-agnostic configuration key
    * @return value if exists
-   * @throws IOException if error in fetching password or
+   * @throws java.io.IOException if error in fetching password or
    *     ConfigurationPropertyNotFoundException for missing key
    */
   private String getMandatoryPasswordString(String key) throws IOException {
@@ -653,6 +669,22 @@ public class AbfsConfiguration{
 
   public int getMaxBackoffIntervalMilliseconds() {
     return this.maxBackoffInterval;
+  }
+
+  public boolean getLinearRetryForConnectionTimeoutEnabled() {
+    return linearRetryForConnectionTimeoutEnabled;
+  }
+
+  public int getMinBackoffIntervalMillisecondsForConnectionTimeout() {
+    return this.minBackoffIntervalForConnectionTimeout;
+  }
+
+  public int getMaxBackoffIntervalMillisecondsForConnectionTimeout() {
+    return this.maxBackoffIntervalForConnectionTimeout;
+  }
+
+  public boolean getLinearRetryDoubleStepUpEnabled() {
+    return linearRetryDoubleStepUpEnabled;
   }
 
   public int getBackoffIntervalMilliseconds() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -1175,6 +1175,11 @@ public class AbfsConfiguration{
     this.enableAbfsListIterator = enableAbfsListIterator;
   }
 
+  @VisibleForTesting
+  public void setLinearRetryDoubleStepUpEnabled(final boolean linearRetryDoubleStepUpEnabled) {
+    this.linearRetryDoubleStepUpEnabled = linearRetryDoubleStepUpEnabled;
+  }
+
   public boolean getRenameResilience() {
     return renameResilience;
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -150,10 +150,6 @@ public class AbfsConfiguration{
       DefaultValue = DEFAULT_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED)
   private boolean linearRetryForConnectionTimeoutEnabled;
 
-  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = AZURE_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED,
-      DefaultValue = DEFAULT_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED)
-  private boolean staticRetryForConnectionTimeoutEnabled;
-
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT,
       DefaultValue = DEFAULT_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT)
   private int minBackoffIntervalForConnectionTimeout;
@@ -165,6 +161,14 @@ public class AbfsConfiguration{
   @BooleanConfigurationValidatorAnnotation(ConfigurationKey = AZURE_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED,
       DefaultValue = DEFAULT_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED)
   private boolean linearRetryDoubleStepUpEnabled;
+
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = AZURE_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED,
+      DefaultValue = DEFAULT_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED)
+  private boolean staticRetryForConnectionTimeoutEnabled;
+
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_STATIC_RETRY_INTERVAL,
+      DefaultValue = DEFAULT_STATIC_RETRY_INTERVAL)
+  private int staticRetryInterval;
 
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_BACKOFF_INTERVAL,
       DefaultValue = DEFAULT_BACKOFF_INTERVAL)
@@ -681,6 +685,10 @@ public class AbfsConfiguration{
 
   public boolean getStaticRetryForConnectionTimeoutEnabled() {
     return staticRetryForConnectionTimeoutEnabled;
+  }
+
+  public int getStaticRetryInterval() {
+    return staticRetryInterval;
   }
 
   public int getMinBackoffIntervalMillisecondsForConnectionTimeout() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -150,6 +150,10 @@ public class AbfsConfiguration{
       DefaultValue = DEFAULT_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED)
   private boolean linearRetryForConnectionTimeoutEnabled;
 
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = AZURE_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED,
+      DefaultValue = DEFAULT_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED)
+  private boolean staticRetryForConnectionTimeoutEnabled;
+
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT,
       DefaultValue = DEFAULT_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT)
   private int minBackoffIntervalForConnectionTimeout;
@@ -673,6 +677,10 @@ public class AbfsConfiguration{
 
   public boolean getLinearRetryForConnectionTimeoutEnabled() {
     return linearRetryForConnectionTimeoutEnabled;
+  }
+
+  public boolean getStaticRetryForConnectionTimeoutEnabled() {
+    return staticRetryForConnectionTimeoutEnabled;
   }
 
   public int getMinBackoffIntervalMillisecondsForConnectionTimeout() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -456,7 +456,7 @@ public class AbfsConfiguration{
    * looks for an account-agnostic value.
    * @param key Account-agnostic configuration key
    * @return value in String form if one exists, else null
-   * @throws java.io.IOException
+   * @throws IOException
    */
   public String getPasswordString(String key) throws IOException {
     char[] passchars = rawConfig.getPassword(accountConf(key));
@@ -471,12 +471,12 @@ public class AbfsConfiguration{
 
   /**
    * Returns a value for the key if the value exists and is not null.
-   * Otherwise, throws {@link org.apache.hadoop.fs.azurebfs.contracts.exceptions.ConfigurationPropertyNotFoundException} with
+   * Otherwise, throws {@link ConfigurationPropertyNotFoundException} with
    * key name.
    *
    * @param key Account-agnostic configuration key
    * @return value if exists
-   * @throws java.io.IOException if error in fetching password or
+   * @throws IOException if error in fetching password or
    *     ConfigurationPropertyNotFoundException for missing key
    */
   private String getMandatoryPasswordString(String key) throws IOException {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -893,7 +893,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * @param destination destination of rename.
    * @param tracingContext trace context
    * @param sourceEtag etag of source file. may be null or empty
-   * @throws org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException failure, excluding any recovery from overload failures.
+   * @throws AzureBlobFileSystemException failure, excluding any recovery from overload failures.
    * @return true if recovery was needed and succeeded.
    */
   public boolean rename(final Path source,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -56,6 +56,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.fs.azurebfs.services.LinearRetryPolicy;
+import org.apache.hadoop.fs.azurebfs.services.StaticRetryPolicy;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.Futures;
@@ -1645,6 +1646,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             new ExponentialRetryPolicy(abfsConfiguration))
         .withLinearRetryPolicy(
             new LinearRetryPolicy(abfsConfiguration))
+        .withStaticRetryPolicy(
+            new StaticRetryPolicy(abfsConfiguration))
         .withAbfsCounters(abfsCounters)
         .withAbfsPerfTracker(abfsPerfTracker)
         .build();

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -191,11 +191,11 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   private ExecutorService boundedThreadPool;
 
   /**
-   * FileSystem Store for {@link org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem} for Abfs operations.
-   * Built using the {@link org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore.AzureBlobFileSystemStoreBuilder} with parameters
+   * FileSystem Store for {@link AzureBlobFileSystem} for Abfs operations.
+   * Built using the {@link AzureBlobFileSystemStoreBuilder} with parameters
    * required.
    * @param abfsStoreBuilder Builder for AzureBlobFileSystemStore.
-   * @throws java.io.IOException Throw IOE in case of failure during constructing.
+   * @throws IOException Throw IOE in case of failure during constructing.
    */
   public AzureBlobFileSystemStore(
       AzureBlobFileSystemStoreBuilder abfsStoreBuilder) throws IOException {
@@ -604,7 +604,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * @param umask
    * @param isAppendBlob
    * @return
-   * @throws org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException
+   * @throws AzureBlobFileSystemException
    */
   private AbfsRestOperation conditionalCreateOverwriteFile(final String relativePath,
       final FileSystem.Statistics statistics,
@@ -667,7 +667,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
   /**
    * Method to populate AbfsOutputStreamContext with different parameters to
-   * be used to construct {@link org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream}.
+   * be used to construct {@link AbfsOutputStream}.
    *
    * @param isAppendBlob   is Append blob support enabled?
    * @param lease          instance of AbfsLease for this AbfsOutputStream.
@@ -876,7 +876,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    *
    * @param path file name
    * @param tracingContext TracingContext instance to track correlation IDs
-   * @throws org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException on any exception while breaking the lease
+   * @throws AzureBlobFileSystemException on any exception while breaking the lease
    */
   public void breakLease(final Path path, final TracingContext tracingContext) throws AzureBlobFileSystemException {
     LOG.debug("lease path: {}", path);
@@ -1574,7 +1574,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * @param accountName    Name of the account being used to access Azure
    *                       data store.
    * @param isSecure       Tells if https is being used or http.
-   * @throws java.io.IOException
+   * @throws IOException
    */
   private void initializeClient(URI uri, String fileSystemName,
       String accountName, boolean isSecure)

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -55,6 +55,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.fs.azurebfs.services.LinearRetryPolicy;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.Futures;
@@ -190,11 +191,11 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   private ExecutorService boundedThreadPool;
 
   /**
-   * FileSystem Store for {@link AzureBlobFileSystem} for Abfs operations.
-   * Built using the {@link AzureBlobFileSystemStoreBuilder} with parameters
+   * FileSystem Store for {@link org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem} for Abfs operations.
+   * Built using the {@link org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore.AzureBlobFileSystemStoreBuilder} with parameters
    * required.
    * @param abfsStoreBuilder Builder for AzureBlobFileSystemStore.
-   * @throws IOException Throw IOE in case of failure during constructing.
+   * @throws java.io.IOException Throw IOE in case of failure during constructing.
    */
   public AzureBlobFileSystemStore(
       AzureBlobFileSystemStoreBuilder abfsStoreBuilder) throws IOException {
@@ -603,7 +604,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * @param umask
    * @param isAppendBlob
    * @return
-   * @throws AzureBlobFileSystemException
+   * @throws org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException
    */
   private AbfsRestOperation conditionalCreateOverwriteFile(final String relativePath,
       final FileSystem.Statistics statistics,
@@ -666,7 +667,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
   /**
    * Method to populate AbfsOutputStreamContext with different parameters to
-   * be used to construct {@link AbfsOutputStream}.
+   * be used to construct {@link org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream}.
    *
    * @param isAppendBlob   is Append blob support enabled?
    * @param lease          instance of AbfsLease for this AbfsOutputStream.
@@ -875,7 +876,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    *
    * @param path file name
    * @param tracingContext TracingContext instance to track correlation IDs
-   * @throws AzureBlobFileSystemException on any exception while breaking the lease
+   * @throws org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException on any exception while breaking the lease
    */
   public void breakLease(final Path path, final TracingContext tracingContext) throws AzureBlobFileSystemException {
     LOG.debug("lease path: {}", path);
@@ -892,7 +893,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * @param destination destination of rename.
    * @param tracingContext trace context
    * @param sourceEtag etag of source file. may be null or empty
-   * @throws AzureBlobFileSystemException failure, excluding any recovery from overload failures.
+   * @throws org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException failure, excluding any recovery from overload failures.
    * @return true if recovery was needed and succeeded.
    */
   public boolean rename(final Path source,
@@ -1573,7 +1574,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * @param accountName    Name of the account being used to access Azure
    *                       data store.
    * @param isSecure       Tells if https is being used or http.
-   * @throws IOException
+   * @throws java.io.IOException
    */
   private void initializeClient(URI uri, String fileSystemName,
       String accountName, boolean isSecure)
@@ -1642,6 +1643,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     return new AbfsClientContextBuilder()
         .withExponentialRetryPolicy(
             new ExponentialRetryPolicy(abfsConfiguration))
+        .withLinearRetryPolicy(
+            new LinearRetryPolicy(abfsConfiguration))
         .withAbfsCounters(abfsCounters)
         .withAbfsPerfTracker(abfsPerfTracker)
         .build();

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -74,7 +74,7 @@ public final class ConfigurationKeys {
    * This stops a single stream overloading the shared thread pool.
    * {@value}
    * <p>
-   * Default is {@link org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations#BLOCK_UPLOAD_ACTIVE_BLOCKS_DEFAULT}
+   * Default is {@link FileSystemConfigurations#BLOCK_UPLOAD_ACTIVE_BLOCKS_DEFAULT}
    */
   public static final String FS_AZURE_BLOCK_UPLOAD_ACTIVE_BLOCKS =
       "fs.azure.block.upload.active.blocks";
@@ -91,7 +91,7 @@ public final class ConfigurationKeys {
    * <br>
    * Options include: "disk"(Default), "array", and "bytebuffer".
    * <br>
-   * Default is {@link org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations#DATA_BLOCKS_BUFFER_DEFAULT}.
+   * Default is {@link FileSystemConfigurations#DATA_BLOCKS_BUFFER_DEFAULT}.
    * Value: {@value}
    */
   public static final String DATA_BLOCKS_BUFFER =
@@ -112,7 +112,7 @@ public final class ConfigurationKeys {
 
   /**
    * Read ahead range parameter which can be set by user.
-   * Default value is {@link org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations#DEFAULT_READ_AHEAD_RANGE}.
+   * Default value is {@link FileSystemConfigurations#DEFAULT_READ_AHEAD_RANGE}.
    * This might reduce number of calls to remote as next requested
    * data could already be present in buffer {@value}.
    */
@@ -268,7 +268,7 @@ public final class ConfigurationKeys {
    * Optional config to enable a lock free pread which will bypass buffer in AbfsInputStream.
    * This is not a config which can be set at cluster level. It can be used as
    * an option on FutureDataInputStreamBuilder.
-   * @see org.apache.hadoop.fs.FileSystem#openFile(org.apache.hadoop.fs.Path)
+   * @see FileSystem#openFile(org.apache.hadoop.fs.Path)
    */
   public static final String FS_AZURE_BUFFERED_PREAD_DISABLE = "fs.azure.buffered.pread.disable";
   private ConfigurationKeys() {}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -49,6 +49,7 @@ public final class ConfigurationKeys {
   public static final String AZURE_MIN_BACKOFF_INTERVAL = "fs.azure.io.retry.min.backoff.interval";
   public static final String AZURE_MAX_BACKOFF_INTERVAL = "fs.azure.io.retry.max.backoff.interval";
   public static final String AZURE_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = "fs.azure.linear.retry.for.connection.timeout.enabled";
+  public static final String AZURE_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = "fs.azure.static.retry.for.connection.timeout.enabled";
   public static final String AZURE_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = "fs.azure.io.retry.min.backoff.interval.for.connection.timeout";
   public static final String AZURE_MAX_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = "fs.azure.io.retry.max.backoff.interval.for.connection.timeout";
   public static final String AZURE_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED = "fs.azure.linear.retry.double.step.up.enabled";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -49,10 +49,11 @@ public final class ConfigurationKeys {
   public static final String AZURE_MIN_BACKOFF_INTERVAL = "fs.azure.io.retry.min.backoff.interval";
   public static final String AZURE_MAX_BACKOFF_INTERVAL = "fs.azure.io.retry.max.backoff.interval";
   public static final String AZURE_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = "fs.azure.linear.retry.for.connection.timeout.enabled";
-  public static final String AZURE_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = "fs.azure.static.retry.for.connection.timeout.enabled";
   public static final String AZURE_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = "fs.azure.io.retry.min.backoff.interval.for.connection.timeout";
   public static final String AZURE_MAX_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = "fs.azure.io.retry.max.backoff.interval.for.connection.timeout";
   public static final String AZURE_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED = "fs.azure.linear.retry.double.step.up.enabled";
+  public static final String AZURE_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = "fs.azure.static.retry.for.connection.timeout.enabled";
+  public static final String AZURE_STATIC_RETRY_INTERVAL = "fs.azure.static.retry.interval";
   public static final String AZURE_BACKOFF_INTERVAL = "fs.azure.io.retry.backoff.interval";
   public static final String AZURE_MAX_IO_RETRIES = "fs.azure.io.retry.max.retries";
   public static final String AZURE_CUSTOM_TOKEN_FETCH_RETRY_COUNT = "fs.azure.custom.token.fetch.retry.count";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -48,6 +48,10 @@ public final class ConfigurationKeys {
   // Retry strategy defined by the user
   public static final String AZURE_MIN_BACKOFF_INTERVAL = "fs.azure.io.retry.min.backoff.interval";
   public static final String AZURE_MAX_BACKOFF_INTERVAL = "fs.azure.io.retry.max.backoff.interval";
+  public static final String AZURE_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = "fs.azure.linear.retry.for.connection.timeout.enabled";
+  public static final String AZURE_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = "fs.azure.io.retry.min.backoff.interval.for.connection.timeout";
+  public static final String AZURE_MAX_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = "fs.azure.io.retry.max.backoff.interval.for.connection.timeout";
+  public static final String AZURE_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED = "fs.azure.linear.retry.double.step.up.enabled";
   public static final String AZURE_BACKOFF_INTERVAL = "fs.azure.io.retry.backoff.interval";
   public static final String AZURE_MAX_IO_RETRIES = "fs.azure.io.retry.max.retries";
   public static final String AZURE_CUSTOM_TOKEN_FETCH_RETRY_COUNT = "fs.azure.custom.token.fetch.retry.count";
@@ -70,7 +74,7 @@ public final class ConfigurationKeys {
    * This stops a single stream overloading the shared thread pool.
    * {@value}
    * <p>
-   * Default is {@link FileSystemConfigurations#BLOCK_UPLOAD_ACTIVE_BLOCKS_DEFAULT}
+   * Default is {@link org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations#BLOCK_UPLOAD_ACTIVE_BLOCKS_DEFAULT}
    */
   public static final String FS_AZURE_BLOCK_UPLOAD_ACTIVE_BLOCKS =
       "fs.azure.block.upload.active.blocks";
@@ -87,7 +91,7 @@ public final class ConfigurationKeys {
    * <br>
    * Options include: "disk"(Default), "array", and "bytebuffer".
    * <br>
-   * Default is {@link FileSystemConfigurations#DATA_BLOCKS_BUFFER_DEFAULT}.
+   * Default is {@link org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations#DATA_BLOCKS_BUFFER_DEFAULT}.
    * Value: {@value}
    */
   public static final String DATA_BLOCKS_BUFFER =
@@ -108,7 +112,7 @@ public final class ConfigurationKeys {
 
   /**
    * Read ahead range parameter which can be set by user.
-   * Default value is {@link FileSystemConfigurations#DEFAULT_READ_AHEAD_RANGE}.
+   * Default value is {@link org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations#DEFAULT_READ_AHEAD_RANGE}.
    * This might reduce number of calls to remote as next requested
    * data could already be present in buffer {@value}.
    */
@@ -264,7 +268,7 @@ public final class ConfigurationKeys {
    * Optional config to enable a lock free pread which will bypass buffer in AbfsInputStream.
    * This is not a config which can be set at cluster level. It can be used as
    * an option on FutureDataInputStreamBuilder.
-   * @see FileSystem#openFile(org.apache.hadoop.fs.Path)
+   * @see org.apache.hadoop.fs.FileSystem#openFile(org.apache.hadoop.fs.Path)
    */
   public static final String FS_AZURE_BUFFERED_PREAD_DISABLE = "fs.azure.buffered.pread.disable";
   private ConfigurationKeys() {}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -41,6 +41,7 @@ public final class FileSystemConfigurations {
   public static final int DEFAULT_MIN_BACKOFF_INTERVAL = 3 * 1000;  // 3s
   public static final int DEFAULT_MAX_BACKOFF_INTERVAL = 30 * 1000;  // 30s
   public static final boolean DEFAULT_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = true;
+  public static final boolean DEFAULT_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = true;
   public static final int DEFAULT_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = 500;  // 500ms
   public static final int DEFAULT_MAX_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = 30 * 1000;  // 30s
   public static final boolean DEFAULT_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED = true;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -42,6 +42,7 @@ public final class FileSystemConfigurations {
   public static final int DEFAULT_MAX_BACKOFF_INTERVAL = 30 * 1000;  // 30s
   public static final boolean DEFAULT_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = true;
   public static final boolean DEFAULT_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = true;
+  public static final int DEFAULT_STATIC_RETRY_INTERVAL = 2 * 1000; // 2s
   public static final int DEFAULT_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = 500;  // 500ms
   public static final int DEFAULT_MAX_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = 30 * 1000;  // 30s
   public static final boolean DEFAULT_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED = true;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -40,10 +40,10 @@ public final class FileSystemConfigurations {
   // Retry parameter defaults.
   public static final int DEFAULT_MIN_BACKOFF_INTERVAL = 3 * 1000;  // 3s
   public static final int DEFAULT_MAX_BACKOFF_INTERVAL = 30 * 1000;  // 30s
-  public static final boolean DEFAULT_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = false;
+  public static final boolean DEFAULT_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = true;
   public static final int DEFAULT_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = 500;  // 500ms
   public static final int DEFAULT_MAX_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = 30 * 1000;  // 30s
-  public static final boolean DEFAULT_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED = false;
+  public static final boolean DEFAULT_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED = true;
   public static final int DEFAULT_BACKOFF_INTERVAL = 3 * 1000;  // 3s
   public static final int DEFAULT_MAX_RETRY_ATTEMPTS = 30;
   public static final int DEFAULT_CUSTOM_TOKEN_FETCH_RETRY_COUNT = 3;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -40,6 +40,10 @@ public final class FileSystemConfigurations {
   // Retry parameter defaults.
   public static final int DEFAULT_MIN_BACKOFF_INTERVAL = 3 * 1000;  // 3s
   public static final int DEFAULT_MAX_BACKOFF_INTERVAL = 30 * 1000;  // 30s
+  public static final boolean DEFAULT_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = false;
+  public static final int DEFAULT_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = 500;  // 500ms
+  public static final int DEFAULT_MAX_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = 30 * 1000;  // 30s
+  public static final boolean DEFAULT_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED = false;
   public static final int DEFAULT_BACKOFF_INTERVAL = 3 * 1000;  // 3s
   public static final int DEFAULT_MAX_RETRY_ATTEMPTS = 30;
   public static final int DEFAULT_CUSTOM_TOKEN_FETCH_RETRY_COUNT = 3;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/InternalConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/InternalConstants.java
@@ -43,4 +43,8 @@ public final class InternalConstants {
    */
   public static final String CAPABILITY_SAFE_READAHEAD =
       "fs.azure.capability.readahead.safe";
+
+  public static final String EXPONENTIAL_RETRY_POLICY = "Exponential Retry Policy";
+  public static final String STATIC_RETRY_POLICY = "Static Retry Policy";
+  public static final String LINEAR_RETRY_POLICY = "Linear Retry Policy";
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -229,10 +229,12 @@ public class AbfsClient implements Closeable {
   }
 
   public RetryPolicy getRetryPolicy(final String failureReason) {
-    if (failureReason == null || !failureReason.equals(CONNECTION_TIMEOUT_ABBREVIATION))
-      return getExponentialRetryPolicy();
-    else
+    if (CONNECTION_TIMEOUT_ABBREVIATION.equals(failureReason)) {
       return getLinearRetryPolicy();
+    }
+    else {
+      return getExponentialRetryPolicy();
+    }
   }
 
   SharedKeyCredentials getSharedKeyCredentials() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -229,7 +229,8 @@ public class AbfsClient implements Closeable {
   }
 
   public RetryPolicy getRetryPolicy(final String failureReason) {
-    if (CONNECTION_TIMEOUT_ABBREVIATION.equals(failureReason)) {
+    if (CONNECTION_TIMEOUT_ABBREVIATION.equals(failureReason)
+      && getAbfsConfiguration().getLinearRetryForConnectionTimeoutEnabled()) {
       return getLinearRetryPolicy();
     }
     else {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -92,6 +92,7 @@ public class AbfsClient implements Closeable {
   private final SharedKeyCredentials sharedKeyCredentials;
   private final String xMsVersion = "2019-12-12";
   private final ExponentialRetryPolicy retryPolicy;
+  private final LinearRetryPolicy linearRetryPolicy;
   private final String filesystem;
   private final AbfsConfiguration abfsConfiguration;
   private final String userAgent;
@@ -125,6 +126,7 @@ public class AbfsClient implements Closeable {
     this.filesystem = baseUrlString.substring(baseUrlString.lastIndexOf(FORWARD_SLASH) + 1);
     this.abfsConfiguration = abfsConfiguration;
     this.retryPolicy = abfsClientContext.getExponentialRetryPolicy();
+    this.linearRetryPolicy = abfsClientContext.getLinearRetryPolicy();
     this.accountName = abfsConfiguration.getAccountName().substring(0, abfsConfiguration.getAccountName().indexOf(AbfsHttpConstants.DOT));
     this.authType = abfsConfiguration.getAuthType(accountName);
     this.intercept = AbfsThrottlingInterceptFactory.getInstance(accountName, abfsConfiguration);
@@ -219,6 +221,10 @@ public class AbfsClient implements Closeable {
 
   ExponentialRetryPolicy getRetryPolicy() {
     return retryPolicy;
+  }
+
+  public LinearRetryPolicy getLinearRetryPolicy() {
+    return linearRetryPolicy;
   }
 
   SharedKeyCredentials getSharedKeyCredentials() {
@@ -521,7 +527,7 @@ public class AbfsClient implements Closeable {
    * @param isNamespaceEnabled        whether namespace enabled account or not
    * @return AbfsClientRenameResult result of rename operation indicating the
    * AbfsRest operation, rename recovery and incomplete metadata state failure.
-   * @throws AzureBlobFileSystemException failure, excluding any recovery from overload failures.
+   * @throws org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException failure, excluding any recovery from overload failures.
    */
   public AbfsClientRenameResult renamePath(
           final String source,
@@ -1190,8 +1196,8 @@ public class AbfsClient implements Closeable {
    * @param path  Path for which access check needs to be performed
    * @param rwx   The permission to be checked on the path
    * @param tracingContext Tracks identifiers for request header
-   * @return      The {@link AbfsRestOperation} object for the operation
-   * @throws AzureBlobFileSystemException in case of bad requests
+   * @return      The {@link org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation} object for the operation
+   * @throws org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException in case of bad requests
    */
   public AbfsRestOperation checkAccess(String path, String rwx, TracingContext tracingContext)
       throws AzureBlobFileSystemException {
@@ -1232,7 +1238,7 @@ public class AbfsClient implements Closeable {
    * @param operation
    * @param queryBuilder
    * @return sasToken - returned for optional re-use.
-   * @throws SASTokenProviderException
+   * @throws org.apache.hadoop.fs.azurebfs.contracts.exceptions.SASTokenProviderException
    */
   private String appendSASTokenToQuery(String path, String operation, AbfsUriQueryBuilder queryBuilder) throws SASTokenProviderException {
     return appendSASTokenToQuery(path, operation, queryBuilder, null);
@@ -1245,7 +1251,7 @@ public class AbfsClient implements Closeable {
    * @param queryBuilder
    * @param cachedSasToken - previously acquired SAS token to be reused.
    * @return sasToken - returned for optional re-use.
-   * @throws SASTokenProviderException
+   * @throws org.apache.hadoop.fs.azurebfs.contracts.exceptions.SASTokenProviderException
    */
   private String appendSASTokenToQuery(String path,
                                        String operation,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -527,7 +527,7 @@ public class AbfsClient implements Closeable {
    * @param isNamespaceEnabled        whether namespace enabled account or not
    * @return AbfsClientRenameResult result of rename operation indicating the
    * AbfsRest operation, rename recovery and incomplete metadata state failure.
-   * @throws org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException failure, excluding any recovery from overload failures.
+   * @throws AzureBlobFileSystemException failure, excluding any recovery from overload failures.
    */
   public AbfsClientRenameResult renamePath(
           final String source,
@@ -1196,8 +1196,8 @@ public class AbfsClient implements Closeable {
    * @param path  Path for which access check needs to be performed
    * @param rwx   The permission to be checked on the path
    * @param tracingContext Tracks identifiers for request header
-   * @return      The {@link org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation} object for the operation
-   * @throws org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException in case of bad requests
+   * @return      The {@link AbfsRestOperation} object for the operation
+   * @throws AzureBlobFileSystemException in case of bad requests
    */
   public AbfsRestOperation checkAccess(String path, String rwx, TracingContext tracingContext)
       throws AzureBlobFileSystemException {
@@ -1238,7 +1238,7 @@ public class AbfsClient implements Closeable {
    * @param operation
    * @param queryBuilder
    * @return sasToken - returned for optional re-use.
-   * @throws org.apache.hadoop.fs.azurebfs.contracts.exceptions.SASTokenProviderException
+   * @throws SASTokenProviderException
    */
   private String appendSASTokenToQuery(String path, String operation, AbfsUriQueryBuilder queryBuilder) throws SASTokenProviderException {
     return appendSASTokenToQuery(path, operation, queryBuilder, null);
@@ -1251,7 +1251,7 @@ public class AbfsClient implements Closeable {
    * @param queryBuilder
    * @param cachedSasToken - previously acquired SAS token to be reused.
    * @return sasToken - returned for optional re-use.
-   * @throws org.apache.hadoop.fs.azurebfs.contracts.exceptions.SASTokenProviderException
+   * @throws SASTokenProviderException
    */
   private String appendSASTokenToQuery(String path,
                                        String operation,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContext.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
+import javax.sound.sampled.Line;
+
 /**
  * Class to hold extra configurations for AbfsClient and further classes
  * inside AbfsClient.
@@ -25,20 +27,27 @@ package org.apache.hadoop.fs.azurebfs.services;
 public class AbfsClientContext {
 
   private final ExponentialRetryPolicy exponentialRetryPolicy;
+  private final LinearRetryPolicy linearRetryPolicy;
   private final AbfsPerfTracker abfsPerfTracker;
   private final AbfsCounters abfsCounters;
 
   AbfsClientContext(
       ExponentialRetryPolicy exponentialRetryPolicy,
+      LinearRetryPolicy linearRetryPolicy,
       AbfsPerfTracker abfsPerfTracker,
       AbfsCounters abfsCounters) {
     this.exponentialRetryPolicy = exponentialRetryPolicy;
+    this.linearRetryPolicy = linearRetryPolicy;
     this.abfsPerfTracker = abfsPerfTracker;
     this.abfsCounters = abfsCounters;
   }
 
   public ExponentialRetryPolicy getExponentialRetryPolicy() {
     return exponentialRetryPolicy;
+  }
+
+  public LinearRetryPolicy getLinearRetryPolicy() {
+    return linearRetryPolicy;
   }
 
   public AbfsPerfTracker getAbfsPerfTracker() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContext.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
-import javax.sound.sampled.Line;
-
 /**
  * Class to hold extra configurations for AbfsClient and further classes
  * inside AbfsClient.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContext.java
@@ -26,16 +26,19 @@ public class AbfsClientContext {
 
   private final ExponentialRetryPolicy exponentialRetryPolicy;
   private final LinearRetryPolicy linearRetryPolicy;
+  private final StaticRetryPolicy staticRetryPolicy;
   private final AbfsPerfTracker abfsPerfTracker;
   private final AbfsCounters abfsCounters;
 
   AbfsClientContext(
       ExponentialRetryPolicy exponentialRetryPolicy,
       LinearRetryPolicy linearRetryPolicy,
+      StaticRetryPolicy staticRetryPolicy,
       AbfsPerfTracker abfsPerfTracker,
       AbfsCounters abfsCounters) {
     this.exponentialRetryPolicy = exponentialRetryPolicy;
     this.linearRetryPolicy = linearRetryPolicy;
+    this.staticRetryPolicy = staticRetryPolicy;
     this.abfsPerfTracker = abfsPerfTracker;
     this.abfsCounters = abfsCounters;
   }
@@ -46,6 +49,10 @@ public class AbfsClientContext {
 
   public LinearRetryPolicy getLinearRetryPolicy() {
     return linearRetryPolicy;
+  }
+
+  public StaticRetryPolicy getStaticRetryPolicy() {
+    return staticRetryPolicy;
   }
 
   public AbfsPerfTracker getAbfsPerfTracker() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContextBuilder.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContextBuilder.java
@@ -59,7 +59,10 @@ public class AbfsClientContextBuilder {
    */
   public AbfsClientContext build() {
     //validate the values
-    return new AbfsClientContext(exponentialRetryPolicy, linearRetryPolicy, abfsPerfTracker,
+    return new AbfsClientContext(
+        exponentialRetryPolicy,
+        linearRetryPolicy,
+        abfsPerfTracker,
         abfsCounters);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContextBuilder.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContextBuilder.java
@@ -26,6 +26,7 @@ public class AbfsClientContextBuilder {
 
   private ExponentialRetryPolicy exponentialRetryPolicy;
   private LinearRetryPolicy linearRetryPolicy;
+  private StaticRetryPolicy staticRetryPolicy;
   private AbfsPerfTracker abfsPerfTracker;
   private AbfsCounters abfsCounters;
 
@@ -38,6 +39,12 @@ public class AbfsClientContextBuilder {
   public AbfsClientContextBuilder withLinearRetryPolicy(
       final LinearRetryPolicy linearRetryPolicy) {
     this.linearRetryPolicy = linearRetryPolicy;
+    return this;
+  }
+
+  public AbfsClientContextBuilder withStaticRetryPolicy(
+      final StaticRetryPolicy staticRetryPolicy) {
+    this.staticRetryPolicy = staticRetryPolicy;
     return this;
   }
 
@@ -62,6 +69,7 @@ public class AbfsClientContextBuilder {
     return new AbfsClientContext(
         exponentialRetryPolicy,
         linearRetryPolicy,
+        staticRetryPolicy,
         abfsPerfTracker,
         abfsCounters);
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContextBuilder.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContextBuilder.java
@@ -25,12 +25,19 @@ package org.apache.hadoop.fs.azurebfs.services;
 public class AbfsClientContextBuilder {
 
   private ExponentialRetryPolicy exponentialRetryPolicy;
+  private LinearRetryPolicy linearRetryPolicy;
   private AbfsPerfTracker abfsPerfTracker;
   private AbfsCounters abfsCounters;
 
   public AbfsClientContextBuilder withExponentialRetryPolicy(
       final ExponentialRetryPolicy exponentialRetryPolicy) {
     this.exponentialRetryPolicy = exponentialRetryPolicy;
+    return this;
+  }
+
+  public AbfsClientContextBuilder withLinearRetryPolicy(
+      final LinearRetryPolicy linearRetryPolicy) {
+    this.linearRetryPolicy = linearRetryPolicy;
     return this;
   }
 
@@ -52,7 +59,7 @@ public class AbfsClientContextBuilder {
    */
   public AbfsClientContext build() {
     //validate the values
-    return new AbfsClientContext(exponentialRetryPolicy, abfsPerfTracker,
+    return new AbfsClientContext(exponentialRetryPolicy, linearRetryPolicy, abfsPerfTracker,
         abfsCounters);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsHttpOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsHttpOperation.java
@@ -66,7 +66,7 @@ public class AbfsHttpOperation implements AbfsPerfLoggable {
   private String maskedEncodedUrl;
 
   private HttpURLConnection connection;
-  private int statusCode;
+  private int statusCode = -1;
   private String statusDescription;
   private String storageErrorCode = "";
   private String storageErrorMessage  = "";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsHttpOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsHttpOperation.java
@@ -66,7 +66,7 @@ public class AbfsHttpOperation implements AbfsPerfLoggable {
   private String maskedEncodedUrl;
 
   private HttpURLConnection connection;
-  private int statusCode = -1;
+  private int statusCode;
   private String statusDescription;
   private String storageErrorCode = "";
   private String storageErrorMessage  = "";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -238,7 +238,7 @@ public class AbfsRestOperation {
         ++retryCount;
         tracingContext.setRetryCount(retryCount);
         long retryInterval = retryPolicy.getRetryInterval(retryCount);
-        LOG.debug("Rest operation {} failed. failureReason: {}, retryCount = {}, retryPolicy: {}, sleepInterval: {}",
+        LOG.debug("Rest operation {} failed with failureReason: {}. Retrying with retryCount = {}, retryPolicy: {} and sleepInterval: {}",
             operationType, failureReason, retryCount, getRetryPolicyStr(retryPolicy), retryInterval);
         Thread.sleep(retryInterval);
       } catch (InterruptedException ex) {
@@ -433,6 +433,11 @@ public class AbfsRestOperation {
     }
   }
 
+  /**
+   * Utility function to get the retry policy used as String for logging purpose.
+   * @param retryPolicy
+   * @return Retry Policy as String
+   */
   @VisibleForTesting
   String getRetryPolicyStr(final RetryPolicy retryPolicy) {
     if (retryPolicy instanceof StaticRetryPolicy) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -226,6 +226,7 @@ public class AbfsRestOperation {
       requestHeaders.add(httpHeader);
     }
 
+    // By Default Exponential Retry Policy Will be used
     retryCount = 0;
     retryPolicy = client.getExponentialRetryPolicy();
     LOG.debug("First execution of REST operation - {}", operationType);
@@ -233,9 +234,10 @@ public class AbfsRestOperation {
       try {
         ++retryCount;
         tracingContext.setRetryCount(retryCount);
-        LOG.debug("Retrying REST operation {}. RetryCount = {}",
-            operationType, retryCount);
-        Thread.sleep(retryPolicy.getRetryInterval(retryCount));
+        long retryInterval = retryPolicy.getRetryInterval(retryCount);
+        LOG.debug("Rest operation {} failed. failureReason: {}, retryCount = {}, retryPolicy: {}, sleepInterval: {}",
+            operationType, failureReason, retryCount, getRetryPolicyStr(), retryInterval);
+        Thread.sleep(retryInterval);
       } catch (InterruptedException ex) {
         Thread.currentThread().interrupt();
       }
@@ -426,5 +428,9 @@ public class AbfsRestOperation {
     if (abfsCounters != null) {
       abfsCounters.incrementCounter(statistic, value);
     }
+  }
+
+  private String getRetryPolicyStr() {
+    return "RetryPolicy";
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding;
 
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_CONTINUE;
-import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_TIMEOUT_ABBREVIATION;
 
 /**
  * The AbfsRestOperation for Rest AbfsClient.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -369,7 +369,7 @@ public class AbfsRestOperation {
    * Sign an operation.
    * @param httpOperation operation to sign
    * @param bytesToSign how many bytes to sign for shared key auth.
-   * @throws java.io.IOException failure
+   * @throws IOException failure
    */
   @VisibleForTesting
   public void signRequest(final AbfsHttpOperation httpOperation, int bytesToSign) throws IOException {
@@ -397,7 +397,7 @@ public class AbfsRestOperation {
   }
 
   /**
-   * Creates new object of {@link org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation} with the url, method, and
+   * Creates new object of {@link AbfsHttpOperation} with the url, method, and
    * requestHeaders fields of the AbfsRestOperation object.
    */
   @VisibleForTesting

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
@@ -120,6 +120,7 @@ public class ExponentialRetryPolicy extends RetryPolicy {
    * @param retryCount The current retry attempt count.
    * @return backoff Interval time
    */
+  @Override
   public long getRetryInterval(final int retryCount) {
     final long boundedRandDelta = (int) (this.deltaBackoff * MIN_RANDOM_RATIO)
         + this.randRef.nextInt((int) (this.deltaBackoff * MAX_RANDOM_RATIO)

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
@@ -29,7 +29,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_CON
 /**
  * Retry policy used by AbfsClient.
  * */
-public class ExponentialRetryPolicy extends RetryPolicy{
+public class ExponentialRetryPolicy extends RetryPolicy {
   /**
    * Represents the default amount of time used when calculating a random delta in the exponential
    * delay between retries.
@@ -79,11 +79,6 @@ public class ExponentialRetryPolicy extends RetryPolicy{
   private final int minBackoff;
 
   /**
-   * The maximum number of retry attempts.
-   */
-  private final int retryCount;
-
-  /**
    * Initializes a new instance of the {@link ExponentialRetryPolicy} class.
    */
   public ExponentialRetryPolicy(final int maxIoRetries) {
@@ -105,36 +100,17 @@ public class ExponentialRetryPolicy extends RetryPolicy{
   /**
    * Initializes a new instance of the {@link ExponentialRetryPolicy} class.
    *
-   * @param retryCount The maximum number of retry attempts.
+   * @param maxRetryCount The maximum number of retry attempts.
    * @param minBackoff The minimum backoff time.
    * @param maxBackoff The maximum backoff time.
    * @param deltaBackoff The value that will be used to calculate a random delta in the exponential delay
    *                     between retries.
    */
-  public ExponentialRetryPolicy(final int retryCount, final int minBackoff, final int maxBackoff, final int deltaBackoff) {
-    this.retryCount = retryCount;
+  public ExponentialRetryPolicy(final int maxRetryCount, final int minBackoff, final int maxBackoff, final int deltaBackoff) {
+    super(maxRetryCount);
     this.minBackoff = minBackoff;
     this.maxBackoff = maxBackoff;
     this.deltaBackoff = deltaBackoff;
-  }
-
-  /**
-   * Returns if a request should be retried based on the retry count, current response,
-   * and the current strategy. The valid http status code lies in the range of 1xx-5xx.
-   * But an invalid status code might be set due to network or timeout kind of issues.
-   * Such invalid status code also qualify for retry.
-   *
-   * @param retryCount The current retry attempt count.
-   * @param statusCode The status code of the response, or -1 for socket error.
-   * @return true if the request should be retried; false otherwise.
-   */
-  public boolean shouldRetry(final int retryCount, final int statusCode) {
-    return retryCount < this.retryCount
-        && (statusCode < HTTP_CONTINUE
-        || statusCode == HttpURLConnection.HTTP_CLIENT_TIMEOUT
-        || (statusCode >= HttpURLConnection.HTTP_INTERNAL_ERROR
-            && statusCode != HttpURLConnection.HTTP_NOT_IMPLEMENTED
-            && statusCode != HttpURLConnection.HTTP_VERSION));
   }
 
   /**
@@ -154,11 +130,6 @@ public class ExponentialRetryPolicy extends RetryPolicy{
     final long retryInterval = (int) Math.round(Math.min(this.minBackoff + incrementDelta, maxBackoff));
 
     return retryInterval;
-  }
-
-  @VisibleForTesting
-  int getRetryCount() {
-    return this.retryCount;
   }
 
   @VisibleForTesting

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
@@ -29,7 +29,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_CON
 /**
  * Retry policy used by AbfsClient.
  * */
-public class ExponentialRetryPolicy {
+public class ExponentialRetryPolicy extends RetryPolicy{
   /**
    * Represents the default amount of time used when calculating a random delta in the exponential
    * delay between retries.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/LinearRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/LinearRetryPolicy.java
@@ -18,35 +18,29 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
-import java.net.HttpURLConnection;
-
-import org.checkerframework.checker.units.qual.min;
-
 import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
 import org.apache.hadoop.classification.VisibleForTesting;
 
-import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_CONTINUE;
-
 /**
- * Retry policy used by AbfsClient.
+ * Linear Retry policy used by AbfsClient.
  * */
 public class LinearRetryPolicy extends RetryPolicy{
   
   /**
-   * Represents the default maximum amount of time used when calculating the exponential
-   * delay between retries.
+   * Represents the default maximum amount of time used when calculating the
+   * linear delay between retries.
    */
   private static final int DEFAULT_MAX_BACKOFF = 1000 * 30; // 30s
 
   /**
-   * Represents the default minimum amount of time used when calculating the exponential
-   * delay between retries.
+   * Represents the default minimum amount of time used when calculating the
+   * linear delay between retries.
    */
   private static final int DEFAULT_MIN_BACKOFF = 500 * 1; // 500ms
 
   /**
-   * Represents the default minimum amount of time used when calculating the exponential
-   * delay between retries.
+   * Represents the delta by which retry interval should be incremented
+   * for each retry count
    */
   private static final int INTERVAL_DELTA_ONE_SEND = 1000; // 1s
 
@@ -112,6 +106,7 @@ public class LinearRetryPolicy extends RetryPolicy{
    * Returns if a request should be retried based on the retry count
    *
    * @param retryCount The current retry attempt count.
+   * @param statusCode The status code of last failed request
    * @return true if the request should be retried; false otherwise.
    */
   public boolean shouldRetry(final int retryCount, final int statusCode) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/LinearRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/LinearRetryPolicy.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.classification.VisibleForTesting;
 /**
  * Linear Retry policy used by AbfsClient.
  * */
-public class LinearRetryPolicy extends RetryPolicy{
+public class LinearRetryPolicy extends RetryPolicy {
   
   /**
    * Represents the default maximum amount of time used when calculating the
@@ -42,7 +42,7 @@ public class LinearRetryPolicy extends RetryPolicy{
    * Represents the delta by which retry interval should be incremented
    * for each retry count
    */
-  private static final int INTERVAL_DELTA_ONE_SEND = 1000; // 1s
+  private static final int INTERVAL_DELTA_ONE_SECOND = 1000; // 1s
 
   /**
    * The maximum backoff time.
@@ -53,11 +53,6 @@ public class LinearRetryPolicy extends RetryPolicy{
    * The minimum backoff time.
    */
   private final int minBackoff;
-
-  /**
-   * The maximum number of retry attempts.
-   */
-  private final int retryCount;
 
   /**
    * Whether we want to double up the retry interval
@@ -90,27 +85,16 @@ public class LinearRetryPolicy extends RetryPolicy{
   /**
    * Initializes a new instance of the {@link LinearRetryPolicy} class.
    *
-   * @param retryCount The maximum number of retry attempts.
+   * @param maxRetryCount The maximum number of retry attempts.
    * @param minBackoff The minimum backoff time.
    * @param maxBackoff The maximum backoff time.
    * @param doubleStepUpEnabled Type of linear increment, double or increment
    */
-  public LinearRetryPolicy(final int retryCount, final int minBackoff, final int maxBackoff, final boolean doubleStepUpEnabled) {
-    this.retryCount = retryCount;
+  public LinearRetryPolicy(final int maxRetryCount, final int minBackoff, final int maxBackoff, final boolean doubleStepUpEnabled) {
+    super(maxRetryCount);
     this.minBackoff = minBackoff;
     this.maxBackoff = maxBackoff;
     this.doubleStepUpEnabled = doubleStepUpEnabled;
-  }
-
-  /**
-   * Returns if a request should be retried based on the retry count
-   *
-   * @param retryCount The current retry attempt count.
-   * @param statusCode The status code of last failed request
-   * @return true if the request should be retried; false otherwise.
-   */
-  public boolean shouldRetry(final int retryCount, final int statusCode) {
-    return retryCount < this.retryCount;
   }
 
   /**
@@ -127,16 +111,11 @@ public class LinearRetryPolicy extends RetryPolicy{
 
     final double incrementDelta = doubleStepUpEnabled
         ? minBackoff * Math.pow(2, retryCount)
-        : minBackoff + retryCount * INTERVAL_DELTA_ONE_SEND;
+        : minBackoff + retryCount * INTERVAL_DELTA_ONE_SECOND;
 
     final long retryInterval = (int) Math.round(Math.min(incrementDelta, maxBackoff));
 
     return retryInterval;
-  }
-
-  @VisibleForTesting
-  int getRetryCount() {
-    return this.retryCount;
   }
 
   @VisibleForTesting
@@ -153,5 +132,4 @@ public class LinearRetryPolicy extends RetryPolicy{
   boolean getDoubleStepUpEnabled() {
     return this.doubleStepUpEnabled;
   }
-
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/LinearRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/LinearRetryPolicy.java
@@ -105,6 +105,7 @@ public class LinearRetryPolicy extends RetryPolicy {
    * @param retryCount The current retry attempt count.
    * @return backoff Interval time
    */
+  @Override
   public long getRetryInterval(final int retryCount) {
     if (retryCount <= 0) {
       return minBackoff;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/LinearRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/LinearRetryPolicy.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import java.net.HttpURLConnection;
+
+import org.checkerframework.checker.units.qual.min;
+
+import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
+import org.apache.hadoop.classification.VisibleForTesting;
+
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_CONTINUE;
+
+/**
+ * Retry policy used by AbfsClient.
+ * */
+public class LinearRetryPolicy {
+  
+  /**
+   * Represents the default maximum amount of time used when calculating the exponential
+   * delay between retries.
+   */
+  private static final int DEFAULT_MAX_BACKOFF = 1000 * 30; // 30s
+
+  /**
+   * Represents the default minimum amount of time used when calculating the exponential
+   * delay between retries.
+   */
+  private static final int DEFAULT_MIN_BACKOFF = 500 * 1; // 500ms
+
+  /**
+   * The maximum backoff time.
+   */
+  private final int maxBackoff;
+
+  /**
+   * The minimum backoff time.
+   */
+  private final int minBackoff;
+
+  /**
+   * The maximum number of retry attempts.
+   */
+  private final int maxRetryCount;
+
+  /**
+   * Whether we want to double up the retry interval
+   * True: Double Up
+   * False: Increase by 1.
+   */
+  private final boolean doubleStepUpEnabled;
+
+  /**
+   * Initializes a new instance of the {@link org.apache.hadoop.fs.azurebfs.services.LinearRetryPolicy} class.
+   */
+  public LinearRetryPolicy(final int maxIoRetries) {
+
+    this(maxIoRetries, DEFAULT_MIN_BACKOFF, DEFAULT_MAX_BACKOFF,
+        true);
+  }
+
+  /**
+   * Initializes a new instance of the {@link org.apache.hadoop.fs.azurebfs.services.LinearRetryPolicy} class.
+   *
+   * @param conf The {@link org.apache.hadoop.fs.azurebfs.AbfsConfiguration} from which to retrieve retry configuration.
+   */
+  public LinearRetryPolicy(AbfsConfiguration conf) {
+    this(conf.getMaxIoRetries(),
+        conf.getMinBackoffIntervalMillisecondsForConnectionTimeout(),
+        conf.getMaxBackoffIntervalMillisecondsForConnectionTimeout(),
+        conf.getLinearRetryDoubleStepUpEnabled());
+  }
+
+  /**
+   * Initializes a new instance of the {@link org.apache.hadoop.fs.azurebfs.services.LinearRetryPolicy} class.
+   *
+   * @param maxRetryCount The maximum number of retry attempts.
+   * @param minBackoff The minimum backoff time.
+   * @param maxBackoff The maximum backoff time.
+   * @param doubleStepUpEnabled Type of linear increment, double or increment
+   */
+  public LinearRetryPolicy(final int maxRetryCount, final int minBackoff, final int maxBackoff, final boolean doubleStepUpEnabled) {
+    this.maxRetryCount = maxRetryCount;
+    this.minBackoff = minBackoff;
+    this.maxBackoff = maxBackoff;
+    this.doubleStepUpEnabled = doubleStepUpEnabled;
+  }
+
+  /**
+   * Returns backoff interval between 80% and 120% of the desired backoff,
+   * multiply by 2^n-1 for exponential.
+   *
+   * @param retryCount The current retry attempt count.
+   * @return backoff Interval time
+   */
+  public long getRetryInterval(final int retryCount) {
+    final double incrementDelta = doubleStepUpEnabled
+        ? minBackoff * Math.pow(2, retryCount)
+        : minBackoff * retryCount;
+
+    final long retryInterval = (int) Math.round(Math.min(minBackoff + incrementDelta, maxBackoff));
+
+    return retryInterval;
+  }
+
+  @VisibleForTesting
+  int getRetryCount() {
+    return this.maxRetryCount;
+  }
+
+  @VisibleForTesting
+  int getMinBackoff() {
+    return this.minBackoff;
+  }
+
+  @VisibleForTesting
+  int getMaxBackoff() {
+    return maxBackoff;
+  }
+
+  @VisibleForTesting
+  boolean getDoubleStepUpEnabled() {
+    return this.doubleStepUpEnabled;
+  }
+
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/LinearRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/LinearRetryPolicy.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.classification.VisibleForTesting;
  * Linear Retry policy used by AbfsClient.
  * */
 public class LinearRetryPolicy extends RetryPolicy {
-  
+
   /**
    * Represents the default maximum amount of time used when calculating the
    * linear delay between retries.
@@ -63,6 +63,7 @@ public class LinearRetryPolicy extends RetryPolicy {
 
   /**
    * Initializes a new instance of the {@link LinearRetryPolicy} class.
+   * @param maxIoRetries Maximum Retry Count Allowed
    */
   public LinearRetryPolicy(final int maxIoRetries) {
 
@@ -72,7 +73,6 @@ public class LinearRetryPolicy extends RetryPolicy {
 
   /**
    * Initializes a new instance of the {@link LinearRetryPolicy} class.
-   *
    * @param conf The {@link AbfsConfiguration} from which to retrieve retry configuration.
    */
   public LinearRetryPolicy(AbfsConfiguration conf) {
@@ -106,8 +106,9 @@ public class LinearRetryPolicy extends RetryPolicy {
    * @return backoff Interval time
    */
   public long getRetryInterval(final int retryCount) {
-    if (retryCount <= 0)
-        return minBackoff;
+    if (retryCount <= 0) {
+      return minBackoff;
+    }
 
     final double incrementDelta = doubleStepUpEnabled
         ? minBackoff * Math.pow(2, retryCount)

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/LinearRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/LinearRetryPolicy.java
@@ -67,7 +67,7 @@ public class LinearRetryPolicy {
   private final boolean doubleStepUpEnabled;
 
   /**
-   * Initializes a new instance of the {@link org.apache.hadoop.fs.azurebfs.services.LinearRetryPolicy} class.
+   * Initializes a new instance of the {@link LinearRetryPolicy} class.
    */
   public LinearRetryPolicy(final int maxIoRetries) {
 
@@ -76,9 +76,9 @@ public class LinearRetryPolicy {
   }
 
   /**
-   * Initializes a new instance of the {@link org.apache.hadoop.fs.azurebfs.services.LinearRetryPolicy} class.
+   * Initializes a new instance of the {@link LinearRetryPolicy} class.
    *
-   * @param conf The {@link org.apache.hadoop.fs.azurebfs.AbfsConfiguration} from which to retrieve retry configuration.
+   * @param conf The {@link AbfsConfiguration} from which to retrieve retry configuration.
    */
   public LinearRetryPolicy(AbfsConfiguration conf) {
     this(conf.getMaxIoRetries(),
@@ -88,7 +88,7 @@ public class LinearRetryPolicy {
   }
 
   /**
-   * Initializes a new instance of the {@link org.apache.hadoop.fs.azurebfs.services.LinearRetryPolicy} class.
+   * Initializes a new instance of the {@link LinearRetryPolicy} class.
    *
    * @param maxRetryCount The maximum number of retry attempts.
    * @param minBackoff The minimum backoff time.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RetryPolicy.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import java.net.HttpURLConnection;
+
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_CONTINUE;
+
+public abstract class RetryPolicy {
+
+  /**
+   * Returns if a request should be retried based on the retry count, current response,
+   * and the current strategy. The valid http status code lies in the range of 1xx-5xx.
+   * But an invalid status code might be set due to network or timeout kind of issues.
+   * Such invalid status code also qualify for retry.
+   *
+   * @param retryCount The current retry attempt count.
+   * @param statusCode The status code of the response, or -1 for socket error.
+   * @return true if the request should be retried; false otherwise.
+   */
+  public abstract boolean shouldRetry(final int retryCount, final int statusCode);
+
+  public abstract long getRetryInterval(final int retryCount);
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RetryPolicy.java
@@ -18,17 +18,16 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
-import java.net.HttpURLConnection;
-
-import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_CONTINUE;
-
+/**
+ * Abstract Class for Retry policy to be used by {@link AbfsClient}
+ * Implementation to be used is based on retry cause.
+ */
 public abstract class RetryPolicy {
 
   /**
    * Returns if a request should be retried based on the retry count, current response,
-   * and the current strategy. The valid http status code lies in the range of 1xx-5xx.
-   * But an invalid status code might be set due to network or timeout kind of issues.
-   * Such invalid status code also qualify for retry.
+   * and the current strategy.
+   * Child class should define exact behavior
    *
    * @param retryCount The current retry attempt count.
    * @param statusCode The status code of the response, or -1 for socket error.
@@ -36,5 +35,12 @@ public abstract class RetryPolicy {
    */
   public abstract boolean shouldRetry(final int retryCount, final int statusCode);
 
+  /**
+   * Returns backoff interval to be used for a particular retry count
+   * Child class should define how they want to calculate retry interval
+   *
+   * @param retryCount The current retry attempt count.
+   * @return backoff Interval time
+   */
   public abstract long getRetryInterval(final int retryCount);
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/StaticRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/StaticRetryPolicy.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
+import org.apache.hadoop.classification.VisibleForTesting;
+
+/**
+ * Linear Retry policy used by AbfsClient.
+ * */
+public class StaticRetryPolicy extends RetryPolicy {
+
+  private static final int STATIC_RETRY_INTERVAL = 2000; // 2s
+
+  /**
+   * Initializes a new instance of the {@link StaticRetryPolicy} class.
+   * @param maxIoRetries Maximum Retry Count Allowed
+   */
+  public StaticRetryPolicy(final int maxIoRetries) {
+    super(maxIoRetries);
+  }
+
+  /**
+   * Initializes a new instance of the {@link StaticRetryPolicy} class.
+   * @param conf The {@link AbfsConfiguration} from which to retrieve retry configuration.
+   */
+  public StaticRetryPolicy(AbfsConfiguration conf) {
+    this(conf.getMaxIoRetries());
+  }
+
+  /**
+   * Returns a constant backoff interval independent of retry count;
+   *
+   * @param retryCount The current retry attempt count.
+   * @return backoff Interval time
+   */
+  @Override
+  public long getRetryInterval(final int retryCount) {
+    return STATIC_RETRY_INTERVAL;
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/StaticRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/StaticRetryPolicy.java
@@ -26,7 +26,12 @@ import org.apache.hadoop.classification.VisibleForTesting;
  * */
 public class StaticRetryPolicy extends RetryPolicy {
 
-  private static final int STATIC_RETRY_INTERVAL = 2000; // 2s
+  private static final int STATIC_RETRY_INTERVAL_DEFAULT = 2000; // 2s
+
+  /**
+   * Represents the constant retry interval to be used with Static Retry Policy
+   */
+  private int retryInterval;
 
   /**
    * Initializes a new instance of the {@link StaticRetryPolicy} class.
@@ -34,6 +39,7 @@ public class StaticRetryPolicy extends RetryPolicy {
    */
   public StaticRetryPolicy(final int maxIoRetries) {
     super(maxIoRetries);
+    this.retryInterval = STATIC_RETRY_INTERVAL_DEFAULT;
   }
 
   /**
@@ -42,6 +48,7 @@ public class StaticRetryPolicy extends RetryPolicy {
    */
   public StaticRetryPolicy(AbfsConfiguration conf) {
     this(conf.getMaxIoRetries());
+    this.retryInterval = conf.getStaticRetryInterval();
   }
 
   /**
@@ -52,6 +59,6 @@ public class StaticRetryPolicy extends RetryPolicy {
    */
   @Override
   public long getRetryInterval(final int retryCount) {
-    return STATIC_RETRY_INTERVAL;
+    return retryInterval;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -326,7 +326,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
 
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
     when(client.getAuthType()).thenReturn(currentAuthType);
-    when(client.getRetryPolicy()).thenReturn(
+    when(client.getRetryPolicy(null)).thenReturn(
         new ExponentialRetryPolicy(1));
 
     when(client.createDefaultUriQueryBuilder()).thenCallRealMethod();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -326,7 +326,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
 
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
     when(client.getAuthType()).thenReturn(currentAuthType);
-    when(client.getRetryPolicy(null)).thenReturn(
+    when(client.getRetryPolicy(any())).thenReturn(
         new ExponentialRetryPolicy(1));
 
     when(client.createDefaultUriQueryBuilder()).thenCallRealMethod();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsRestOperation.java
@@ -56,6 +56,9 @@ import static org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations.E
 import static org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations.X_HTTP_METHOD_OVERRIDE;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpQueryParams.QUERY_PARAM_ACTION;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpQueryParams.QUERY_PARAM_POSITION;
+import static org.apache.hadoop.fs.azurebfs.constants.InternalConstants.EXPONENTIAL_RETRY_POLICY;
+import static org.apache.hadoop.fs.azurebfs.constants.InternalConstants.LINEAR_RETRY_POLICY;
+import static org.apache.hadoop.fs.azurebfs.constants.InternalConstants.STATIC_RETRY_POLICY;
 import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.FS_AZURE_ABFS_ACCOUNT_NAME;
 import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.TEST_CONFIGURATION_FILE_NAME;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
@@ -354,5 +357,19 @@ public class ITestAbfsRestOperation extends AbstractAbfsIntegrationTest {
     default:
       break;
     }
+  }
+
+  @Test
+  public void testRetryPolicyString() throws Exception {
+    // Gets the AbfsRestOperation.
+    AbfsRestOperation op = getRestOperation();
+    RetryPolicy retryPolicy = new LinearRetryPolicy(10);
+    Assertions.assertThat(op.getRetryPolicyStr(retryPolicy)).isEqualTo(LINEAR_RETRY_POLICY);
+
+    retryPolicy = new StaticRetryPolicy(10);
+    Assertions.assertThat(op.getRetryPolicyStr(retryPolicy)).isEqualTo(STATIC_RETRY_POLICY);
+
+    retryPolicy = new ExponentialRetryPolicy(10);
+    Assertions.assertThat(op.getRetryPolicyStr(retryPolicy)).isEqualTo(EXPONENTIAL_RETRY_POLICY);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsPerfTracker.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsPerfTracker.java
@@ -113,7 +113,7 @@ public final class TestAbfsPerfTracker {
       assertThat(latencyDetails).describedAs("AbfsPerfTracker should return non-null record").isNotNull();
       assertThat(latencyDetails).describedAs("Latency record should be in the correct format")
         .containsPattern("h=[^ ]* t=[^ ]* a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller"
-          + " ce=oneOperationCallee r=Succeeded l=[0-9]+ s=-1 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET"
+          + " ce=oneOperationCallee r=Succeeded l=[0-9]+ s=0 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET"
           + " u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile");
     }
 
@@ -154,7 +154,7 @@ public final class TestAbfsPerfTracker {
       assertThat(latencyDetails).describedAs("Latency record should be in the correct format")
         .containsPattern("h=[^ ]* t=[^ ]* a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller"
                 + " ce=oneOperationCallee r=Succeeded l=[0-9]+ ls=[0-9]+ lc=" + TEST_AGGREGATE_COUNT
-                + " s=-1 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile");
+                + " s=0 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile");
     }
 
     latencyDetails = abfsPerfTracker.getClientLatency();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsPerfTracker.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsPerfTracker.java
@@ -154,7 +154,7 @@ public final class TestAbfsPerfTracker {
       assertThat(latencyDetails).describedAs("Latency record should be in the correct format")
         .containsPattern("h=[^ ]* t=[^ ]* a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller"
                 + " ce=oneOperationCallee r=Succeeded l=[0-9]+ ls=[0-9]+ lc=" + TEST_AGGREGATE_COUNT
-                + " s=0 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile");
+                + " s=-1 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile");
     }
 
     latencyDetails = abfsPerfTracker.getClientLatency();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsPerfTracker.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsPerfTracker.java
@@ -113,7 +113,7 @@ public final class TestAbfsPerfTracker {
       assertThat(latencyDetails).describedAs("AbfsPerfTracker should return non-null record").isNotNull();
       assertThat(latencyDetails).describedAs("Latency record should be in the correct format")
         .containsPattern("h=[^ ]* t=[^ ]* a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller"
-          + " ce=oneOperationCallee r=Succeeded l=[0-9]+ s=0 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET"
+          + " ce=oneOperationCallee r=Succeeded l=[0-9]+ s=-1 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET"
           + " u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile");
     }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsRestOperationMockFailures.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsRestOperationMockFailures.java
@@ -29,8 +29,6 @@ import java.util.ArrayList;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.mockito.AdditionalMatchers;
-import org.mockito.Matchers;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Stubber;
 
@@ -69,7 +67,7 @@ public class TestAbfsRestOperationMockFailures {
     String[] abbreviations = new String[1];
     exceptions[0] = new SocketTimeoutException(CONNECTION_TIMEOUT_JDK_MESSAGE);
     abbreviations[0] = CONNECTION_TIMEOUT_ABBREVIATION;
-    testClientRequestIdForTimeoutRetry(exceptions, abbreviations, 1,1);
+    testClientRequestIdForTimeoutRetry(exceptions, abbreviations, 1, 1);
   }
 
   @Test
@@ -275,10 +273,14 @@ public class TestAbfsRestOperationMockFailures {
     abfsRestOperation.execute(tracingContext);
     Assertions.assertThat(count[0]).isEqualTo(len + 1);
 
-    // Assert that getRetryPolicy was called with
-    // failureReason CT only for Connection Timeout Cases.
+    /**
+     * Assert that getRetryPolicy was called with
+     * failureReason CT only for Connection Timeout Cases.
+     * For every failed request getRetryPolicy will be called three times
+     * It will be called with failureReason CT for every request failing with CT
+     */
     Mockito.verify(abfsClient, Mockito.times(
-        3*numOfCTExceptions))
+        3 * numOfCTExceptions))
         .getRetryPolicy(CONNECTION_TIMEOUT_ABBREVIATION);
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsRestOperationMockFailures.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsRestOperationMockFailures.java
@@ -280,7 +280,7 @@ public class TestAbfsRestOperationMockFailures {
      * It will be called with failureReason CT for every request failing with CT
      */
     Mockito.verify(abfsClient, Mockito.times(
-        3 * numOfCTExceptions))
+        numOfCTExceptions))
         .getRetryPolicy(CONNECTION_TIMEOUT_ABBREVIATION);
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAzureADAuthenticator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAzureADAuthenticator.java
@@ -60,7 +60,7 @@ public class TestAzureADAuthenticator extends AbstractAbfsIntegrationTest {
     ExponentialRetryPolicy retryPolicy = abfsConfig
         .getOauthTokenFetchRetryPolicy();
 
-    Assertions.assertThat(retryPolicy.getRetryCount()).describedAs(
+    Assertions.assertThat(retryPolicy.getMaxRetryCount()).describedAs(
         "retryCount should be the default value {} as the same "
             + "is not configured",
         DEFAULT_AZURE_OAUTH_TOKEN_FETCH_RETRY_MAX_ATTEMPTS)
@@ -103,7 +103,7 @@ public class TestAzureADAuthenticator extends AbstractAbfsIntegrationTest {
     ExponentialRetryPolicy retryPolicy = abfsConfig
         .getOauthTokenFetchRetryPolicy();
 
-    Assertions.assertThat(retryPolicy.getRetryCount())
+    Assertions.assertThat(retryPolicy.getMaxRetryCount())
         .describedAs("retryCount should be {}", TEST_RETRY_COUNT)
         .isEqualTo(TEST_RETRY_COUNT);
     Assertions.assertThat(retryPolicy.getMinBackoff())

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestExponentialRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestExponentialRetryPolicy.java
@@ -265,7 +265,7 @@ public class TestExponentialRetryPolicy extends AbstractAbfsIntegrationTest {
     ExponentialRetryPolicy template = new ExponentialRetryPolicy(
         getAbfsConfig().getMaxIoRetries());
     int testModifier = 1;
-    int expectedMaxRetries = template.getRetryCount() + testModifier;
+    int expectedMaxRetries = template.getMaxRetryCount() + testModifier;
     int expectedMinBackoff = template.getMinBackoff() + testModifier;
     int expectedMaxBackoff = template.getMaxBackoff() + testModifier;
     int expectedDeltaBackoff = template.getDeltaBackoff() + testModifier;
@@ -279,7 +279,7 @@ public class TestExponentialRetryPolicy extends AbstractAbfsIntegrationTest {
     ExponentialRetryPolicy policy = new ExponentialRetryPolicy(
         new AbfsConfiguration(config, "dummyAccountName"));
 
-    Assert.assertEquals("Max retry count was not set as expected.", expectedMaxRetries, policy.getRetryCount());
+    Assert.assertEquals("Max retry count was not set as expected.", expectedMaxRetries, policy.getMaxRetryCount());
     Assert.assertEquals("Min backoff interval was not set as expected.", expectedMinBackoff, policy.getMinBackoff());
     Assert.assertEquals("Max backoff interval was not set as expected.", expectedMaxBackoff, policy.getMaxBackoff());
     Assert.assertEquals("Delta backoff interval was not set as expected.", expectedDeltaBackoff, policy.getDeltaBackoff());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestLinearRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestLinearRetryPolicy.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import org.junit.Test;
+
+import org.apache.hadoop.fs.azurebfs.AbstractAbfsIntegrationTest;
+import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
+
+import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_RESET_ABBREVIATION;
+import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_TIMEOUT_ABBREVIATION;
+
+public class TestLinearRetryPolicy extends AbstractAbfsIntegrationTest {
+
+  public TestLinearRetryPolicy() throws Exception {
+    super();
+  }
+
+  @Test
+  public void testLinearRetryPolicyInitialization() throws Exception {
+    AzureBlobFileSystem fs = getFileSystem();
+    AbfsClient client = fs.getAbfsStore().getClient();
+
+    RetryPolicy retryPolicy = client.getRetryPolicy(CONNECTION_TIMEOUT_ABBREVIATION);
+    assertTrue(retryPolicy instanceof LinearRetryPolicy);
+
+    retryPolicy = client.getRetryPolicy(CONNECTION_RESET_ABBREVIATION);
+    assertTrue(retryPolicy instanceof ExponentialRetryPolicy);
+  }
+
+  @Test
+  public void testLinearRetryIntervalWithDoubleStepUpEnabled() throws Exception {
+    AzureBlobFileSystem fs = getFileSystem();
+    AbfsClient client = fs.getAbfsStore().getClient();
+
+    RetryPolicy retryPolicy = client.getRetryPolicy(CONNECTION_TIMEOUT_ABBREVIATION);
+    assertTrue(retryPolicy instanceof LinearRetryPolicy);
+    assertTrue(((LinearRetryPolicy) retryPolicy).getDoubleStepUpEnabled());
+
+    assertEquals(500, retryPolicy.getRetryInterval(0));
+    assertEquals(1000, retryPolicy.getRetryInterval(1));
+    assertEquals(2000, retryPolicy.getRetryInterval(2));
+    assertEquals(4000, retryPolicy.getRetryInterval(3));
+  }
+
+  @Test
+  public void testLinearRetryIntervalWithDoubleStepUpDisabled() throws Exception {
+    AzureBlobFileSystem fs = getFileSystem();
+    AbfsClient client = fs.getAbfsStore().getClient();
+    client.getAbfsConfiguration().setLinearRetryDoubleStepUpEnabled(false);
+
+    RetryPolicy retryPolicy = new LinearRetryPolicy(client.getAbfsConfiguration());
+    assertTrue(retryPolicy instanceof LinearRetryPolicy);
+    assertFalse(((LinearRetryPolicy) retryPolicy).getDoubleStepUpEnabled());
+
+    assertEquals(500, retryPolicy.getRetryInterval(0));
+    assertEquals(1500, retryPolicy.getRetryInterval(1));
+    assertEquals(2500, retryPolicy.getRetryInterval(2));
+    assertEquals(3500, retryPolicy.getRetryInterval(3));
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestLinearRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestLinearRetryPolicy.java
@@ -20,8 +20,14 @@ package org.apache.hadoop.fs.azurebfs.services;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.azurebfs.AbstractAbfsIntegrationTest;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
+
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_LIST_MAX_RESULTS;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_RESET_ABBREVIATION;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_TIMEOUT_ABBREVIATION;
 
@@ -55,12 +61,15 @@ public class TestLinearRetryPolicy extends AbstractAbfsIntegrationTest {
 
   @Test
   public void testLinearRetryIntervalWithDoubleStepUpEnabled() throws Exception {
-    AzureBlobFileSystem fs = getFileSystem();
+    Configuration config = new Configuration(this.getRawConfiguration());
+    config.set(AZURE_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED, "true");
+    final AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem
+        .newInstance(getFileSystem().getUri(), config);
     AbfsClient client = fs.getAbfsStore().getClient();
 
     RetryPolicy retryPolicy = client.getRetryPolicy(CONNECTION_TIMEOUT_ABBREVIATION);
-    Assertions.assertThat(retryPolicy instanceof LinearRetryPolicy);
-    Assertions.assertThat(((LinearRetryPolicy) retryPolicy).getDoubleStepUpEnabled());
+    Assertions.assertThat(retryPolicy).isInstanceOf(LinearRetryPolicy.class);
+    Assertions.assertThat(((LinearRetryPolicy) retryPolicy).getDoubleStepUpEnabled()).isEqualTo(true);
 
     Assertions.assertThat(retryPolicy.getRetryInterval(0)).isEqualTo(500);
     Assertions.assertThat(retryPolicy.getRetryInterval(1)).isEqualTo(1000);
@@ -70,13 +79,15 @@ public class TestLinearRetryPolicy extends AbstractAbfsIntegrationTest {
 
   @Test
   public void testLinearRetryIntervalWithDoubleStepUpDisabled() throws Exception {
-    AzureBlobFileSystem fs = getFileSystem();
+    Configuration config = new Configuration(this.getRawConfiguration());
+    config.set(AZURE_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED, "false");
+    final AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem
+        .newInstance(getFileSystem().getUri(), config);
     AbfsClient client = fs.getAbfsStore().getClient();
-    client.getAbfsConfiguration().setLinearRetryDoubleStepUpEnabled(false);
 
     RetryPolicy retryPolicy = new LinearRetryPolicy(client.getAbfsConfiguration());
-    Assertions.assertThat(retryPolicy instanceof LinearRetryPolicy);
-    Assertions.assertThat(!((LinearRetryPolicy) retryPolicy).getDoubleStepUpEnabled());
+    Assertions.assertThat(retryPolicy).isInstanceOf(LinearRetryPolicy.class);
+    Assertions.assertThat(((LinearRetryPolicy) retryPolicy).getDoubleStepUpEnabled()).isEqualTo(false);
 
     Assertions.assertThat(retryPolicy.getRetryInterval(0)).isEqualTo(500);
     Assertions.assertThat(retryPolicy.getRetryInterval(1)).isEqualTo(1500);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestLinearRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestLinearRetryPolicy.java
@@ -18,11 +18,10 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
-
 import org.apache.hadoop.fs.azurebfs.AbstractAbfsIntegrationTest;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
-
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_RESET_ABBREVIATION;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_TIMEOUT_ABBREVIATION;
 
@@ -38,10 +37,16 @@ public class TestLinearRetryPolicy extends AbstractAbfsIntegrationTest {
     AbfsClient client = fs.getAbfsStore().getClient();
 
     RetryPolicy retryPolicy = client.getRetryPolicy(CONNECTION_TIMEOUT_ABBREVIATION);
-    assertTrue(retryPolicy instanceof LinearRetryPolicy);
+    Assertions.assertThat(retryPolicy instanceof LinearRetryPolicy);
+
+    retryPolicy = client.getRetryPolicy("");
+    Assertions.assertThat(retryPolicy instanceof ExponentialRetryPolicy);
+
+    retryPolicy = client.getRetryPolicy(null);
+    Assertions.assertThat(retryPolicy instanceof ExponentialRetryPolicy);
 
     retryPolicy = client.getRetryPolicy(CONNECTION_RESET_ABBREVIATION);
-    assertTrue(retryPolicy instanceof ExponentialRetryPolicy);
+    Assertions.assertThat(retryPolicy instanceof ExponentialRetryPolicy);
   }
 
   @Test
@@ -50,13 +55,13 @@ public class TestLinearRetryPolicy extends AbstractAbfsIntegrationTest {
     AbfsClient client = fs.getAbfsStore().getClient();
 
     RetryPolicy retryPolicy = client.getRetryPolicy(CONNECTION_TIMEOUT_ABBREVIATION);
-    assertTrue(retryPolicy instanceof LinearRetryPolicy);
-    assertTrue(((LinearRetryPolicy) retryPolicy).getDoubleStepUpEnabled());
+    Assertions.assertThat(retryPolicy instanceof LinearRetryPolicy);
+    Assertions.assertThat(((LinearRetryPolicy) retryPolicy).getDoubleStepUpEnabled());
 
-    assertEquals(500, retryPolicy.getRetryInterval(0));
-    assertEquals(1000, retryPolicy.getRetryInterval(1));
-    assertEquals(2000, retryPolicy.getRetryInterval(2));
-    assertEquals(4000, retryPolicy.getRetryInterval(3));
+    Assertions.assertThat(500 == retryPolicy.getRetryInterval(0));
+    Assertions.assertThat(1000 == retryPolicy.getRetryInterval(1));
+    Assertions.assertThat(2000 == retryPolicy.getRetryInterval(2));
+    Assertions.assertThat(4000 == retryPolicy.getRetryInterval(3));
   }
 
   @Test
@@ -66,12 +71,12 @@ public class TestLinearRetryPolicy extends AbstractAbfsIntegrationTest {
     client.getAbfsConfiguration().setLinearRetryDoubleStepUpEnabled(false);
 
     RetryPolicy retryPolicy = new LinearRetryPolicy(client.getAbfsConfiguration());
-    assertTrue(retryPolicy instanceof LinearRetryPolicy);
-    assertFalse(((LinearRetryPolicy) retryPolicy).getDoubleStepUpEnabled());
+    Assertions.assertThat(retryPolicy instanceof LinearRetryPolicy);
+    Assertions.assertThat(!((LinearRetryPolicy) retryPolicy).getDoubleStepUpEnabled());
 
-    assertEquals(500, retryPolicy.getRetryInterval(0));
-    assertEquals(1500, retryPolicy.getRetryInterval(1));
-    assertEquals(2500, retryPolicy.getRetryInterval(2));
-    assertEquals(3500, retryPolicy.getRetryInterval(3));
+    Assertions.assertThat(500 == retryPolicy.getRetryInterval(0));
+    Assertions.assertThat(1500 == retryPolicy.getRetryInterval(1));
+    Assertions.assertThat(2500 == retryPolicy.getRetryInterval(2));
+    Assertions.assertThat(3500 == retryPolicy.getRetryInterval(3));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestLinearRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestLinearRetryPolicy.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.fs.azurebfs.AbstractAbfsIntegrationTest;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
 
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_LIST_MAX_RESULTS;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_RESET_ABBREVIATION;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_TIMEOUT_ABBREVIATION;
 
@@ -36,6 +35,9 @@ import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNEC
  * between {@link RetryPolicy}, {@link LinearRetryPolicy}, {@link ExponentialRetryPolicy}
  */
 public class TestLinearRetryPolicy extends AbstractAbfsIntegrationTest {
+
+  private final int MIN_BACKOFF = 500;
+  private final int ONE_SECOND = 1000;
 
   public TestLinearRetryPolicy() throws Exception {
     super();
@@ -71,10 +73,14 @@ public class TestLinearRetryPolicy extends AbstractAbfsIntegrationTest {
     Assertions.assertThat(retryPolicy).isInstanceOf(LinearRetryPolicy.class);
     Assertions.assertThat(((LinearRetryPolicy) retryPolicy).getDoubleStepUpEnabled()).isEqualTo(true);
 
-    Assertions.assertThat(retryPolicy.getRetryInterval(0)).isEqualTo(500);
-    Assertions.assertThat(retryPolicy.getRetryInterval(1)).isEqualTo(1000);
-    Assertions.assertThat(retryPolicy.getRetryInterval(2)).isEqualTo(2000);
-    Assertions.assertThat(retryPolicy.getRetryInterval(3)).isEqualTo(4000);
+    Assertions.assertThat(retryPolicy.getRetryInterval(0))
+        .isEqualTo(MIN_BACKOFF);
+    Assertions.assertThat(retryPolicy.getRetryInterval(1))
+        .isEqualTo(2 * MIN_BACKOFF);
+    Assertions.assertThat(retryPolicy.getRetryInterval(2))
+        .isEqualTo(4 * MIN_BACKOFF);
+    Assertions.assertThat(retryPolicy.getRetryInterval(3))
+        .isEqualTo(8 * MIN_BACKOFF);
   }
 
   @Test
@@ -89,9 +95,13 @@ public class TestLinearRetryPolicy extends AbstractAbfsIntegrationTest {
     Assertions.assertThat(retryPolicy).isInstanceOf(LinearRetryPolicy.class);
     Assertions.assertThat(((LinearRetryPolicy) retryPolicy).getDoubleStepUpEnabled()).isEqualTo(false);
 
-    Assertions.assertThat(retryPolicy.getRetryInterval(0)).isEqualTo(500);
-    Assertions.assertThat(retryPolicy.getRetryInterval(1)).isEqualTo(1500);
-    Assertions.assertThat(retryPolicy.getRetryInterval(2)).isEqualTo(2500);
-    Assertions.assertThat(retryPolicy.getRetryInterval(3)).isEqualTo(3500);
+    Assertions.assertThat(retryPolicy.getRetryInterval(0))
+        .isEqualTo(MIN_BACKOFF);
+    Assertions.assertThat(retryPolicy.getRetryInterval(1))
+        .isEqualTo(ONE_SECOND + MIN_BACKOFF);
+    Assertions.assertThat(retryPolicy.getRetryInterval(2))
+        .isEqualTo(2 * ONE_SECOND + MIN_BACKOFF);
+    Assertions.assertThat(retryPolicy.getRetryInterval(3))
+        .isEqualTo(3 * ONE_SECOND + MIN_BACKOFF);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestLinearRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestLinearRetryPolicy.java
@@ -25,6 +25,10 @@ import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_RESET_ABBREVIATION;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_TIMEOUT_ABBREVIATION;
 
+/**
+ * Class to test the behavior of Linear Retry policy as well the inheritance
+ * between {@link RetryPolicy}, {@link LinearRetryPolicy}, {@link ExponentialRetryPolicy}
+ */
 public class TestLinearRetryPolicy extends AbstractAbfsIntegrationTest {
 
   public TestLinearRetryPolicy() throws Exception {
@@ -36,17 +40,17 @@ public class TestLinearRetryPolicy extends AbstractAbfsIntegrationTest {
     AzureBlobFileSystem fs = getFileSystem();
     AbfsClient client = fs.getAbfsStore().getClient();
 
+    // Assert that linear retry policy will be used only for CT Failures
     RetryPolicy retryPolicy = client.getRetryPolicy(CONNECTION_TIMEOUT_ABBREVIATION);
-    Assertions.assertThat(retryPolicy instanceof LinearRetryPolicy);
+    Assertions.assertThat(retryPolicy).isInstanceOf(LinearRetryPolicy.class);
 
+    // For all other possible values of failureReason, Exponential retry is used
     retryPolicy = client.getRetryPolicy("");
-    Assertions.assertThat(retryPolicy instanceof ExponentialRetryPolicy);
-
+    Assertions.assertThat(retryPolicy).isInstanceOf(ExponentialRetryPolicy.class);
     retryPolicy = client.getRetryPolicy(null);
-    Assertions.assertThat(retryPolicy instanceof ExponentialRetryPolicy);
-
+    Assertions.assertThat(retryPolicy).isInstanceOf(ExponentialRetryPolicy.class);
     retryPolicy = client.getRetryPolicy(CONNECTION_RESET_ABBREVIATION);
-    Assertions.assertThat(retryPolicy instanceof ExponentialRetryPolicy);
+    Assertions.assertThat(retryPolicy).isInstanceOf(ExponentialRetryPolicy.class);
   }
 
   @Test
@@ -58,10 +62,10 @@ public class TestLinearRetryPolicy extends AbstractAbfsIntegrationTest {
     Assertions.assertThat(retryPolicy instanceof LinearRetryPolicy);
     Assertions.assertThat(((LinearRetryPolicy) retryPolicy).getDoubleStepUpEnabled());
 
-    Assertions.assertThat(500 == retryPolicy.getRetryInterval(0));
-    Assertions.assertThat(1000 == retryPolicy.getRetryInterval(1));
-    Assertions.assertThat(2000 == retryPolicy.getRetryInterval(2));
-    Assertions.assertThat(4000 == retryPolicy.getRetryInterval(3));
+    Assertions.assertThat(retryPolicy.getRetryInterval(0)).isEqualTo(500);
+    Assertions.assertThat(retryPolicy.getRetryInterval(1)).isEqualTo(1000);
+    Assertions.assertThat(retryPolicy.getRetryInterval(2)).isEqualTo(2000);
+    Assertions.assertThat(retryPolicy.getRetryInterval(3)).isEqualTo(4000);
   }
 
   @Test
@@ -74,9 +78,9 @@ public class TestLinearRetryPolicy extends AbstractAbfsIntegrationTest {
     Assertions.assertThat(retryPolicy instanceof LinearRetryPolicy);
     Assertions.assertThat(!((LinearRetryPolicy) retryPolicy).getDoubleStepUpEnabled());
 
-    Assertions.assertThat(500 == retryPolicy.getRetryInterval(0));
-    Assertions.assertThat(1500 == retryPolicy.getRetryInterval(1));
-    Assertions.assertThat(2500 == retryPolicy.getRetryInterval(2));
-    Assertions.assertThat(3500 == retryPolicy.getRetryInterval(3));
+    Assertions.assertThat(retryPolicy.getRetryInterval(0)).isEqualTo(500);
+    Assertions.assertThat(retryPolicy.getRetryInterval(1)).isEqualTo(1500);
+    Assertions.assertThat(retryPolicy.getRetryInterval(2)).isEqualTo(2500);
+    Assertions.assertThat(retryPolicy.getRetryInterval(3)).isEqualTo(3500);
   }
 }


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HADOOP-18759
Today when a request fails with connection timeout, it falls back into the loop for exponential retry. Unlike Azure Storage, there are no guarantees of success on exponentially retried request or recommendations for ideal retry policies for Azure network or any other general failures. Faster failure and retry might be more beneficial for such generic connection timeout failures. 

This PR introduces a new Linear Retry Policy which will currently be used only for Connection Timeout failures.
Two types of Linear Backoff calculations will be supported:

1. min-backoff starts with 500 ms and with each attempted retry, back-off increments double, capped at 30 sec max
2. min-backoff starts with 500 ms and with each attempted retry, back-off increments by 1 sec, capped at 30 sec max

Following Configurations will be introduced in the change:
1. "fs.azure.linear.retry.for.connection.timeout.enabled" - default: true, true: linear retry will be used for CT, false: Exponential retry will be used.
2. "fs.azure.io.retry.min.backoff.interval.for.connection.timeout" - default: 500ms
3. "fs.azure.io.retry.max.backoff.interval.for.connection.timeout" - default: 30s
4. "fs.azure.linear.retry.double.step.up.enabled" - default: true, true: Double up the interval for every retry count, false: Add 1s to interval for every retry count

### How was this patch tested?
Test cases added and existing test cases modified

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

