### PR TITLE
YARN-11504. [Federation] YARN Federation Supports Non-HA mode.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -3989,6 +3989,10 @@ public class YarnConfiguration extends Configuration {
       FEDERATION_PREFIX + "failover.enabled";
   public static final boolean DEFAULT_FEDERATION_FAILOVER_ENABLED = true;
 
+  public static final String FEDERATION_NON_HA_ENABLED =
+      FEDERATION_PREFIX + "non-ha.enabled";
+  public static final boolean DEFAULT_FEDERATION_NON_HA_ENABLED = false;
+
   public static final String FEDERATION_STATESTORE_CLIENT_CLASS =
       FEDERATION_PREFIX + "state-store.class";
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/AMRMClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/AMRMClientUtils.java
@@ -94,12 +94,8 @@ public final class AMRMClientUtils {
         token.setService(ClientRMProxy.getAMRMTokenService(configuration));
         setAuthModeInConf(configuration);
       }
-      final T proxyConnection = user.doAs(new PrivilegedExceptionAction<T>() {
-        @Override
-        public T run() throws Exception {
-          return ClientRMProxy.createRMProxy(configuration, protocol);
-        }
-      });
+      final T proxyConnection = user.doAs((PrivilegedExceptionAction<T>) () ->
+         ClientRMProxy.createRMProxyFederation(configuration, protocol));
       return proxyConnection;
 
     } catch (InterruptedException e) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/AMRMClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/AMRMClientUtils.java
@@ -95,7 +95,7 @@ public final class AMRMClientUtils {
         setAuthModeInConf(configuration);
       }
       final T proxyConnection = user.doAs((PrivilegedExceptionAction<T>) () ->
-         ClientRMProxy.createRMProxyFederation(configuration, protocol));
+          ClientRMProxy.createRMProxyFederation(configuration, protocol));
       return proxyConnection;
 
     } catch (InterruptedException e) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/ClientRMProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/ClientRMProxy.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -87,6 +88,13 @@ public class ClientRMProxy<T> extends RMProxy<T>  {
       final Class<T> protocol) throws IOException {
     ClientRMProxy<T> clientRMProxy = new ClientRMProxy<>();
     return createRMProxyFederation(configuration, protocol, clientRMProxy);
+  }
+
+  @VisibleForTesting
+  public static <T> RMFailoverProxyProvider<T> getClientRMFailoverProxyProvider(
+      final YarnConfiguration configuration, final Class<T> protocol) {
+    ClientRMProxy<T> clientRMProxy = new ClientRMProxy<>();
+    return getRMFailoverProxyProvider(configuration, protocol, clientRMProxy);
   }
 
   private static void setAMRMTokenService(final Configuration conf)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/ClientRMProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/ClientRMProxy.java
@@ -73,6 +73,22 @@ public class ClientRMProxy<T> extends RMProxy<T>  {
     return createRMProxy(configuration, protocol, clientRMProxy);
   }
 
+  /**
+   * Create a proxy to the ResourceManager for the specified protocol.
+   * This method is only used for NodeManager#AMRMClientUtils.
+   *
+   * @param configuration Configuration with all the required information.
+   * @param protocol Client protocol for which proxy is being requested.
+   * @param <T> Type of proxy.
+   * @return Proxy to the ResourceManager for the specified client protocol.
+   * @throws IOException io error occur.
+   */
+  public static <T> T createRMProxyFederation(final Configuration configuration,
+      final Class<T> protocol) throws IOException {
+    ClientRMProxy<T> clientRMProxy = new ClientRMProxy<>();
+    return createRMProxyFederation(configuration, protocol, clientRMProxy);
+  }
+
   private static void setAMRMTokenService(final Configuration conf)
       throws IOException {
     for (Token<? extends TokenIdentifier> token : UserGroupInformation

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/RMProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/RMProxy.java
@@ -130,10 +130,16 @@ public class RMProxy<T> {
       final Class<T> protocol, RMProxy<T> instance) throws IOException {
     YarnConfiguration yarnConf = new YarnConfiguration(configuration);
     if (isFederationNonHAEnabled(yarnConf)) {
-      RetryPolicy retryPolicy = createRetryPolicy(yarnConf, true);
-      return newProxyInstance(yarnConf, protocol, instance, retryPolicy);
+      RetryPolicy retryPolicy = createRetryPolicy(yarnConf, false);
+      return newProxyInstanceFederation(yarnConf, protocol, instance, retryPolicy);
     }
     return createRMProxy(configuration, protocol, instance);
+  }
+
+  private static <T> T newProxyInstanceFederation(final YarnConfiguration conf,
+      final Class<T> protocol, RMProxy<T> instance, RetryPolicy retryPolicy) {
+    RMFailoverProxyProvider<T> provider = instance.createRMFailoverProxyProvider(conf, protocol);
+    return (T) RetryProxy.create(protocol, provider, retryPolicy);
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/RMProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/RMProxy.java
@@ -128,10 +128,8 @@ public class RMProxy<T> {
    */
   protected static <T> T createRMProxyFederation(final Configuration configuration,
       final Class<T> protocol, RMProxy<T> instance) throws IOException {
-    YarnConfiguration yarnConf =
-        (configuration instanceof YarnConfiguration) ? (YarnConfiguration) configuration :
-        new YarnConfiguration(configuration);
-    if(isFederationNonHAEnabled(yarnConf)){
+    YarnConfiguration yarnConf = new YarnConfiguration(configuration);
+    if (isFederationNonHAEnabled(yarnConf)) {
       RetryPolicy retryPolicy = createRetryPolicy(yarnConf, true);
       return newProxyInstance(yarnConf, protocol, instance, retryPolicy);
     }
@@ -380,9 +378,11 @@ public class RMProxy<T> {
   /**
    * If RM is not configured with HA, NM will not configure yarn.resourcemanager.ha.rmIds locally.
    *
-   * If federation mode is enabled and RMProxy#isFailoverEnabled returns true, when NM starts Container,
-   * it will try to find the yarn.resourcemanager.ha.rmIds property.
-   * However, an error will occur because this property is not configured if the user has not configured HA.
+   * If federation mode is enabled and RMProxy#isFailoverEnabled returns true,
+   * when NM starts Container, it will try to find the yarn.resourcemanager.ha.rmIds property.
+   *
+   * However, an error will occur because this property is not configured
+   * if the user has not configured HA.
    *
    * To solve this issue, we can configure the yarn.federation.no-ha.enabled property in NM,
    * which tells NM to run in a non-HA environment.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -5328,4 +5328,16 @@
     <value></value>
   </property>
 
+  <property>
+    <description>
+      YARN Federation supports Non-HA mode.
+      If the cluster is not configured with HA but wants to use YARN Federation,
+      this option can be used.
+      Setting it to true enables Non-HA mode, while false disables Non-HA mode.
+      The default value is false.
+    </description>
+    <name>yarn.federation.non-ha.enabled</name>
+    <value>false</value>
+  </property>
+
 </configuration>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/failover/TestFederationRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/failover/TestFederationRMFailoverProxyProvider.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.yarn.server.federation.failover;
+
+import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
+import org.apache.hadoop.yarn.client.ClientRMProxy;
+import org.apache.hadoop.yarn.client.DefaultNoHARMFailoverProxyProvider;
+import org.apache.hadoop.yarn.client.RMFailoverProxyProvider;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * We will test the failover of Federation.
+ */
+public class TestFederationRMFailoverProxyProvider {
+
+  @Test
+  public void testRMFailoverProxyProvider() throws YarnException {
+    YarnConfiguration configuration = new YarnConfiguration();
+
+    RMFailoverProxyProvider<ApplicationClientProtocol> clientRMFailoverProxyProvider =
+        ClientRMProxy.getClientRMFailoverProxyProvider(configuration, ApplicationClientProtocol.class);
+    assertTrue(clientRMFailoverProxyProvider instanceof DefaultNoHARMFailoverProxyProvider);
+
+    FederationProxyProviderUtil.updateConfForFederation(configuration, "SC-1");
+    configuration.setBoolean(YarnConfiguration.FEDERATION_NON_HA_ENABLED,true);
+    RMFailoverProxyProvider<ApplicationClientProtocol> clientRMFailoverProxyProvider2 =
+        ClientRMProxy.getClientRMFailoverProxyProvider(configuration, ApplicationClientProtocol.class);
+    assertTrue(clientRMFailoverProxyProvider2 instanceof FederationRMFailoverProxyProvider);
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11504. [Federation] YARN Federation Supports Non-HA mode.

I'm conducting integration testing for YARN Federation and have tested the following modes:

- In non-Federation mode, the Router only forwards client requests and can be considered as a proxy for the Resource Manager (RM).
- In non-HA mode, YARN Federation supports multiple clusters and can run both MapReduce (MR) and Spark jobs.
- In HA mode, YARN Federation also supports multiple clusters and can run both MapReduce (MR) and Spark jobs.

YARN Federation has some areas that need further improvement, and I will continue to submit PRs to enhance this feature.

In `non-HA` mode, I found that the NodeManager of YARN Federation cannot run containers properly.

The specific reason for this issue is as follows:

`ON NMs`

```
//  enable YARN Federation mode is required.
<property>
  <name>yarn.federation.enabled</name>
  <value>true</value>
</property>

// enable AMRMProxy is required.
<property>
  <name>yarn.nodemanager.amrmproxy.enabled</name>
  <value>true</value>
</property>

// enable AMRMProxy FederationInterceptor.
<property>
  <name>yarn.nodemanager.amrmproxy.interceptor-class.pipeline</name>
  <value>org.apache.hadoop.yarn.server.nodemanager.amrmproxy.FederationInterceptor</value>
</property>

// as there is no HA, the failover feature of YARN Federation must be disabled.
<property>
  <name>yarn.federation.failover.enabled</name>
  <value>false</value>
</property>

```

After completing the configuration, NodeManager starts normally but we're facing exceptions when running MapReduce (MR) or Spark jobs.

```
org.apache.hadoop.yarn.server.nodemanager.amrmproxy#registerAndAllocateWithNewSubClusters
\-- UnmanagedAMPoolManager#launchUAM
        \-- UnmanagedApplicationManager#launchUAM
            \-- UnmanagedApplicationManager#createUAMProxy
                   \-- UnmanagedApplicationManager#createRMProxy
                           \-- AMRMClientUtils.createRMProxy
                                  \-- ClientRMProxy.createRMProxy(configuration, protocol);
                                          \-- ClientRMProxy#createRMProxy
                                                   \-- RMProxy#createRMProxy
```

RMProxy#createRMProxy
```
@Private
  protected static <T> T createRMProxy(final Configuration configuration,
      final Class<T> protocol, RMProxy<T> instance) throws IOException {
    YarnConfiguration conf = (configuration instanceof YarnConfiguration)
        ? (YarnConfiguration) configuration
        : new YarnConfiguration(configuration);
    RetryPolicy retryPolicy = createRetryPolicy(conf, isFailoverEnabled(conf));
    return newProxyInstance(conf, protocol, instance, retryPolicy);
  }
```

RMProxy#isFailoverEnabled
```
private static boolean isFailoverEnabled(YarnConfiguration conf) {
    if (HAUtil.isHAEnabled(conf)) {
      // Considering Resource Manager HA is enabled.
      return true;
    }
    if (HAUtil.isFederationEnabled(conf) && HAUtil.isFederationFailoverEnabled(conf)) {
      // Considering both federation and federation failover are enabled.
      return true;
    }
    return false;
  }
```

 - We set `yarn.federation.enabled` to true, then `HAUtil.isFederationEnabled` will return true.
 - We set `yarn.federation.failover.enabled` to false, then ` HAUtil.isFederationFailoverEnabled(conf)` will return false.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

