### PR TITLE
YARN-11510. [Federation] Fix NodeManager#TestFederationInterceptor Flaky Unit Test.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -3075,6 +3075,10 @@ public class YarnConfiguration extends Configuration {
       + "amrmproxy.enabled";
   public static final boolean DEFAULT_AMRM_PROXY_ENABLED = false;
 
+  public static final String AMRM_PROXY_WAIT_UAM_REGISTER_DONE =
+      NM_PREFIX + "amrmproxy.wait.uam-register.done";
+  public static final boolean DEFAULT_AMRM_PROXY_WAIT_UAM_REGISTER_DONE = false;
+
   public static final String AMRM_PROXY_ADDRESS = NM_PREFIX
       + "amrmproxy.address";
   public static final int DEFAULT_AMRM_PROXY_PORT = 8049;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -5363,7 +5363,7 @@
     <name>yarn.nodemanager.amrmproxy.wait.uam-register.done</name>
     <value>false</value>
   </property>
-  
+
   <property>
     <description>
       YARN Federation supports Non-HA mode.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -5328,4 +5328,14 @@
     <value></value>
   </property>
 
+  <property>
+    <description>
+      Whether we wait for uam registration to complete.
+      The default value is false. If we set it to true,
+      the UAM needs to be registered before attempting to allocate a container.
+    </description>
+    <name>yarn.nodemanager.amrmproxy.wait.uam-register.done</name>
+    <value>false</value>
+  </property>
+
 </configuration>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/MockResourceManagerFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/MockResourceManagerFacade.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.util.ArrayList;
@@ -183,7 +184,7 @@ import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
  * change the implementation with care.
  */
 public class MockResourceManagerFacade implements ApplicationClientProtocol,
-    ApplicationMasterProtocol, ResourceManagerAdministrationProtocol {
+    ApplicationMasterProtocol, ResourceManagerAdministrationProtocol, Closeable {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(MockResourceManagerFacade.class);
@@ -966,5 +967,10 @@ public class MockResourceManagerFacade implements ApplicationClientProtocol,
   @VisibleForTesting
   public HashMap<ApplicationId, List<ContainerId>> getApplicationContainerIdMap() {
     return applicationContainerIdMap;
+  }
+
+  @Override
+  public void close() throws IOException {
+    isRunning = false;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/MockResourceManagerFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/MockResourceManagerFacade.java
@@ -971,6 +971,6 @@ public class MockResourceManagerFacade implements ApplicationClientProtocol,
 
   @Override
   public void close() throws IOException {
-    isRunning = false;
+    LOG.info("MockResourceManagerFacade Close.");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.registry.client.api.RegistryOperations;
 import org.apache.hadoop.registry.client.impl.FSRegistryOperationsService;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
@@ -595,7 +596,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
         Assert.assertEquals(1, interceptor.getUnmanagedAMPoolSize());
 
         // Waiting for SC-1 to time out.
-        Thread.sleep(800);
+        GenericTestUtils.waitFor(() -> interceptor.getTimedOutSCs(true).size() == 1, 100, 1000);
 
         // SC1 should be initialized to be timed out
         Assert.assertEquals(1, interceptor.getTimedOutSCs(true).size());
@@ -891,7 +892,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
         Assert.assertEquals(1, interceptor.getUnmanagedAMPoolSize());
 
         // Waiting for SC-1 to time out.
-        Thread.sleep(800);
+        GenericTestUtils.waitFor(() -> interceptor.getTimedOutSCs(true).size() == 1, 100, 1000);
 
         // SC1 should be initialized to be timed out
         Assert.assertEquals(1, interceptor.getTimedOutSCs(true).size());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
@@ -175,6 +175,9 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
     conf.setLong(YarnConfiguration.FEDERATION_AMRMPROXY_SUBCLUSTER_TIMEOUT,
         500);
 
+    // Wait UAM Register Down
+    conf.setBoolean(YarnConfiguration.AMRM_PROXY_WAIT_UAM_REGISTER_DONE, true);
+
     return conf;
   }
 
@@ -590,6 +593,10 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
         interceptor.recover(recoveredDataMap);
 
         Assert.assertEquals(1, interceptor.getUnmanagedAMPoolSize());
+
+        // Waiting for SC-1 to time out.
+        Thread.sleep(800);
+
         // SC1 should be initialized to be timed out
         Assert.assertEquals(1, interceptor.getTimedOutSCs(true).size());
 
@@ -848,7 +855,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
         List<Container> containers =
             getContainersAndAssert(numberOfContainers, numberOfContainers * 2);
         for (Container c : containers) {
-          LOG.info("Allocated container " + c.getId());
+          LOG.info("Allocated container {}", c.getId());
         }
         Assert.assertEquals(1, interceptor.getUnmanagedAMPoolSize());
 
@@ -882,6 +889,10 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
         int numberOfContainers = 3;
         // Should re-attach secondaries and get the three running containers
         Assert.assertEquals(1, interceptor.getUnmanagedAMPoolSize());
+
+        // Waiting for SC-1 to time out.
+        Thread.sleep(800);
+
         // SC1 should be initialized to be timed out
         Assert.assertEquals(1, interceptor.getTimedOutSCs(true).size());
         Assert.assertEquals(numberOfContainers,


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: YARN-11510. [Federation] Fix NodeManager#TestFederationInterceptor Flaky Unit Test.

- Issue 1: java.lang.IllegalArgumentException: not a proxy instance

```
2023-06-10 16:38:39,932 ERROR [main] ipc.RPC (RPC.java:stopProxy(811)) - RPC.stopProxy called on non proxy: class=org.apache.hadoop.yarn.server.MockResourceManagerFacade
java.lang.IllegalArgumentException: not a proxy instance
    at java.lang.reflect.Proxy.getInvocationHandler(Proxy.java:816)
    at org.apache.hadoop.ipc.RPC.stopProxy(RPC.java:802)
    at org.apache.hadoop.yarn.server.AMRMClientRelayer.shutdown(AMRMClientRelayer.java:198)
    at org.apache.hadoop.yarn.server.nodemanager.amrmproxy.FederationInterceptor.shutdown(FederationInterceptor.java:883)
    at org.apache.hadoop.yarn.server.nodemanager.amrmproxy.TestFederationInterceptor.tearDown(TestFederationInterceptor.java:145)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

> Issue Cause and Solution

This issue is because `MockResourceManagerFacade` does not implement `Closeable`, so it cannot be closed properly.
We can solve the issue by letting `MockResourceManagerFacade` implements `Closeable`.

----

- Issue 2:  TestFederationInterceptor#testRecoverWithoutAMRMProxyHA getTimedOutSCs(SC-1) Error.

```
// Line 594
Assert.assertEquals(1, interceptor.getTimedOutSCs(true).size());

java.lang.AssertionError:
Expected :1
Actual :0
<Click to see difference>

at org.junit.Assert.fail(Assert.java:89)
at org.junit.Assert.failNotEquals(Assert.java:835)
at org.junit.Assert.assertEquals(Assert.java:647)
at org.junit.Assert.assertEquals(Assert.java:633)
at org.apache.hadoop.yarn.server.nodemanager.amrmproxy.TestFederationInterceptor$3.run(TestFederationInterceptor.java:594)
at java.security.AccessController.doPrivileged(Native Method)
at javax.security.auth.Subject.doAs(Subject.java:422)
at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1953)
at org.apache.hadoop.yarn.server.nodemanager.amrmproxy.TestFederationInterceptor.testRecover(TestFederationInterceptor.java:534)
at org.apache.hadoop.yarn.server.nodemanager.amrmproxy.TestFederationInterceptor.testRecoverWithoutAMRMProxyHA(TestFederationInterceptor.java:517)
```

> Issue Cause and Solution

This issue is because we need to wait for the timeout of SC-1, which takes 500ms. However, if the program executes very quickly, this process may take less than 500ms, resulting in an assertion error when judging that the subcluster has expired.
We sleep in the program for `800ms` to ensure that `SC-1` times out.

----

- Issue 3:  TestFederationInterceptor#ttestSubClusterTimeOut AllocateAsync should not be called before launchUAM

```
2023-06-10 17:28:24,986 INFO [pool-23-thread-1] uam.UnmanagedAMPoolManager (UnmanagedAMPoolManager.java:launchUAM(210)) - Launching UAM id [SC-1](https://issues.apache.org/jira/browse/SCB-1) for application application_123456_0001
2023-06-10 17:28:24,986 ERROR [main] amrmproxy.FederationInterceptor (FederationInterceptor.java:allocate(780)) - Exception encountered while processing heart beat for appattempt_123456_0001_000001
org.apache.hadoop.yarn.exceptions.YarnException: AllocateAsync should not be called before launchUAM
at org.apache.hadoop.yarn.server.uam.UnmanagedApplicationManager.allocateAsync(UnmanagedApplicationManager.java:325)
at org.apache.hadoop.yarn.server.uam.UnmanagedAMPoolManager.allocateAsync(UnmanagedAMPoolManager.java:325)
```

> Issue Cause and Solution

This issue is because our registration of UAM and allocation of Containers through AllocateAsync are asynchronous. This is reasonable for production environments, as we can allocate containers once the UAM is successfully registered. However, for testing scenarios, we need to wait for the UAM to be registered before we allocate containers.

Our new configuration parameter is 'yarn.nodemanager.amrmproxy.wait.uam-register.done', which is set to false by default.
In the unit tests, we set 'yarn.nodemanager.amrmproxy.wait.uam-register.done' to true to ensure that UAM has completed registration before allocating containers.


### How was this patch tested?

Junit Test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

