### PR TITLE
HDFS-17040. Namenode web UI should set content type to application/octet-stream when uploading a file.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/explorer.js
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/explorer.js
@@ -518,7 +518,8 @@
             url: url,
             data: file.file,
             processData: false,
-            crossDomain: true
+            crossDomain: true,
+            contentType: 'application/octet-stream'
           }).always(function(data) {
             numCompleted++;
             if(numCompleted == files.length) {


### PR DESCRIPTION
### Description of PR

HDFS-17040

When uploading a file WebHDFS will set the content type to application/x-www-form-urlencoded, as this is the default used by jQuery

This causes knox to urlencode the request body so that uploading a CVS file 1,2,3 will result 1%2C2%2C3.

Instead of application/x-www-form-urlencoded I think the encoding should be set to application/octet-stream.

### How was this patch tested?

Pending

### For code changes:

content type is explicitly set to octet stream
