### PR TITLE
HDFS-17042 Add rpcCallSuccesses and OverallRpcProcessingTime to RpcMetrics for Namenode

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProcessingDetails.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProcessingDetails.java
@@ -20,13 +20,15 @@ package org.apache.hadoop.ipc;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcResponseHeaderProto.RpcStatusProto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
 
 /**
- * Stores the times that a call takes to be processed through each step.
+ * Stores the times that a call takes to be processed through each step and
+ * its response status.
  */
 @InterfaceStability.Unstable
 @InterfaceAudience.Private
@@ -52,6 +54,9 @@ public class ProcessingDetails {
   }
 
   private long[] timings = new long[Timing.values().length];
+
+  // Rpc return status of this call
+  private RpcStatusProto returnStatus = RpcStatusProto.SUCCESS;
 
   ProcessingDetails(TimeUnit timeUnit) {
     this.valueTimeUnit = timeUnit;
@@ -79,6 +84,14 @@ public class ProcessingDetails {
 
   public void add(Timing type, long value, TimeUnit timeUnit) {
     timings[type.ordinal()] += valueTimeUnit.convert(value, timeUnit);
+  }
+
+  public void setReturnStatus(RpcStatusProto status) {
+    this.returnStatus = status;
+  }
+
+  public RpcStatusProto getReturnStatus() {
+    return returnStatus;
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -600,18 +600,18 @@ public abstract class Server {
     }
   }
 
-  void updateMetrics(Call call, long processingStartTime, boolean connDropped) {
+  void updateMetrics(Call call, long processingStartTimeNanos, boolean connDropped) {
     totalRequests.increment();
     // delta = handler + processing + response
-    long completionTime = Time.monotonicNowNanos();
-    long deltaNanos = completionTime - processingStartTime;
-    long arrivalTime = call.timestampNanos;
+    long completionTimeNanos = Time.monotonicNowNanos();
+    long deltaNanos = completionTimeNanos - processingStartTimeNanos;
+    long arrivalTimeNanos = call.timestampNanos;
 
     ProcessingDetails details = call.getProcessingDetails();
     // queue time is the delta between when the call first arrived and when it
     // began being serviced, minus the time it took to be put into the queue
     details.set(Timing.QUEUE,
-        processingStartTime - arrivalTime - details.get(Timing.ENQUEUE));
+        processingStartTimeNanos - arrivalTimeNanos - details.get(Timing.ENQUEUE));
     deltaNanos -= details.get(Timing.PROCESSING);
     deltaNanos -= details.get(Timing.RESPONSE);
     details.set(Timing.HANDLER, deltaNanos);
@@ -638,9 +638,9 @@ public abstract class Server {
     String name = call.getDetailedMetricsName();
     rpcDetailedMetrics.addProcessingTime(name, processingTime);
     // Overall processing time is from arrival to completion.
-    rpcDetailedMetrics.addOverallProcessingTime(name,
-        rpcMetrics.getMetricsTimeUnit().convert(completionTime - arrivalTime,
-            TimeUnit.NANOSECONDS));
+    long overallProcessingTime = rpcMetrics.getMetricsTimeUnit()
+        .convert(completionTimeNanos - arrivalTimeNanos, TimeUnit.NANOSECONDS);
+    rpcDetailedMetrics.addOverallProcessingTime(name, overallProcessingTime);
     callQueue.addResponseTime(name, call, details);
     if (isLogSlowRPC()) {
       logSlowRpcCalls(name, call, details);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -640,6 +640,9 @@ public abstract class Server {
     if (isLogSlowRPC()) {
       logSlowRpcCalls(name, call, details);
     }
+    if (details.getReturnStatus() == RpcStatusProto.SUCCESS) {
+      rpcMetrics.incrRpcCallSuccesses();
+    }
   }
 
   void updateDeferredMetrics(String name, long processingTime) {
@@ -1237,6 +1240,7 @@ public abstract class Server {
         setResponseFields(value, responseParams);
         sendResponse();
 
+        details.setReturnStatus(responseParams.returnStatus);
         deltaNanos = Time.monotonicNowNanos() - startNanos;
         details.set(Timing.RESPONSE, deltaNanos, TimeUnit.NANOSECONDS);
       } else {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcDetailedMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcDetailedMetrics.java
@@ -26,6 +26,9 @@ import org.apache.hadoop.metrics2.lib.MutableRatesWithAggregation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.commons.lang3.StringUtils.capitalize;
+
+
 /**
  * This class is for maintaining RPC method related statistics
  * and publishing them through the metrics interfaces.
@@ -33,13 +36,25 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 @Metrics(about="Per method RPC metrics", context="rpcdetailed")
 public class RpcDetailedMetrics {
+  static final String OVERALL_PROCESSING_PREFIX = "Overall";
 
+  // per-method RPC processing time
   @Metric MutableRatesWithAggregation rates;
   @Metric MutableRatesWithAggregation deferredRpcRates;
+  /**
+   * per-method overall RPC processing time, from request arrival to when the
+   * response is sent back.
+   */
+  @Metric MutableRatesWithAggregation overallRpcProcessingRates;
 
   static final Logger LOG = LoggerFactory.getLogger(RpcDetailedMetrics.class);
   final MetricsRegistry registry;
   final String name;
+
+  // Mainly to facilitate testing in TestRPC.java
+  public MutableRatesWithAggregation getOverallRpcProcessingRates() {
+    return overallRpcProcessingRates;
+  }
 
   RpcDetailedMetrics(int port) {
     name = "RpcDetailedActivityForPort"+ port;
@@ -62,6 +77,7 @@ public class RpcDetailedMetrics {
   public void init(Class<?> protocol) {
     rates.init(protocol);
     deferredRpcRates.init(protocol, "Deferred");
+    overallRpcProcessingRates.init(protocol);
   }
 
   /**
@@ -76,6 +92,16 @@ public class RpcDetailedMetrics {
 
   public void addDeferredProcessingTime(String name, long processingTime) {
     deferredRpcRates.add(name, processingTime);
+  }
+
+  /**
+   * Add an overall RPC processing time sample
+   * @param rpcCallName of the RPC call
+   * @param overallProcessingTime  the overall RPC processing time
+   */
+  public void addOverallProcessingTime(String rpcCallName, long overallProcessingTime) {
+    String metric = OVERALL_PROCESSING_PREFIX + capitalize(rpcCallName);
+    overallRpcProcessingRates.add(metric, overallProcessingTime);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcDetailedMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcDetailedMetrics.java
@@ -34,6 +34,7 @@ import static org.apache.commons.lang3.StringUtils.capitalize;
 @InterfaceAudience.Private
 @Metrics(about="Per method RPC metrics", context="rpcdetailed")
 public class RpcDetailedMetrics {
+  static final String DEFERRED_PREFIX = "Deferred";
   static final String OVERALL_PROCESSING_PREFIX = "Overall";
 
   // per-method RPC processing time
@@ -74,8 +75,8 @@ public class RpcDetailedMetrics {
    */
   public void init(Class<?> protocol) {
     rates.init(protocol);
-    deferredRpcRates.init(protocol, "Deferred");
-    overallRpcProcessingRates.init(protocol);
+    deferredRpcRates.init(protocol, DEFERRED_PREFIX);
+    overallRpcProcessingRates.init(protocol, OVERALL_PROCESSING_PREFIX);
   }
 
   /**
@@ -93,13 +94,12 @@ public class RpcDetailedMetrics {
   }
 
   /**
-   * Add an overall RPC processing time sample
+   * Add an overall RPC processing time sample.
    * @param rpcCallName of the RPC call
    * @param overallProcessingTime  the overall RPC processing time
    */
   public void addOverallProcessingTime(String rpcCallName, long overallProcessingTime) {
-    String metric = OVERALL_PROCESSING_PREFIX + capitalize(rpcCallName);
-    overallRpcProcessingRates.add(metric, overallProcessingTime);
+    overallRpcProcessingRates.add(rpcCallName, overallProcessingTime);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcDetailedMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcDetailedMetrics.java
@@ -25,9 +25,7 @@ import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableRatesWithAggregation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import static org.apache.commons.lang3.StringUtils.capitalize;
-
 
 /**
  * This class is for maintaining RPC method related statistics

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcDetailedMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcDetailedMetrics.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableRatesWithAggregation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static org.apache.commons.lang3.StringUtils.capitalize;
 
 /**
  * This class is for maintaining RPC method related statistics

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -335,7 +335,7 @@ public class RpcMetrics {
   /**
    * One RPC call success event.
    */
-  public  void incrRpcCallSuccesses() {
+  public void incrRpcCallSuccesses() {
     rpcCallSuccesses.incr();
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -138,6 +138,8 @@ public class RpcMetrics {
   MutableCounterLong rpcSlowCalls;
   @Metric("Number of requeue calls")
   MutableCounterLong rpcRequeueCalls;
+  @Metric("Number of successful RPC calls")
+  MutableCounterLong rpcCallSuccesses;
 
   @Metric("Number of open connections") public int numOpenConnections() {
     return server.getNumOpenConnections();
@@ -328,6 +330,13 @@ public class RpcMetrics {
    */
   public void incrRequeueCalls() {
     rpcRequeueCalls.incr();
+  }
+
+  /**
+   * One RPC call success event
+   */
+  public  void incrRpcCallSuccesses() {
+    rpcCallSuccesses.incr();
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -333,7 +333,7 @@ public class RpcMetrics {
   }
 
   /**
-   * One RPC call success event
+   * One RPC call success event.
    */
   public  void incrRpcCallSuccesses() {
     rpcCallSuccesses.incr();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableRatesWithAggregation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableRatesWithAggregation.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static org.apache.commons.lang3.StringUtils.capitalize;
 
+
 /**
  * Helper class to manage a group of mutable rate metrics.
  *

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableRatesWithAggregation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableRatesWithAggregation.java
@@ -59,7 +59,7 @@ public class MutableRatesWithAggregation extends MutableMetric {
   private final ThreadLocal<ConcurrentMap<String, ThreadSafeSampleStat>>
       threadLocalMetricsMap = new ThreadLocal<>();
   // prefix for metric name
-  private String prefix = "";
+  private String typePrefix = "";
 
   /**
    * Initialize the registry with all the methods in a protocol
@@ -162,7 +162,7 @@ public class MutableRatesWithAggregation extends MutableMetric {
   private synchronized MutableRate addMetricIfNotExists(String name) {
     MutableRate metric = globalMetrics.get(name);
     if (metric == null) {
-      String metricName = prefix + capitalize(name);
+      String metricName = typePrefix + capitalize(name);
       metric = new MutableRate(metricName, metricName, false);
       metric.setUpdateTimeStamp(true);
       globalMetrics.put(name, metric);
@@ -187,7 +187,7 @@ public class MutableRatesWithAggregation extends MutableMetric {
   }
 
   public void init(Class<?> protocol, String prefix) {
-    this.prefix = prefix;
+    this.typePrefix = prefix;
     init(protocol);
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableRatesWithAggregation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableRatesWithAggregation.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.metrics2.util.SampleStat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import static org.apache.commons.lang3.StringUtils.capitalize;
 
 /**
  * Helper class to manage a group of mutable rate metrics.
@@ -59,7 +59,7 @@ public class MutableRatesWithAggregation extends MutableMetric {
   private final ThreadLocal<ConcurrentMap<String, ThreadSafeSampleStat>>
       threadLocalMetricsMap = new ThreadLocal<>();
   // prefix for metric name
-  private String typePrefix = "";
+  private String prefix = "";
 
   /**
    * Initialize the registry with all the methods in a protocol
@@ -162,7 +162,8 @@ public class MutableRatesWithAggregation extends MutableMetric {
   private synchronized MutableRate addMetricIfNotExists(String name) {
     MutableRate metric = globalMetrics.get(name);
     if (metric == null) {
-      metric = new MutableRate(name + typePrefix, name + typePrefix, false);
+      String metricName = prefix + capitalize(name);
+      metric = new MutableRate(metricName, metricName, false);
       metric.setUpdateTimeStamp(true);
       globalMetrics.put(name, metric);
     }
@@ -186,7 +187,7 @@ public class MutableRatesWithAggregation extends MutableMetric {
   }
 
   public void init(Class<?> protocol, String prefix) {
-    this.typePrefix = prefix;
+    this.prefix = prefix;
     init(protocol);
   }
 

--- a/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
@@ -82,6 +82,9 @@ The default timeunit used for RPC metrics is milliseconds (as per the below desc
 | `RpcAuthenticationSuccesses` | Total number of authentication successes |
 | `RpcAuthorizationFailures` | Total number of authorization failures |
 | `RpcAuthorizationSuccesses` | Total number of authorization successes |
+| `RpcClientBackoff` | Total number of client backoff requests |
+| `RpcSlowCalls` | Total number of slow RPC calls |
+| `RpcCallsSuccesses` | Total number of RPC calls that are successfully processed |
 | `NumOpenConnections` | Current number of open connections |
 | `NumInProcessHandler` | Current number of handlers on working |
 | `CallQueueLength` | Current length of the call queue |

--- a/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
@@ -145,8 +145,10 @@ to FairCallQueue metrics. For each level of priority, rpcqueue and rpcprocessing
 rpcdetailed context
 ===================
 
-Metrics of rpcdetailed context are exposed in unified manner by RPC layer. Two metrics are exposed for each RPC based on its name. Metrics named "(RPC method name)NumOps" indicates total number of method calls, and metrics named "(RPC method name)AvgTime" shows average turn around time for method calls in milliseconds.
+Metrics of rpcdetailed context are exposed in unified manner by RPC layer. Two metrics are exposed for each RPC based on its name. Metrics named "(RPC method name)NumOps" indicates total number of method calls, and metrics named "(RPC method name)AvgTime" shows average processing time for method calls in milliseconds.
 Please note that the AvgTime metrics do not include time spent waiting to acquire locks on data structures (see RpcLockWaitTimeAvgTime).
+Metrics named "Overall(RPC method name)AvgTime" shows the average overall processing time for method calls
+in milliseconds. It is measured from request arrival to when the response is sent back to the client.
 
 rpcdetailed
 -----------

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -1419,11 +1419,9 @@ public class TestRPC extends TestRpcBase {
       }
       MetricsRecordBuilder rpcMetrics =
           getMetrics(server.getRpcMetrics().name());
-      assertEquals("Expected correct rpcCallSuccesses count", 10,
-          getLongCounter("RpcCallSuccesses", rpcMetrics));
+      assertCounter("RpcCallSuccesses", 10L, rpcMetrics);
       // rpcQueueTimeNumOps equals total number of RPC calls.
-      assertEquals("Expected correct rpcQueueTime count", 10,
-          getLongCounter("RpcQueueTimeNumOps", rpcMetrics));
+      assertCounter("RpcQueueTimeNumOps", 10L, rpcMetrics);
 
       // 2 failed responses with ERROR status and 1 more successful response.
       for (int i = 0; i < 2; i++) {
@@ -1435,11 +1433,8 @@ public class TestRPC extends TestRpcBase {
       proxy.ping(null, newEmptyRequest());
 
       rpcMetrics = getMetrics(server.getRpcMetrics().name());
-      assertEquals("Expected correct rpcCallSuccesses count", 11,
-          getLongCounter("RpcCallSuccesses", rpcMetrics));
-      // rpcQueueTimeNumOps equals total number of RPC calls.
-      assertEquals("Expected correct rpcQueueTime count", 13,
-          getLongCounter("RpcQueueTimeNumOps", rpcMetrics));
+      assertCounter("RpcCallSuccesses", 11L, rpcMetrics);
+      assertCounter("RpcQueueTimeNumOps", 13L, rpcMetrics);
     } finally {
       stop(server, proxy);
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -97,6 +97,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static org.apache.hadoop.test.MetricsAsserts.assertGaugeGt;
+import static org.apache.hadoop.test.MetricsAsserts.assertGaugeGte;
 import static org.apache.hadoop.test.MetricsAsserts.mockMetricsRecordBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
@@ -1466,9 +1467,11 @@ public class TestRPC extends TestRpcBase {
           server.rpcDetailedMetrics.getOverallRpcProcessingRates();
       rates.snapshot(rb, true);
 
-      // Verify the ping request. AvgTime should be non-zero.
+      // Verify the ping request.
+      // Overall processing time for ping is zero when this test is run together with
+      // the rest of tests. Thus, we use assertGaugeGte() for OverallPingAvgTime.
       assertCounter("OverallPingNumOps", 1L, rb);
-      assertGaugeGt("OverallPingAvgTime", 0, rb);
+      assertGaugeGte("OverallPingAvgTime", 0.0, rb);
 
       // Verify lockAndSleep requests. AvgTime should be greater than 10 ms,
       // since we sleep for 10 and 12 ms respectively.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -1445,7 +1445,7 @@ public class TestRPC extends TestRpcBase {
   }
 
   /**
-   * Test per-type overall RPC processing time metric
+   * Test per-type overall RPC processing time metric.
    */
   @Test
   public void testOverallRpcProcessingTimeMetric() throws Exception {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
@@ -328,7 +328,20 @@ public class TestMutableMetrics {
     verify(rb, times(1))
         .addCounter(info("GetLongNumOps", "Number of ops for getLong"), 0L);
     verify(rb, times(1)).addCounter(
-        info("GetLongDeferredNumOps", "Number of ops for getLongDeferred"), 0L);
+        info("DeferredGetLongNumOps", "Number of ops for deferredGetLong"), 0L);
+
+    // Add some samples and verify
+    rb = mockMetricsRecordBuilder();
+    rates.add("testRpcMethod", 10);
+    deferredRpcRates.add("testRpcMethod", 100);
+    deferredRpcRates.add("testRpcMethod", 500);
+    rates.snapshot(rb, true);
+    deferredRpcRates.snapshot(rb, true);
+
+    assertCounter("TestRpcMethodNumOps", 1L, rb);
+    assertGauge("TestRpcMethodAvgTime", 10.0, rb);
+    assertCounter("DeferredTestRpcMethodNumOps", 2L, rb);
+    assertGauge("DeferredTestRpcMethodAvgTime", 300.0, rb);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
@@ -366,8 +366,9 @@ public class MetricsAsserts {
    */
   public static void assertGaugeGte(String name, double greater,
       MetricsRecordBuilder rb) {
+    double curValue = getDoubleGauge(name, rb);
     Assert.assertTrue("Bad value for metric " + name,
-        getDoubleGauge(name, rb) >= greater);
+        curValue >= greater);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
@@ -359,7 +359,7 @@ public class MetricsAsserts {
   }
 
   /**
-   * Assert that a double gauge metric is greater than or equal to a value
+   * Assert that a double gauge metric is greater than or equal to a value.
    * @param name  of the metric
    * @param greater value of the metric should be greater than or equal to this
    * @param rb  the record builder mock used to getMetrics

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
@@ -359,6 +359,18 @@ public class MetricsAsserts {
   }
 
   /**
+   * Assert that a double gauge metric is greater than or equal to a value
+   * @param name  of the metric
+   * @param greater value of the metric should be greater than or equal to this
+   * @param rb  the record builder mock used to getMetrics
+   */
+  public static void assertGaugeGte(String name, double greater,
+      MetricsRecordBuilder rb) {
+    Assert.assertTrue("Bad value for metric " + name,
+        getDoubleGauge(name, rb) >= greater);
+  }
+
+  /**
    * Assert that a double gauge metric is greater than a value
    * @param name  of the metric
    * @param greater value of the metric should be greater than this


### PR DESCRIPTION
### Description of PR
Add two new types of metrics to the existing NN RpcMetrics/RpcDetailedMetrics. These two metrics can then be used as part of SLA/SLO for the HDFS service.

- RpcCallSuccesses: it measures the number of RPC requests where they are successfully processed by a NN (e.g., with a response with an RpcStatus RpcStatusProto.SUCCESS). Then, together with RpcQueueNumOps (which refers the total number of RPC requests), we can derive the RpcErrorRate for our NN, as (RpcQueueNumOps - RpcCallSuccesses) / RpcQueueNumOps. 

- OverallRpcProcessingTime for each RPC method: this metric measures the overall RPC processing time for each RPC method at the NN. It covers the time from when a request arrives at the NN to when a response is sent back. We are already emitting processingTime for each RPC method today in RpcDetailedMetrics. We want to extend it to emit overallRpcProcessingTime for each RPC method, which includes enqueueTime, queueTime, processingTime, responseTime, and handlerTime.

### How was this patch tested?
```
mvn test -Dtest="TestProtoBufRpc"
mvn test -Dtest="TestRPC"
mvn test -Dtest="TestMutableMetrics"
```

