### PR TITLE
HADOOP-18646. Upgrade Netty to 4.1.89.Final to fix CVE-2022-41881 (#5435)

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -295,12 +295,8 @@ io.netty:netty-resolver-dns-classes-macos:4.1.77.Final
 io.netty:netty-transport-native-epoll:4.1.77.Final
 io.netty:netty-transport-native-kqueue:4.1.77.Final
 io.netty:netty-resolver-dns-native-macos:4.1.77.Final
-io.opencensus:opencensus-api:0.24.0
-io.opencensus:opencensus-contrib-grpc-metrics:0.24.0
-io.opentracing:opentracing-api:0.33.0
-io.opentracing:opentracing-noop:0.33.0
-io.opentracing:opentracing-util:0.33.0
-io.perfmark:perfmark-api:0.19.0
+io.opencensus:opencensus-api:0.12.3
+io.opencensus:opencensus-contrib-grpc-metrics:0.12.3
 io.reactivex:rxjava:1.3.8
 io.reactivex:rxjava-string:1.1.1
 io.reactivex:rxnetty:0.4.20

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -144,7 +144,7 @@
     <gson.version>2.9.0</gson.version>
     <metrics.version>3.2.4</metrics.version>
     <netty3.version>3.10.6.Final</netty3.version>
-    <netty4.version>4.1.77.Final</netty4.version>
+    <netty4.version>4.1.89.Final</netty4.version>
     <snappy-java.version>1.1.8.2</snappy-java.version>
     <lz4-java.version>1.7.1</lz4-java.version>
 


### PR DESCRIPTION


This fixes CVE-2022-41881.

This also upgrades io.opencensus dependencies to 0.12.3

Contributed by Aleksandr Nikolaev

(cherry picked from commit 734f7abfb8b84a4c20dbae5073cf2d4fb60adc1c)

 Conflicts:
	hadoop-project/pom.xml

