### PR TITLE
YARN-11429. Improve the updateTestDataAutomatically in TestRMWebServices.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySched.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySched.java
@@ -336,7 +336,7 @@ public class TestRMWebServicesCapacitySched extends JerseyTestBase {
       JSONException, IOException {
     assertJsonType(response);
     JSONObject json = response.getEntity(JSONObject.class);
-    String actual = json.toString(2);
+    String actual = prettyPrintJson(json.toString(2));
     updateTestDataAutomatically(expectedResourceFilename, actual);
     assertEquals(
         prettyPrintJson(getResourceAsString(expectedResourceFilename)),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-AbsoluteMode.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-AbsoluteMode.json
@@ -1,1739 +1,1679 @@
-{"scheduler": {"schedulerInfo": {
-  "type": "capacityScheduler",
-  "capacity": 100,
-  "usedCapacity": 0,
-  "maxCapacity": 100,
-  "weight": -1,
-  "normalizedWeight": 0,
-  "queueName": "root",
-  "queuePath": "root",
-  "maxParallelApps": 2147483647,
-  "isAbsoluteResource": true,
-  "queues": {"queue": [
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.test2",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 0,
-      "absoluteMaxCapacity": 0,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "test2",
-      "isAbsoluteResource": true,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
+{
+  "scheduler" : {
+    "schedulerInfo" : {
+      "type" : "capacityScheduler",
+      "capacity" : 100,
+      "usedCapacity" : 0,
+      "maxCapacity" : 100,
+      "weight" : -1,
+      "normalizedWeight" : 0,
+      "queueName" : "root",
+      "queuePath" : "root",
+      "maxParallelApps" : 2147483647,
+      "isAbsoluteResource" : true,
+      "queues" : {
+        "queue" : [ {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.test2",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 0,
+          "absoluteMaxCapacity" : 0,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "test2",
+          "isAbsoluteResource" : true,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
           },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 0,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 0,
+              "maxAMLimitPercentage" : 10,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 1024,
+                "vCores" : 5,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1024
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 5
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 1024,
+                "vCores" : 5,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1024
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 5
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 1024,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1024
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 1024,
+            "vCores" : 5,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1024
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 5
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "absolute",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 0,
+          "maxApplicationsPerUser" : 0,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 1024,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1024
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 1024,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1024
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.test1",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 0,
+          "absoluteMaxCapacity" : 0,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "test1",
+          "isAbsoluteResource" : true,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 0,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 0,
+              "maxAMLimitPercentage" : 10,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 2048,
+                "vCores" : 10,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 2048
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 10
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 2048,
+                "vCores" : 10,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 2048
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 10
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 1024,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1024
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 2048,
+            "vCores" : 10,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 2048
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 10
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "absolute",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 0,
+          "maxApplicationsPerUser" : 0,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 1024,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1024
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 1024,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1024
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.default",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 0,
+          "absoluteMaxCapacity" : 0,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "default",
+          "isAbsoluteResource" : true,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 0,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 0,
+              "maxAMLimitPercentage" : 10,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 3064,
+                "vCores" : 15,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 3064
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 15
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 3064,
+                "vCores" : 15,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 3064
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 15
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 1024,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1024
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 3064,
+            "vCores" : 15,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 3064
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 15
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "absolute",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 0,
+          "maxApplicationsPerUser" : 0,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 1024,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1024
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 1024,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1024
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        } ]
       },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 0,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 0,
-        "maxAMLimitPercentage": 10,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 1024,
-          "vCores": 5,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1024
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 5
+      "capacities" : {
+        "queueCapacitiesByPartition" : [ {
+          "partitionName" : "",
+          "capacity" : 100,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "absoluteMaxCapacity" : 100,
+          "maxAMLimitPercentage" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "configuredMinResource" : {
+            "memory" : 6136,
+            "vCores" : 30,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 6136
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 30
+              } ]
             }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "configuredMaxResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 1024,
-          "vCores": 5,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1024
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 5
+          },
+          "effectiveMinResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "effectiveMaxResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
+          }
+        } ]
+      },
+      "health" : {
+        "lastrun" : 0,
+        "operationsInfo" : [ {
+          "operation" : "last-allocation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-release",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-preemption",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-reservation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        } ],
+        "lastRunDetails" : [ {
+          "operation" : "releases",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "allocations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "reservations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        } ]
+      },
+      "maximumAllocation" : {
+        "memory" : 8192,
+        "vCores" : 4,
+        "resourceInformations" : {
+          "resourceInformation" : [ {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "memory-mb",
+            "resourceType" : "COUNTABLE",
+            "units" : "Mi",
+            "value" : 8192
+          }, {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "vcores",
+            "resourceType" : "COUNTABLE",
+            "units" : "",
+            "value" : 4
+          } ]
         }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 1024,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1024
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 1024,
-        "vCores": 5,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1024
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 5
-          }
-        ]}
       },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
+      "queueAcls" : {
+        "queueAcl" : [ {
+          "accessType" : "ADMINISTER_QUEUE",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "APPLICATION_MAX_PRIORITY",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "SUBMIT_APP",
+          "accessControlList" : "*"
+        } ]
       },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "absolute",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 0,
-      "maxApplicationsPerUser": 0,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 1024,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1024
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 1024,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1024
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.test1",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 0,
-      "absoluteMaxCapacity": 0,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "test1",
-      "isAbsoluteResource": true,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 0,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 0,
-        "maxAMLimitPercentage": 10,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 2048,
-          "vCores": 10,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 2048
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 10
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 2048,
-          "vCores": 10,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 2048
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 10
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 1024,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1024
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 2048,
-        "vCores": 10,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 2048
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 10
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "absolute",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 0,
-      "maxApplicationsPerUser": 0,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 1024,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1024
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 1024,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1024
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.default",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 0,
-      "absoluteMaxCapacity": 0,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "default",
-      "isAbsoluteResource": true,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 0,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 0,
-        "maxAMLimitPercentage": 10,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 3064,
-          "vCores": 15,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 3064
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 15
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 3064,
-          "vCores": 15,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 3064
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 15
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 1024,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1024
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 3064,
-        "vCores": 15,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 3064
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 15
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "absolute",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 0,
-      "maxApplicationsPerUser": 0,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 1024,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1024
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 1024,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1024
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
+      "queuePriority" : 0,
+      "orderingPolicyInfo" : "utilization",
+      "mode" : "absolute",
+      "queueType" : "parent",
+      "creationMethod" : "static",
+      "autoCreationEligibility" : "off",
+      "autoQueueTemplateProperties" : { },
+      "autoQueueParentTemplateProperties" : { },
+      "autoQueueLeafTemplateProperties" : { }
     }
-  ]},
-  "capacities": {"queueCapacitiesByPartition": [{
-    "partitionName": "",
-    "capacity": 100,
-    "usedCapacity": 0,
-    "maxCapacity": 100,
-    "absoluteCapacity": 100,
-    "absoluteUsedCapacity": 0,
-    "absoluteMaxCapacity": 100,
-    "maxAMLimitPercentage": 0,
-    "weight": -1,
-    "normalizedWeight": 0,
-    "configuredMinResource": {
-      "memory": 6136,
-      "vCores": 30,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 6136
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 30
-        }
-      ]}
-    },
-    "configuredMaxResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "effectiveMinResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "effectiveMaxResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    }
-  }]},
-  "health": {
-    "lastrun": 0,
-    "operationsInfo": [
-      {
-        "operation": "last-allocation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-release",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-preemption",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-reservation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      }
-    ],
-    "lastRunDetails": [
-      {
-        "operation": "releases",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "allocations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "reservations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }
-    ]
-  },
-  "maximumAllocation": {
-    "memory": 8192,
-    "vCores": 4,
-    "resourceInformations": {"resourceInformation": [
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "memory-mb",
-        "resourceType": "COUNTABLE",
-        "units": "Mi",
-        "value": 8192
-      },
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "vcores",
-        "resourceType": "COUNTABLE",
-        "units": "",
-        "value": 4
-      }
-    ]}
-  },
-  "queueAcls": {"queueAcl": [
-    {
-      "accessType": "ADMINISTER_QUEUE",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "APPLICATION_MAX_PRIORITY",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "SUBMIT_APP",
-      "accessControlList": "*"
-    }
-  ]},
-  "queuePriority": 0,
-  "orderingPolicyInfo": "utilization",
-  "mode": "absolute",
-  "queueType": "parent",
-  "creationMethod": "static",
-  "autoCreationEligibility": "off",
-  "autoQueueTemplateProperties": {},
-  "autoQueueParentTemplateProperties": {},
-  "autoQueueLeafTemplateProperties": {}
-}}}
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-AbsoluteModeLegacyAutoCreation.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-AbsoluteModeLegacyAutoCreation.json
@@ -1,1592 +1,1539 @@
-{"scheduler": {"schedulerInfo": {
-  "type": "capacityScheduler",
-  "capacity": 100,
-  "usedCapacity": 0,
-  "maxCapacity": 100,
-  "weight": -1,
-  "normalizedWeight": 0,
-  "queueName": "root",
-  "queuePath": "root",
-  "maxParallelApps": 2147483647,
-  "isAbsoluteResource": false,
-  "queues": {"queue": [
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.default",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 0,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "default",
-      "isAbsoluteResource": false,
-      "state": "STOPPED",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
+{
+  "scheduler" : {
+    "schedulerInfo" : {
+      "type" : "capacityScheduler",
+      "capacity" : 100,
+      "usedCapacity" : 0,
+      "maxCapacity" : 100,
+      "weight" : -1,
+      "normalizedWeight" : 0,
+      "queueName" : "root",
+      "queuePath" : "root",
+      "maxParallelApps" : 2147483647,
+      "isAbsoluteResource" : false,
+      "queues" : {
+        "queue" : [ {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.default",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 0,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "default",
+          "isAbsoluteResource" : false,
+          "state" : "STOPPED",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
           },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 0,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 8388608,
+                "vCores" : 8192,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8388608
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 8192
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 839680,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 839680
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 8388608,
+            "vCores" : 8192,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8388608
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 8192
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "percentage",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 0,
+          "maxApplicationsPerUser" : 0,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 839680,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 839680
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 839680,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 839680
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "queuePath" : "root.managed",
+          "capacity" : 0.048828125,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 0.048828125,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "managed",
+          "isAbsoluteResource" : true,
+          "state" : "RUNNING",
+          "queues" : {
+            "queue" : [ {
+              "type" : "capacitySchedulerLeafQueueInfo",
+              "queuePath" : "root.managed.queue1",
+              "capacity" : 50,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 0.024414062,
+              "absoluteMaxCapacity" : 100,
+              "absoluteUsedCapacity" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "numApplications" : 0,
+              "maxParallelApps" : 2147483647,
+              "queueName" : "queue1",
+              "isAbsoluteResource" : true,
+              "state" : "RUNNING",
+              "resourcesUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "hideReservationQueues" : false,
+              "nodeLabels" : [ "*" ],
+              "allocatedContainers" : 0,
+              "reservedContainers" : 0,
+              "pendingContainers" : 0,
+              "capacities" : {
+                "queueCapacitiesByPartition" : [ {
+                  "partitionName" : "",
+                  "capacity" : 50,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 0.024414062,
+                  "absoluteUsedCapacity" : 0,
+                  "absoluteMaxCapacity" : 100,
+                  "maxAMLimitPercentage" : 10,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "configuredMinResource" : {
+                    "memory" : 2048,
+                    "vCores" : 2,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 2048
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 2
+                      } ]
+                    }
+                  },
+                  "configuredMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMinResource" : {
+                    "memory" : 2048,
+                    "vCores" : 2,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 2048
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 2
+                      } ]
+                    }
+                  },
+                  "effectiveMaxResource" : {
+                    "memory" : 8388608,
+                    "vCores" : 8192,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 8388608
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 8192
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "resources" : {
+                "resourceUsagesByPartition" : [ {
+                  "partitionName" : "",
+                  "used" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "reserved" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "pending" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amLimit" : {
+                    "memory" : 839680,
+                    "vCores" : 1,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 839680
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 1
+                      } ]
+                    }
+                  },
+                  "userAmLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "minEffectiveCapacity" : {
+                "memory" : 2048,
+                "vCores" : 2,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 2048
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 2
+                  } ]
+                }
+              },
+              "maxEffectiveCapacity" : {
+                "memory" : 8388608,
+                "vCores" : 8192,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8388608
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 8192
+                  } ]
+                }
+              },
+              "maximumAllocation" : {
+                "memory" : 8192,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8192
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "queueAcls" : {
+                "queueAcl" : [ {
+                  "accessType" : "ADMINISTER_QUEUE",
+                  "accessControlList" : "admin "
+                }, {
+                  "accessType" : "APPLICATION_MAX_PRIORITY",
+                  "accessControlList" : "*"
+                }, {
+                  "accessType" : "SUBMIT_APP",
+                  "accessControlList" : "user "
+                } ]
+              },
+              "queuePriority" : 0,
+              "orderingPolicyInfo" : "fifo",
+              "autoCreateChildQueueEnabled" : false,
+              "leafQueueTemplate" : { },
+              "mode" : "absolute",
+              "queueType" : "leaf",
+              "creationMethod" : "dynamicLegacy",
+              "autoCreationEligibility" : "off",
+              "autoQueueTemplateProperties" : { },
+              "autoQueueParentTemplateProperties" : { },
+              "autoQueueLeafTemplateProperties" : { },
+              "numActiveApplications" : 0,
+              "numPendingApplications" : 0,
+              "numContainers" : 0,
+              "maxApplications" : 2,
+              "maxApplicationsPerUser" : 2,
+              "userLimit" : 100,
+              "users" : { },
+              "userLimitFactor" : 1,
+              "configuredMaxAMResourceLimit" : 0.1,
+              "AMResourceLimit" : {
+                "memory" : 839680,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 839680
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "usedAMResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAMResourceLimit" : {
+                "memory" : 839680,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 839680
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "preemptionDisabled" : true,
+              "intraQueuePreemptionDisabled" : true,
+              "defaultPriority" : 0,
+              "isAutoCreatedLeafQueue" : true,
+              "maxApplicationLifetime" : -1,
+              "defaultApplicationLifetime" : -1
+            } ]
+          },
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0.048828125,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 0.048828125,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 4096,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 4096
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 4096,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 4096
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 8388608,
+                "vCores" : 8192,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8388608
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 8192
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 4096,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 4096
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 8388608,
+            "vCores" : 8192,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8388608
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 8192
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "utilization",
+          "autoCreateChildQueueEnabled" : true,
+          "leafQueueTemplate" : {
+            "property" : [ {
+              "name" : "leaf-queue-template.acl_administer_queue",
+              "value" : "admin"
+            }, {
+              "name" : "leaf-queue-template.capacity",
+              "value" : "[memory=2048,vcores=2]"
+            }, {
+              "name" : "leaf-queue-template.acl_submit_applications",
+              "value" : "user"
+            } ]
+          },
+          "mode" : "absolute",
+          "queueType" : "parent",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "legacy",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { }
+        } ]
       },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 0,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+      "capacities" : {
+        "queueCapacitiesByPartition" : [ {
+          "partitionName" : "",
+          "capacity" : 100,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "absoluteMaxCapacity" : 100,
+          "maxAMLimitPercentage" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "configuredMinResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "configuredMaxResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "effectiveMinResource" : {
+            "memory" : 8388608,
+            "vCores" : 8192,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8388608
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 8192
+              } ]
             }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 8388608,
-          "vCores": 8192,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 8388608
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 8192
+          },
+          "effectiveMaxResource" : {
+            "memory" : 8388608,
+            "vCores" : 8192,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8388608
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 8192
+              } ]
             }
-          ]}
+          }
+        } ]
+      },
+      "health" : {
+        "lastrun" : 0,
+        "operationsInfo" : [ {
+          "operation" : "last-allocation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-release",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-preemption",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-reservation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        } ],
+        "lastRunDetails" : [ {
+          "operation" : "releases",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "allocations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "reservations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        } ]
+      },
+      "maximumAllocation" : {
+        "memory" : 8192,
+        "vCores" : 4,
+        "resourceInformations" : {
+          "resourceInformation" : [ {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "memory-mb",
+            "resourceType" : "COUNTABLE",
+            "units" : "Mi",
+            "value" : 8192
+          }, {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "vcores",
+            "resourceType" : "COUNTABLE",
+            "units" : "",
+            "value" : 4
+          } ]
         }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 839680,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 839680
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
       },
-      "maxEffectiveCapacity": {
-        "memory": 8388608,
-        "vCores": 8192,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8388608
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 8192
-          }
-        ]}
+      "queueAcls" : {
+        "queueAcl" : [ {
+          "accessType" : "ADMINISTER_QUEUE",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "APPLICATION_MAX_PRIORITY",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "SUBMIT_APP",
+          "accessControlList" : "*"
+        } ]
       },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "percentage",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 0,
-      "maxApplicationsPerUser": 0,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 839680,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 839680
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 839680,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 839680
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "queuePath": "root.managed",
-      "capacity": 0.048828125,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 0.048828125,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "managed",
-      "isAbsoluteResource": true,
-      "state": "RUNNING",
-      "queues": {"queue": [{
-        "type": "capacitySchedulerLeafQueueInfo",
-        "queuePath": "root.managed.queue1",
-        "capacity": 50,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 0.024414062,
-        "absoluteMaxCapacity": 100,
-        "absoluteUsedCapacity": 0,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "numApplications": 0,
-        "maxParallelApps": 2147483647,
-        "queueName": "queue1",
-        "isAbsoluteResource": true,
-        "state": "RUNNING",
-        "resourcesUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "hideReservationQueues": false,
-        "nodeLabels": ["*"],
-        "allocatedContainers": 0,
-        "reservedContainers": 0,
-        "pendingContainers": 0,
-        "capacities": {"queueCapacitiesByPartition": [{
-          "partitionName": "",
-          "capacity": 50,
-          "usedCapacity": 0,
-          "maxCapacity": 100,
-          "absoluteCapacity": 0.024414062,
-          "absoluteUsedCapacity": 0,
-          "absoluteMaxCapacity": 100,
-          "maxAMLimitPercentage": 10,
-          "weight": -1,
-          "normalizedWeight": 0,
-          "configuredMinResource": {
-            "memory": 2048,
-            "vCores": 2,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 2048
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 2
-              }
-            ]}
-          },
-          "configuredMaxResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 8192,
-                "minimumAllocation": 1024,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 4,
-                "minimumAllocation": 1,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "effectiveMinResource": {
-            "memory": 2048,
-            "vCores": 2,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 2048
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 2
-              }
-            ]}
-          },
-          "effectiveMaxResource": {
-            "memory": 8388608,
-            "vCores": 8192,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 8388608
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 8192
-              }
-            ]}
-          }
-        }]},
-        "resources": {"resourceUsagesByPartition": [{
-          "partitionName": "",
-          "used": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "reserved": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "pending": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "amUsed": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "amLimit": {
-            "memory": 839680,
-            "vCores": 1,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 839680
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 1
-              }
-            ]}
-          },
-          "userAmLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          }
-        }]},
-        "minEffectiveCapacity": {
-          "memory": 2048,
-          "vCores": 2,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 2048
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 2
-            }
-          ]}
-        },
-        "maxEffectiveCapacity": {
-          "memory": 8388608,
-          "vCores": 8192,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 8388608
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 8192
-            }
-          ]}
-        },
-        "maximumAllocation": {
-          "memory": 8192,
-          "vCores": 4,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 8192
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 4
-            }
-          ]}
-        },
-        "queueAcls": {"queueAcl": [
-          {
-            "accessType": "ADMINISTER_QUEUE",
-            "accessControlList": "admin "
-          },
-          {
-            "accessType": "APPLICATION_MAX_PRIORITY",
-            "accessControlList": "*"
-          },
-          {
-            "accessType": "SUBMIT_APP",
-            "accessControlList": "user "
-          }
-        ]},
-        "queuePriority": 0,
-        "orderingPolicyInfo": "fifo",
-        "autoCreateChildQueueEnabled": false,
-        "leafQueueTemplate": {},
-        "mode": "absolute",
-        "queueType": "leaf",
-        "creationMethod": "dynamicLegacy",
-        "autoCreationEligibility": "off",
-        "autoQueueTemplateProperties": {},
-        "autoQueueParentTemplateProperties": {},
-        "autoQueueLeafTemplateProperties": {},
-        "numActiveApplications": 0,
-        "numPendingApplications": 0,
-        "numContainers": 0,
-        "maxApplications": 2,
-        "maxApplicationsPerUser": 2,
-        "userLimit": 100,
-        "users": {},
-        "userLimitFactor": 1,
-        "configuredMaxAMResourceLimit": 0.1,
-        "AMResourceLimit": {
-          "memory": 839680,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 839680
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "usedAMResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "userAMResourceLimit": {
-          "memory": 839680,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 839680
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "preemptionDisabled": true,
-        "intraQueuePreemptionDisabled": true,
-        "defaultPriority": 0,
-        "isAutoCreatedLeafQueue": true,
-        "maxApplicationLifetime": -1,
-        "defaultApplicationLifetime": -1
-      }]},
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0.048828125,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 0.048828125,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 0,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 4096,
-          "vCores": 4,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 4096
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 4
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 4096,
-          "vCores": 4,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 4096
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 4
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 8388608,
-          "vCores": 8192,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 8388608
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 8192
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 4096,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 4096
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 8388608,
-        "vCores": 8192,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8388608
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 8192
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "utilization",
-      "autoCreateChildQueueEnabled": true,
-      "leafQueueTemplate": {"property": [
-        {
-          "name": "leaf-queue-template.acl_administer_queue",
-          "value": "admin"
-        },
-        {
-          "name": "leaf-queue-template.capacity",
-          "value": "[memory=2048,vcores=2]"
-        },
-        {
-          "name": "leaf-queue-template.acl_submit_applications",
-          "value": "user"
-        }
-      ]},
-      "mode": "absolute",
-      "queueType": "parent",
-      "creationMethod": "static",
-      "autoCreationEligibility": "legacy",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {}
+      "queuePriority" : 0,
+      "orderingPolicyInfo" : "utilization",
+      "mode" : "percentage",
+      "queueType" : "parent",
+      "creationMethod" : "static",
+      "autoCreationEligibility" : "off",
+      "autoQueueTemplateProperties" : { },
+      "autoQueueParentTemplateProperties" : { },
+      "autoQueueLeafTemplateProperties" : { }
     }
-  ]},
-  "capacities": {"queueCapacitiesByPartition": [{
-    "partitionName": "",
-    "capacity": 100,
-    "usedCapacity": 0,
-    "maxCapacity": 100,
-    "absoluteCapacity": 100,
-    "absoluteUsedCapacity": 0,
-    "absoluteMaxCapacity": 100,
-    "maxAMLimitPercentage": 0,
-    "weight": -1,
-    "normalizedWeight": 0,
-    "configuredMinResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "configuredMaxResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "effectiveMinResource": {
-      "memory": 8388608,
-      "vCores": 8192,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 8388608
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 8192
-        }
-      ]}
-    },
-    "effectiveMaxResource": {
-      "memory": 8388608,
-      "vCores": 8192,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 8388608
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 8192
-        }
-      ]}
-    }
-  }]},
-  "health": {
-    "lastrun": 0,
-    "operationsInfo": [
-      {
-        "operation": "last-allocation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-release",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-preemption",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-reservation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      }
-    ],
-    "lastRunDetails": [
-      {
-        "operation": "releases",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "allocations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "reservations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }
-    ]
-  },
-  "maximumAllocation": {
-    "memory": 8192,
-    "vCores": 4,
-    "resourceInformations": {"resourceInformation": [
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "memory-mb",
-        "resourceType": "COUNTABLE",
-        "units": "Mi",
-        "value": 8192
-      },
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "vcores",
-        "resourceType": "COUNTABLE",
-        "units": "",
-        "value": 4
-      }
-    ]}
-  },
-  "queueAcls": {"queueAcl": [
-    {
-      "accessType": "ADMINISTER_QUEUE",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "APPLICATION_MAX_PRIORITY",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "SUBMIT_APP",
-      "accessControlList": "*"
-    }
-  ]},
-  "queuePriority": 0,
-  "orderingPolicyInfo": "utilization",
-  "mode": "percentage",
-  "queueType": "parent",
-  "creationMethod": "static",
-  "autoCreationEligibility": "off",
-  "autoQueueTemplateProperties": {},
-  "autoQueueParentTemplateProperties": {},
-  "autoQueueLeafTemplateProperties": {}
-}}}
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-PerUserResources.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-PerUserResources.json
@@ -1,5442 +1,5268 @@
-{"scheduler": {"schedulerInfo": {
-  "type": "capacityScheduler",
-  "capacity": 100,
-  "usedCapacity": 0,
-  "maxCapacity": 100,
-  "weight": -1,
-  "normalizedWeight": 0,
-  "queueName": "root",
-  "queuePath": "root",
-  "maxParallelApps": 2147483647,
-  "isAbsoluteResource": false,
-  "queues": {"queue": [
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.c",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 0,
-      "absoluteMaxCapacity": 0,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "c",
-      "isAbsoluteResource": true,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
+{
+  "scheduler" : {
+    "schedulerInfo" : {
+      "type" : "capacityScheduler",
+      "capacity" : 100,
+      "usedCapacity" : 0,
+      "maxCapacity" : 100,
+      "weight" : -1,
+      "normalizedWeight" : 0,
+      "queueName" : "root",
+      "queuePath" : "root",
+      "maxParallelApps" : 2147483647,
+      "isAbsoluteResource" : false,
+      "queues" : {
+        "queue" : [ {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.c",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 0,
+          "absoluteMaxCapacity" : 0,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "c",
+          "isAbsoluteResource" : true,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
           },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 0,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 0,
+              "maxAMLimitPercentage" : 10,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 1024,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1024
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 1024,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1024
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 1024,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1024
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 1024,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1024
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "absolute",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 0,
+          "maxApplicationsPerUser" : 0,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 1024,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1024
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 1024,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1024
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "queuePath" : "root.a",
+          "capacity" : 10.5,
+          "usedCapacity" : 0,
+          "maxCapacity" : 50,
+          "absoluteCapacity" : 10.5,
+          "absoluteMaxCapacity" : 50,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 42,
+          "queueName" : "a",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "queues" : {
+            "queue" : [ {
+              "type" : "capacitySchedulerLeafQueueInfo",
+              "queuePath" : "root.a.a2",
+              "capacity" : 70,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 7.35,
+              "absoluteMaxCapacity" : 50,
+              "absoluteUsedCapacity" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "numApplications" : 0,
+              "maxParallelApps" : 2147483647,
+              "queueName" : "a2",
+              "isAbsoluteResource" : false,
+              "state" : "RUNNING",
+              "resourcesUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "hideReservationQueues" : false,
+              "nodeLabels" : [ "*" ],
+              "allocatedContainers" : 0,
+              "reservedContainers" : 0,
+              "pendingContainers" : 0,
+              "capacities" : {
+                "queueCapacitiesByPartition" : [ {
+                  "partitionName" : "",
+                  "capacity" : 70,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 7.35,
+                  "absoluteUsedCapacity" : 0,
+                  "absoluteMaxCapacity" : 50,
+                  "maxAMLimitPercentage" : 10,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "configuredMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "configuredMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "resources" : {
+                "resourceUsagesByPartition" : [ {
+                  "partitionName" : "",
+                  "used" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "reserved" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "pending" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "userAmLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "minEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maxEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maximumAllocation" : {
+                "memory" : 8192,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8192
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "queueAcls" : {
+                "queueAcl" : [ {
+                  "accessType" : "ADMINISTER_QUEUE",
+                  "accessControlList" : " "
+                }, {
+                  "accessType" : "APPLICATION_MAX_PRIORITY",
+                  "accessControlList" : "*"
+                }, {
+                  "accessType" : "SUBMIT_APP",
+                  "accessControlList" : " "
+                } ]
+              },
+              "queuePriority" : 0,
+              "orderingPolicyInfo" : "fifo",
+              "autoCreateChildQueueEnabled" : false,
+              "leafQueueTemplate" : { },
+              "mode" : "percentage",
+              "queueType" : "leaf",
+              "creationMethod" : "static",
+              "autoCreationEligibility" : "off",
+              "autoQueueTemplateProperties" : { },
+              "autoQueueParentTemplateProperties" : { },
+              "autoQueueLeafTemplateProperties" : { },
+              "numActiveApplications" : 0,
+              "numPendingApplications" : 0,
+              "numContainers" : 0,
+              "maxApplications" : 735,
+              "maxApplicationsPerUser" : 735,
+              "userLimit" : 100,
+              "users" : { },
+              "userLimitFactor" : 100,
+              "configuredMaxAMResourceLimit" : 0.1,
+              "AMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "usedAMResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "preemptionDisabled" : true,
+              "intraQueuePreemptionDisabled" : true,
+              "defaultPriority" : 0,
+              "isAutoCreatedLeafQueue" : false,
+              "maxApplicationLifetime" : 100,
+              "defaultApplicationLifetime" : 50
+            }, {
+              "queuePath" : "root.a.a1",
+              "capacity" : 30.000002,
+              "usedCapacity" : 0,
+              "maxCapacity" : 50,
+              "absoluteCapacity" : 3.15,
+              "absoluteMaxCapacity" : 25,
+              "absoluteUsedCapacity" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "numApplications" : 0,
+              "maxParallelApps" : 2147483647,
+              "queueName" : "a1",
+              "isAbsoluteResource" : false,
+              "state" : "RUNNING",
+              "queues" : {
+                "queue" : [ {
+                  "type" : "capacitySchedulerLeafQueueInfo",
+                  "queuePath" : "root.a.a1.a1a",
+                  "capacity" : 65,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 2.0475001,
+                  "absoluteMaxCapacity" : 25,
+                  "absoluteUsedCapacity" : 0,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "numApplications" : 0,
+                  "maxParallelApps" : 2147483647,
+                  "queueName" : "a1a",
+                  "isAbsoluteResource" : false,
+                  "state" : "RUNNING",
+                  "resourcesUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "hideReservationQueues" : false,
+                  "nodeLabels" : [ "*" ],
+                  "allocatedContainers" : 0,
+                  "reservedContainers" : 0,
+                  "pendingContainers" : 0,
+                  "capacities" : {
+                    "queueCapacitiesByPartition" : [ {
+                      "partitionName" : "",
+                      "capacity" : 65,
+                      "usedCapacity" : 0,
+                      "maxCapacity" : 100,
+                      "absoluteCapacity" : 2.0475001,
+                      "absoluteUsedCapacity" : 0,
+                      "absoluteMaxCapacity" : 25,
+                      "maxAMLimitPercentage" : 10,
+                      "weight" : -1,
+                      "normalizedWeight" : 0,
+                      "configuredMinResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 8192,
+                            "minimumAllocation" : 1024,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 4,
+                            "minimumAllocation" : 1,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "configuredMaxResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 8192,
+                            "minimumAllocation" : 1024,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 4,
+                            "minimumAllocation" : 1,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "effectiveMinResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "effectiveMaxResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "resources" : {
+                    "resourceUsagesByPartition" : [ {
+                      "partitionName" : "",
+                      "used" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "reserved" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "pending" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "amUsed" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "amLimit" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "userAmLimit" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "minEffectiveCapacity" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "maxEffectiveCapacity" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "maximumAllocation" : {
+                    "memory" : 8192,
+                    "vCores" : 4,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 8192
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 4
+                      } ]
+                    }
+                  },
+                  "queueAcls" : {
+                    "queueAcl" : [ {
+                      "accessType" : "ADMINISTER_QUEUE",
+                      "accessControlList" : " "
+                    }, {
+                      "accessType" : "APPLICATION_MAX_PRIORITY",
+                      "accessControlList" : "*"
+                    }, {
+                      "accessType" : "SUBMIT_APP",
+                      "accessControlList" : " "
+                    } ]
+                  },
+                  "queuePriority" : 0,
+                  "orderingPolicyInfo" : "fifo",
+                  "autoCreateChildQueueEnabled" : false,
+                  "leafQueueTemplate" : { },
+                  "mode" : "percentage",
+                  "queueType" : "leaf",
+                  "creationMethod" : "static",
+                  "autoCreationEligibility" : "off",
+                  "autoQueueTemplateProperties" : { },
+                  "autoQueueParentTemplateProperties" : { },
+                  "autoQueueLeafTemplateProperties" : { },
+                  "numActiveApplications" : 0,
+                  "numPendingApplications" : 0,
+                  "numContainers" : 0,
+                  "maxApplications" : 204,
+                  "maxApplicationsPerUser" : 204,
+                  "userLimit" : 100,
+                  "users" : { },
+                  "userLimitFactor" : 1,
+                  "configuredMaxAMResourceLimit" : 0.1,
+                  "AMResourceLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "usedAMResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "userAMResourceLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "preemptionDisabled" : true,
+                  "intraQueuePreemptionDisabled" : true,
+                  "defaultPriority" : 0,
+                  "isAutoCreatedLeafQueue" : false,
+                  "maxApplicationLifetime" : -1,
+                  "defaultApplicationLifetime" : -1
+                }, {
+                  "type" : "capacitySchedulerLeafQueueInfo",
+                  "queuePath" : "root.a.a1.a1b",
+                  "capacity" : 15.000001,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 0.47250003,
+                  "absoluteMaxCapacity" : 25,
+                  "absoluteUsedCapacity" : 0,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "numApplications" : 0,
+                  "maxParallelApps" : 2147483647,
+                  "queueName" : "a1b",
+                  "isAbsoluteResource" : false,
+                  "state" : "RUNNING",
+                  "resourcesUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "hideReservationQueues" : false,
+                  "nodeLabels" : [ "*" ],
+                  "allocatedContainers" : 0,
+                  "reservedContainers" : 0,
+                  "pendingContainers" : 0,
+                  "capacities" : {
+                    "queueCapacitiesByPartition" : [ {
+                      "partitionName" : "",
+                      "capacity" : 15.000001,
+                      "usedCapacity" : 0,
+                      "maxCapacity" : 100,
+                      "absoluteCapacity" : 0.47250003,
+                      "absoluteUsedCapacity" : 0,
+                      "absoluteMaxCapacity" : 25,
+                      "maxAMLimitPercentage" : 10,
+                      "weight" : -1,
+                      "normalizedWeight" : 0,
+                      "configuredMinResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 8192,
+                            "minimumAllocation" : 1024,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 4,
+                            "minimumAllocation" : 1,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "configuredMaxResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 8192,
+                            "minimumAllocation" : 1024,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 4,
+                            "minimumAllocation" : 1,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "effectiveMinResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "effectiveMaxResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "resources" : {
+                    "resourceUsagesByPartition" : [ {
+                      "partitionName" : "",
+                      "used" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "reserved" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "pending" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "amUsed" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "amLimit" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "userAmLimit" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "minEffectiveCapacity" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "maxEffectiveCapacity" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "maximumAllocation" : {
+                    "memory" : 8192,
+                    "vCores" : 4,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 8192
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 4
+                      } ]
+                    }
+                  },
+                  "queueAcls" : {
+                    "queueAcl" : [ {
+                      "accessType" : "ADMINISTER_QUEUE",
+                      "accessControlList" : " "
+                    }, {
+                      "accessType" : "APPLICATION_MAX_PRIORITY",
+                      "accessControlList" : "*"
+                    }, {
+                      "accessType" : "SUBMIT_APP",
+                      "accessControlList" : " "
+                    } ]
+                  },
+                  "queuePriority" : 0,
+                  "orderingPolicyInfo" : "fifo",
+                  "autoCreateChildQueueEnabled" : false,
+                  "leafQueueTemplate" : { },
+                  "mode" : "percentage",
+                  "queueType" : "leaf",
+                  "creationMethod" : "static",
+                  "autoCreationEligibility" : "off",
+                  "autoQueueTemplateProperties" : { },
+                  "autoQueueParentTemplateProperties" : { },
+                  "autoQueueLeafTemplateProperties" : { },
+                  "numActiveApplications" : 0,
+                  "numPendingApplications" : 0,
+                  "numContainers" : 0,
+                  "maxApplications" : 47,
+                  "maxApplicationsPerUser" : 47,
+                  "userLimit" : 100,
+                  "users" : { },
+                  "userLimitFactor" : 1,
+                  "configuredMaxAMResourceLimit" : 0.1,
+                  "AMResourceLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "usedAMResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "userAMResourceLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "preemptionDisabled" : true,
+                  "intraQueuePreemptionDisabled" : true,
+                  "defaultPriority" : 0,
+                  "isAutoCreatedLeafQueue" : false,
+                  "maxApplicationLifetime" : -1,
+                  "defaultApplicationLifetime" : -1
+                }, {
+                  "queuePath" : "root.a.a1.a1c",
+                  "capacity" : 20,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 0.63,
+                  "absoluteMaxCapacity" : 25,
+                  "absoluteUsedCapacity" : 0,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "numApplications" : 0,
+                  "maxParallelApps" : 2147483647,
+                  "queueName" : "a1c",
+                  "isAbsoluteResource" : false,
+                  "state" : "RUNNING",
+                  "queues" : { },
+                  "resourcesUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "hideReservationQueues" : false,
+                  "nodeLabels" : [ "*" ],
+                  "allocatedContainers" : 0,
+                  "reservedContainers" : 0,
+                  "pendingContainers" : 0,
+                  "capacities" : {
+                    "queueCapacitiesByPartition" : [ {
+                      "partitionName" : "",
+                      "capacity" : 20,
+                      "usedCapacity" : 0,
+                      "maxCapacity" : 100,
+                      "absoluteCapacity" : 0.63,
+                      "absoluteUsedCapacity" : 0,
+                      "absoluteMaxCapacity" : 25,
+                      "maxAMLimitPercentage" : 0,
+                      "weight" : -1,
+                      "normalizedWeight" : 0,
+                      "configuredMinResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 8192,
+                            "minimumAllocation" : 1024,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 4,
+                            "minimumAllocation" : 1,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "configuredMaxResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 8192,
+                            "minimumAllocation" : 1024,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 4,
+                            "minimumAllocation" : 1,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "effectiveMinResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "effectiveMaxResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "resources" : {
+                    "resourceUsagesByPartition" : [ {
+                      "partitionName" : "",
+                      "used" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "reserved" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "pending" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "minEffectiveCapacity" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "maxEffectiveCapacity" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "maximumAllocation" : {
+                    "memory" : 8192,
+                    "vCores" : 4,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 8192
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 4
+                      } ]
+                    }
+                  },
+                  "queueAcls" : {
+                    "queueAcl" : [ {
+                      "accessType" : "ADMINISTER_QUEUE",
+                      "accessControlList" : " "
+                    }, {
+                      "accessType" : "APPLICATION_MAX_PRIORITY",
+                      "accessControlList" : "*"
+                    }, {
+                      "accessType" : "SUBMIT_APP",
+                      "accessControlList" : " "
+                    } ]
+                  },
+                  "queuePriority" : 0,
+                  "orderingPolicyInfo" : "utilization",
+                  "autoCreateChildQueueEnabled" : true,
+                  "leafQueueTemplate" : {
+                    "property" : [ {
+                      "name" : "leaf-queue-template.capacity",
+                      "value" : "50"
+                    } ]
+                  },
+                  "mode" : "percentage",
+                  "queueType" : "parent",
+                  "creationMethod" : "static",
+                  "autoCreationEligibility" : "legacy",
+                  "autoQueueTemplateProperties" : { },
+                  "autoQueueParentTemplateProperties" : { },
+                  "autoQueueLeafTemplateProperties" : { }
+                } ]
+              },
+              "resourcesUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "hideReservationQueues" : false,
+              "nodeLabels" : [ "*" ],
+              "allocatedContainers" : 0,
+              "reservedContainers" : 0,
+              "pendingContainers" : 0,
+              "capacities" : {
+                "queueCapacitiesByPartition" : [ {
+                  "partitionName" : "",
+                  "capacity" : 30.000002,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 50,
+                  "absoluteCapacity" : 3.15,
+                  "absoluteUsedCapacity" : 0,
+                  "absoluteMaxCapacity" : 25,
+                  "maxAMLimitPercentage" : 0,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "configuredMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "configuredMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "resources" : {
+                "resourceUsagesByPartition" : [ {
+                  "partitionName" : "",
+                  "used" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "reserved" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "pending" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "minEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maxEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maximumAllocation" : {
+                "memory" : 8192,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8192
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "queueAcls" : {
+                "queueAcl" : [ {
+                  "accessType" : "ADMINISTER_QUEUE",
+                  "accessControlList" : " "
+                }, {
+                  "accessType" : "APPLICATION_MAX_PRIORITY",
+                  "accessControlList" : "*"
+                }, {
+                  "accessType" : "SUBMIT_APP",
+                  "accessControlList" : " "
+                } ]
+              },
+              "queuePriority" : 0,
+              "orderingPolicyInfo" : "utilization",
+              "autoCreateChildQueueEnabled" : false,
+              "leafQueueTemplate" : { },
+              "mode" : "percentage",
+              "queueType" : "parent",
+              "creationMethod" : "static",
+              "autoCreationEligibility" : "off",
+              "autoQueueTemplateProperties" : { },
+              "autoQueueParentTemplateProperties" : { },
+              "autoQueueLeafTemplateProperties" : { }
+            } ]
+          },
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 10.5,
+              "usedCapacity" : 0,
+              "maxCapacity" : 50,
+              "absoluteCapacity" : 10.5,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 50,
+              "maxAMLimitPercentage" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "utilization",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "percentage",
+          "queueType" : "parent",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { }
+        }, {
+          "queuePath" : "root.b",
+          "capacity" : 89.5,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 89.5,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 2,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "b",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "queues" : {
+            "queue" : [ {
+              "type" : "capacitySchedulerLeafQueueInfo",
+              "queuePath" : "root.b.b1",
+              "capacity" : 60.000004,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 53.7,
+              "absoluteMaxCapacity" : 100,
+              "absoluteUsedCapacity" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "numApplications" : 2,
+              "maxParallelApps" : 2147483647,
+              "queueName" : "b1",
+              "isAbsoluteResource" : false,
+              "state" : "RUNNING",
+              "resourcesUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "hideReservationQueues" : false,
+              "nodeLabels" : [ "*" ],
+              "allocatedContainers" : 0,
+              "reservedContainers" : 0,
+              "pendingContainers" : 2,
+              "capacities" : {
+                "queueCapacitiesByPartition" : [ {
+                  "partitionName" : "",
+                  "capacity" : 60.000004,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 53.7,
+                  "absoluteUsedCapacity" : 0,
+                  "absoluteMaxCapacity" : 100,
+                  "maxAMLimitPercentage" : 10,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "configuredMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "configuredMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "resources" : {
+                "resourceUsagesByPartition" : [ {
+                  "partitionName" : "",
+                  "used" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "reserved" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "pending" : {
+                    "memory" : 2048,
+                    "vCores" : 2,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 2048
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 2
+                      } ]
+                    }
+                  },
+                  "amUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "userAmLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "minEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maxEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maximumAllocation" : {
+                "memory" : 8192,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8192
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "queueAcls" : {
+                "queueAcl" : [ {
+                  "accessType" : "ADMINISTER_QUEUE",
+                  "accessControlList" : " "
+                }, {
+                  "accessType" : "APPLICATION_MAX_PRIORITY",
+                  "accessControlList" : "*"
+                }, {
+                  "accessType" : "SUBMIT_APP",
+                  "accessControlList" : " "
+                } ]
+              },
+              "queuePriority" : 0,
+              "orderingPolicyInfo" : "fifo",
+              "autoCreateChildQueueEnabled" : false,
+              "leafQueueTemplate" : { },
+              "mode" : "percentage",
+              "queueType" : "leaf",
+              "creationMethod" : "static",
+              "autoCreationEligibility" : "off",
+              "autoQueueTemplateProperties" : { },
+              "autoQueueParentTemplateProperties" : { },
+              "autoQueueLeafTemplateProperties" : { },
+              "numActiveApplications" : 0,
+              "numPendingApplications" : 2,
+              "numContainers" : 0,
+              "maxApplications" : 5370,
+              "maxApplicationsPerUser" : 5370,
+              "userLimit" : 100,
+              "users" : {
+                "user" : [ {
+                  "username" : "user1",
+                  "resourcesUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "numPendingApplications" : 1,
+                  "numActiveApplications" : 0,
+                  "AMResourceUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "userResourceLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "resources" : {
+                    "resourceUsagesByPartition" : [ {
+                      "partitionName" : "",
+                      "used" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "reserved" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "pending" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "amUsed" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "amLimit" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "userAmLimit" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "userWeight" : 1,
+                  "isActive" : false
+                }, {
+                  "username" : "user2",
+                  "resourcesUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "numPendingApplications" : 1,
+                  "numActiveApplications" : 0,
+                  "AMResourceUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "userResourceLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "resources" : {
+                    "resourceUsagesByPartition" : [ {
+                      "partitionName" : "",
+                      "used" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "reserved" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "pending" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "amUsed" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "amLimit" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "userAmLimit" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "userWeight" : 1,
+                  "isActive" : false
+                } ]
+              },
+              "userLimitFactor" : 100,
+              "configuredMaxAMResourceLimit" : 0.1,
+              "AMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "usedAMResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "preemptionDisabled" : true,
+              "intraQueuePreemptionDisabled" : true,
+              "defaultPriority" : 0,
+              "isAutoCreatedLeafQueue" : false,
+              "maxApplicationLifetime" : -1,
+              "defaultApplicationLifetime" : -1
+            }, {
+              "type" : "capacitySchedulerLeafQueueInfo",
+              "queuePath" : "root.b.b2",
+              "capacity" : 39.5,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 35.3525,
+              "absoluteMaxCapacity" : 100,
+              "absoluteUsedCapacity" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "numApplications" : 0,
+              "maxParallelApps" : 2147483647,
+              "queueName" : "b2",
+              "isAbsoluteResource" : false,
+              "state" : "RUNNING",
+              "resourcesUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "hideReservationQueues" : false,
+              "nodeLabels" : [ "*" ],
+              "allocatedContainers" : 0,
+              "reservedContainers" : 0,
+              "pendingContainers" : 0,
+              "capacities" : {
+                "queueCapacitiesByPartition" : [ {
+                  "partitionName" : "",
+                  "capacity" : 39.5,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 35.3525,
+                  "absoluteUsedCapacity" : 0,
+                  "absoluteMaxCapacity" : 100,
+                  "maxAMLimitPercentage" : 10,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "configuredMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "configuredMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "resources" : {
+                "resourceUsagesByPartition" : [ {
+                  "partitionName" : "",
+                  "used" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "reserved" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "pending" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "userAmLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "minEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maxEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maximumAllocation" : {
+                "memory" : 8192,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8192
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "queueAcls" : {
+                "queueAcl" : [ {
+                  "accessType" : "ADMINISTER_QUEUE",
+                  "accessControlList" : " "
+                }, {
+                  "accessType" : "APPLICATION_MAX_PRIORITY",
+                  "accessControlList" : "*"
+                }, {
+                  "accessType" : "SUBMIT_APP",
+                  "accessControlList" : " "
+                } ]
+              },
+              "queuePriority" : 0,
+              "orderingPolicyInfo" : "fifo",
+              "autoCreateChildQueueEnabled" : false,
+              "leafQueueTemplate" : { },
+              "mode" : "percentage",
+              "queueType" : "leaf",
+              "creationMethod" : "static",
+              "autoCreationEligibility" : "off",
+              "autoQueueTemplateProperties" : { },
+              "autoQueueParentTemplateProperties" : { },
+              "autoQueueLeafTemplateProperties" : { },
+              "numActiveApplications" : 0,
+              "numPendingApplications" : 0,
+              "numContainers" : 0,
+              "maxApplications" : 3535,
+              "maxApplicationsPerUser" : 3535,
+              "userLimit" : 100,
+              "users" : { },
+              "userLimitFactor" : 100,
+              "configuredMaxAMResourceLimit" : 0.1,
+              "AMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "usedAMResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "preemptionDisabled" : true,
+              "intraQueuePreemptionDisabled" : true,
+              "defaultPriority" : 0,
+              "isAutoCreatedLeafQueue" : false,
+              "maxApplicationLifetime" : -1,
+              "defaultApplicationLifetime" : -1
+            }, {
+              "type" : "capacitySchedulerLeafQueueInfo",
+              "queuePath" : "root.b.b3",
+              "capacity" : 0.5,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 0.4475,
+              "absoluteMaxCapacity" : 100,
+              "absoluteUsedCapacity" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "numApplications" : 0,
+              "maxParallelApps" : 2147483647,
+              "queueName" : "b3",
+              "isAbsoluteResource" : false,
+              "state" : "RUNNING",
+              "resourcesUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "hideReservationQueues" : false,
+              "nodeLabels" : [ "*" ],
+              "allocatedContainers" : 0,
+              "reservedContainers" : 0,
+              "pendingContainers" : 0,
+              "capacities" : {
+                "queueCapacitiesByPartition" : [ {
+                  "partitionName" : "",
+                  "capacity" : 0.5,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 0.4475,
+                  "absoluteUsedCapacity" : 0,
+                  "absoluteMaxCapacity" : 100,
+                  "maxAMLimitPercentage" : 10,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "configuredMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "configuredMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "resources" : {
+                "resourceUsagesByPartition" : [ {
+                  "partitionName" : "",
+                  "used" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "reserved" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "pending" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "userAmLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "minEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maxEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maximumAllocation" : {
+                "memory" : 8192,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8192
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "queueAcls" : {
+                "queueAcl" : [ {
+                  "accessType" : "ADMINISTER_QUEUE",
+                  "accessControlList" : " "
+                }, {
+                  "accessType" : "APPLICATION_MAX_PRIORITY",
+                  "accessControlList" : "*"
+                }, {
+                  "accessType" : "SUBMIT_APP",
+                  "accessControlList" : " "
+                } ]
+              },
+              "queuePriority" : 0,
+              "orderingPolicyInfo" : "fifo",
+              "autoCreateChildQueueEnabled" : false,
+              "leafQueueTemplate" : { },
+              "mode" : "percentage",
+              "queueType" : "leaf",
+              "creationMethod" : "static",
+              "autoCreationEligibility" : "off",
+              "autoQueueTemplateProperties" : { },
+              "autoQueueParentTemplateProperties" : { },
+              "autoQueueLeafTemplateProperties" : { },
+              "numActiveApplications" : 0,
+              "numPendingApplications" : 0,
+              "numContainers" : 0,
+              "maxApplications" : 44,
+              "maxApplicationsPerUser" : 44,
+              "userLimit" : 100,
+              "users" : { },
+              "userLimitFactor" : 100,
+              "configuredMaxAMResourceLimit" : 0.1,
+              "AMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "usedAMResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "preemptionDisabled" : true,
+              "intraQueuePreemptionDisabled" : true,
+              "defaultPriority" : 0,
+              "isAutoCreatedLeafQueue" : false,
+              "maxApplicationLifetime" : -1,
+              "defaultApplicationLifetime" : -1
+            } ]
+          },
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 2,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 89.5,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 89.5,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 2048,
+                "vCores" : 2,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 2048
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 2
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "utilization",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "percentage",
+          "queueType" : "parent",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { }
+        } ]
       },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 0,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 0,
-        "maxAMLimitPercentage": 10,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 1024,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1024
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+      "capacities" : {
+        "queueCapacitiesByPartition" : [ {
+          "partitionName" : "",
+          "capacity" : 100,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "absoluteMaxCapacity" : 100,
+          "maxAMLimitPercentage" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "configuredMinResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "configuredMaxResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 1024,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1024
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "effectiveMinResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "effectiveMaxResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
+          }
+        } ]
+      },
+      "health" : {
+        "lastrun" : 0,
+        "operationsInfo" : [ {
+          "operation" : "last-allocation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-release",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-preemption",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-reservation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        } ],
+        "lastRunDetails" : [ {
+          "operation" : "releases",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "allocations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "reservations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        } ]
+      },
+      "maximumAllocation" : {
+        "memory" : 8192,
+        "vCores" : 4,
+        "resourceInformations" : {
+          "resourceInformation" : [ {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "memory-mb",
+            "resourceType" : "COUNTABLE",
+            "units" : "Mi",
+            "value" : 8192
+          }, {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "vcores",
+            "resourceType" : "COUNTABLE",
+            "units" : "",
+            "value" : 4
+          } ]
         }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 1024,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1024
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 1024,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1024
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
       },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
+      "queueAcls" : {
+        "queueAcl" : [ {
+          "accessType" : "ADMINISTER_QUEUE",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "APPLICATION_MAX_PRIORITY",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "SUBMIT_APP",
+          "accessControlList" : "*"
+        } ]
       },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "absolute",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 0,
-      "maxApplicationsPerUser": 0,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 1024,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1024
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 1024,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1024
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "queuePath": "root.a",
-      "capacity": 10.5,
-      "usedCapacity": 0,
-      "maxCapacity": 50,
-      "absoluteCapacity": 10.5,
-      "absoluteMaxCapacity": 50,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 42,
-      "queueName": "a",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "queues": {"queue": [
-        {
-          "type": "capacitySchedulerLeafQueueInfo",
-          "queuePath": "root.a.a2",
-          "capacity": 70,
-          "usedCapacity": 0,
-          "maxCapacity": 100,
-          "absoluteCapacity": 7.35,
-          "absoluteMaxCapacity": 50,
-          "absoluteUsedCapacity": 0,
-          "weight": -1,
-          "normalizedWeight": 0,
-          "numApplications": 0,
-          "maxParallelApps": 2147483647,
-          "queueName": "a2",
-          "isAbsoluteResource": false,
-          "state": "RUNNING",
-          "resourcesUsed": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "hideReservationQueues": false,
-          "nodeLabels": ["*"],
-          "allocatedContainers": 0,
-          "reservedContainers": 0,
-          "pendingContainers": 0,
-          "capacities": {"queueCapacitiesByPartition": [{
-            "partitionName": "",
-            "capacity": 70,
-            "usedCapacity": 0,
-            "maxCapacity": 100,
-            "absoluteCapacity": 7.35,
-            "absoluteUsedCapacity": 0,
-            "absoluteMaxCapacity": 50,
-            "maxAMLimitPercentage": 10,
-            "weight": -1,
-            "normalizedWeight": 0,
-            "configuredMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "configuredMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "resources": {"resourceUsagesByPartition": [{
-            "partitionName": "",
-            "used": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "reserved": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "pending": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "amUsed": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "amLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "userAmLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "minEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maxEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maximumAllocation": {
-            "memory": 8192,
-            "vCores": 4,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 8192
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 4
-              }
-            ]}
-          },
-          "queueAcls": {"queueAcl": [
-            {
-              "accessType": "ADMINISTER_QUEUE",
-              "accessControlList": " "
-            },
-            {
-              "accessType": "APPLICATION_MAX_PRIORITY",
-              "accessControlList": "*"
-            },
-            {
-              "accessType": "SUBMIT_APP",
-              "accessControlList": " "
-            }
-          ]},
-          "queuePriority": 0,
-          "orderingPolicyInfo": "fifo",
-          "autoCreateChildQueueEnabled": false,
-          "leafQueueTemplate": {},
-          "mode": "percentage",
-          "queueType": "leaf",
-          "creationMethod": "static",
-          "autoCreationEligibility": "off",
-          "autoQueueTemplateProperties": {},
-          "autoQueueParentTemplateProperties": {},
-          "autoQueueLeafTemplateProperties": {},
-          "numActiveApplications": 0,
-          "numPendingApplications": 0,
-          "numContainers": 0,
-          "maxApplications": 735,
-          "maxApplicationsPerUser": 735,
-          "userLimit": 100,
-          "users": {},
-          "userLimitFactor": 100,
-          "configuredMaxAMResourceLimit": 0.1,
-          "AMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "usedAMResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "userAMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "preemptionDisabled": true,
-          "intraQueuePreemptionDisabled": true,
-          "defaultPriority": 0,
-          "isAutoCreatedLeafQueue": false,
-          "maxApplicationLifetime": 100,
-          "defaultApplicationLifetime": 50
-        },
-        {
-          "queuePath": "root.a.a1",
-          "capacity": 30.000002,
-          "usedCapacity": 0,
-          "maxCapacity": 50,
-          "absoluteCapacity": 3.15,
-          "absoluteMaxCapacity": 25,
-          "absoluteUsedCapacity": 0,
-          "weight": -1,
-          "normalizedWeight": 0,
-          "numApplications": 0,
-          "maxParallelApps": 2147483647,
-          "queueName": "a1",
-          "isAbsoluteResource": false,
-          "state": "RUNNING",
-          "queues": {"queue": [
-            {
-              "type": "capacitySchedulerLeafQueueInfo",
-              "queuePath": "root.a.a1.a1a",
-              "capacity": 65,
-              "usedCapacity": 0,
-              "maxCapacity": 100,
-              "absoluteCapacity": 2.0475001,
-              "absoluteMaxCapacity": 25,
-              "absoluteUsedCapacity": 0,
-              "weight": -1,
-              "normalizedWeight": 0,
-              "numApplications": 0,
-              "maxParallelApps": 2147483647,
-              "queueName": "a1a",
-              "isAbsoluteResource": false,
-              "state": "RUNNING",
-              "resourcesUsed": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "hideReservationQueues": false,
-              "nodeLabels": ["*"],
-              "allocatedContainers": 0,
-              "reservedContainers": 0,
-              "pendingContainers": 0,
-              "capacities": {"queueCapacitiesByPartition": [{
-                "partitionName": "",
-                "capacity": 65,
-                "usedCapacity": 0,
-                "maxCapacity": 100,
-                "absoluteCapacity": 2.0475001,
-                "absoluteUsedCapacity": 0,
-                "absoluteMaxCapacity": 25,
-                "maxAMLimitPercentage": 10,
-                "weight": -1,
-                "normalizedWeight": 0,
-                "configuredMinResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 8192,
-                      "minimumAllocation": 1024,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 4,
-                      "minimumAllocation": 1,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "configuredMaxResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 8192,
-                      "minimumAllocation": 1024,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 4,
-                      "minimumAllocation": 1,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "effectiveMinResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "effectiveMaxResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                }
-              }]},
-              "resources": {"resourceUsagesByPartition": [{
-                "partitionName": "",
-                "used": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "reserved": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "pending": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "amUsed": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "amLimit": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "userAmLimit": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                }
-              }]},
-              "minEffectiveCapacity": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "maxEffectiveCapacity": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "maximumAllocation": {
-                "memory": 8192,
-                "vCores": 4,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 8192
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 4
-                  }
-                ]}
-              },
-              "queueAcls": {"queueAcl": [
-                {
-                  "accessType": "ADMINISTER_QUEUE",
-                  "accessControlList": " "
-                },
-                {
-                  "accessType": "APPLICATION_MAX_PRIORITY",
-                  "accessControlList": "*"
-                },
-                {
-                  "accessType": "SUBMIT_APP",
-                  "accessControlList": " "
-                }
-              ]},
-              "queuePriority": 0,
-              "orderingPolicyInfo": "fifo",
-              "autoCreateChildQueueEnabled": false,
-              "leafQueueTemplate": {},
-              "mode": "percentage",
-              "queueType": "leaf",
-              "creationMethod": "static",
-              "autoCreationEligibility": "off",
-              "autoQueueTemplateProperties": {},
-              "autoQueueParentTemplateProperties": {},
-              "autoQueueLeafTemplateProperties": {},
-              "numActiveApplications": 0,
-              "numPendingApplications": 0,
-              "numContainers": 0,
-              "maxApplications": 204,
-              "maxApplicationsPerUser": 204,
-              "userLimit": 100,
-              "users": {},
-              "userLimitFactor": 1,
-              "configuredMaxAMResourceLimit": 0.1,
-              "AMResourceLimit": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "usedAMResource": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "userAMResourceLimit": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "preemptionDisabled": true,
-              "intraQueuePreemptionDisabled": true,
-              "defaultPriority": 0,
-              "isAutoCreatedLeafQueue": false,
-              "maxApplicationLifetime": -1,
-              "defaultApplicationLifetime": -1
-            },
-            {
-              "type": "capacitySchedulerLeafQueueInfo",
-              "queuePath": "root.a.a1.a1b",
-              "capacity": 15.000001,
-              "usedCapacity": 0,
-              "maxCapacity": 100,
-              "absoluteCapacity": 0.47250003,
-              "absoluteMaxCapacity": 25,
-              "absoluteUsedCapacity": 0,
-              "weight": -1,
-              "normalizedWeight": 0,
-              "numApplications": 0,
-              "maxParallelApps": 2147483647,
-              "queueName": "a1b",
-              "isAbsoluteResource": false,
-              "state": "RUNNING",
-              "resourcesUsed": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "hideReservationQueues": false,
-              "nodeLabels": ["*"],
-              "allocatedContainers": 0,
-              "reservedContainers": 0,
-              "pendingContainers": 0,
-              "capacities": {"queueCapacitiesByPartition": [{
-                "partitionName": "",
-                "capacity": 15.000001,
-                "usedCapacity": 0,
-                "maxCapacity": 100,
-                "absoluteCapacity": 0.47250003,
-                "absoluteUsedCapacity": 0,
-                "absoluteMaxCapacity": 25,
-                "maxAMLimitPercentage": 10,
-                "weight": -1,
-                "normalizedWeight": 0,
-                "configuredMinResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 8192,
-                      "minimumAllocation": 1024,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 4,
-                      "minimumAllocation": 1,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "configuredMaxResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 8192,
-                      "minimumAllocation": 1024,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 4,
-                      "minimumAllocation": 1,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "effectiveMinResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "effectiveMaxResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                }
-              }]},
-              "resources": {"resourceUsagesByPartition": [{
-                "partitionName": "",
-                "used": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "reserved": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "pending": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "amUsed": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "amLimit": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "userAmLimit": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                }
-              }]},
-              "minEffectiveCapacity": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "maxEffectiveCapacity": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "maximumAllocation": {
-                "memory": 8192,
-                "vCores": 4,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 8192
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 4
-                  }
-                ]}
-              },
-              "queueAcls": {"queueAcl": [
-                {
-                  "accessType": "ADMINISTER_QUEUE",
-                  "accessControlList": " "
-                },
-                {
-                  "accessType": "APPLICATION_MAX_PRIORITY",
-                  "accessControlList": "*"
-                },
-                {
-                  "accessType": "SUBMIT_APP",
-                  "accessControlList": " "
-                }
-              ]},
-              "queuePriority": 0,
-              "orderingPolicyInfo": "fifo",
-              "autoCreateChildQueueEnabled": false,
-              "leafQueueTemplate": {},
-              "mode": "percentage",
-              "queueType": "leaf",
-              "creationMethod": "static",
-              "autoCreationEligibility": "off",
-              "autoQueueTemplateProperties": {},
-              "autoQueueParentTemplateProperties": {},
-              "autoQueueLeafTemplateProperties": {},
-              "numActiveApplications": 0,
-              "numPendingApplications": 0,
-              "numContainers": 0,
-              "maxApplications": 47,
-              "maxApplicationsPerUser": 47,
-              "userLimit": 100,
-              "users": {},
-              "userLimitFactor": 1,
-              "configuredMaxAMResourceLimit": 0.1,
-              "AMResourceLimit": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "usedAMResource": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "userAMResourceLimit": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "preemptionDisabled": true,
-              "intraQueuePreemptionDisabled": true,
-              "defaultPriority": 0,
-              "isAutoCreatedLeafQueue": false,
-              "maxApplicationLifetime": -1,
-              "defaultApplicationLifetime": -1
-            },
-            {
-              "queuePath": "root.a.a1.a1c",
-              "capacity": 20,
-              "usedCapacity": 0,
-              "maxCapacity": 100,
-              "absoluteCapacity": 0.63,
-              "absoluteMaxCapacity": 25,
-              "absoluteUsedCapacity": 0,
-              "weight": -1,
-              "normalizedWeight": 0,
-              "numApplications": 0,
-              "maxParallelApps": 2147483647,
-              "queueName": "a1c",
-              "isAbsoluteResource": false,
-              "state": "RUNNING",
-              "queues": {},
-              "resourcesUsed": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "hideReservationQueues": false,
-              "nodeLabels": ["*"],
-              "allocatedContainers": 0,
-              "reservedContainers": 0,
-              "pendingContainers": 0,
-              "capacities": {"queueCapacitiesByPartition": [{
-                "partitionName": "",
-                "capacity": 20,
-                "usedCapacity": 0,
-                "maxCapacity": 100,
-                "absoluteCapacity": 0.63,
-                "absoluteUsedCapacity": 0,
-                "absoluteMaxCapacity": 25,
-                "maxAMLimitPercentage": 0,
-                "weight": -1,
-                "normalizedWeight": 0,
-                "configuredMinResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 8192,
-                      "minimumAllocation": 1024,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 4,
-                      "minimumAllocation": 1,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "configuredMaxResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 8192,
-                      "minimumAllocation": 1024,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 4,
-                      "minimumAllocation": 1,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "effectiveMinResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "effectiveMaxResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                }
-              }]},
-              "resources": {"resourceUsagesByPartition": [{
-                "partitionName": "",
-                "used": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "reserved": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "pending": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                }
-              }]},
-              "minEffectiveCapacity": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "maxEffectiveCapacity": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "maximumAllocation": {
-                "memory": 8192,
-                "vCores": 4,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 8192
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 4
-                  }
-                ]}
-              },
-              "queueAcls": {"queueAcl": [
-                {
-                  "accessType": "ADMINISTER_QUEUE",
-                  "accessControlList": " "
-                },
-                {
-                  "accessType": "APPLICATION_MAX_PRIORITY",
-                  "accessControlList": "*"
-                },
-                {
-                  "accessType": "SUBMIT_APP",
-                  "accessControlList": " "
-                }
-              ]},
-              "queuePriority": 0,
-              "orderingPolicyInfo": "utilization",
-              "autoCreateChildQueueEnabled": true,
-              "leafQueueTemplate": {"property": [{
-                "name": "leaf-queue-template.capacity",
-                "value": "50"
-              }]},
-              "mode": "percentage",
-              "queueType": "parent",
-              "creationMethod": "static",
-              "autoCreationEligibility": "legacy",
-              "autoQueueTemplateProperties": {},
-              "autoQueueParentTemplateProperties": {},
-              "autoQueueLeafTemplateProperties": {}
-            }
-          ]},
-          "resourcesUsed": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "hideReservationQueues": false,
-          "nodeLabels": ["*"],
-          "allocatedContainers": 0,
-          "reservedContainers": 0,
-          "pendingContainers": 0,
-          "capacities": {"queueCapacitiesByPartition": [{
-            "partitionName": "",
-            "capacity": 30.000002,
-            "usedCapacity": 0,
-            "maxCapacity": 50,
-            "absoluteCapacity": 3.15,
-            "absoluteUsedCapacity": 0,
-            "absoluteMaxCapacity": 25,
-            "maxAMLimitPercentage": 0,
-            "weight": -1,
-            "normalizedWeight": 0,
-            "configuredMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "configuredMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "resources": {"resourceUsagesByPartition": [{
-            "partitionName": "",
-            "used": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "reserved": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "pending": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "minEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maxEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maximumAllocation": {
-            "memory": 8192,
-            "vCores": 4,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 8192
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 4
-              }
-            ]}
-          },
-          "queueAcls": {"queueAcl": [
-            {
-              "accessType": "ADMINISTER_QUEUE",
-              "accessControlList": " "
-            },
-            {
-              "accessType": "APPLICATION_MAX_PRIORITY",
-              "accessControlList": "*"
-            },
-            {
-              "accessType": "SUBMIT_APP",
-              "accessControlList": " "
-            }
-          ]},
-          "queuePriority": 0,
-          "orderingPolicyInfo": "utilization",
-          "autoCreateChildQueueEnabled": false,
-          "leafQueueTemplate": {},
-          "mode": "percentage",
-          "queueType": "parent",
-          "creationMethod": "static",
-          "autoCreationEligibility": "off",
-          "autoQueueTemplateProperties": {},
-          "autoQueueParentTemplateProperties": {},
-          "autoQueueLeafTemplateProperties": {}
-        }
-      ]},
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 10.5,
-        "usedCapacity": 0,
-        "maxCapacity": 50,
-        "absoluteCapacity": 10.5,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 50,
-        "maxAMLimitPercentage": 0,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "utilization",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "percentage",
-      "queueType": "parent",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {}
-    },
-    {
-      "queuePath": "root.b",
-      "capacity": 89.5,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 89.5,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 2,
-      "maxParallelApps": 2147483647,
-      "queueName": "b",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "queues": {"queue": [
-        {
-          "type": "capacitySchedulerLeafQueueInfo",
-          "queuePath": "root.b.b1",
-          "capacity": 60.000004,
-          "usedCapacity": 0,
-          "maxCapacity": 100,
-          "absoluteCapacity": 53.7,
-          "absoluteMaxCapacity": 100,
-          "absoluteUsedCapacity": 0,
-          "weight": -1,
-          "normalizedWeight": 0,
-          "numApplications": 2,
-          "maxParallelApps": 2147483647,
-          "queueName": "b1",
-          "isAbsoluteResource": false,
-          "state": "RUNNING",
-          "resourcesUsed": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "hideReservationQueues": false,
-          "nodeLabels": ["*"],
-          "allocatedContainers": 0,
-          "reservedContainers": 0,
-          "pendingContainers": 2,
-          "capacities": {"queueCapacitiesByPartition": [{
-            "partitionName": "",
-            "capacity": 60.000004,
-            "usedCapacity": 0,
-            "maxCapacity": 100,
-            "absoluteCapacity": 53.7,
-            "absoluteUsedCapacity": 0,
-            "absoluteMaxCapacity": 100,
-            "maxAMLimitPercentage": 10,
-            "weight": -1,
-            "normalizedWeight": 0,
-            "configuredMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "configuredMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "resources": {"resourceUsagesByPartition": [{
-            "partitionName": "",
-            "used": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "reserved": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "pending": {
-              "memory": 2048,
-              "vCores": 2,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 2048
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 2
-                }
-              ]}
-            },
-            "amUsed": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "amLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "userAmLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "minEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maxEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maximumAllocation": {
-            "memory": 8192,
-            "vCores": 4,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 8192
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 4
-              }
-            ]}
-          },
-          "queueAcls": {"queueAcl": [
-            {
-              "accessType": "ADMINISTER_QUEUE",
-              "accessControlList": " "
-            },
-            {
-              "accessType": "APPLICATION_MAX_PRIORITY",
-              "accessControlList": "*"
-            },
-            {
-              "accessType": "SUBMIT_APP",
-              "accessControlList": " "
-            }
-          ]},
-          "queuePriority": 0,
-          "orderingPolicyInfo": "fifo",
-          "autoCreateChildQueueEnabled": false,
-          "leafQueueTemplate": {},
-          "mode": "percentage",
-          "queueType": "leaf",
-          "creationMethod": "static",
-          "autoCreationEligibility": "off",
-          "autoQueueTemplateProperties": {},
-          "autoQueueParentTemplateProperties": {},
-          "autoQueueLeafTemplateProperties": {},
-          "numActiveApplications": 0,
-          "numPendingApplications": 2,
-          "numContainers": 0,
-          "maxApplications": 5370,
-          "maxApplicationsPerUser": 5370,
-          "userLimit": 100,
-          "users": {"user": [
-            {
-              "username": "user1",
-              "resourcesUsed": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "numPendingApplications": 1,
-              "numActiveApplications": 0,
-              "AMResourceUsed": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "userResourceLimit": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "resources": {"resourceUsagesByPartition": [{
-                "partitionName": "",
-                "used": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "reserved": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "pending": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "amUsed": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "amLimit": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "userAmLimit": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                }
-              }]},
-              "userWeight": 1,
-              "isActive": false
-            },
-            {
-              "username": "user2",
-              "resourcesUsed": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "numPendingApplications": 1,
-              "numActiveApplications": 0,
-              "AMResourceUsed": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "userResourceLimit": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "resources": {"resourceUsagesByPartition": [{
-                "partitionName": "",
-                "used": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "reserved": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "pending": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "amUsed": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "amLimit": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "userAmLimit": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                }
-              }]},
-              "userWeight": 1,
-              "isActive": false
-            }
-          ]},
-          "userLimitFactor": 100,
-          "configuredMaxAMResourceLimit": 0.1,
-          "AMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "usedAMResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "userAMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "preemptionDisabled": true,
-          "intraQueuePreemptionDisabled": true,
-          "defaultPriority": 0,
-          "isAutoCreatedLeafQueue": false,
-          "maxApplicationLifetime": -1,
-          "defaultApplicationLifetime": -1
-        },
-        {
-          "type": "capacitySchedulerLeafQueueInfo",
-          "queuePath": "root.b.b2",
-          "capacity": 39.5,
-          "usedCapacity": 0,
-          "maxCapacity": 100,
-          "absoluteCapacity": 35.3525,
-          "absoluteMaxCapacity": 100,
-          "absoluteUsedCapacity": 0,
-          "weight": -1,
-          "normalizedWeight": 0,
-          "numApplications": 0,
-          "maxParallelApps": 2147483647,
-          "queueName": "b2",
-          "isAbsoluteResource": false,
-          "state": "RUNNING",
-          "resourcesUsed": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "hideReservationQueues": false,
-          "nodeLabels": ["*"],
-          "allocatedContainers": 0,
-          "reservedContainers": 0,
-          "pendingContainers": 0,
-          "capacities": {"queueCapacitiesByPartition": [{
-            "partitionName": "",
-            "capacity": 39.5,
-            "usedCapacity": 0,
-            "maxCapacity": 100,
-            "absoluteCapacity": 35.3525,
-            "absoluteUsedCapacity": 0,
-            "absoluteMaxCapacity": 100,
-            "maxAMLimitPercentage": 10,
-            "weight": -1,
-            "normalizedWeight": 0,
-            "configuredMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "configuredMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "resources": {"resourceUsagesByPartition": [{
-            "partitionName": "",
-            "used": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "reserved": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "pending": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "amUsed": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "amLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "userAmLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "minEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maxEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maximumAllocation": {
-            "memory": 8192,
-            "vCores": 4,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 8192
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 4
-              }
-            ]}
-          },
-          "queueAcls": {"queueAcl": [
-            {
-              "accessType": "ADMINISTER_QUEUE",
-              "accessControlList": " "
-            },
-            {
-              "accessType": "APPLICATION_MAX_PRIORITY",
-              "accessControlList": "*"
-            },
-            {
-              "accessType": "SUBMIT_APP",
-              "accessControlList": " "
-            }
-          ]},
-          "queuePriority": 0,
-          "orderingPolicyInfo": "fifo",
-          "autoCreateChildQueueEnabled": false,
-          "leafQueueTemplate": {},
-          "mode": "percentage",
-          "queueType": "leaf",
-          "creationMethod": "static",
-          "autoCreationEligibility": "off",
-          "autoQueueTemplateProperties": {},
-          "autoQueueParentTemplateProperties": {},
-          "autoQueueLeafTemplateProperties": {},
-          "numActiveApplications": 0,
-          "numPendingApplications": 0,
-          "numContainers": 0,
-          "maxApplications": 3535,
-          "maxApplicationsPerUser": 3535,
-          "userLimit": 100,
-          "users": {},
-          "userLimitFactor": 100,
-          "configuredMaxAMResourceLimit": 0.1,
-          "AMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "usedAMResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "userAMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "preemptionDisabled": true,
-          "intraQueuePreemptionDisabled": true,
-          "defaultPriority": 0,
-          "isAutoCreatedLeafQueue": false,
-          "maxApplicationLifetime": -1,
-          "defaultApplicationLifetime": -1
-        },
-        {
-          "type": "capacitySchedulerLeafQueueInfo",
-          "queuePath": "root.b.b3",
-          "capacity": 0.5,
-          "usedCapacity": 0,
-          "maxCapacity": 100,
-          "absoluteCapacity": 0.4475,
-          "absoluteMaxCapacity": 100,
-          "absoluteUsedCapacity": 0,
-          "weight": -1,
-          "normalizedWeight": 0,
-          "numApplications": 0,
-          "maxParallelApps": 2147483647,
-          "queueName": "b3",
-          "isAbsoluteResource": false,
-          "state": "RUNNING",
-          "resourcesUsed": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "hideReservationQueues": false,
-          "nodeLabels": ["*"],
-          "allocatedContainers": 0,
-          "reservedContainers": 0,
-          "pendingContainers": 0,
-          "capacities": {"queueCapacitiesByPartition": [{
-            "partitionName": "",
-            "capacity": 0.5,
-            "usedCapacity": 0,
-            "maxCapacity": 100,
-            "absoluteCapacity": 0.4475,
-            "absoluteUsedCapacity": 0,
-            "absoluteMaxCapacity": 100,
-            "maxAMLimitPercentage": 10,
-            "weight": -1,
-            "normalizedWeight": 0,
-            "configuredMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "configuredMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "resources": {"resourceUsagesByPartition": [{
-            "partitionName": "",
-            "used": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "reserved": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "pending": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "amUsed": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "amLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "userAmLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "minEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maxEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maximumAllocation": {
-            "memory": 8192,
-            "vCores": 4,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 8192
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 4
-              }
-            ]}
-          },
-          "queueAcls": {"queueAcl": [
-            {
-              "accessType": "ADMINISTER_QUEUE",
-              "accessControlList": " "
-            },
-            {
-              "accessType": "APPLICATION_MAX_PRIORITY",
-              "accessControlList": "*"
-            },
-            {
-              "accessType": "SUBMIT_APP",
-              "accessControlList": " "
-            }
-          ]},
-          "queuePriority": 0,
-          "orderingPolicyInfo": "fifo",
-          "autoCreateChildQueueEnabled": false,
-          "leafQueueTemplate": {},
-          "mode": "percentage",
-          "queueType": "leaf",
-          "creationMethod": "static",
-          "autoCreationEligibility": "off",
-          "autoQueueTemplateProperties": {},
-          "autoQueueParentTemplateProperties": {},
-          "autoQueueLeafTemplateProperties": {},
-          "numActiveApplications": 0,
-          "numPendingApplications": 0,
-          "numContainers": 0,
-          "maxApplications": 44,
-          "maxApplicationsPerUser": 44,
-          "userLimit": 100,
-          "users": {},
-          "userLimitFactor": 100,
-          "configuredMaxAMResourceLimit": 0.1,
-          "AMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "usedAMResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "userAMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "preemptionDisabled": true,
-          "intraQueuePreemptionDisabled": true,
-          "defaultPriority": 0,
-          "isAutoCreatedLeafQueue": false,
-          "maxApplicationLifetime": -1,
-          "defaultApplicationLifetime": -1
-        }
-      ]},
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 2,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 89.5,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 89.5,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 0,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 2048,
-          "vCores": 2,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 2048
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 2
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "utilization",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "percentage",
-      "queueType": "parent",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {}
+      "queuePriority" : 0,
+      "orderingPolicyInfo" : "utilization",
+      "mode" : "percentage",
+      "queueType" : "parent",
+      "creationMethod" : "static",
+      "autoCreationEligibility" : "off",
+      "autoQueueTemplateProperties" : { },
+      "autoQueueParentTemplateProperties" : { },
+      "autoQueueLeafTemplateProperties" : { }
     }
-  ]},
-  "capacities": {"queueCapacitiesByPartition": [{
-    "partitionName": "",
-    "capacity": 100,
-    "usedCapacity": 0,
-    "maxCapacity": 100,
-    "absoluteCapacity": 100,
-    "absoluteUsedCapacity": 0,
-    "absoluteMaxCapacity": 100,
-    "maxAMLimitPercentage": 0,
-    "weight": -1,
-    "normalizedWeight": 0,
-    "configuredMinResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "configuredMaxResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "effectiveMinResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "effectiveMaxResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    }
-  }]},
-  "health": {
-    "lastrun": 0,
-    "operationsInfo": [
-      {
-        "operation": "last-allocation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-release",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-preemption",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-reservation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      }
-    ],
-    "lastRunDetails": [
-      {
-        "operation": "releases",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "allocations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "reservations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }
-    ]
-  },
-  "maximumAllocation": {
-    "memory": 8192,
-    "vCores": 4,
-    "resourceInformations": {"resourceInformation": [
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "memory-mb",
-        "resourceType": "COUNTABLE",
-        "units": "Mi",
-        "value": 8192
-      },
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "vcores",
-        "resourceType": "COUNTABLE",
-        "units": "",
-        "value": 4
-      }
-    ]}
-  },
-  "queueAcls": {"queueAcl": [
-    {
-      "accessType": "ADMINISTER_QUEUE",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "APPLICATION_MAX_PRIORITY",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "SUBMIT_APP",
-      "accessControlList": "*"
-    }
-  ]},
-  "queuePriority": 0,
-  "orderingPolicyInfo": "utilization",
-  "mode": "percentage",
-  "queueType": "parent",
-  "creationMethod": "static",
-  "autoCreationEligibility": "off",
-  "autoQueueTemplateProperties": {},
-  "autoQueueParentTemplateProperties": {},
-  "autoQueueLeafTemplateProperties": {}
-}}}
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-PercentageMode.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-PercentageMode.json
@@ -1,1739 +1,1679 @@
-{"scheduler": {"schedulerInfo": {
-  "type": "capacityScheduler",
-  "capacity": 100,
-  "usedCapacity": 0,
-  "maxCapacity": 100,
-  "weight": -1,
-  "normalizedWeight": 0,
-  "queueName": "root",
-  "queuePath": "root",
-  "maxParallelApps": 2147483647,
-  "isAbsoluteResource": false,
-  "queues": {"queue": [
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.test2",
-      "capacity": 50,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 50,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "test2",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
+{
+  "scheduler" : {
+    "schedulerInfo" : {
+      "type" : "capacityScheduler",
+      "capacity" : 100,
+      "usedCapacity" : 0,
+      "maxCapacity" : 100,
+      "weight" : -1,
+      "normalizedWeight" : 0,
+      "queueName" : "root",
+      "queuePath" : "root",
+      "maxParallelApps" : 2147483647,
+      "isAbsoluteResource" : false,
+      "queues" : {
+        "queue" : [ {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.test2",
+          "capacity" : 50,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 50,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "test2",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
           },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 50,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 50,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "percentage",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 5000,
+          "maxApplicationsPerUser" : 5000,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.test1",
+          "capacity" : 50,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 50,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "test1",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 50,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 50,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "percentage",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 5000,
+          "maxApplicationsPerUser" : 5000,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.default",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 0,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "default",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 0,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "percentage",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 0,
+          "maxApplicationsPerUser" : 0,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        } ]
       },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 50,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 50,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+      "capacities" : {
+        "queueCapacitiesByPartition" : [ {
+          "partitionName" : "",
+          "capacity" : 100,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "absoluteMaxCapacity" : 100,
+          "maxAMLimitPercentage" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "configuredMinResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "configuredMaxResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "effectiveMinResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "effectiveMaxResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
+          }
+        } ]
+      },
+      "health" : {
+        "lastrun" : 0,
+        "operationsInfo" : [ {
+          "operation" : "last-allocation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-release",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-preemption",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-reservation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        } ],
+        "lastRunDetails" : [ {
+          "operation" : "releases",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "allocations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "reservations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        } ]
+      },
+      "maximumAllocation" : {
+        "memory" : 8192,
+        "vCores" : 4,
+        "resourceInformations" : {
+          "resourceInformation" : [ {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "memory-mb",
+            "resourceType" : "COUNTABLE",
+            "units" : "Mi",
+            "value" : 8192
+          }, {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "vcores",
+            "resourceType" : "COUNTABLE",
+            "units" : "",
+            "value" : 4
+          } ]
         }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
       },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
+      "queueAcls" : {
+        "queueAcl" : [ {
+          "accessType" : "ADMINISTER_QUEUE",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "APPLICATION_MAX_PRIORITY",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "SUBMIT_APP",
+          "accessControlList" : "*"
+        } ]
       },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "percentage",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 5000,
-      "maxApplicationsPerUser": 5000,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.test1",
-      "capacity": 50,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 50,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "test1",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 50,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 50,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "percentage",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 5000,
-      "maxApplicationsPerUser": 5000,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.default",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 0,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "default",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 0,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "percentage",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 0,
-      "maxApplicationsPerUser": 0,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
+      "queuePriority" : 0,
+      "orderingPolicyInfo" : "utilization",
+      "mode" : "percentage",
+      "queueType" : "parent",
+      "creationMethod" : "static",
+      "autoCreationEligibility" : "off",
+      "autoQueueTemplateProperties" : { },
+      "autoQueueParentTemplateProperties" : { },
+      "autoQueueLeafTemplateProperties" : { }
     }
-  ]},
-  "capacities": {"queueCapacitiesByPartition": [{
-    "partitionName": "",
-    "capacity": 100,
-    "usedCapacity": 0,
-    "maxCapacity": 100,
-    "absoluteCapacity": 100,
-    "absoluteUsedCapacity": 0,
-    "absoluteMaxCapacity": 100,
-    "maxAMLimitPercentage": 0,
-    "weight": -1,
-    "normalizedWeight": 0,
-    "configuredMinResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "configuredMaxResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "effectiveMinResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "effectiveMaxResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    }
-  }]},
-  "health": {
-    "lastrun": 0,
-    "operationsInfo": [
-      {
-        "operation": "last-allocation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-release",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-preemption",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-reservation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      }
-    ],
-    "lastRunDetails": [
-      {
-        "operation": "releases",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "allocations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "reservations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }
-    ]
-  },
-  "maximumAllocation": {
-    "memory": 8192,
-    "vCores": 4,
-    "resourceInformations": {"resourceInformation": [
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "memory-mb",
-        "resourceType": "COUNTABLE",
-        "units": "Mi",
-        "value": 8192
-      },
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "vcores",
-        "resourceType": "COUNTABLE",
-        "units": "",
-        "value": 4
-      }
-    ]}
-  },
-  "queueAcls": {"queueAcl": [
-    {
-      "accessType": "ADMINISTER_QUEUE",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "APPLICATION_MAX_PRIORITY",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "SUBMIT_APP",
-      "accessControlList": "*"
-    }
-  ]},
-  "queuePriority": 0,
-  "orderingPolicyInfo": "utilization",
-  "mode": "percentage",
-  "queueType": "parent",
-  "creationMethod": "static",
-  "autoCreationEligibility": "off",
-  "autoQueueTemplateProperties": {},
-  "autoQueueParentTemplateProperties": {},
-  "autoQueueLeafTemplateProperties": {}
-}}}
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-PercentageModeLegacyAutoCreation.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-PercentageModeLegacyAutoCreation.json
@@ -1,1580 +1,1526 @@
-{"scheduler": {"schedulerInfo": {
-  "type": "capacityScheduler",
-  "capacity": 100,
-  "usedCapacity": 0,
-  "maxCapacity": 100,
-  "weight": -1,
-  "normalizedWeight": 0,
-  "queueName": "root",
-  "queuePath": "root",
-  "maxParallelApps": 2147483647,
-  "isAbsoluteResource": false,
-  "queues": {"queue": [
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.test1",
-      "capacity": 50,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 50,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "test1",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
+{
+  "scheduler" : {
+    "schedulerInfo" : {
+      "type" : "capacityScheduler",
+      "capacity" : 100,
+      "usedCapacity" : 0,
+      "maxCapacity" : 100,
+      "weight" : -1,
+      "normalizedWeight" : 0,
+      "queueName" : "root",
+      "queuePath" : "root",
+      "maxParallelApps" : 2147483647,
+      "isAbsoluteResource" : false,
+      "queues" : {
+        "queue" : [ {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.test1",
+          "capacity" : 50,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 50,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "test1",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
           },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 50,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 50,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "percentage",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 5000,
+          "maxApplicationsPerUser" : 5000,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.default",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 0,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "default",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 0,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "percentage",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 0,
+          "maxApplicationsPerUser" : 0,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "queuePath" : "root.managedtest2",
+          "capacity" : 50,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 50,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "managedtest2",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "queues" : { },
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 50,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 50,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "utilization",
+          "autoCreateChildQueueEnabled" : true,
+          "leafQueueTemplate" : { },
+          "mode" : "percentage",
+          "queueType" : "parent",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "legacy",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { }
+        } ]
       },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 50,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 50,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+      "capacities" : {
+        "queueCapacitiesByPartition" : [ {
+          "partitionName" : "",
+          "capacity" : 100,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "absoluteMaxCapacity" : 100,
+          "maxAMLimitPercentage" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "configuredMinResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "configuredMaxResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "effectiveMinResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "effectiveMaxResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
+          }
+        } ]
+      },
+      "health" : {
+        "lastrun" : 0,
+        "operationsInfo" : [ {
+          "operation" : "last-allocation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-release",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-preemption",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-reservation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        } ],
+        "lastRunDetails" : [ {
+          "operation" : "releases",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "allocations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "reservations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        } ]
+      },
+      "maximumAllocation" : {
+        "memory" : 8192,
+        "vCores" : 4,
+        "resourceInformations" : {
+          "resourceInformation" : [ {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "memory-mb",
+            "resourceType" : "COUNTABLE",
+            "units" : "Mi",
+            "value" : 8192
+          }, {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "vcores",
+            "resourceType" : "COUNTABLE",
+            "units" : "",
+            "value" : 4
+          } ]
         }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
       },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
+      "queueAcls" : {
+        "queueAcl" : [ {
+          "accessType" : "ADMINISTER_QUEUE",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "APPLICATION_MAX_PRIORITY",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "SUBMIT_APP",
+          "accessControlList" : "*"
+        } ]
       },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "percentage",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 5000,
-      "maxApplicationsPerUser": 5000,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.default",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 0,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "default",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 0,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "percentage",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 0,
-      "maxApplicationsPerUser": 0,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "queuePath": "root.managedtest2",
-      "capacity": 50,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 50,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "managedtest2",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "queues": {},
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 50,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 50,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 0,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "utilization",
-      "autoCreateChildQueueEnabled": true,
-      "leafQueueTemplate": {},
-      "mode": "percentage",
-      "queueType": "parent",
-      "creationMethod": "static",
-      "autoCreationEligibility": "legacy",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {}
+      "queuePriority" : 0,
+      "orderingPolicyInfo" : "utilization",
+      "mode" : "percentage",
+      "queueType" : "parent",
+      "creationMethod" : "static",
+      "autoCreationEligibility" : "off",
+      "autoQueueTemplateProperties" : { },
+      "autoQueueParentTemplateProperties" : { },
+      "autoQueueLeafTemplateProperties" : { }
     }
-  ]},
-  "capacities": {"queueCapacitiesByPartition": [{
-    "partitionName": "",
-    "capacity": 100,
-    "usedCapacity": 0,
-    "maxCapacity": 100,
-    "absoluteCapacity": 100,
-    "absoluteUsedCapacity": 0,
-    "absoluteMaxCapacity": 100,
-    "maxAMLimitPercentage": 0,
-    "weight": -1,
-    "normalizedWeight": 0,
-    "configuredMinResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "configuredMaxResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "effectiveMinResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "effectiveMaxResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    }
-  }]},
-  "health": {
-    "lastrun": 0,
-    "operationsInfo": [
-      {
-        "operation": "last-allocation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-release",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-preemption",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-reservation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      }
-    ],
-    "lastRunDetails": [
-      {
-        "operation": "releases",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "allocations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "reservations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }
-    ]
-  },
-  "maximumAllocation": {
-    "memory": 8192,
-    "vCores": 4,
-    "resourceInformations": {"resourceInformation": [
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "memory-mb",
-        "resourceType": "COUNTABLE",
-        "units": "Mi",
-        "value": 8192
-      },
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "vcores",
-        "resourceType": "COUNTABLE",
-        "units": "",
-        "value": 4
-      }
-    ]}
-  },
-  "queueAcls": {"queueAcl": [
-    {
-      "accessType": "ADMINISTER_QUEUE",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "APPLICATION_MAX_PRIORITY",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "SUBMIT_APP",
-      "accessControlList": "*"
-    }
-  ]},
-  "queuePriority": 0,
-  "orderingPolicyInfo": "utilization",
-  "mode": "percentage",
-  "queueType": "parent",
-  "creationMethod": "static",
-  "autoCreationEligibility": "off",
-  "autoQueueTemplateProperties": {},
-  "autoQueueParentTemplateProperties": {},
-  "autoQueueLeafTemplateProperties": {}
-}}}
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-WeightMode.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-WeightMode.json
@@ -1,2224 +1,2148 @@
-{"scheduler": {"schedulerInfo": {
-  "type": "capacityScheduler",
-  "capacity": 100,
-  "usedCapacity": 0,
-  "maxCapacity": 100,
-  "weight": 1,
-  "normalizedWeight": 1,
-  "queueName": "root",
-  "queuePath": "root",
-  "maxParallelApps": 2147483647,
-  "isAbsoluteResource": false,
-  "queues": {"queue": [
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.test2",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 22.222223,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 10,
-      "normalizedWeight": 0.22222222,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "test2",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
+{
+  "scheduler" : {
+    "schedulerInfo" : {
+      "type" : "capacityScheduler",
+      "capacity" : 100,
+      "usedCapacity" : 0,
+      "maxCapacity" : 100,
+      "weight" : 1,
+      "normalizedWeight" : 1,
+      "queueName" : "root",
+      "queuePath" : "root",
+      "maxParallelApps" : 2147483647,
+      "isAbsoluteResource" : false,
+      "queues" : {
+        "queue" : [ {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.test2",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 22.222223,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 10,
+          "normalizedWeight" : 0.22222222,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "test2",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
           },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 22.222223,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : 10,
+              "normalizedWeight" : 0.22222222,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 2222,
+          "maxApplicationsPerUser" : 2222,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.test1",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 11.111112,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 5,
+          "normalizedWeight" : 0.11111111,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "test1",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 11.111112,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : 5,
+              "normalizedWeight" : 0.11111111,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 1111,
+          "maxApplicationsPerUser" : 1111,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.parent",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 44.444447,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 20,
+          "normalizedWeight" : 0.44444445,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "parent",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 44.444447,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : 20,
+              "normalizedWeight" : 0.44444445,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 4444,
+          "maxApplicationsPerUser" : 4444,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.default",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 22.222223,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 10,
+          "normalizedWeight" : 0.22222222,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "default",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 22.222223,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : 10,
+              "normalizedWeight" : 0.22222222,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 2222,
+          "maxApplicationsPerUser" : 2222,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        } ]
       },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 22.222223,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": 10,
-        "normalizedWeight": 0.22222222,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+      "capacities" : {
+        "queueCapacitiesByPartition" : [ {
+          "partitionName" : "",
+          "capacity" : 100,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "absoluteMaxCapacity" : 100,
+          "maxAMLimitPercentage" : 0,
+          "weight" : 1,
+          "normalizedWeight" : 1,
+          "configuredMinResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "configuredMaxResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "effectiveMinResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "effectiveMaxResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
+          }
+        } ]
+      },
+      "health" : {
+        "lastrun" : 0,
+        "operationsInfo" : [ {
+          "operation" : "last-allocation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-release",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-preemption",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-reservation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        } ],
+        "lastRunDetails" : [ {
+          "operation" : "releases",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "allocations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "reservations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        } ]
+      },
+      "maximumAllocation" : {
+        "memory" : 8192,
+        "vCores" : 4,
+        "resourceInformations" : {
+          "resourceInformation" : [ {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "memory-mb",
+            "resourceType" : "COUNTABLE",
+            "units" : "Mi",
+            "value" : 8192
+          }, {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "vcores",
+            "resourceType" : "COUNTABLE",
+            "units" : "",
+            "value" : 4
+          } ]
         }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
       },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
+      "queueAcls" : {
+        "queueAcl" : [ {
+          "accessType" : "ADMINISTER_QUEUE",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "APPLICATION_MAX_PRIORITY",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "SUBMIT_APP",
+          "accessControlList" : "*"
+        } ]
       },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 2222,
-      "maxApplicationsPerUser": 2222,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.test1",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 11.111112,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 5,
-      "normalizedWeight": 0.11111111,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "test1",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 11.111112,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": 5,
-        "normalizedWeight": 0.11111111,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 1111,
-      "maxApplicationsPerUser": 1111,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.parent",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 44.444447,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 20,
-      "normalizedWeight": 0.44444445,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "parent",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 44.444447,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": 20,
-        "normalizedWeight": 0.44444445,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 4444,
-      "maxApplicationsPerUser": 4444,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.default",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 22.222223,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 10,
-      "normalizedWeight": 0.22222222,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "default",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 22.222223,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": 10,
-        "normalizedWeight": 0.22222222,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 2222,
-      "maxApplicationsPerUser": 2222,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
+      "queuePriority" : 0,
+      "orderingPolicyInfo" : "utilization",
+      "mode" : "weight",
+      "queueType" : "parent",
+      "creationMethod" : "static",
+      "autoCreationEligibility" : "off",
+      "autoQueueTemplateProperties" : { },
+      "autoQueueParentTemplateProperties" : { },
+      "autoQueueLeafTemplateProperties" : { }
     }
-  ]},
-  "capacities": {"queueCapacitiesByPartition": [{
-    "partitionName": "",
-    "capacity": 100,
-    "usedCapacity": 0,
-    "maxCapacity": 100,
-    "absoluteCapacity": 100,
-    "absoluteUsedCapacity": 0,
-    "absoluteMaxCapacity": 100,
-    "maxAMLimitPercentage": 0,
-    "weight": 1,
-    "normalizedWeight": 1,
-    "configuredMinResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "configuredMaxResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "effectiveMinResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "effectiveMaxResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    }
-  }]},
-  "health": {
-    "lastrun": 0,
-    "operationsInfo": [
-      {
-        "operation": "last-allocation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-release",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-preemption",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-reservation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      }
-    ],
-    "lastRunDetails": [
-      {
-        "operation": "releases",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "allocations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "reservations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }
-    ]
-  },
-  "maximumAllocation": {
-    "memory": 8192,
-    "vCores": 4,
-    "resourceInformations": {"resourceInformation": [
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "memory-mb",
-        "resourceType": "COUNTABLE",
-        "units": "Mi",
-        "value": 8192
-      },
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "vcores",
-        "resourceType": "COUNTABLE",
-        "units": "",
-        "value": 4
-      }
-    ]}
-  },
-  "queueAcls": {"queueAcl": [
-    {
-      "accessType": "ADMINISTER_QUEUE",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "APPLICATION_MAX_PRIORITY",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "SUBMIT_APP",
-      "accessControlList": "*"
-    }
-  ]},
-  "queuePriority": 0,
-  "orderingPolicyInfo": "utilization",
-  "mode": "weight",
-  "queueType": "parent",
-  "creationMethod": "static",
-  "autoCreationEligibility": "off",
-  "autoQueueTemplateProperties": {},
-  "autoQueueParentTemplateProperties": {},
-  "autoQueueLeafTemplateProperties": {}
-}}}
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-WeightModeWithAutoCreatedQueues-After.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-WeightModeWithAutoCreatedQueues-After.json
@@ -1,6006 +1,5818 @@
-{"scheduler": {"schedulerInfo": {
-  "type": "capacityScheduler",
-  "capacity": 100,
-  "usedCapacity": 0,
-  "maxCapacity": 100,
-  "weight": 1,
-  "normalizedWeight": 1,
-  "queueName": "root",
-  "queuePath": "root",
-  "maxParallelApps": 2147483647,
-  "isAbsoluteResource": false,
-  "queues": {"queue": [
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.test2",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 20,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 10,
-      "normalizedWeight": 0.2,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "test2",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
+{
+  "scheduler" : {
+    "schedulerInfo" : {
+      "type" : "capacityScheduler",
+      "capacity" : 100,
+      "usedCapacity" : 0,
+      "maxCapacity" : 100,
+      "weight" : 1,
+      "normalizedWeight" : 1,
+      "queueName" : "root",
+      "queuePath" : "root",
+      "maxParallelApps" : 2147483647,
+      "isAbsoluteResource" : false,
+      "queues" : {
+        "queue" : [ {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.test2",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 20,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 10,
+          "normalizedWeight" : 0.2,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "test2",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
           },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 20,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": 10,
-        "normalizedWeight": 0.2,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 245760,
-          "vCores": 240,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 245760
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 240
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 122880,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 122880
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 245760,
-        "vCores": 240,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 245760
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 240
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 1228800,
-        "vCores": 1200,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1200
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 2000,
-      "maxApplicationsPerUser": 2000,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 122880,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 122880
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 122880,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 122880
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.test1",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 10,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 5,
-      "normalizedWeight": 0.1,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "test1",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 10,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": 5,
-        "normalizedWeight": 0.1,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 122880,
-          "vCores": 120,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 122880
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 120
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 122880,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 122880
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 122880,
-        "vCores": 120,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 122880
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 120
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 1228800,
-        "vCores": 1200,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1200
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 1000,
-      "maxApplicationsPerUser": 1000,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 122880,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 122880
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 122880,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 122880
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.default",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 20,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 10,
-      "normalizedWeight": 0.2,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "default",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 20,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": 10,
-        "normalizedWeight": 0.2,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 245760,
-          "vCores": 240,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 245760
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 240
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 122880,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 122880
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 245760,
-        "vCores": 240,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 245760
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 240
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 1228800,
-        "vCores": 1200,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1200
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 2000,
-      "maxApplicationsPerUser": 2000,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 122880,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 122880
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 122880,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 122880
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.auto1",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 2,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 1,
-      "normalizedWeight": 0.02,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "auto1",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 2,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 100,
-        "weight": 1,
-        "normalizedWeight": 0.02,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 24575,
-          "vCores": 23,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 24575
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 23
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 1228800,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 24575,
-        "vCores": 23,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 24575
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 23
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 1228800,
-        "vCores": 1200,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1200
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "leaf",
-      "creationMethod": "dynamicFlexible",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 200,
-      "maxApplicationsPerUser": 200,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": -1,
-      "configuredMaxAMResourceLimit": 1,
-      "AMResourceLimit": {
-        "memory": 1228800,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 1228800,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.auto2",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 2,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 1,
-      "normalizedWeight": 0.02,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "auto2",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 2,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 100,
-        "weight": 1,
-        "normalizedWeight": 0.02,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 24575,
-          "vCores": 23,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 24575
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 23
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 1228800,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 24575,
-        "vCores": 23,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 24575
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 23
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 1228800,
-        "vCores": 1200,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1200
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "leaf",
-      "creationMethod": "dynamicFlexible",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 200,
-      "maxApplicationsPerUser": 200,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": -1,
-      "configuredMaxAMResourceLimit": 1,
-      "AMResourceLimit": {
-        "memory": 1228800,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 1228800,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.auto3",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 2,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 1,
-      "normalizedWeight": 0.02,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "auto3",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 2,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 100,
-        "weight": 1,
-        "normalizedWeight": 0.02,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 24575,
-          "vCores": 23,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 24575
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 23
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 1228800,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 24575,
-        "vCores": 23,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 24575
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 23
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 1228800,
-        "vCores": 1200,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1200
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "leaf",
-      "creationMethod": "dynamicFlexible",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 200,
-      "maxApplicationsPerUser": 200,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": -1,
-      "configuredMaxAMResourceLimit": 1,
-      "AMResourceLimit": {
-        "memory": 1228800,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 1228800,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "queuePath": "root.parent",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 40,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 20,
-      "normalizedWeight": 0.4,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "parent",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "queues": {"queue": [{
-        "queuePath": "root.parent.autoParent3",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 40,
-        "absoluteMaxCapacity": 100,
-        "absoluteUsedCapacity": 0,
-        "weight": 1,
-        "normalizedWeight": 1,
-        "numApplications": 0,
-        "maxParallelApps": 2147483647,
-        "queueName": "autoParent3",
-        "isAbsoluteResource": false,
-        "state": "RUNNING",
-        "queues": {"queue": [{
-          "type": "capacitySchedulerLeafQueueInfo",
-          "queuePath": "root.parent.autoParent3.auto6",
-          "capacity": 0,
-          "usedCapacity": 0,
-          "maxCapacity": 100,
-          "absoluteCapacity": 40,
-          "absoluteMaxCapacity": 100,
-          "absoluteUsedCapacity": 0,
-          "weight": 1,
-          "normalizedWeight": 1,
-          "numApplications": 0,
-          "maxParallelApps": 2147483647,
-          "queueName": "auto6",
-          "isAbsoluteResource": false,
-          "state": "RUNNING",
-          "resourcesUsed": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "hideReservationQueues": false,
-          "nodeLabels": ["*"],
-          "allocatedContainers": 0,
-          "reservedContainers": 0,
-          "pendingContainers": 0,
-          "capacities": {"queueCapacitiesByPartition": [{
-            "partitionName": "",
-            "capacity": 0,
-            "usedCapacity": 0,
-            "maxCapacity": 100,
-            "absoluteCapacity": 40,
-            "absoluteUsedCapacity": 0,
-            "absoluteMaxCapacity": 100,
-            "maxAMLimitPercentage": 100,
-            "weight": 1,
-            "normalizedWeight": 1,
-            "configuredMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 20,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : 10,
+              "normalizedWeight" : 0.2,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
                 }
-              ]}
-            },
-            "configuredMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
                 }
-              ]}
-            },
-            "effectiveMinResource": {
-              "memory": 491520,
-              "vCores": 480,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 491520
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 480
+              },
+              "effectiveMinResource" : {
+                "memory" : 245760,
+                "vCores" : 240,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 245760
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 240
+                  } ]
                 }
-              ]}
-            },
-            "effectiveMaxResource": {
-              "memory": 1228800,
-              "vCores": 1200,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 1228800
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 1200
+              },
+              "effectiveMaxResource" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
                 }
-              ]}
-            }
-          }]},
-          "resources": {"resourceUsagesByPartition": [{
-            "partitionName": "",
-            "used": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
                 }
-              ]}
-            },
-            "reserved": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
                 }
-              ]}
-            },
-            "pending": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
                 }
-              ]}
-            },
-            "amUsed": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
                 }
-              ]}
-            },
-            "amLimit": {
-              "memory": 1228800,
-              "vCores": 1,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 1228800
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 1
+              },
+              "amLimit" : {
+                "memory" : 122880,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 122880
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
                 }
-              ]}
-            },
-            "userAmLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
                 }
-              ]}
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 245760,
+            "vCores" : 240,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 245760
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 240
+              } ]
             }
-          }]},
-          "minEffectiveCapacity": {
-            "memory": 491520,
-            "vCores": 480,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 491520
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 480
-              }
-            ]}
           },
-          "maxEffectiveCapacity": {
-            "memory": 1228800,
-            "vCores": 1200,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 1228800
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 1200
-              }
-            ]}
-          },
-          "maximumAllocation": {
-            "memory": 8192,
-            "vCores": 4,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 8192
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 4
-              }
-            ]}
-          },
-          "queueAcls": {"queueAcl": [
-            {
-              "accessType": "ADMINISTER_QUEUE",
-              "accessControlList": "wildAdmin2 "
-            },
-            {
-              "accessType": "APPLICATION_MAX_PRIORITY",
-              "accessControlList": "*"
-            },
-            {
-              "accessType": "SUBMIT_APP",
-              "accessControlList": "wildUser2 "
+          "maxEffectiveCapacity" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
             }
-          ]},
-          "queuePriority": 0,
-          "orderingPolicyInfo": "fifo",
-          "autoCreateChildQueueEnabled": false,
-          "leafQueueTemplate": {},
-          "mode": "weight",
-          "queueType": "leaf",
-          "creationMethod": "dynamicFlexible",
-          "autoCreationEligibility": "off",
-          "autoQueueTemplateProperties": {},
-          "autoQueueParentTemplateProperties": {},
-          "autoQueueLeafTemplateProperties": {},
-          "numActiveApplications": 0,
-          "numPendingApplications": 0,
-          "numContainers": 0,
-          "maxApplications": 4000,
-          "maxApplicationsPerUser": 4000,
-          "userLimit": 100,
-          "users": {},
-          "userLimitFactor": -1,
-          "configuredMaxAMResourceLimit": 1,
-          "AMResourceLimit": {
-            "memory": 1228800,
-            "vCores": 1,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 1228800
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 1
-              }
-            ]}
           },
-          "usedAMResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "userAMResourceLimit": {
-            "memory": 1228800,
-            "vCores": 1,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 1228800
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 1
-              }
-            ]}
-          },
-          "preemptionDisabled": true,
-          "intraQueuePreemptionDisabled": true,
-          "defaultPriority": 0,
-          "isAutoCreatedLeafQueue": false,
-          "maxApplicationLifetime": -1,
-          "defaultApplicationLifetime": -1
-        }]},
-        "resourcesUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
             }
-          ]}
-        },
-        "hideReservationQueues": false,
-        "nodeLabels": ["*"],
-        "allocatedContainers": 0,
-        "reservedContainers": 0,
-        "pendingContainers": 0,
-        "capacities": {"queueCapacitiesByPartition": [{
-          "partitionName": "",
-          "capacity": 0,
-          "usedCapacity": 0,
-          "maxCapacity": 100,
-          "absoluteCapacity": 40,
-          "absoluteUsedCapacity": 0,
-          "absoluteMaxCapacity": 100,
-          "maxAMLimitPercentage": 0,
-          "weight": 1,
-          "normalizedWeight": 1,
-          "configuredMinResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 8192,
-                "minimumAllocation": 1024,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 4,
-                "minimumAllocation": 1,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
           },
-          "configuredMaxResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 8192,
-                "minimumAllocation": 1024,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 4,
-                "minimumAllocation": 1,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
           },
-          "effectiveMinResource": {
-            "memory": 491520,
-            "vCores": 480,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 491520
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 480
-              }
-            ]}
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 2000,
+          "maxApplicationsPerUser" : 2000,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 122880,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 122880
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
           },
-          "effectiveMaxResource": {
-            "memory": 1228800,
-            "vCores": 1200,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 1228800
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 122880,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 122880
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.test1",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 10,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 5,
+          "normalizedWeight" : 0.1,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "test1",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 10,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : 5,
+              "normalizedWeight" : 0.1,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
               },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 1200
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 122880,
+                "vCores" : 120,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 122880
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 120
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
+                }
               }
-            ]}
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 122880,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 122880
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 122880,
+            "vCores" : 120,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 122880
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 120
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 1000,
+          "maxApplicationsPerUser" : 1000,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 122880,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 122880
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 122880,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 122880
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.default",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 20,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 10,
+          "normalizedWeight" : 0.2,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "default",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 20,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : 10,
+              "normalizedWeight" : 0.2,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 245760,
+                "vCores" : 240,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 245760
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 240
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 122880,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 122880
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 245760,
+            "vCores" : 240,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 245760
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 240
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 2000,
+          "maxApplicationsPerUser" : 2000,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 122880,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 122880
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 122880,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 122880
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.auto1",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 2,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 1,
+          "normalizedWeight" : 0.02,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "auto1",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 2,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 100,
+              "weight" : 1,
+              "normalizedWeight" : 0.02,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 24575,
+                "vCores" : 23,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 24575
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 23
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 1228800,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 24575,
+            "vCores" : 23,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 24575
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 23
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "leaf",
+          "creationMethod" : "dynamicFlexible",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 200,
+          "maxApplicationsPerUser" : 200,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : -1,
+          "configuredMaxAMResourceLimit" : 1,
+          "AMResourceLimit" : {
+            "memory" : 1228800,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 1228800,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.auto2",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 2,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 1,
+          "normalizedWeight" : 0.02,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "auto2",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 2,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 100,
+              "weight" : 1,
+              "normalizedWeight" : 0.02,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 24575,
+                "vCores" : 23,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 24575
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 23
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 1228800,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 24575,
+            "vCores" : 23,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 24575
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 23
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "leaf",
+          "creationMethod" : "dynamicFlexible",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 200,
+          "maxApplicationsPerUser" : 200,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : -1,
+          "configuredMaxAMResourceLimit" : 1,
+          "AMResourceLimit" : {
+            "memory" : 1228800,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 1228800,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.auto3",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 2,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 1,
+          "normalizedWeight" : 0.02,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "auto3",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 2,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 100,
+              "weight" : 1,
+              "normalizedWeight" : 0.02,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 24575,
+                "vCores" : 23,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 24575
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 23
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 1228800,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 24575,
+            "vCores" : 23,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 24575
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 23
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "leaf",
+          "creationMethod" : "dynamicFlexible",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 200,
+          "maxApplicationsPerUser" : 200,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : -1,
+          "configuredMaxAMResourceLimit" : 1,
+          "AMResourceLimit" : {
+            "memory" : 1228800,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 1228800,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "queuePath" : "root.parent",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 40,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 20,
+          "normalizedWeight" : 0.4,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "parent",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "queues" : {
+            "queue" : [ {
+              "queuePath" : "root.parent.autoParent3",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 40,
+              "absoluteMaxCapacity" : 100,
+              "absoluteUsedCapacity" : 0,
+              "weight" : 1,
+              "normalizedWeight" : 1,
+              "numApplications" : 0,
+              "maxParallelApps" : 2147483647,
+              "queueName" : "autoParent3",
+              "isAbsoluteResource" : false,
+              "state" : "RUNNING",
+              "queues" : {
+                "queue" : [ {
+                  "type" : "capacitySchedulerLeafQueueInfo",
+                  "queuePath" : "root.parent.autoParent3.auto6",
+                  "capacity" : 0,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 40,
+                  "absoluteMaxCapacity" : 100,
+                  "absoluteUsedCapacity" : 0,
+                  "weight" : 1,
+                  "normalizedWeight" : 1,
+                  "numApplications" : 0,
+                  "maxParallelApps" : 2147483647,
+                  "queueName" : "auto6",
+                  "isAbsoluteResource" : false,
+                  "state" : "RUNNING",
+                  "resourcesUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "hideReservationQueues" : false,
+                  "nodeLabels" : [ "*" ],
+                  "allocatedContainers" : 0,
+                  "reservedContainers" : 0,
+                  "pendingContainers" : 0,
+                  "capacities" : {
+                    "queueCapacitiesByPartition" : [ {
+                      "partitionName" : "",
+                      "capacity" : 0,
+                      "usedCapacity" : 0,
+                      "maxCapacity" : 100,
+                      "absoluteCapacity" : 40,
+                      "absoluteUsedCapacity" : 0,
+                      "absoluteMaxCapacity" : 100,
+                      "maxAMLimitPercentage" : 100,
+                      "weight" : 1,
+                      "normalizedWeight" : 1,
+                      "configuredMinResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 8192,
+                            "minimumAllocation" : 1024,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 4,
+                            "minimumAllocation" : 1,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "configuredMaxResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 8192,
+                            "minimumAllocation" : 1024,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 4,
+                            "minimumAllocation" : 1,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "effectiveMinResource" : {
+                        "memory" : 491520,
+                        "vCores" : 480,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 491520
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 480
+                          } ]
+                        }
+                      },
+                      "effectiveMaxResource" : {
+                        "memory" : 1228800,
+                        "vCores" : 1200,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 1228800
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 1200
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "resources" : {
+                    "resourceUsagesByPartition" : [ {
+                      "partitionName" : "",
+                      "used" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "reserved" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "pending" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "amUsed" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "amLimit" : {
+                        "memory" : 1228800,
+                        "vCores" : 1,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 1228800
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 1
+                          } ]
+                        }
+                      },
+                      "userAmLimit" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "minEffectiveCapacity" : {
+                    "memory" : 491520,
+                    "vCores" : 480,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 491520
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 480
+                      } ]
+                    }
+                  },
+                  "maxEffectiveCapacity" : {
+                    "memory" : 1228800,
+                    "vCores" : 1200,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 1228800
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 1200
+                      } ]
+                    }
+                  },
+                  "maximumAllocation" : {
+                    "memory" : 8192,
+                    "vCores" : 4,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 8192
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 4
+                      } ]
+                    }
+                  },
+                  "queueAcls" : {
+                    "queueAcl" : [ {
+                      "accessType" : "ADMINISTER_QUEUE",
+                      "accessControlList" : "wildAdmin2 "
+                    }, {
+                      "accessType" : "APPLICATION_MAX_PRIORITY",
+                      "accessControlList" : "*"
+                    }, {
+                      "accessType" : "SUBMIT_APP",
+                      "accessControlList" : "wildUser2 "
+                    } ]
+                  },
+                  "queuePriority" : 0,
+                  "orderingPolicyInfo" : "fifo",
+                  "autoCreateChildQueueEnabled" : false,
+                  "leafQueueTemplate" : { },
+                  "mode" : "weight",
+                  "queueType" : "leaf",
+                  "creationMethod" : "dynamicFlexible",
+                  "autoCreationEligibility" : "off",
+                  "autoQueueTemplateProperties" : { },
+                  "autoQueueParentTemplateProperties" : { },
+                  "autoQueueLeafTemplateProperties" : { },
+                  "numActiveApplications" : 0,
+                  "numPendingApplications" : 0,
+                  "numContainers" : 0,
+                  "maxApplications" : 4000,
+                  "maxApplicationsPerUser" : 4000,
+                  "userLimit" : 100,
+                  "users" : { },
+                  "userLimitFactor" : -1,
+                  "configuredMaxAMResourceLimit" : 1,
+                  "AMResourceLimit" : {
+                    "memory" : 1228800,
+                    "vCores" : 1,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 1228800
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 1
+                      } ]
+                    }
+                  },
+                  "usedAMResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "userAMResourceLimit" : {
+                    "memory" : 1228800,
+                    "vCores" : 1,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 1228800
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 1
+                      } ]
+                    }
+                  },
+                  "preemptionDisabled" : true,
+                  "intraQueuePreemptionDisabled" : true,
+                  "defaultPriority" : 0,
+                  "isAutoCreatedLeafQueue" : false,
+                  "maxApplicationLifetime" : -1,
+                  "defaultApplicationLifetime" : -1
+                } ]
+              },
+              "resourcesUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "hideReservationQueues" : false,
+              "nodeLabels" : [ "*" ],
+              "allocatedContainers" : 0,
+              "reservedContainers" : 0,
+              "pendingContainers" : 0,
+              "capacities" : {
+                "queueCapacitiesByPartition" : [ {
+                  "partitionName" : "",
+                  "capacity" : 0,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 40,
+                  "absoluteUsedCapacity" : 0,
+                  "absoluteMaxCapacity" : 100,
+                  "maxAMLimitPercentage" : 0,
+                  "weight" : 1,
+                  "normalizedWeight" : 1,
+                  "configuredMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "configuredMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMinResource" : {
+                    "memory" : 491520,
+                    "vCores" : 480,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 491520
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 480
+                      } ]
+                    }
+                  },
+                  "effectiveMaxResource" : {
+                    "memory" : 1228800,
+                    "vCores" : 1200,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 1228800
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 1200
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "resources" : {
+                "resourceUsagesByPartition" : [ {
+                  "partitionName" : "",
+                  "used" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "reserved" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "pending" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "minEffectiveCapacity" : {
+                "memory" : 491520,
+                "vCores" : 480,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 491520
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 480
+                  } ]
+                }
+              },
+              "maxEffectiveCapacity" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
+                }
+              },
+              "maximumAllocation" : {
+                "memory" : 8192,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8192
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "queueAcls" : {
+                "queueAcl" : [ {
+                  "accessType" : "ADMINISTER_QUEUE",
+                  "accessControlList" : "parentAdmin2 "
+                }, {
+                  "accessType" : "APPLICATION_MAX_PRIORITY",
+                  "accessControlList" : "*"
+                }, {
+                  "accessType" : "SUBMIT_APP",
+                  "accessControlList" : "parentUser2 "
+                } ]
+              },
+              "queuePriority" : 0,
+              "orderingPolicyInfo" : "utilization",
+              "autoCreateChildQueueEnabled" : false,
+              "leafQueueTemplate" : { },
+              "mode" : "weight",
+              "queueType" : "parent",
+              "creationMethod" : "dynamicFlexible",
+              "autoCreationEligibility" : "flexible",
+              "autoQueueTemplateProperties" : { },
+              "autoQueueParentTemplateProperties" : { },
+              "autoQueueLeafTemplateProperties" : {
+                "property" : [ {
+                  "name" : "acl_administer_queue",
+                  "value" : "wildAdmin2"
+                }, {
+                  "name" : "acl_submit_applications",
+                  "value" : "wildUser2"
+                } ]
+              }
+            } ]
+          },
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 40,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 0,
+              "weight" : 20,
+              "normalizedWeight" : 0.4,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 491520,
+                "vCores" : 480,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 491520
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 480
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 491520,
+            "vCores" : 480,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 491520
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 480
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "utilization",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "parent",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "flexible",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : {
+            "property" : [ {
+              "name" : "acl_administer_queue",
+              "value" : "parentAdmin2"
+            }, {
+              "name" : "acl_submit_applications",
+              "value" : "parentUser2"
+            } ]
+          },
+          "autoQueueLeafTemplateProperties" : {
+            "property" : [ {
+              "name" : "acl_administer_queue",
+              "value" : "wildAdmin1"
+            }, {
+              "name" : "acl_submit_applications",
+              "value" : "wildUser1"
+            } ]
           }
-        }]},
-        "resources": {"resourceUsagesByPartition": [{
-          "partitionName": "",
-          "used": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
+        }, {
+          "queuePath" : "root.autoParent1",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 2,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 1,
+          "normalizedWeight" : 0.02,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "autoParent1",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "queues" : {
+            "queue" : [ {
+              "type" : "capacitySchedulerLeafQueueInfo",
+              "queuePath" : "root.autoParent1.auto4",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 2,
+              "absoluteMaxCapacity" : 100,
+              "absoluteUsedCapacity" : 0,
+              "weight" : 1,
+              "normalizedWeight" : 1,
+              "numApplications" : 0,
+              "maxParallelApps" : 2147483647,
+              "queueName" : "auto4",
+              "isAbsoluteResource" : false,
+              "state" : "RUNNING",
+              "resourcesUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
               },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "reserved": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
+              "hideReservationQueues" : false,
+              "nodeLabels" : [ "*" ],
+              "allocatedContainers" : 0,
+              "reservedContainers" : 0,
+              "pendingContainers" : 0,
+              "capacities" : {
+                "queueCapacitiesByPartition" : [ {
+                  "partitionName" : "",
+                  "capacity" : 0,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 2,
+                  "absoluteUsedCapacity" : 0,
+                  "absoluteMaxCapacity" : 100,
+                  "maxAMLimitPercentage" : 100,
+                  "weight" : 1,
+                  "normalizedWeight" : 1,
+                  "configuredMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "configuredMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMinResource" : {
+                    "memory" : 24575,
+                    "vCores" : 23,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 24575
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 23
+                      } ]
+                    }
+                  },
+                  "effectiveMaxResource" : {
+                    "memory" : 1228800,
+                    "vCores" : 1200,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 1228800
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 1200
+                      } ]
+                    }
+                  }
+                } ]
               },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "pending": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
+              "resources" : {
+                "resourceUsagesByPartition" : [ {
+                  "partitionName" : "",
+                  "used" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "reserved" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "pending" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amLimit" : {
+                    "memory" : 1228800,
+                    "vCores" : 1,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 1228800
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 1
+                      } ]
+                    }
+                  },
+                  "userAmLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
               },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
+              "minEffectiveCapacity" : {
+                "memory" : 24575,
+                "vCores" : 23,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 24575
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 23
+                  } ]
+                }
+              },
+              "maxEffectiveCapacity" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
+                }
+              },
+              "maximumAllocation" : {
+                "memory" : 8192,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8192
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "queueAcls" : {
+                "queueAcl" : [ {
+                  "accessType" : "ADMINISTER_QUEUE",
+                  "accessControlList" : "admin1 "
+                }, {
+                  "accessType" : "APPLICATION_MAX_PRIORITY",
+                  "accessControlList" : "*"
+                }, {
+                  "accessType" : "SUBMIT_APP",
+                  "accessControlList" : "user1 "
+                } ]
+              },
+              "queuePriority" : 0,
+              "orderingPolicyInfo" : "fifo",
+              "autoCreateChildQueueEnabled" : false,
+              "leafQueueTemplate" : { },
+              "mode" : "weight",
+              "queueType" : "leaf",
+              "creationMethod" : "dynamicFlexible",
+              "autoCreationEligibility" : "off",
+              "autoQueueTemplateProperties" : { },
+              "autoQueueParentTemplateProperties" : { },
+              "autoQueueLeafTemplateProperties" : { },
+              "numActiveApplications" : 0,
+              "numPendingApplications" : 0,
+              "numContainers" : 0,
+              "maxApplications" : 300,
+              "maxApplicationsPerUser" : 300,
+              "userLimit" : 100,
+              "users" : { },
+              "userLimitFactor" : -1,
+              "configuredMaxAMResourceLimit" : 1,
+              "AMResourceLimit" : {
+                "memory" : 1228800,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "usedAMResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAMResourceLimit" : {
+                "memory" : 1228800,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "preemptionDisabled" : true,
+              "intraQueuePreemptionDisabled" : true,
+              "defaultPriority" : 0,
+              "isAutoCreatedLeafQueue" : false,
+              "maxApplicationLifetime" : -1,
+              "defaultApplicationLifetime" : -1
+            } ]
+          },
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 2,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 0,
+              "weight" : 1,
+              "normalizedWeight" : 0.02,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 24575,
+                "vCores" : 23,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 24575
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 23
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
+                }
               }
-            ]}
-          }
-        }]},
-        "minEffectiveCapacity": {
-          "memory": 491520,
-          "vCores": 480,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 491520
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 480
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 24575,
+            "vCores" : 23,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 24575
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 23
+              } ]
             }
-          ]}
-        },
-        "maxEffectiveCapacity": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
             }
-          ]}
-        },
-        "maximumAllocation": {
-          "memory": 8192,
-          "vCores": 4,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 8192
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 4
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
             }
-          ]}
-        },
-        "queueAcls": {"queueAcl": [
-          {
-            "accessType": "ADMINISTER_QUEUE",
-            "accessControlList": "parentAdmin2 "
           },
-          {
-            "accessType": "APPLICATION_MAX_PRIORITY",
-            "accessControlList": "*"
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : "parentAdmin1 "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : "parentUser1 "
+            } ]
           },
-          {
-            "accessType": "SUBMIT_APP",
-            "accessControlList": "parentUser2 "
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "utilization",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "parent",
+          "creationMethod" : "dynamicFlexible",
+          "autoCreationEligibility" : "flexible",
+          "autoQueueTemplateProperties" : {
+            "property" : [ {
+              "name" : "maximum-applications",
+              "value" : "300"
+            } ]
+          },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : {
+            "property" : [ {
+              "name" : "acl_administer_queue",
+              "value" : "admin1"
+            }, {
+              "name" : "acl_submit_applications",
+              "value" : "user1"
+            } ]
           }
-        ]},
-        "queuePriority": 0,
-        "orderingPolicyInfo": "utilization",
-        "autoCreateChildQueueEnabled": false,
-        "leafQueueTemplate": {},
-        "mode": "weight",
-        "queueType": "parent",
-        "creationMethod": "dynamicFlexible",
-        "autoCreationEligibility": "flexible",
-        "autoQueueTemplateProperties": {},
-        "autoQueueParentTemplateProperties": {},
-        "autoQueueLeafTemplateProperties": {"property": [
-          {
-            "name": "acl_administer_queue",
-            "value": "wildAdmin2"
+        }, {
+          "queuePath" : "root.autoParent2",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 2,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 1,
+          "normalizedWeight" : 0.02,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "autoParent2",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "queues" : {
+            "queue" : [ {
+              "type" : "capacitySchedulerLeafQueueInfo",
+              "queuePath" : "root.autoParent2.auto5",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 2,
+              "absoluteMaxCapacity" : 100,
+              "absoluteUsedCapacity" : 0,
+              "weight" : 1,
+              "normalizedWeight" : 1,
+              "numApplications" : 0,
+              "maxParallelApps" : 2147483647,
+              "queueName" : "auto5",
+              "isAbsoluteResource" : false,
+              "state" : "RUNNING",
+              "resourcesUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "hideReservationQueues" : false,
+              "nodeLabels" : [ "*" ],
+              "allocatedContainers" : 0,
+              "reservedContainers" : 0,
+              "pendingContainers" : 0,
+              "capacities" : {
+                "queueCapacitiesByPartition" : [ {
+                  "partitionName" : "",
+                  "capacity" : 0,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 2,
+                  "absoluteUsedCapacity" : 0,
+                  "absoluteMaxCapacity" : 100,
+                  "maxAMLimitPercentage" : 100,
+                  "weight" : 1,
+                  "normalizedWeight" : 1,
+                  "configuredMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "configuredMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMinResource" : {
+                    "memory" : 24575,
+                    "vCores" : 23,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 24575
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 23
+                      } ]
+                    }
+                  },
+                  "effectiveMaxResource" : {
+                    "memory" : 1228800,
+                    "vCores" : 1200,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 1228800
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 1200
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "resources" : {
+                "resourceUsagesByPartition" : [ {
+                  "partitionName" : "",
+                  "used" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "reserved" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "pending" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amLimit" : {
+                    "memory" : 1228800,
+                    "vCores" : 1,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 1228800
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 1
+                      } ]
+                    }
+                  },
+                  "userAmLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "minEffectiveCapacity" : {
+                "memory" : 24575,
+                "vCores" : 23,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 24575
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 23
+                  } ]
+                }
+              },
+              "maxEffectiveCapacity" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
+                }
+              },
+              "maximumAllocation" : {
+                "memory" : 8192,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8192
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "queueAcls" : {
+                "queueAcl" : [ {
+                  "accessType" : "ADMINISTER_QUEUE",
+                  "accessControlList" : "wildAdmin1 "
+                }, {
+                  "accessType" : "APPLICATION_MAX_PRIORITY",
+                  "accessControlList" : "*"
+                }, {
+                  "accessType" : "SUBMIT_APP",
+                  "accessControlList" : "wildUser1 "
+                } ]
+              },
+              "queuePriority" : 0,
+              "orderingPolicyInfo" : "fifo",
+              "autoCreateChildQueueEnabled" : false,
+              "leafQueueTemplate" : { },
+              "mode" : "weight",
+              "queueType" : "leaf",
+              "creationMethod" : "dynamicFlexible",
+              "autoCreationEligibility" : "off",
+              "autoQueueTemplateProperties" : { },
+              "autoQueueParentTemplateProperties" : { },
+              "autoQueueLeafTemplateProperties" : { },
+              "numActiveApplications" : 0,
+              "numPendingApplications" : 0,
+              "numContainers" : 0,
+              "maxApplications" : 200,
+              "maxApplicationsPerUser" : 200,
+              "userLimit" : 100,
+              "users" : { },
+              "userLimitFactor" : -1,
+              "configuredMaxAMResourceLimit" : 1,
+              "AMResourceLimit" : {
+                "memory" : 1228800,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "usedAMResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAMResourceLimit" : {
+                "memory" : 1228800,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "preemptionDisabled" : true,
+              "intraQueuePreemptionDisabled" : true,
+              "defaultPriority" : 0,
+              "isAutoCreatedLeafQueue" : false,
+              "maxApplicationLifetime" : -1,
+              "defaultApplicationLifetime" : -1
+            } ]
           },
-          {
-            "name": "acl_submit_applications",
-            "value": "wildUser2"
-          }
-        ]}
-      }]},
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
           },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 2,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 0,
+              "weight" : 1,
+              "normalizedWeight" : 0.02,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 24575,
+                "vCores" : 23,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 24575
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 23
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 24575,
+            "vCores" : 23,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 24575
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 23
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : "parentAdmin1 "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : "parentUser1 "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "utilization",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "parent",
+          "creationMethod" : "dynamicFlexible",
+          "autoCreationEligibility" : "flexible",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : {
+            "property" : [ {
+              "name" : "acl_administer_queue",
+              "value" : "wildAdmin1"
+            }, {
+              "name" : "acl_submit_applications",
+              "value" : "wildUser1"
+            } ]
           }
-        ]}
+        } ]
       },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 40,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 0,
-        "weight": 20,
-        "normalizedWeight": 0.4,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+      "capacities" : {
+        "queueCapacitiesByPartition" : [ {
+          "partitionName" : "",
+          "capacity" : 100,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "absoluteMaxCapacity" : 100,
+          "maxAMLimitPercentage" : 0,
+          "weight" : 1,
+          "normalizedWeight" : 1,
+          "configuredMinResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 491520,
-          "vCores": 480,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 491520
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 480
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 491520,
-        "vCores": 480,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 491520
           },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 480
+          "configuredMaxResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "effectiveMinResource" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
+            }
+          },
+          "effectiveMaxResource" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
+            }
           }
-        ]}
+        } ]
       },
-      "maxEffectiveCapacity": {
-        "memory": 1228800,
-        "vCores": 1200,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1200
+      "health" : {
+        "lastrun" : 0,
+        "operationsInfo" : [ {
+          "operation" : "last-allocation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-release",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-preemption",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-reservation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        } ],
+        "lastRunDetails" : [ {
+          "operation" : "releases",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
           }
-        ]}
+        }, {
+          "operation" : "allocations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "reservations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        } ]
       },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
+      "maximumAllocation" : {
+        "memory" : 8192,
+        "vCores" : 4,
+        "resourceInformations" : {
+          "resourceInformation" : [ {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "memory-mb",
+            "resourceType" : "COUNTABLE",
+            "units" : "Mi",
+            "value" : 8192
+          }, {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "vcores",
+            "resourceType" : "COUNTABLE",
+            "units" : "",
+            "value" : 4
+          } ]
+        }
       },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "utilization",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "parent",
-      "creationMethod": "static",
-      "autoCreationEligibility": "flexible",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {"property": [
-        {
-          "name": "acl_administer_queue",
-          "value": "parentAdmin2"
-        },
-        {
-          "name": "acl_submit_applications",
-          "value": "parentUser2"
-        }
-      ]},
-      "autoQueueLeafTemplateProperties": {"property": [
-        {
-          "name": "acl_administer_queue",
-          "value": "wildAdmin1"
-        },
-        {
-          "name": "acl_submit_applications",
-          "value": "wildUser1"
-        }
-      ]}
-    },
-    {
-      "queuePath": "root.autoParent1",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 2,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 1,
-      "normalizedWeight": 0.02,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "autoParent1",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "queues": {"queue": [{
-        "type": "capacitySchedulerLeafQueueInfo",
-        "queuePath": "root.autoParent1.auto4",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 2,
-        "absoluteMaxCapacity": 100,
-        "absoluteUsedCapacity": 0,
-        "weight": 1,
-        "normalizedWeight": 1,
-        "numApplications": 0,
-        "maxParallelApps": 2147483647,
-        "queueName": "auto4",
-        "isAbsoluteResource": false,
-        "state": "RUNNING",
-        "resourcesUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "hideReservationQueues": false,
-        "nodeLabels": ["*"],
-        "allocatedContainers": 0,
-        "reservedContainers": 0,
-        "pendingContainers": 0,
-        "capacities": {"queueCapacitiesByPartition": [{
-          "partitionName": "",
-          "capacity": 0,
-          "usedCapacity": 0,
-          "maxCapacity": 100,
-          "absoluteCapacity": 2,
-          "absoluteUsedCapacity": 0,
-          "absoluteMaxCapacity": 100,
-          "maxAMLimitPercentage": 100,
-          "weight": 1,
-          "normalizedWeight": 1,
-          "configuredMinResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 8192,
-                "minimumAllocation": 1024,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 4,
-                "minimumAllocation": 1,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "configuredMaxResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 8192,
-                "minimumAllocation": 1024,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 4,
-                "minimumAllocation": 1,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "effectiveMinResource": {
-            "memory": 24575,
-            "vCores": 23,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 24575
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 23
-              }
-            ]}
-          },
-          "effectiveMaxResource": {
-            "memory": 1228800,
-            "vCores": 1200,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 1228800
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 1200
-              }
-            ]}
-          }
-        }]},
-        "resources": {"resourceUsagesByPartition": [{
-          "partitionName": "",
-          "used": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "reserved": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "pending": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "amUsed": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "amLimit": {
-            "memory": 1228800,
-            "vCores": 1,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 1228800
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 1
-              }
-            ]}
-          },
-          "userAmLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          }
-        }]},
-        "minEffectiveCapacity": {
-          "memory": 24575,
-          "vCores": 23,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 24575
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 23
-            }
-          ]}
-        },
-        "maxEffectiveCapacity": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
-            }
-          ]}
-        },
-        "maximumAllocation": {
-          "memory": 8192,
-          "vCores": 4,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 8192
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 4
-            }
-          ]}
-        },
-        "queueAcls": {"queueAcl": [
-          {
-            "accessType": "ADMINISTER_QUEUE",
-            "accessControlList": "admin1 "
-          },
-          {
-            "accessType": "APPLICATION_MAX_PRIORITY",
-            "accessControlList": "*"
-          },
-          {
-            "accessType": "SUBMIT_APP",
-            "accessControlList": "user1 "
-          }
-        ]},
-        "queuePriority": 0,
-        "orderingPolicyInfo": "fifo",
-        "autoCreateChildQueueEnabled": false,
-        "leafQueueTemplate": {},
-        "mode": "weight",
-        "queueType": "leaf",
-        "creationMethod": "dynamicFlexible",
-        "autoCreationEligibility": "off",
-        "autoQueueTemplateProperties": {},
-        "autoQueueParentTemplateProperties": {},
-        "autoQueueLeafTemplateProperties": {},
-        "numActiveApplications": 0,
-        "numPendingApplications": 0,
-        "numContainers": 0,
-        "maxApplications": 300,
-        "maxApplicationsPerUser": 300,
-        "userLimit": 100,
-        "users": {},
-        "userLimitFactor": -1,
-        "configuredMaxAMResourceLimit": 1,
-        "AMResourceLimit": {
-          "memory": 1228800,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "usedAMResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "userAMResourceLimit": {
-          "memory": 1228800,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "preemptionDisabled": true,
-        "intraQueuePreemptionDisabled": true,
-        "defaultPriority": 0,
-        "isAutoCreatedLeafQueue": false,
-        "maxApplicationLifetime": -1,
-        "defaultApplicationLifetime": -1
-      }]},
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
+      "queueAcls" : {
+        "queueAcl" : [ {
+          "accessType" : "ADMINISTER_QUEUE",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "APPLICATION_MAX_PRIORITY",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "SUBMIT_APP",
+          "accessControlList" : "*"
+        } ]
       },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 2,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 0,
-        "weight": 1,
-        "normalizedWeight": 0.02,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 24575,
-          "vCores": 23,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 24575
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 23
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 24575,
-        "vCores": 23,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 24575
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 23
-          }
-        ]}
+      "queuePriority" : 0,
+      "orderingPolicyInfo" : "utilization",
+      "mode" : "weight",
+      "queueType" : "parent",
+      "creationMethod" : "static",
+      "autoCreationEligibility" : "flexible",
+      "autoQueueTemplateProperties" : { },
+      "autoQueueParentTemplateProperties" : {
+        "property" : [ {
+          "name" : "acl_administer_queue",
+          "value" : "parentAdmin1"
+        }, {
+          "name" : "acl_submit_applications",
+          "value" : "parentUser1"
+        } ]
       },
-      "maxEffectiveCapacity": {
-        "memory": 1228800,
-        "vCores": 1200,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1200
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": "parentAdmin1 "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": "parentUser1 "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "utilization",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "parent",
-      "creationMethod": "dynamicFlexible",
-      "autoCreationEligibility": "flexible",
-      "autoQueueTemplateProperties": {"property": [{
-        "name": "maximum-applications",
-        "value": "300"
-      }]},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {"property": [
-        {
-          "name": "acl_administer_queue",
-          "value": "admin1"
-        },
-        {
-          "name": "acl_submit_applications",
-          "value": "user1"
-        }
-      ]}
-    },
-    {
-      "queuePath": "root.autoParent2",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 2,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 1,
-      "normalizedWeight": 0.02,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "autoParent2",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "queues": {"queue": [{
-        "type": "capacitySchedulerLeafQueueInfo",
-        "queuePath": "root.autoParent2.auto5",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 2,
-        "absoluteMaxCapacity": 100,
-        "absoluteUsedCapacity": 0,
-        "weight": 1,
-        "normalizedWeight": 1,
-        "numApplications": 0,
-        "maxParallelApps": 2147483647,
-        "queueName": "auto5",
-        "isAbsoluteResource": false,
-        "state": "RUNNING",
-        "resourcesUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "hideReservationQueues": false,
-        "nodeLabels": ["*"],
-        "allocatedContainers": 0,
-        "reservedContainers": 0,
-        "pendingContainers": 0,
-        "capacities": {"queueCapacitiesByPartition": [{
-          "partitionName": "",
-          "capacity": 0,
-          "usedCapacity": 0,
-          "maxCapacity": 100,
-          "absoluteCapacity": 2,
-          "absoluteUsedCapacity": 0,
-          "absoluteMaxCapacity": 100,
-          "maxAMLimitPercentage": 100,
-          "weight": 1,
-          "normalizedWeight": 1,
-          "configuredMinResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 8192,
-                "minimumAllocation": 1024,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 4,
-                "minimumAllocation": 1,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "configuredMaxResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 8192,
-                "minimumAllocation": 1024,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 4,
-                "minimumAllocation": 1,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "effectiveMinResource": {
-            "memory": 24575,
-            "vCores": 23,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 24575
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 23
-              }
-            ]}
-          },
-          "effectiveMaxResource": {
-            "memory": 1228800,
-            "vCores": 1200,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 1228800
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 1200
-              }
-            ]}
-          }
-        }]},
-        "resources": {"resourceUsagesByPartition": [{
-          "partitionName": "",
-          "used": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "reserved": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "pending": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "amUsed": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "amLimit": {
-            "memory": 1228800,
-            "vCores": 1,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 1228800
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 1
-              }
-            ]}
-          },
-          "userAmLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          }
-        }]},
-        "minEffectiveCapacity": {
-          "memory": 24575,
-          "vCores": 23,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 24575
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 23
-            }
-          ]}
-        },
-        "maxEffectiveCapacity": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
-            }
-          ]}
-        },
-        "maximumAllocation": {
-          "memory": 8192,
-          "vCores": 4,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 8192
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 4
-            }
-          ]}
-        },
-        "queueAcls": {"queueAcl": [
-          {
-            "accessType": "ADMINISTER_QUEUE",
-            "accessControlList": "wildAdmin1 "
-          },
-          {
-            "accessType": "APPLICATION_MAX_PRIORITY",
-            "accessControlList": "*"
-          },
-          {
-            "accessType": "SUBMIT_APP",
-            "accessControlList": "wildUser1 "
-          }
-        ]},
-        "queuePriority": 0,
-        "orderingPolicyInfo": "fifo",
-        "autoCreateChildQueueEnabled": false,
-        "leafQueueTemplate": {},
-        "mode": "weight",
-        "queueType": "leaf",
-        "creationMethod": "dynamicFlexible",
-        "autoCreationEligibility": "off",
-        "autoQueueTemplateProperties": {},
-        "autoQueueParentTemplateProperties": {},
-        "autoQueueLeafTemplateProperties": {},
-        "numActiveApplications": 0,
-        "numPendingApplications": 0,
-        "numContainers": 0,
-        "maxApplications": 200,
-        "maxApplicationsPerUser": 200,
-        "userLimit": 100,
-        "users": {},
-        "userLimitFactor": -1,
-        "configuredMaxAMResourceLimit": 1,
-        "AMResourceLimit": {
-          "memory": 1228800,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "usedAMResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "userAMResourceLimit": {
-          "memory": 1228800,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "preemptionDisabled": true,
-        "intraQueuePreemptionDisabled": true,
-        "defaultPriority": 0,
-        "isAutoCreatedLeafQueue": false,
-        "maxApplicationLifetime": -1,
-        "defaultApplicationLifetime": -1
-      }]},
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 2,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 0,
-        "weight": 1,
-        "normalizedWeight": 0.02,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 24575,
-          "vCores": 23,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 24575
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 23
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 24575,
-        "vCores": 23,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 24575
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 23
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 1228800,
-        "vCores": 1200,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1200
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": "parentAdmin1 "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": "parentUser1 "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "utilization",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "parent",
-      "creationMethod": "dynamicFlexible",
-      "autoCreationEligibility": "flexible",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {"property": [
-        {
-          "name": "acl_administer_queue",
-          "value": "wildAdmin1"
-        },
-        {
-          "name": "acl_submit_applications",
-          "value": "wildUser1"
-        }
-      ]}
+      "autoQueueLeafTemplateProperties" : { }
     }
-  ]},
-  "capacities": {"queueCapacitiesByPartition": [{
-    "partitionName": "",
-    "capacity": 100,
-    "usedCapacity": 0,
-    "maxCapacity": 100,
-    "absoluteCapacity": 100,
-    "absoluteUsedCapacity": 0,
-    "absoluteMaxCapacity": 100,
-    "maxAMLimitPercentage": 0,
-    "weight": 1,
-    "normalizedWeight": 1,
-    "configuredMinResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "configuredMaxResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "effectiveMinResource": {
-      "memory": 1228800,
-      "vCores": 1200,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 1228800
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 1200
-        }
-      ]}
-    },
-    "effectiveMaxResource": {
-      "memory": 1228800,
-      "vCores": 1200,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 1228800
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 1200
-        }
-      ]}
-    }
-  }]},
-  "health": {
-    "lastrun": 0,
-    "operationsInfo": [
-      {
-        "operation": "last-allocation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-release",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-preemption",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-reservation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      }
-    ],
-    "lastRunDetails": [
-      {
-        "operation": "releases",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "allocations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "reservations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }
-    ]
-  },
-  "maximumAllocation": {
-    "memory": 8192,
-    "vCores": 4,
-    "resourceInformations": {"resourceInformation": [
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "memory-mb",
-        "resourceType": "COUNTABLE",
-        "units": "Mi",
-        "value": 8192
-      },
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "vcores",
-        "resourceType": "COUNTABLE",
-        "units": "",
-        "value": 4
-      }
-    ]}
-  },
-  "queueAcls": {"queueAcl": [
-    {
-      "accessType": "ADMINISTER_QUEUE",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "APPLICATION_MAX_PRIORITY",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "SUBMIT_APP",
-      "accessControlList": "*"
-    }
-  ]},
-  "queuePriority": 0,
-  "orderingPolicyInfo": "utilization",
-  "mode": "weight",
-  "queueType": "parent",
-  "creationMethod": "static",
-  "autoCreationEligibility": "flexible",
-  "autoQueueTemplateProperties": {},
-  "autoQueueParentTemplateProperties": {"property": [
-    {
-      "name": "acl_administer_queue",
-      "value": "parentAdmin1"
-    },
-    {
-      "name": "acl_submit_applications",
-      "value": "parentUser1"
-    }
-  ]},
-  "autoQueueLeafTemplateProperties": {}
-}}}
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-WeightModeWithAutoCreatedQueues-Before.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response-WeightModeWithAutoCreatedQueues-Before.json
@@ -1,2092 +1,2019 @@
-{"scheduler": {"schedulerInfo": {
-  "type": "capacityScheduler",
-  "capacity": 100,
-  "usedCapacity": 0,
-  "maxCapacity": 100,
-  "weight": 1,
-  "normalizedWeight": 1,
-  "queueName": "root",
-  "queuePath": "root",
-  "maxParallelApps": 2147483647,
-  "isAbsoluteResource": false,
-  "queues": {"queue": [
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.test2",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 22.222223,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 10,
-      "normalizedWeight": 0.22222222,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "test2",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
+{
+  "scheduler" : {
+    "schedulerInfo" : {
+      "type" : "capacityScheduler",
+      "capacity" : 100,
+      "usedCapacity" : 0,
+      "maxCapacity" : 100,
+      "weight" : 1,
+      "normalizedWeight" : 1,
+      "queueName" : "root",
+      "queuePath" : "root",
+      "maxParallelApps" : 2147483647,
+      "isAbsoluteResource" : false,
+      "queues" : {
+        "queue" : [ {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.test2",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 22.222223,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 10,
+          "normalizedWeight" : 0.22222222,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "test2",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
           },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 22.222223,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : 10,
+              "normalizedWeight" : 0.22222222,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 273066,
+                "vCores" : 266,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 273066
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 266
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 122880,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 122880
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 273066,
+            "vCores" : 266,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 273066
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 266
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 2222,
+          "maxApplicationsPerUser" : 2222,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 122880,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 122880
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 122880,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 122880
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.test1",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 11.111112,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 5,
+          "normalizedWeight" : 0.11111111,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "test1",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 11.111112,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : 5,
+              "normalizedWeight" : 0.11111111,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 136533,
+                "vCores" : 133,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 136533
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 133
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 122880,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 122880
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 136533,
+            "vCores" : 133,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 136533
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 133
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 1111,
+          "maxApplicationsPerUser" : 1111,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 122880,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 122880
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 122880,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 122880
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.default",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 22.222223,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 10,
+          "normalizedWeight" : 0.22222222,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "default",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 22.222223,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 10,
+              "weight" : 10,
+              "normalizedWeight" : 0.22222222,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 273066,
+                "vCores" : 266,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 273066
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 266
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 122880,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 122880
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 273066,
+            "vCores" : 266,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 273066
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 266
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 2222,
+          "maxApplicationsPerUser" : 2222,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 122880,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 122880
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 122880,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 122880
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "queuePath" : "root.parent",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 44.444447,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : 20,
+          "normalizedWeight" : 0.44444445,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "parent",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "queues" : { },
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 44.444447,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 0,
+              "weight" : 20,
+              "normalizedWeight" : 0.44444445,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 546133,
+                "vCores" : 533,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 546133
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 533
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 1228800,
+                "vCores" : 1200,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1228800
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1200
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 546133,
+            "vCores" : 533,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 546133
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 533
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "utilization",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "weight",
+          "queueType" : "parent",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "flexible",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : {
+            "property" : [ {
+              "name" : "acl_administer_queue",
+              "value" : "parentAdmin2"
+            }, {
+              "name" : "acl_submit_applications",
+              "value" : "parentUser2"
+            } ]
+          },
+          "autoQueueLeafTemplateProperties" : {
+            "property" : [ {
+              "name" : "acl_administer_queue",
+              "value" : "wildAdmin1"
+            }, {
+              "name" : "acl_submit_applications",
+              "value" : "wildUser1"
+            } ]
           }
-        ]}
+        } ]
       },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 22.222223,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": 10,
-        "normalizedWeight": 0.22222222,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+      "capacities" : {
+        "queueCapacitiesByPartition" : [ {
+          "partitionName" : "",
+          "capacity" : 100,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "absoluteMaxCapacity" : 100,
+          "maxAMLimitPercentage" : 0,
+          "weight" : 1,
+          "normalizedWeight" : 1,
+          "configuredMinResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "configuredMaxResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 273066,
-          "vCores": 266,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 273066
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 266
+          },
+          "effectiveMinResource" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
             }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
+          },
+          "effectiveMaxResource" : {
+            "memory" : 1228800,
+            "vCores" : 1200,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1228800
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1200
+              } ]
             }
-          ]}
+          }
+        } ]
+      },
+      "health" : {
+        "lastrun" : 0,
+        "operationsInfo" : [ {
+          "operation" : "last-allocation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-release",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-preemption",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-reservation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        } ],
+        "lastRunDetails" : [ {
+          "operation" : "releases",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "allocations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "reservations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        } ]
+      },
+      "maximumAllocation" : {
+        "memory" : 8192,
+        "vCores" : 4,
+        "resourceInformations" : {
+          "resourceInformation" : [ {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "memory-mb",
+            "resourceType" : "COUNTABLE",
+            "units" : "Mi",
+            "value" : 8192
+          }, {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "vcores",
+            "resourceType" : "COUNTABLE",
+            "units" : "",
+            "value" : 4
+          } ]
         }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 122880,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 122880
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 273066,
-        "vCores": 266,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 273066
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 266
-          }
-        ]}
       },
-      "maxEffectiveCapacity": {
-        "memory": 1228800,
-        "vCores": 1200,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1200
-          }
-        ]}
+      "queueAcls" : {
+        "queueAcl" : [ {
+          "accessType" : "ADMINISTER_QUEUE",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "APPLICATION_MAX_PRIORITY",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "SUBMIT_APP",
+          "accessControlList" : "*"
+        } ]
       },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
+      "queuePriority" : 0,
+      "orderingPolicyInfo" : "utilization",
+      "mode" : "weight",
+      "queueType" : "parent",
+      "creationMethod" : "static",
+      "autoCreationEligibility" : "flexible",
+      "autoQueueTemplateProperties" : { },
+      "autoQueueParentTemplateProperties" : {
+        "property" : [ {
+          "name" : "acl_administer_queue",
+          "value" : "parentAdmin1"
+        }, {
+          "name" : "acl_submit_applications",
+          "value" : "parentUser1"
+        } ]
       },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 2222,
-      "maxApplicationsPerUser": 2222,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 122880,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 122880
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 122880,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 122880
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.test1",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 11.111112,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 5,
-      "normalizedWeight": 0.11111111,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "test1",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 11.111112,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": 5,
-        "normalizedWeight": 0.11111111,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 136533,
-          "vCores": 133,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 136533
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 133
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 122880,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 122880
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 136533,
-        "vCores": 133,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 136533
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 133
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 1228800,
-        "vCores": 1200,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1200
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 1111,
-      "maxApplicationsPerUser": 1111,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 122880,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 122880
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 122880,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 122880
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.default",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 22.222223,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 10,
-      "normalizedWeight": 0.22222222,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "default",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 22.222223,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 10,
-        "weight": 10,
-        "normalizedWeight": 0.22222222,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 273066,
-          "vCores": 266,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 273066
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 266
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 122880,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 122880
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 273066,
-        "vCores": 266,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 273066
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 266
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 1228800,
-        "vCores": 1200,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1200
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 2222,
-      "maxApplicationsPerUser": 2222,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 122880,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 122880
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 122880,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 122880
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "queuePath": "root.parent",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 44.444447,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": 20,
-      "normalizedWeight": 0.44444445,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "parent",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "queues": {},
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 44.444447,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 0,
-        "weight": 20,
-        "normalizedWeight": 0.44444445,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 546133,
-          "vCores": 533,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 546133
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 533
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 1228800,
-          "vCores": 1200,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1228800
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1200
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 546133,
-        "vCores": 533,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 546133
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 533
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 1228800,
-        "vCores": 1200,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1228800
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1200
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "utilization",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "weight",
-      "queueType": "parent",
-      "creationMethod": "static",
-      "autoCreationEligibility": "flexible",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {"property": [
-        {
-          "name": "acl_administer_queue",
-          "value": "parentAdmin2"
-        },
-        {
-          "name": "acl_submit_applications",
-          "value": "parentUser2"
-        }
-      ]},
-      "autoQueueLeafTemplateProperties": {"property": [
-        {
-          "name": "acl_administer_queue",
-          "value": "wildAdmin1"
-        },
-        {
-          "name": "acl_submit_applications",
-          "value": "wildUser1"
-        }
-      ]}
+      "autoQueueLeafTemplateProperties" : { }
     }
-  ]},
-  "capacities": {"queueCapacitiesByPartition": [{
-    "partitionName": "",
-    "capacity": 100,
-    "usedCapacity": 0,
-    "maxCapacity": 100,
-    "absoluteCapacity": 100,
-    "absoluteUsedCapacity": 0,
-    "absoluteMaxCapacity": 100,
-    "maxAMLimitPercentage": 0,
-    "weight": 1,
-    "normalizedWeight": 1,
-    "configuredMinResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "configuredMaxResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "effectiveMinResource": {
-      "memory": 1228800,
-      "vCores": 1200,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 1228800
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 1200
-        }
-      ]}
-    },
-    "effectiveMaxResource": {
-      "memory": 1228800,
-      "vCores": 1200,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 1228800
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 1200
-        }
-      ]}
-    }
-  }]},
-  "health": {
-    "lastrun": 0,
-    "operationsInfo": [
-      {
-        "operation": "last-allocation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-release",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-preemption",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-reservation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      }
-    ],
-    "lastRunDetails": [
-      {
-        "operation": "releases",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "allocations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "reservations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }
-    ]
-  },
-  "maximumAllocation": {
-    "memory": 8192,
-    "vCores": 4,
-    "resourceInformations": {"resourceInformation": [
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "memory-mb",
-        "resourceType": "COUNTABLE",
-        "units": "Mi",
-        "value": 8192
-      },
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "vcores",
-        "resourceType": "COUNTABLE",
-        "units": "",
-        "value": 4
-      }
-    ]}
-  },
-  "queueAcls": {"queueAcl": [
-    {
-      "accessType": "ADMINISTER_QUEUE",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "APPLICATION_MAX_PRIORITY",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "SUBMIT_APP",
-      "accessControlList": "*"
-    }
-  ]},
-  "queuePriority": 0,
-  "orderingPolicyInfo": "utilization",
-  "mode": "weight",
-  "queueType": "parent",
-  "creationMethod": "static",
-  "autoCreationEligibility": "flexible",
-  "autoQueueTemplateProperties": {},
-  "autoQueueParentTemplateProperties": {"property": [
-    {
-      "name": "acl_administer_queue",
-      "value": "parentAdmin1"
-    },
-    {
-      "name": "acl_submit_applications",
-      "value": "parentUser1"
-    }
-  ]},
-  "autoQueueLeafTemplateProperties": {}
-}}}
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp/scheduler-response.json
@@ -1,4989 +1,4830 @@
-{"scheduler": {"schedulerInfo": {
-  "type": "capacityScheduler",
-  "capacity": 100,
-  "usedCapacity": 0,
-  "maxCapacity": 100,
-  "weight": -1,
-  "normalizedWeight": 0,
-  "queueName": "root",
-  "queuePath": "root",
-  "maxParallelApps": 2147483647,
-  "isAbsoluteResource": false,
-  "queues": {"queue": [
-    {
-      "type": "capacitySchedulerLeafQueueInfo",
-      "queuePath": "root.c",
-      "capacity": 0,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 0,
-      "absoluteMaxCapacity": 0,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "c",
-      "isAbsoluteResource": true,
-      "state": "RUNNING",
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
+{
+  "scheduler" : {
+    "schedulerInfo" : {
+      "type" : "capacityScheduler",
+      "capacity" : 100,
+      "usedCapacity" : 0,
+      "maxCapacity" : 100,
+      "weight" : -1,
+      "normalizedWeight" : 0,
+      "queueName" : "root",
+      "queuePath" : "root",
+      "maxParallelApps" : 2147483647,
+      "isAbsoluteResource" : false,
+      "queues" : {
+        "queue" : [ {
+          "type" : "capacitySchedulerLeafQueueInfo",
+          "queuePath" : "root.c",
+          "capacity" : 0,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 0,
+          "absoluteMaxCapacity" : 0,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "c",
+          "isAbsoluteResource" : true,
+          "state" : "RUNNING",
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
           },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 0,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 0,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 0,
+              "maxAMLimitPercentage" : 10,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 1024,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1024
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 1024,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1024
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "amLimit" : {
+                "memory" : 1024,
+                "vCores" : 1,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 1024
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 1
+                  } ]
+                }
+              },
+              "userAmLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 1024,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1024
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "fifo",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "absolute",
+          "queueType" : "leaf",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { },
+          "numActiveApplications" : 0,
+          "numPendingApplications" : 0,
+          "numContainers" : 0,
+          "maxApplications" : 0,
+          "maxApplicationsPerUser" : 0,
+          "userLimit" : 100,
+          "users" : { },
+          "userLimitFactor" : 1,
+          "configuredMaxAMResourceLimit" : 0.1,
+          "AMResourceLimit" : {
+            "memory" : 1024,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1024
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "usedAMResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "userAMResourceLimit" : {
+            "memory" : 1024,
+            "vCores" : 1,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 1024
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 1
+              } ]
+            }
+          },
+          "preemptionDisabled" : true,
+          "intraQueuePreemptionDisabled" : true,
+          "defaultPriority" : 0,
+          "isAutoCreatedLeafQueue" : false,
+          "maxApplicationLifetime" : -1,
+          "defaultApplicationLifetime" : -1
+        }, {
+          "queuePath" : "root.a",
+          "capacity" : 10.5,
+          "usedCapacity" : 0,
+          "maxCapacity" : 50,
+          "absoluteCapacity" : 10.5,
+          "absoluteMaxCapacity" : 50,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 42,
+          "queueName" : "a",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "queues" : {
+            "queue" : [ {
+              "type" : "capacitySchedulerLeafQueueInfo",
+              "queuePath" : "root.a.a2",
+              "capacity" : 70,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 7.35,
+              "absoluteMaxCapacity" : 50,
+              "absoluteUsedCapacity" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "numApplications" : 0,
+              "maxParallelApps" : 2147483647,
+              "queueName" : "a2",
+              "isAbsoluteResource" : false,
+              "state" : "RUNNING",
+              "resourcesUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "hideReservationQueues" : false,
+              "nodeLabels" : [ "*" ],
+              "allocatedContainers" : 0,
+              "reservedContainers" : 0,
+              "pendingContainers" : 0,
+              "capacities" : {
+                "queueCapacitiesByPartition" : [ {
+                  "partitionName" : "",
+                  "capacity" : 70,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 7.35,
+                  "absoluteUsedCapacity" : 0,
+                  "absoluteMaxCapacity" : 50,
+                  "maxAMLimitPercentage" : 10,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "configuredMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "configuredMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "resources" : {
+                "resourceUsagesByPartition" : [ {
+                  "partitionName" : "",
+                  "used" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "reserved" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "pending" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "userAmLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "minEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maxEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maximumAllocation" : {
+                "memory" : 8192,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8192
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "queueAcls" : {
+                "queueAcl" : [ {
+                  "accessType" : "ADMINISTER_QUEUE",
+                  "accessControlList" : " "
+                }, {
+                  "accessType" : "APPLICATION_MAX_PRIORITY",
+                  "accessControlList" : "*"
+                }, {
+                  "accessType" : "SUBMIT_APP",
+                  "accessControlList" : " "
+                } ]
+              },
+              "queuePriority" : 0,
+              "orderingPolicyInfo" : "fifo",
+              "autoCreateChildQueueEnabled" : false,
+              "leafQueueTemplate" : { },
+              "mode" : "percentage",
+              "queueType" : "leaf",
+              "creationMethod" : "static",
+              "autoCreationEligibility" : "off",
+              "autoQueueTemplateProperties" : { },
+              "autoQueueParentTemplateProperties" : { },
+              "autoQueueLeafTemplateProperties" : { },
+              "numActiveApplications" : 0,
+              "numPendingApplications" : 0,
+              "numContainers" : 0,
+              "maxApplications" : 735,
+              "maxApplicationsPerUser" : 735,
+              "userLimit" : 100,
+              "users" : { },
+              "userLimitFactor" : 100,
+              "configuredMaxAMResourceLimit" : 0.1,
+              "AMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "usedAMResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "preemptionDisabled" : true,
+              "intraQueuePreemptionDisabled" : true,
+              "defaultPriority" : 0,
+              "isAutoCreatedLeafQueue" : false,
+              "maxApplicationLifetime" : 100,
+              "defaultApplicationLifetime" : 50
+            }, {
+              "queuePath" : "root.a.a1",
+              "capacity" : 30.000002,
+              "usedCapacity" : 0,
+              "maxCapacity" : 50,
+              "absoluteCapacity" : 3.15,
+              "absoluteMaxCapacity" : 25,
+              "absoluteUsedCapacity" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "numApplications" : 0,
+              "maxParallelApps" : 2147483647,
+              "queueName" : "a1",
+              "isAbsoluteResource" : false,
+              "state" : "RUNNING",
+              "queues" : {
+                "queue" : [ {
+                  "type" : "capacitySchedulerLeafQueueInfo",
+                  "queuePath" : "root.a.a1.a1a",
+                  "capacity" : 65,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 2.0475001,
+                  "absoluteMaxCapacity" : 25,
+                  "absoluteUsedCapacity" : 0,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "numApplications" : 0,
+                  "maxParallelApps" : 2147483647,
+                  "queueName" : "a1a",
+                  "isAbsoluteResource" : false,
+                  "state" : "RUNNING",
+                  "resourcesUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "hideReservationQueues" : false,
+                  "nodeLabels" : [ "*" ],
+                  "allocatedContainers" : 0,
+                  "reservedContainers" : 0,
+                  "pendingContainers" : 0,
+                  "capacities" : {
+                    "queueCapacitiesByPartition" : [ {
+                      "partitionName" : "",
+                      "capacity" : 65,
+                      "usedCapacity" : 0,
+                      "maxCapacity" : 100,
+                      "absoluteCapacity" : 2.0475001,
+                      "absoluteUsedCapacity" : 0,
+                      "absoluteMaxCapacity" : 25,
+                      "maxAMLimitPercentage" : 10,
+                      "weight" : -1,
+                      "normalizedWeight" : 0,
+                      "configuredMinResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 8192,
+                            "minimumAllocation" : 1024,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 4,
+                            "minimumAllocation" : 1,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "configuredMaxResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 8192,
+                            "minimumAllocation" : 1024,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 4,
+                            "minimumAllocation" : 1,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "effectiveMinResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "effectiveMaxResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "resources" : {
+                    "resourceUsagesByPartition" : [ {
+                      "partitionName" : "",
+                      "used" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "reserved" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "pending" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "amUsed" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "amLimit" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "userAmLimit" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "minEffectiveCapacity" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "maxEffectiveCapacity" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "maximumAllocation" : {
+                    "memory" : 8192,
+                    "vCores" : 4,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 8192
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 4
+                      } ]
+                    }
+                  },
+                  "queueAcls" : {
+                    "queueAcl" : [ {
+                      "accessType" : "ADMINISTER_QUEUE",
+                      "accessControlList" : " "
+                    }, {
+                      "accessType" : "APPLICATION_MAX_PRIORITY",
+                      "accessControlList" : "*"
+                    }, {
+                      "accessType" : "SUBMIT_APP",
+                      "accessControlList" : " "
+                    } ]
+                  },
+                  "queuePriority" : 0,
+                  "orderingPolicyInfo" : "fifo",
+                  "autoCreateChildQueueEnabled" : false,
+                  "leafQueueTemplate" : { },
+                  "mode" : "percentage",
+                  "queueType" : "leaf",
+                  "creationMethod" : "static",
+                  "autoCreationEligibility" : "off",
+                  "autoQueueTemplateProperties" : { },
+                  "autoQueueParentTemplateProperties" : { },
+                  "autoQueueLeafTemplateProperties" : { },
+                  "numActiveApplications" : 0,
+                  "numPendingApplications" : 0,
+                  "numContainers" : 0,
+                  "maxApplications" : 204,
+                  "maxApplicationsPerUser" : 204,
+                  "userLimit" : 100,
+                  "users" : { },
+                  "userLimitFactor" : 1,
+                  "configuredMaxAMResourceLimit" : 0.1,
+                  "AMResourceLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "usedAMResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "userAMResourceLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "preemptionDisabled" : true,
+                  "intraQueuePreemptionDisabled" : true,
+                  "defaultPriority" : 0,
+                  "isAutoCreatedLeafQueue" : false,
+                  "maxApplicationLifetime" : -1,
+                  "defaultApplicationLifetime" : -1
+                }, {
+                  "type" : "capacitySchedulerLeafQueueInfo",
+                  "queuePath" : "root.a.a1.a1b",
+                  "capacity" : 15.000001,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 0.47250003,
+                  "absoluteMaxCapacity" : 25,
+                  "absoluteUsedCapacity" : 0,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "numApplications" : 0,
+                  "maxParallelApps" : 2147483647,
+                  "queueName" : "a1b",
+                  "isAbsoluteResource" : false,
+                  "state" : "RUNNING",
+                  "resourcesUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "hideReservationQueues" : false,
+                  "nodeLabels" : [ "*" ],
+                  "allocatedContainers" : 0,
+                  "reservedContainers" : 0,
+                  "pendingContainers" : 0,
+                  "capacities" : {
+                    "queueCapacitiesByPartition" : [ {
+                      "partitionName" : "",
+                      "capacity" : 15.000001,
+                      "usedCapacity" : 0,
+                      "maxCapacity" : 100,
+                      "absoluteCapacity" : 0.47250003,
+                      "absoluteUsedCapacity" : 0,
+                      "absoluteMaxCapacity" : 25,
+                      "maxAMLimitPercentage" : 10,
+                      "weight" : -1,
+                      "normalizedWeight" : 0,
+                      "configuredMinResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 8192,
+                            "minimumAllocation" : 1024,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 4,
+                            "minimumAllocation" : 1,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "configuredMaxResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 8192,
+                            "minimumAllocation" : 1024,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 4,
+                            "minimumAllocation" : 1,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "effectiveMinResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "effectiveMaxResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "resources" : {
+                    "resourceUsagesByPartition" : [ {
+                      "partitionName" : "",
+                      "used" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "reserved" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "pending" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "amUsed" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "amLimit" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "userAmLimit" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "minEffectiveCapacity" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "maxEffectiveCapacity" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "maximumAllocation" : {
+                    "memory" : 8192,
+                    "vCores" : 4,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 8192
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 4
+                      } ]
+                    }
+                  },
+                  "queueAcls" : {
+                    "queueAcl" : [ {
+                      "accessType" : "ADMINISTER_QUEUE",
+                      "accessControlList" : " "
+                    }, {
+                      "accessType" : "APPLICATION_MAX_PRIORITY",
+                      "accessControlList" : "*"
+                    }, {
+                      "accessType" : "SUBMIT_APP",
+                      "accessControlList" : " "
+                    } ]
+                  },
+                  "queuePriority" : 0,
+                  "orderingPolicyInfo" : "fifo",
+                  "autoCreateChildQueueEnabled" : false,
+                  "leafQueueTemplate" : { },
+                  "mode" : "percentage",
+                  "queueType" : "leaf",
+                  "creationMethod" : "static",
+                  "autoCreationEligibility" : "off",
+                  "autoQueueTemplateProperties" : { },
+                  "autoQueueParentTemplateProperties" : { },
+                  "autoQueueLeafTemplateProperties" : { },
+                  "numActiveApplications" : 0,
+                  "numPendingApplications" : 0,
+                  "numContainers" : 0,
+                  "maxApplications" : 47,
+                  "maxApplicationsPerUser" : 47,
+                  "userLimit" : 100,
+                  "users" : { },
+                  "userLimitFactor" : 1,
+                  "configuredMaxAMResourceLimit" : 0.1,
+                  "AMResourceLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "usedAMResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "userAMResourceLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "preemptionDisabled" : true,
+                  "intraQueuePreemptionDisabled" : true,
+                  "defaultPriority" : 0,
+                  "isAutoCreatedLeafQueue" : false,
+                  "maxApplicationLifetime" : -1,
+                  "defaultApplicationLifetime" : -1
+                }, {
+                  "queuePath" : "root.a.a1.a1c",
+                  "capacity" : 20,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 0.63,
+                  "absoluteMaxCapacity" : 25,
+                  "absoluteUsedCapacity" : 0,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "numApplications" : 0,
+                  "maxParallelApps" : 2147483647,
+                  "queueName" : "a1c",
+                  "isAbsoluteResource" : false,
+                  "state" : "RUNNING",
+                  "queues" : { },
+                  "resourcesUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "hideReservationQueues" : false,
+                  "nodeLabels" : [ "*" ],
+                  "allocatedContainers" : 0,
+                  "reservedContainers" : 0,
+                  "pendingContainers" : 0,
+                  "capacities" : {
+                    "queueCapacitiesByPartition" : [ {
+                      "partitionName" : "",
+                      "capacity" : 20,
+                      "usedCapacity" : 0,
+                      "maxCapacity" : 100,
+                      "absoluteCapacity" : 0.63,
+                      "absoluteUsedCapacity" : 0,
+                      "absoluteMaxCapacity" : 25,
+                      "maxAMLimitPercentage" : 0,
+                      "weight" : -1,
+                      "normalizedWeight" : 0,
+                      "configuredMinResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 8192,
+                            "minimumAllocation" : 1024,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 4,
+                            "minimumAllocation" : 1,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "configuredMaxResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 8192,
+                            "minimumAllocation" : 1024,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 4,
+                            "minimumAllocation" : 1,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "effectiveMinResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "effectiveMaxResource" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "resources" : {
+                    "resourceUsagesByPartition" : [ {
+                      "partitionName" : "",
+                      "used" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "reserved" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      },
+                      "pending" : {
+                        "memory" : 0,
+                        "vCores" : 0,
+                        "resourceInformations" : {
+                          "resourceInformation" : [ {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "memory-mb",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "Mi",
+                            "value" : 0
+                          }, {
+                            "attributes" : { },
+                            "maximumAllocation" : 9223372036854775807,
+                            "minimumAllocation" : 0,
+                            "name" : "vcores",
+                            "resourceType" : "COUNTABLE",
+                            "units" : "",
+                            "value" : 0
+                          } ]
+                        }
+                      }
+                    } ]
+                  },
+                  "minEffectiveCapacity" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "maxEffectiveCapacity" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "maximumAllocation" : {
+                    "memory" : 8192,
+                    "vCores" : 4,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 8192
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 4
+                      } ]
+                    }
+                  },
+                  "queueAcls" : {
+                    "queueAcl" : [ {
+                      "accessType" : "ADMINISTER_QUEUE",
+                      "accessControlList" : " "
+                    }, {
+                      "accessType" : "APPLICATION_MAX_PRIORITY",
+                      "accessControlList" : "*"
+                    }, {
+                      "accessType" : "SUBMIT_APP",
+                      "accessControlList" : " "
+                    } ]
+                  },
+                  "queuePriority" : 0,
+                  "orderingPolicyInfo" : "utilization",
+                  "autoCreateChildQueueEnabled" : true,
+                  "leafQueueTemplate" : {
+                    "property" : [ {
+                      "name" : "leaf-queue-template.capacity",
+                      "value" : "50"
+                    } ]
+                  },
+                  "mode" : "percentage",
+                  "queueType" : "parent",
+                  "creationMethod" : "static",
+                  "autoCreationEligibility" : "legacy",
+                  "autoQueueTemplateProperties" : { },
+                  "autoQueueParentTemplateProperties" : { },
+                  "autoQueueLeafTemplateProperties" : { }
+                } ]
+              },
+              "resourcesUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "hideReservationQueues" : false,
+              "nodeLabels" : [ "*" ],
+              "allocatedContainers" : 0,
+              "reservedContainers" : 0,
+              "pendingContainers" : 0,
+              "capacities" : {
+                "queueCapacitiesByPartition" : [ {
+                  "partitionName" : "",
+                  "capacity" : 30.000002,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 50,
+                  "absoluteCapacity" : 3.15,
+                  "absoluteUsedCapacity" : 0,
+                  "absoluteMaxCapacity" : 25,
+                  "maxAMLimitPercentage" : 0,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "configuredMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "configuredMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "resources" : {
+                "resourceUsagesByPartition" : [ {
+                  "partitionName" : "",
+                  "used" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "reserved" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "pending" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "minEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maxEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maximumAllocation" : {
+                "memory" : 8192,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8192
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "queueAcls" : {
+                "queueAcl" : [ {
+                  "accessType" : "ADMINISTER_QUEUE",
+                  "accessControlList" : " "
+                }, {
+                  "accessType" : "APPLICATION_MAX_PRIORITY",
+                  "accessControlList" : "*"
+                }, {
+                  "accessType" : "SUBMIT_APP",
+                  "accessControlList" : " "
+                } ]
+              },
+              "queuePriority" : 0,
+              "orderingPolicyInfo" : "utilization",
+              "autoCreateChildQueueEnabled" : false,
+              "leafQueueTemplate" : { },
+              "mode" : "percentage",
+              "queueType" : "parent",
+              "creationMethod" : "static",
+              "autoCreationEligibility" : "off",
+              "autoQueueTemplateProperties" : { },
+              "autoQueueParentTemplateProperties" : { },
+              "autoQueueLeafTemplateProperties" : { }
+            } ]
+          },
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 10.5,
+              "usedCapacity" : 0,
+              "maxCapacity" : 50,
+              "absoluteCapacity" : 10.5,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 50,
+              "maxAMLimitPercentage" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "utilization",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "percentage",
+          "queueType" : "parent",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { }
+        }, {
+          "queuePath" : "root.b",
+          "capacity" : 89.5,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 89.5,
+          "absoluteMaxCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "numApplications" : 0,
+          "maxParallelApps" : 2147483647,
+          "queueName" : "b",
+          "isAbsoluteResource" : false,
+          "state" : "RUNNING",
+          "queues" : {
+            "queue" : [ {
+              "type" : "capacitySchedulerLeafQueueInfo",
+              "queuePath" : "root.b.b1",
+              "capacity" : 60.000004,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 53.7,
+              "absoluteMaxCapacity" : 100,
+              "absoluteUsedCapacity" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "numApplications" : 0,
+              "maxParallelApps" : 2147483647,
+              "queueName" : "b1",
+              "isAbsoluteResource" : false,
+              "state" : "RUNNING",
+              "resourcesUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "hideReservationQueues" : false,
+              "nodeLabels" : [ "*" ],
+              "allocatedContainers" : 0,
+              "reservedContainers" : 0,
+              "pendingContainers" : 0,
+              "capacities" : {
+                "queueCapacitiesByPartition" : [ {
+                  "partitionName" : "",
+                  "capacity" : 60.000004,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 53.7,
+                  "absoluteUsedCapacity" : 0,
+                  "absoluteMaxCapacity" : 100,
+                  "maxAMLimitPercentage" : 10,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "configuredMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "configuredMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "resources" : {
+                "resourceUsagesByPartition" : [ {
+                  "partitionName" : "",
+                  "used" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "reserved" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "pending" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "userAmLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "minEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maxEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maximumAllocation" : {
+                "memory" : 8192,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8192
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "queueAcls" : {
+                "queueAcl" : [ {
+                  "accessType" : "ADMINISTER_QUEUE",
+                  "accessControlList" : " "
+                }, {
+                  "accessType" : "APPLICATION_MAX_PRIORITY",
+                  "accessControlList" : "*"
+                }, {
+                  "accessType" : "SUBMIT_APP",
+                  "accessControlList" : " "
+                } ]
+              },
+              "queuePriority" : 0,
+              "orderingPolicyInfo" : "fifo",
+              "autoCreateChildQueueEnabled" : false,
+              "leafQueueTemplate" : { },
+              "mode" : "percentage",
+              "queueType" : "leaf",
+              "creationMethod" : "static",
+              "autoCreationEligibility" : "off",
+              "autoQueueTemplateProperties" : { },
+              "autoQueueParentTemplateProperties" : { },
+              "autoQueueLeafTemplateProperties" : { },
+              "numActiveApplications" : 0,
+              "numPendingApplications" : 0,
+              "numContainers" : 0,
+              "maxApplications" : 5370,
+              "maxApplicationsPerUser" : 5370,
+              "userLimit" : 100,
+              "users" : { },
+              "userLimitFactor" : 100,
+              "configuredMaxAMResourceLimit" : 0.1,
+              "AMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "usedAMResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "preemptionDisabled" : true,
+              "intraQueuePreemptionDisabled" : true,
+              "defaultPriority" : 0,
+              "isAutoCreatedLeafQueue" : false,
+              "maxApplicationLifetime" : -1,
+              "defaultApplicationLifetime" : -1
+            }, {
+              "type" : "capacitySchedulerLeafQueueInfo",
+              "queuePath" : "root.b.b2",
+              "capacity" : 39.5,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 35.3525,
+              "absoluteMaxCapacity" : 100,
+              "absoluteUsedCapacity" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "numApplications" : 0,
+              "maxParallelApps" : 2147483647,
+              "queueName" : "b2",
+              "isAbsoluteResource" : false,
+              "state" : "RUNNING",
+              "resourcesUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "hideReservationQueues" : false,
+              "nodeLabels" : [ "*" ],
+              "allocatedContainers" : 0,
+              "reservedContainers" : 0,
+              "pendingContainers" : 0,
+              "capacities" : {
+                "queueCapacitiesByPartition" : [ {
+                  "partitionName" : "",
+                  "capacity" : 39.5,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 35.3525,
+                  "absoluteUsedCapacity" : 0,
+                  "absoluteMaxCapacity" : 100,
+                  "maxAMLimitPercentage" : 10,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "configuredMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "configuredMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "resources" : {
+                "resourceUsagesByPartition" : [ {
+                  "partitionName" : "",
+                  "used" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "reserved" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "pending" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "userAmLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "minEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maxEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maximumAllocation" : {
+                "memory" : 8192,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8192
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "queueAcls" : {
+                "queueAcl" : [ {
+                  "accessType" : "ADMINISTER_QUEUE",
+                  "accessControlList" : " "
+                }, {
+                  "accessType" : "APPLICATION_MAX_PRIORITY",
+                  "accessControlList" : "*"
+                }, {
+                  "accessType" : "SUBMIT_APP",
+                  "accessControlList" : " "
+                } ]
+              },
+              "queuePriority" : 0,
+              "orderingPolicyInfo" : "fifo",
+              "autoCreateChildQueueEnabled" : false,
+              "leafQueueTemplate" : { },
+              "mode" : "percentage",
+              "queueType" : "leaf",
+              "creationMethod" : "static",
+              "autoCreationEligibility" : "off",
+              "autoQueueTemplateProperties" : { },
+              "autoQueueParentTemplateProperties" : { },
+              "autoQueueLeafTemplateProperties" : { },
+              "numActiveApplications" : 0,
+              "numPendingApplications" : 0,
+              "numContainers" : 0,
+              "maxApplications" : 3535,
+              "maxApplicationsPerUser" : 3535,
+              "userLimit" : 100,
+              "users" : { },
+              "userLimitFactor" : 100,
+              "configuredMaxAMResourceLimit" : 0.1,
+              "AMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "usedAMResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "preemptionDisabled" : true,
+              "intraQueuePreemptionDisabled" : true,
+              "defaultPriority" : 0,
+              "isAutoCreatedLeafQueue" : false,
+              "maxApplicationLifetime" : -1,
+              "defaultApplicationLifetime" : -1
+            }, {
+              "type" : "capacitySchedulerLeafQueueInfo",
+              "queuePath" : "root.b.b3",
+              "capacity" : 0.5,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 0.4475,
+              "absoluteMaxCapacity" : 100,
+              "absoluteUsedCapacity" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "numApplications" : 0,
+              "maxParallelApps" : 2147483647,
+              "queueName" : "b3",
+              "isAbsoluteResource" : false,
+              "state" : "RUNNING",
+              "resourcesUsed" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "hideReservationQueues" : false,
+              "nodeLabels" : [ "*" ],
+              "allocatedContainers" : 0,
+              "reservedContainers" : 0,
+              "pendingContainers" : 0,
+              "capacities" : {
+                "queueCapacitiesByPartition" : [ {
+                  "partitionName" : "",
+                  "capacity" : 0.5,
+                  "usedCapacity" : 0,
+                  "maxCapacity" : 100,
+                  "absoluteCapacity" : 0.4475,
+                  "absoluteUsedCapacity" : 0,
+                  "absoluteMaxCapacity" : 100,
+                  "maxAMLimitPercentage" : 10,
+                  "weight" : -1,
+                  "normalizedWeight" : 0,
+                  "configuredMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "configuredMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 8192,
+                        "minimumAllocation" : 1024,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 4,
+                        "minimumAllocation" : 1,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMinResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "effectiveMaxResource" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "resources" : {
+                "resourceUsagesByPartition" : [ {
+                  "partitionName" : "",
+                  "used" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "reserved" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "pending" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amUsed" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "amLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  },
+                  "userAmLimit" : {
+                    "memory" : 0,
+                    "vCores" : 0,
+                    "resourceInformations" : {
+                      "resourceInformation" : [ {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "memory-mb",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "Mi",
+                        "value" : 0
+                      }, {
+                        "attributes" : { },
+                        "maximumAllocation" : 9223372036854775807,
+                        "minimumAllocation" : 0,
+                        "name" : "vcores",
+                        "resourceType" : "COUNTABLE",
+                        "units" : "",
+                        "value" : 0
+                      } ]
+                    }
+                  }
+                } ]
+              },
+              "minEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maxEffectiveCapacity" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "maximumAllocation" : {
+                "memory" : 8192,
+                "vCores" : 4,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 8192
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 4
+                  } ]
+                }
+              },
+              "queueAcls" : {
+                "queueAcl" : [ {
+                  "accessType" : "ADMINISTER_QUEUE",
+                  "accessControlList" : " "
+                }, {
+                  "accessType" : "APPLICATION_MAX_PRIORITY",
+                  "accessControlList" : "*"
+                }, {
+                  "accessType" : "SUBMIT_APP",
+                  "accessControlList" : " "
+                } ]
+              },
+              "queuePriority" : 0,
+              "orderingPolicyInfo" : "fifo",
+              "autoCreateChildQueueEnabled" : false,
+              "leafQueueTemplate" : { },
+              "mode" : "percentage",
+              "queueType" : "leaf",
+              "creationMethod" : "static",
+              "autoCreationEligibility" : "off",
+              "autoQueueTemplateProperties" : { },
+              "autoQueueParentTemplateProperties" : { },
+              "autoQueueLeafTemplateProperties" : { },
+              "numActiveApplications" : 0,
+              "numPendingApplications" : 0,
+              "numContainers" : 0,
+              "maxApplications" : 44,
+              "maxApplicationsPerUser" : 44,
+              "userLimit" : 100,
+              "users" : { },
+              "userLimitFactor" : 100,
+              "configuredMaxAMResourceLimit" : 0.1,
+              "AMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "usedAMResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "userAMResourceLimit" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "preemptionDisabled" : true,
+              "intraQueuePreemptionDisabled" : true,
+              "defaultPriority" : 0,
+              "isAutoCreatedLeafQueue" : false,
+              "maxApplicationLifetime" : -1,
+              "defaultApplicationLifetime" : -1
+            } ]
+          },
+          "resourcesUsed" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "hideReservationQueues" : false,
+          "nodeLabels" : [ "*" ],
+          "allocatedContainers" : 0,
+          "reservedContainers" : 0,
+          "pendingContainers" : 0,
+          "capacities" : {
+            "queueCapacitiesByPartition" : [ {
+              "partitionName" : "",
+              "capacity" : 89.5,
+              "usedCapacity" : 0,
+              "maxCapacity" : 100,
+              "absoluteCapacity" : 89.5,
+              "absoluteUsedCapacity" : 0,
+              "absoluteMaxCapacity" : 100,
+              "maxAMLimitPercentage" : 0,
+              "weight" : -1,
+              "normalizedWeight" : 0,
+              "configuredMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "configuredMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 8192,
+                    "minimumAllocation" : 1024,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 4,
+                    "minimumAllocation" : 1,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMinResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "effectiveMaxResource" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "resources" : {
+            "resourceUsagesByPartition" : [ {
+              "partitionName" : "",
+              "used" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "reserved" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              },
+              "pending" : {
+                "memory" : 0,
+                "vCores" : 0,
+                "resourceInformations" : {
+                  "resourceInformation" : [ {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "memory-mb",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "Mi",
+                    "value" : 0
+                  }, {
+                    "attributes" : { },
+                    "maximumAllocation" : 9223372036854775807,
+                    "minimumAllocation" : 0,
+                    "name" : "vcores",
+                    "resourceType" : "COUNTABLE",
+                    "units" : "",
+                    "value" : 0
+                  } ]
+                }
+              }
+            } ]
+          },
+          "minEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maxEffectiveCapacity" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          },
+          "maximumAllocation" : {
+            "memory" : 8192,
+            "vCores" : 4,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 8192
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 4
+              } ]
+            }
+          },
+          "queueAcls" : {
+            "queueAcl" : [ {
+              "accessType" : "ADMINISTER_QUEUE",
+              "accessControlList" : " "
+            }, {
+              "accessType" : "APPLICATION_MAX_PRIORITY",
+              "accessControlList" : "*"
+            }, {
+              "accessType" : "SUBMIT_APP",
+              "accessControlList" : " "
+            } ]
+          },
+          "queuePriority" : 0,
+          "orderingPolicyInfo" : "utilization",
+          "autoCreateChildQueueEnabled" : false,
+          "leafQueueTemplate" : { },
+          "mode" : "percentage",
+          "queueType" : "parent",
+          "creationMethod" : "static",
+          "autoCreationEligibility" : "off",
+          "autoQueueTemplateProperties" : { },
+          "autoQueueParentTemplateProperties" : { },
+          "autoQueueLeafTemplateProperties" : { }
+        } ]
       },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 0,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 0,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 0,
-        "maxAMLimitPercentage": 10,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 1024,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1024
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+      "capacities" : {
+        "queueCapacitiesByPartition" : [ {
+          "partitionName" : "",
+          "capacity" : 100,
+          "usedCapacity" : 0,
+          "maxCapacity" : 100,
+          "absoluteCapacity" : 100,
+          "absoluteUsedCapacity" : 0,
+          "absoluteMaxCapacity" : 100,
+          "maxAMLimitPercentage" : 0,
+          "weight" : -1,
+          "normalizedWeight" : 0,
+          "configuredMinResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "configuredMaxResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 8192,
+                "minimumAllocation" : 1024,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 4,
+                "minimumAllocation" : 1,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 1024,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1024
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "effectiveMinResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
+          },
+          "effectiveMaxResource" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
             }
-          ]}
+          }
+        } ]
+      },
+      "health" : {
+        "lastrun" : 0,
+        "operationsInfo" : [ {
+          "operation" : "last-allocation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-release",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-preemption",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        }, {
+          "operation" : "last-reservation",
+          "nodeId" : "N/A",
+          "containerId" : "N/A",
+          "queue" : "N/A"
+        } ],
+        "lastRunDetails" : [ {
+          "operation" : "releases",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "allocations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        }, {
+          "operation" : "reservations",
+          "count" : 0,
+          "resources" : {
+            "memory" : 0,
+            "vCores" : 0,
+            "resourceInformations" : {
+              "resourceInformation" : [ {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "memory-mb",
+                "resourceType" : "COUNTABLE",
+                "units" : "Mi",
+                "value" : 0
+              }, {
+                "attributes" : { },
+                "maximumAllocation" : 9223372036854775807,
+                "minimumAllocation" : 0,
+                "name" : "vcores",
+                "resourceType" : "COUNTABLE",
+                "units" : "",
+                "value" : 0
+              } ]
+            }
+          }
+        } ]
+      },
+      "maximumAllocation" : {
+        "memory" : 8192,
+        "vCores" : 4,
+        "resourceInformations" : {
+          "resourceInformation" : [ {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "memory-mb",
+            "resourceType" : "COUNTABLE",
+            "units" : "Mi",
+            "value" : 8192
+          }, {
+            "attributes" : { },
+            "maximumAllocation" : 9223372036854775807,
+            "minimumAllocation" : 0,
+            "name" : "vcores",
+            "resourceType" : "COUNTABLE",
+            "units" : "",
+            "value" : 4
+          } ]
         }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amUsed": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "amLimit": {
-          "memory": 1024,
-          "vCores": 1,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 1024
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 1
-            }
-          ]}
-        },
-        "userAmLimit": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 1024,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1024
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
       },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
+      "queueAcls" : {
+        "queueAcl" : [ {
+          "accessType" : "ADMINISTER_QUEUE",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "APPLICATION_MAX_PRIORITY",
+          "accessControlList" : "*"
+        }, {
+          "accessType" : "SUBMIT_APP",
+          "accessControlList" : "*"
+        } ]
       },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "fifo",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "absolute",
-      "queueType": "leaf",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {},
-      "numActiveApplications": 0,
-      "numPendingApplications": 0,
-      "numContainers": 0,
-      "maxApplications": 0,
-      "maxApplicationsPerUser": 0,
-      "userLimit": 100,
-      "users": {},
-      "userLimitFactor": 1,
-      "configuredMaxAMResourceLimit": 0.1,
-      "AMResourceLimit": {
-        "memory": 1024,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1024
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "usedAMResource": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "userAMResourceLimit": {
-        "memory": 1024,
-        "vCores": 1,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 1024
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 1
-          }
-        ]}
-      },
-      "preemptionDisabled": true,
-      "intraQueuePreemptionDisabled": true,
-      "defaultPriority": 0,
-      "isAutoCreatedLeafQueue": false,
-      "maxApplicationLifetime": -1,
-      "defaultApplicationLifetime": -1
-    },
-    {
-      "queuePath": "root.a",
-      "capacity": 10.5,
-      "usedCapacity": 0,
-      "maxCapacity": 50,
-      "absoluteCapacity": 10.5,
-      "absoluteMaxCapacity": 50,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 42,
-      "queueName": "a",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "queues": {"queue": [
-        {
-          "type": "capacitySchedulerLeafQueueInfo",
-          "queuePath": "root.a.a2",
-          "capacity": 70,
-          "usedCapacity": 0,
-          "maxCapacity": 100,
-          "absoluteCapacity": 7.35,
-          "absoluteMaxCapacity": 50,
-          "absoluteUsedCapacity": 0,
-          "weight": -1,
-          "normalizedWeight": 0,
-          "numApplications": 0,
-          "maxParallelApps": 2147483647,
-          "queueName": "a2",
-          "isAbsoluteResource": false,
-          "state": "RUNNING",
-          "resourcesUsed": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "hideReservationQueues": false,
-          "nodeLabels": ["*"],
-          "allocatedContainers": 0,
-          "reservedContainers": 0,
-          "pendingContainers": 0,
-          "capacities": {"queueCapacitiesByPartition": [{
-            "partitionName": "",
-            "capacity": 70,
-            "usedCapacity": 0,
-            "maxCapacity": 100,
-            "absoluteCapacity": 7.35,
-            "absoluteUsedCapacity": 0,
-            "absoluteMaxCapacity": 50,
-            "maxAMLimitPercentage": 10,
-            "weight": -1,
-            "normalizedWeight": 0,
-            "configuredMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "configuredMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "resources": {"resourceUsagesByPartition": [{
-            "partitionName": "",
-            "used": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "reserved": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "pending": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "amUsed": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "amLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "userAmLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "minEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maxEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maximumAllocation": {
-            "memory": 8192,
-            "vCores": 4,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 8192
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 4
-              }
-            ]}
-          },
-          "queueAcls": {"queueAcl": [
-            {
-              "accessType": "ADMINISTER_QUEUE",
-              "accessControlList": " "
-            },
-            {
-              "accessType": "APPLICATION_MAX_PRIORITY",
-              "accessControlList": "*"
-            },
-            {
-              "accessType": "SUBMIT_APP",
-              "accessControlList": " "
-            }
-          ]},
-          "queuePriority": 0,
-          "orderingPolicyInfo": "fifo",
-          "autoCreateChildQueueEnabled": false,
-          "leafQueueTemplate": {},
-          "mode": "percentage",
-          "queueType": "leaf",
-          "creationMethod": "static",
-          "autoCreationEligibility": "off",
-          "autoQueueTemplateProperties": {},
-          "autoQueueParentTemplateProperties": {},
-          "autoQueueLeafTemplateProperties": {},
-          "numActiveApplications": 0,
-          "numPendingApplications": 0,
-          "numContainers": 0,
-          "maxApplications": 735,
-          "maxApplicationsPerUser": 735,
-          "userLimit": 100,
-          "users": {},
-          "userLimitFactor": 100,
-          "configuredMaxAMResourceLimit": 0.1,
-          "AMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "usedAMResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "userAMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "preemptionDisabled": true,
-          "intraQueuePreemptionDisabled": true,
-          "defaultPriority": 0,
-          "isAutoCreatedLeafQueue": false,
-          "maxApplicationLifetime": 100,
-          "defaultApplicationLifetime": 50
-        },
-        {
-          "queuePath": "root.a.a1",
-          "capacity": 30.000002,
-          "usedCapacity": 0,
-          "maxCapacity": 50,
-          "absoluteCapacity": 3.15,
-          "absoluteMaxCapacity": 25,
-          "absoluteUsedCapacity": 0,
-          "weight": -1,
-          "normalizedWeight": 0,
-          "numApplications": 0,
-          "maxParallelApps": 2147483647,
-          "queueName": "a1",
-          "isAbsoluteResource": false,
-          "state": "RUNNING",
-          "queues": {"queue": [
-            {
-              "type": "capacitySchedulerLeafQueueInfo",
-              "queuePath": "root.a.a1.a1a",
-              "capacity": 65,
-              "usedCapacity": 0,
-              "maxCapacity": 100,
-              "absoluteCapacity": 2.0475001,
-              "absoluteMaxCapacity": 25,
-              "absoluteUsedCapacity": 0,
-              "weight": -1,
-              "normalizedWeight": 0,
-              "numApplications": 0,
-              "maxParallelApps": 2147483647,
-              "queueName": "a1a",
-              "isAbsoluteResource": false,
-              "state": "RUNNING",
-              "resourcesUsed": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "hideReservationQueues": false,
-              "nodeLabels": ["*"],
-              "allocatedContainers": 0,
-              "reservedContainers": 0,
-              "pendingContainers": 0,
-              "capacities": {"queueCapacitiesByPartition": [{
-                "partitionName": "",
-                "capacity": 65,
-                "usedCapacity": 0,
-                "maxCapacity": 100,
-                "absoluteCapacity": 2.0475001,
-                "absoluteUsedCapacity": 0,
-                "absoluteMaxCapacity": 25,
-                "maxAMLimitPercentage": 10,
-                "weight": -1,
-                "normalizedWeight": 0,
-                "configuredMinResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 8192,
-                      "minimumAllocation": 1024,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 4,
-                      "minimumAllocation": 1,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "configuredMaxResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 8192,
-                      "minimumAllocation": 1024,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 4,
-                      "minimumAllocation": 1,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "effectiveMinResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "effectiveMaxResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                }
-              }]},
-              "resources": {"resourceUsagesByPartition": [{
-                "partitionName": "",
-                "used": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "reserved": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "pending": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "amUsed": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "amLimit": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "userAmLimit": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                }
-              }]},
-              "minEffectiveCapacity": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "maxEffectiveCapacity": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "maximumAllocation": {
-                "memory": 8192,
-                "vCores": 4,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 8192
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 4
-                  }
-                ]}
-              },
-              "queueAcls": {"queueAcl": [
-                {
-                  "accessType": "ADMINISTER_QUEUE",
-                  "accessControlList": " "
-                },
-                {
-                  "accessType": "APPLICATION_MAX_PRIORITY",
-                  "accessControlList": "*"
-                },
-                {
-                  "accessType": "SUBMIT_APP",
-                  "accessControlList": " "
-                }
-              ]},
-              "queuePriority": 0,
-              "orderingPolicyInfo": "fifo",
-              "autoCreateChildQueueEnabled": false,
-              "leafQueueTemplate": {},
-              "mode": "percentage",
-              "queueType": "leaf",
-              "creationMethod": "static",
-              "autoCreationEligibility": "off",
-              "autoQueueTemplateProperties": {},
-              "autoQueueParentTemplateProperties": {},
-              "autoQueueLeafTemplateProperties": {},
-              "numActiveApplications": 0,
-              "numPendingApplications": 0,
-              "numContainers": 0,
-              "maxApplications": 204,
-              "maxApplicationsPerUser": 204,
-              "userLimit": 100,
-              "users": {},
-              "userLimitFactor": 1,
-              "configuredMaxAMResourceLimit": 0.1,
-              "AMResourceLimit": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "usedAMResource": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "userAMResourceLimit": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "preemptionDisabled": true,
-              "intraQueuePreemptionDisabled": true,
-              "defaultPriority": 0,
-              "isAutoCreatedLeafQueue": false,
-              "maxApplicationLifetime": -1,
-              "defaultApplicationLifetime": -1
-            },
-            {
-              "type": "capacitySchedulerLeafQueueInfo",
-              "queuePath": "root.a.a1.a1b",
-              "capacity": 15.000001,
-              "usedCapacity": 0,
-              "maxCapacity": 100,
-              "absoluteCapacity": 0.47250003,
-              "absoluteMaxCapacity": 25,
-              "absoluteUsedCapacity": 0,
-              "weight": -1,
-              "normalizedWeight": 0,
-              "numApplications": 0,
-              "maxParallelApps": 2147483647,
-              "queueName": "a1b",
-              "isAbsoluteResource": false,
-              "state": "RUNNING",
-              "resourcesUsed": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "hideReservationQueues": false,
-              "nodeLabels": ["*"],
-              "allocatedContainers": 0,
-              "reservedContainers": 0,
-              "pendingContainers": 0,
-              "capacities": {"queueCapacitiesByPartition": [{
-                "partitionName": "",
-                "capacity": 15.000001,
-                "usedCapacity": 0,
-                "maxCapacity": 100,
-                "absoluteCapacity": 0.47250003,
-                "absoluteUsedCapacity": 0,
-                "absoluteMaxCapacity": 25,
-                "maxAMLimitPercentage": 10,
-                "weight": -1,
-                "normalizedWeight": 0,
-                "configuredMinResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 8192,
-                      "minimumAllocation": 1024,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 4,
-                      "minimumAllocation": 1,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "configuredMaxResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 8192,
-                      "minimumAllocation": 1024,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 4,
-                      "minimumAllocation": 1,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "effectiveMinResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "effectiveMaxResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                }
-              }]},
-              "resources": {"resourceUsagesByPartition": [{
-                "partitionName": "",
-                "used": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "reserved": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "pending": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "amUsed": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "amLimit": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "userAmLimit": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                }
-              }]},
-              "minEffectiveCapacity": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "maxEffectiveCapacity": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "maximumAllocation": {
-                "memory": 8192,
-                "vCores": 4,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 8192
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 4
-                  }
-                ]}
-              },
-              "queueAcls": {"queueAcl": [
-                {
-                  "accessType": "ADMINISTER_QUEUE",
-                  "accessControlList": " "
-                },
-                {
-                  "accessType": "APPLICATION_MAX_PRIORITY",
-                  "accessControlList": "*"
-                },
-                {
-                  "accessType": "SUBMIT_APP",
-                  "accessControlList": " "
-                }
-              ]},
-              "queuePriority": 0,
-              "orderingPolicyInfo": "fifo",
-              "autoCreateChildQueueEnabled": false,
-              "leafQueueTemplate": {},
-              "mode": "percentage",
-              "queueType": "leaf",
-              "creationMethod": "static",
-              "autoCreationEligibility": "off",
-              "autoQueueTemplateProperties": {},
-              "autoQueueParentTemplateProperties": {},
-              "autoQueueLeafTemplateProperties": {},
-              "numActiveApplications": 0,
-              "numPendingApplications": 0,
-              "numContainers": 0,
-              "maxApplications": 47,
-              "maxApplicationsPerUser": 47,
-              "userLimit": 100,
-              "users": {},
-              "userLimitFactor": 1,
-              "configuredMaxAMResourceLimit": 0.1,
-              "AMResourceLimit": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "usedAMResource": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "userAMResourceLimit": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "preemptionDisabled": true,
-              "intraQueuePreemptionDisabled": true,
-              "defaultPriority": 0,
-              "isAutoCreatedLeafQueue": false,
-              "maxApplicationLifetime": -1,
-              "defaultApplicationLifetime": -1
-            },
-            {
-              "queuePath": "root.a.a1.a1c",
-              "capacity": 20,
-              "usedCapacity": 0,
-              "maxCapacity": 100,
-              "absoluteCapacity": 0.63,
-              "absoluteMaxCapacity": 25,
-              "absoluteUsedCapacity": 0,
-              "weight": -1,
-              "normalizedWeight": 0,
-              "numApplications": 0,
-              "maxParallelApps": 2147483647,
-              "queueName": "a1c",
-              "isAbsoluteResource": false,
-              "state": "RUNNING",
-              "queues": {},
-              "resourcesUsed": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "hideReservationQueues": false,
-              "nodeLabels": ["*"],
-              "allocatedContainers": 0,
-              "reservedContainers": 0,
-              "pendingContainers": 0,
-              "capacities": {"queueCapacitiesByPartition": [{
-                "partitionName": "",
-                "capacity": 20,
-                "usedCapacity": 0,
-                "maxCapacity": 100,
-                "absoluteCapacity": 0.63,
-                "absoluteUsedCapacity": 0,
-                "absoluteMaxCapacity": 25,
-                "maxAMLimitPercentage": 0,
-                "weight": -1,
-                "normalizedWeight": 0,
-                "configuredMinResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 8192,
-                      "minimumAllocation": 1024,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 4,
-                      "minimumAllocation": 1,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "configuredMaxResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 8192,
-                      "minimumAllocation": 1024,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 4,
-                      "minimumAllocation": 1,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "effectiveMinResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "effectiveMaxResource": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                }
-              }]},
-              "resources": {"resourceUsagesByPartition": [{
-                "partitionName": "",
-                "used": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "reserved": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                },
-                "pending": {
-                  "memory": 0,
-                  "vCores": 0,
-                  "resourceInformations": {"resourceInformation": [
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "memory-mb",
-                      "resourceType": "COUNTABLE",
-                      "units": "Mi",
-                      "value": 0
-                    },
-                    {
-                      "attributes": {},
-                      "maximumAllocation": 9223372036854775807,
-                      "minimumAllocation": 0,
-                      "name": "vcores",
-                      "resourceType": "COUNTABLE",
-                      "units": "",
-                      "value": 0
-                    }
-                  ]}
-                }
-              }]},
-              "minEffectiveCapacity": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "maxEffectiveCapacity": {
-                "memory": 0,
-                "vCores": 0,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 0
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 0
-                  }
-                ]}
-              },
-              "maximumAllocation": {
-                "memory": 8192,
-                "vCores": 4,
-                "resourceInformations": {"resourceInformation": [
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "memory-mb",
-                    "resourceType": "COUNTABLE",
-                    "units": "Mi",
-                    "value": 8192
-                  },
-                  {
-                    "attributes": {},
-                    "maximumAllocation": 9223372036854775807,
-                    "minimumAllocation": 0,
-                    "name": "vcores",
-                    "resourceType": "COUNTABLE",
-                    "units": "",
-                    "value": 4
-                  }
-                ]}
-              },
-              "queueAcls": {"queueAcl": [
-                {
-                  "accessType": "ADMINISTER_QUEUE",
-                  "accessControlList": " "
-                },
-                {
-                  "accessType": "APPLICATION_MAX_PRIORITY",
-                  "accessControlList": "*"
-                },
-                {
-                  "accessType": "SUBMIT_APP",
-                  "accessControlList": " "
-                }
-              ]},
-              "queuePriority": 0,
-              "orderingPolicyInfo": "utilization",
-              "autoCreateChildQueueEnabled": true,
-              "leafQueueTemplate": {"property": [{
-                "name": "leaf-queue-template.capacity",
-                "value": "50"
-              }]},
-              "mode": "percentage",
-              "queueType": "parent",
-              "creationMethod": "static",
-              "autoCreationEligibility": "legacy",
-              "autoQueueTemplateProperties": {},
-              "autoQueueParentTemplateProperties": {},
-              "autoQueueLeafTemplateProperties": {}
-            }
-          ]},
-          "resourcesUsed": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "hideReservationQueues": false,
-          "nodeLabels": ["*"],
-          "allocatedContainers": 0,
-          "reservedContainers": 0,
-          "pendingContainers": 0,
-          "capacities": {"queueCapacitiesByPartition": [{
-            "partitionName": "",
-            "capacity": 30.000002,
-            "usedCapacity": 0,
-            "maxCapacity": 50,
-            "absoluteCapacity": 3.15,
-            "absoluteUsedCapacity": 0,
-            "absoluteMaxCapacity": 25,
-            "maxAMLimitPercentage": 0,
-            "weight": -1,
-            "normalizedWeight": 0,
-            "configuredMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "configuredMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "resources": {"resourceUsagesByPartition": [{
-            "partitionName": "",
-            "used": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "reserved": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "pending": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "minEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maxEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maximumAllocation": {
-            "memory": 8192,
-            "vCores": 4,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 8192
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 4
-              }
-            ]}
-          },
-          "queueAcls": {"queueAcl": [
-            {
-              "accessType": "ADMINISTER_QUEUE",
-              "accessControlList": " "
-            },
-            {
-              "accessType": "APPLICATION_MAX_PRIORITY",
-              "accessControlList": "*"
-            },
-            {
-              "accessType": "SUBMIT_APP",
-              "accessControlList": " "
-            }
-          ]},
-          "queuePriority": 0,
-          "orderingPolicyInfo": "utilization",
-          "autoCreateChildQueueEnabled": false,
-          "leafQueueTemplate": {},
-          "mode": "percentage",
-          "queueType": "parent",
-          "creationMethod": "static",
-          "autoCreationEligibility": "off",
-          "autoQueueTemplateProperties": {},
-          "autoQueueParentTemplateProperties": {},
-          "autoQueueLeafTemplateProperties": {}
-        }
-      ]},
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 10.5,
-        "usedCapacity": 0,
-        "maxCapacity": 50,
-        "absoluteCapacity": 10.5,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 50,
-        "maxAMLimitPercentage": 0,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "utilization",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "percentage",
-      "queueType": "parent",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {}
-    },
-    {
-      "queuePath": "root.b",
-      "capacity": 89.5,
-      "usedCapacity": 0,
-      "maxCapacity": 100,
-      "absoluteCapacity": 89.5,
-      "absoluteMaxCapacity": 100,
-      "absoluteUsedCapacity": 0,
-      "weight": -1,
-      "normalizedWeight": 0,
-      "numApplications": 0,
-      "maxParallelApps": 2147483647,
-      "queueName": "b",
-      "isAbsoluteResource": false,
-      "state": "RUNNING",
-      "queues": {"queue": [
-        {
-          "type": "capacitySchedulerLeafQueueInfo",
-          "queuePath": "root.b.b1",
-          "capacity": 60.000004,
-          "usedCapacity": 0,
-          "maxCapacity": 100,
-          "absoluteCapacity": 53.7,
-          "absoluteMaxCapacity": 100,
-          "absoluteUsedCapacity": 0,
-          "weight": -1,
-          "normalizedWeight": 0,
-          "numApplications": 0,
-          "maxParallelApps": 2147483647,
-          "queueName": "b1",
-          "isAbsoluteResource": false,
-          "state": "RUNNING",
-          "resourcesUsed": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "hideReservationQueues": false,
-          "nodeLabels": ["*"],
-          "allocatedContainers": 0,
-          "reservedContainers": 0,
-          "pendingContainers": 0,
-          "capacities": {"queueCapacitiesByPartition": [{
-            "partitionName": "",
-            "capacity": 60.000004,
-            "usedCapacity": 0,
-            "maxCapacity": 100,
-            "absoluteCapacity": 53.7,
-            "absoluteUsedCapacity": 0,
-            "absoluteMaxCapacity": 100,
-            "maxAMLimitPercentage": 10,
-            "weight": -1,
-            "normalizedWeight": 0,
-            "configuredMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "configuredMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "resources": {"resourceUsagesByPartition": [{
-            "partitionName": "",
-            "used": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "reserved": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "pending": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "amUsed": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "amLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "userAmLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "minEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maxEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maximumAllocation": {
-            "memory": 8192,
-            "vCores": 4,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 8192
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 4
-              }
-            ]}
-          },
-          "queueAcls": {"queueAcl": [
-            {
-              "accessType": "ADMINISTER_QUEUE",
-              "accessControlList": " "
-            },
-            {
-              "accessType": "APPLICATION_MAX_PRIORITY",
-              "accessControlList": "*"
-            },
-            {
-              "accessType": "SUBMIT_APP",
-              "accessControlList": " "
-            }
-          ]},
-          "queuePriority": 0,
-          "orderingPolicyInfo": "fifo",
-          "autoCreateChildQueueEnabled": false,
-          "leafQueueTemplate": {},
-          "mode": "percentage",
-          "queueType": "leaf",
-          "creationMethod": "static",
-          "autoCreationEligibility": "off",
-          "autoQueueTemplateProperties": {},
-          "autoQueueParentTemplateProperties": {},
-          "autoQueueLeafTemplateProperties": {},
-          "numActiveApplications": 0,
-          "numPendingApplications": 0,
-          "numContainers": 0,
-          "maxApplications": 5370,
-          "maxApplicationsPerUser": 5370,
-          "userLimit": 100,
-          "users": {},
-          "userLimitFactor": 100,
-          "configuredMaxAMResourceLimit": 0.1,
-          "AMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "usedAMResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "userAMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "preemptionDisabled": true,
-          "intraQueuePreemptionDisabled": true,
-          "defaultPriority": 0,
-          "isAutoCreatedLeafQueue": false,
-          "maxApplicationLifetime": -1,
-          "defaultApplicationLifetime": -1
-        },
-        {
-          "type": "capacitySchedulerLeafQueueInfo",
-          "queuePath": "root.b.b2",
-          "capacity": 39.5,
-          "usedCapacity": 0,
-          "maxCapacity": 100,
-          "absoluteCapacity": 35.3525,
-          "absoluteMaxCapacity": 100,
-          "absoluteUsedCapacity": 0,
-          "weight": -1,
-          "normalizedWeight": 0,
-          "numApplications": 0,
-          "maxParallelApps": 2147483647,
-          "queueName": "b2",
-          "isAbsoluteResource": false,
-          "state": "RUNNING",
-          "resourcesUsed": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "hideReservationQueues": false,
-          "nodeLabels": ["*"],
-          "allocatedContainers": 0,
-          "reservedContainers": 0,
-          "pendingContainers": 0,
-          "capacities": {"queueCapacitiesByPartition": [{
-            "partitionName": "",
-            "capacity": 39.5,
-            "usedCapacity": 0,
-            "maxCapacity": 100,
-            "absoluteCapacity": 35.3525,
-            "absoluteUsedCapacity": 0,
-            "absoluteMaxCapacity": 100,
-            "maxAMLimitPercentage": 10,
-            "weight": -1,
-            "normalizedWeight": 0,
-            "configuredMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "configuredMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "resources": {"resourceUsagesByPartition": [{
-            "partitionName": "",
-            "used": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "reserved": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "pending": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "amUsed": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "amLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "userAmLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "minEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maxEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maximumAllocation": {
-            "memory": 8192,
-            "vCores": 4,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 8192
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 4
-              }
-            ]}
-          },
-          "queueAcls": {"queueAcl": [
-            {
-              "accessType": "ADMINISTER_QUEUE",
-              "accessControlList": " "
-            },
-            {
-              "accessType": "APPLICATION_MAX_PRIORITY",
-              "accessControlList": "*"
-            },
-            {
-              "accessType": "SUBMIT_APP",
-              "accessControlList": " "
-            }
-          ]},
-          "queuePriority": 0,
-          "orderingPolicyInfo": "fifo",
-          "autoCreateChildQueueEnabled": false,
-          "leafQueueTemplate": {},
-          "mode": "percentage",
-          "queueType": "leaf",
-          "creationMethod": "static",
-          "autoCreationEligibility": "off",
-          "autoQueueTemplateProperties": {},
-          "autoQueueParentTemplateProperties": {},
-          "autoQueueLeafTemplateProperties": {},
-          "numActiveApplications": 0,
-          "numPendingApplications": 0,
-          "numContainers": 0,
-          "maxApplications": 3535,
-          "maxApplicationsPerUser": 3535,
-          "userLimit": 100,
-          "users": {},
-          "userLimitFactor": 100,
-          "configuredMaxAMResourceLimit": 0.1,
-          "AMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "usedAMResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "userAMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "preemptionDisabled": true,
-          "intraQueuePreemptionDisabled": true,
-          "defaultPriority": 0,
-          "isAutoCreatedLeafQueue": false,
-          "maxApplicationLifetime": -1,
-          "defaultApplicationLifetime": -1
-        },
-        {
-          "type": "capacitySchedulerLeafQueueInfo",
-          "queuePath": "root.b.b3",
-          "capacity": 0.5,
-          "usedCapacity": 0,
-          "maxCapacity": 100,
-          "absoluteCapacity": 0.4475,
-          "absoluteMaxCapacity": 100,
-          "absoluteUsedCapacity": 0,
-          "weight": -1,
-          "normalizedWeight": 0,
-          "numApplications": 0,
-          "maxParallelApps": 2147483647,
-          "queueName": "b3",
-          "isAbsoluteResource": false,
-          "state": "RUNNING",
-          "resourcesUsed": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "hideReservationQueues": false,
-          "nodeLabels": ["*"],
-          "allocatedContainers": 0,
-          "reservedContainers": 0,
-          "pendingContainers": 0,
-          "capacities": {"queueCapacitiesByPartition": [{
-            "partitionName": "",
-            "capacity": 0.5,
-            "usedCapacity": 0,
-            "maxCapacity": 100,
-            "absoluteCapacity": 0.4475,
-            "absoluteUsedCapacity": 0,
-            "absoluteMaxCapacity": 100,
-            "maxAMLimitPercentage": 10,
-            "weight": -1,
-            "normalizedWeight": 0,
-            "configuredMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "configuredMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 8192,
-                  "minimumAllocation": 1024,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 4,
-                  "minimumAllocation": 1,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMinResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "effectiveMaxResource": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "resources": {"resourceUsagesByPartition": [{
-            "partitionName": "",
-            "used": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "reserved": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "pending": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "amUsed": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "amLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            },
-            "userAmLimit": {
-              "memory": 0,
-              "vCores": 0,
-              "resourceInformations": {"resourceInformation": [
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "memory-mb",
-                  "resourceType": "COUNTABLE",
-                  "units": "Mi",
-                  "value": 0
-                },
-                {
-                  "attributes": {},
-                  "maximumAllocation": 9223372036854775807,
-                  "minimumAllocation": 0,
-                  "name": "vcores",
-                  "resourceType": "COUNTABLE",
-                  "units": "",
-                  "value": 0
-                }
-              ]}
-            }
-          }]},
-          "minEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maxEffectiveCapacity": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "maximumAllocation": {
-            "memory": 8192,
-            "vCores": 4,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 8192
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 4
-              }
-            ]}
-          },
-          "queueAcls": {"queueAcl": [
-            {
-              "accessType": "ADMINISTER_QUEUE",
-              "accessControlList": " "
-            },
-            {
-              "accessType": "APPLICATION_MAX_PRIORITY",
-              "accessControlList": "*"
-            },
-            {
-              "accessType": "SUBMIT_APP",
-              "accessControlList": " "
-            }
-          ]},
-          "queuePriority": 0,
-          "orderingPolicyInfo": "fifo",
-          "autoCreateChildQueueEnabled": false,
-          "leafQueueTemplate": {},
-          "mode": "percentage",
-          "queueType": "leaf",
-          "creationMethod": "static",
-          "autoCreationEligibility": "off",
-          "autoQueueTemplateProperties": {},
-          "autoQueueParentTemplateProperties": {},
-          "autoQueueLeafTemplateProperties": {},
-          "numActiveApplications": 0,
-          "numPendingApplications": 0,
-          "numContainers": 0,
-          "maxApplications": 44,
-          "maxApplicationsPerUser": 44,
-          "userLimit": 100,
-          "users": {},
-          "userLimitFactor": 100,
-          "configuredMaxAMResourceLimit": 0.1,
-          "AMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "usedAMResource": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "userAMResourceLimit": {
-            "memory": 0,
-            "vCores": 0,
-            "resourceInformations": {"resourceInformation": [
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "memory-mb",
-                "resourceType": "COUNTABLE",
-                "units": "Mi",
-                "value": 0
-              },
-              {
-                "attributes": {},
-                "maximumAllocation": 9223372036854775807,
-                "minimumAllocation": 0,
-                "name": "vcores",
-                "resourceType": "COUNTABLE",
-                "units": "",
-                "value": 0
-              }
-            ]}
-          },
-          "preemptionDisabled": true,
-          "intraQueuePreemptionDisabled": true,
-          "defaultPriority": 0,
-          "isAutoCreatedLeafQueue": false,
-          "maxApplicationLifetime": -1,
-          "defaultApplicationLifetime": -1
-        }
-      ]},
-      "resourcesUsed": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "hideReservationQueues": false,
-      "nodeLabels": ["*"],
-      "allocatedContainers": 0,
-      "reservedContainers": 0,
-      "pendingContainers": 0,
-      "capacities": {"queueCapacitiesByPartition": [{
-        "partitionName": "",
-        "capacity": 89.5,
-        "usedCapacity": 0,
-        "maxCapacity": 100,
-        "absoluteCapacity": 89.5,
-        "absoluteUsedCapacity": 0,
-        "absoluteMaxCapacity": 100,
-        "maxAMLimitPercentage": 0,
-        "weight": -1,
-        "normalizedWeight": 0,
-        "configuredMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "configuredMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 8192,
-              "minimumAllocation": 1024,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 4,
-              "minimumAllocation": 1,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMinResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "effectiveMaxResource": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "resources": {"resourceUsagesByPartition": [{
-        "partitionName": "",
-        "used": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "reserved": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        },
-        "pending": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }]},
-      "minEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maxEffectiveCapacity": {
-        "memory": 0,
-        "vCores": 0,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 0
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 0
-          }
-        ]}
-      },
-      "maximumAllocation": {
-        "memory": 8192,
-        "vCores": 4,
-        "resourceInformations": {"resourceInformation": [
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "memory-mb",
-            "resourceType": "COUNTABLE",
-            "units": "Mi",
-            "value": 8192
-          },
-          {
-            "attributes": {},
-            "maximumAllocation": 9223372036854775807,
-            "minimumAllocation": 0,
-            "name": "vcores",
-            "resourceType": "COUNTABLE",
-            "units": "",
-            "value": 4
-          }
-        ]}
-      },
-      "queueAcls": {"queueAcl": [
-        {
-          "accessType": "ADMINISTER_QUEUE",
-          "accessControlList": " "
-        },
-        {
-          "accessType": "APPLICATION_MAX_PRIORITY",
-          "accessControlList": "*"
-        },
-        {
-          "accessType": "SUBMIT_APP",
-          "accessControlList": " "
-        }
-      ]},
-      "queuePriority": 0,
-      "orderingPolicyInfo": "utilization",
-      "autoCreateChildQueueEnabled": false,
-      "leafQueueTemplate": {},
-      "mode": "percentage",
-      "queueType": "parent",
-      "creationMethod": "static",
-      "autoCreationEligibility": "off",
-      "autoQueueTemplateProperties": {},
-      "autoQueueParentTemplateProperties": {},
-      "autoQueueLeafTemplateProperties": {}
+      "queuePriority" : 0,
+      "orderingPolicyInfo" : "utilization",
+      "mode" : "percentage",
+      "queueType" : "parent",
+      "creationMethod" : "static",
+      "autoCreationEligibility" : "off",
+      "autoQueueTemplateProperties" : { },
+      "autoQueueParentTemplateProperties" : { },
+      "autoQueueLeafTemplateProperties" : { }
     }
-  ]},
-  "capacities": {"queueCapacitiesByPartition": [{
-    "partitionName": "",
-    "capacity": 100,
-    "usedCapacity": 0,
-    "maxCapacity": 100,
-    "absoluteCapacity": 100,
-    "absoluteUsedCapacity": 0,
-    "absoluteMaxCapacity": 100,
-    "maxAMLimitPercentage": 0,
-    "weight": -1,
-    "normalizedWeight": 0,
-    "configuredMinResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "configuredMaxResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 8192,
-          "minimumAllocation": 1024,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 4,
-          "minimumAllocation": 1,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "effectiveMinResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    },
-    "effectiveMaxResource": {
-      "memory": 0,
-      "vCores": 0,
-      "resourceInformations": {"resourceInformation": [
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "memory-mb",
-          "resourceType": "COUNTABLE",
-          "units": "Mi",
-          "value": 0
-        },
-        {
-          "attributes": {},
-          "maximumAllocation": 9223372036854775807,
-          "minimumAllocation": 0,
-          "name": "vcores",
-          "resourceType": "COUNTABLE",
-          "units": "",
-          "value": 0
-        }
-      ]}
-    }
-  }]},
-  "health": {
-    "lastrun": 0,
-    "operationsInfo": [
-      {
-        "operation": "last-allocation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-release",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-preemption",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      },
-      {
-        "operation": "last-reservation",
-        "nodeId": "N\/A",
-        "containerId": "N\/A",
-        "queue": "N\/A"
-      }
-    ],
-    "lastRunDetails": [
-      {
-        "operation": "releases",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "allocations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      },
-      {
-        "operation": "reservations",
-        "count": 0,
-        "resources": {
-          "memory": 0,
-          "vCores": 0,
-          "resourceInformations": {"resourceInformation": [
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "memory-mb",
-              "resourceType": "COUNTABLE",
-              "units": "Mi",
-              "value": 0
-            },
-            {
-              "attributes": {},
-              "maximumAllocation": 9223372036854775807,
-              "minimumAllocation": 0,
-              "name": "vcores",
-              "resourceType": "COUNTABLE",
-              "units": "",
-              "value": 0
-            }
-          ]}
-        }
-      }
-    ]
-  },
-  "maximumAllocation": {
-    "memory": 8192,
-    "vCores": 4,
-    "resourceInformations": {"resourceInformation": [
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "memory-mb",
-        "resourceType": "COUNTABLE",
-        "units": "Mi",
-        "value": 8192
-      },
-      {
-        "attributes": {},
-        "maximumAllocation": 9223372036854775807,
-        "minimumAllocation": 0,
-        "name": "vcores",
-        "resourceType": "COUNTABLE",
-        "units": "",
-        "value": 4
-      }
-    ]}
-  },
-  "queueAcls": {"queueAcl": [
-    {
-      "accessType": "ADMINISTER_QUEUE",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "APPLICATION_MAX_PRIORITY",
-      "accessControlList": "*"
-    },
-    {
-      "accessType": "SUBMIT_APP",
-      "accessControlList": "*"
-    }
-  ]},
-  "queuePriority": 0,
-  "orderingPolicyInfo": "utilization",
-  "mode": "percentage",
-  "queueType": "parent",
-  "creationMethod": "static",
-  "autoCreationEligibility": "off",
-  "autoQueueTemplateProperties": {},
-  "autoQueueParentTemplateProperties": {},
-  "autoQueueLeafTemplateProperties": {}
-}}}
+  }
+}


### PR DESCRIPTION

### Description of PR

The goal is to have the same json formatting options when using the `updateTestDataAutomatically` helper function.

### How was this patch tested?

I verified that the updated JSON content is the same as before:
```shell
# before
➜  /Users/tdomok/Work/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp git:(YARN-11429) for f in *.json; do echo -n "$f "; cat $f | jq | md5sum; done
scheduler-response-AbsoluteMode.json 3cd84395f2864bbfcab55d1f81be5f44  -
scheduler-response-AbsoluteModeLegacyAutoCreation.json 4dbd90be628a52fa16eac0bde3774d6d  -
scheduler-response-PerUserResources.json eda777af4bf2f6cbfd3dc4b1a0ac945a  -
scheduler-response-PercentageMode.json 9a1dbd77cb034390092a553bfb04c078  -
scheduler-response-PercentageModeLegacyAutoCreation.json 9ca117ab46a4eb8be261650d26b17ae4  -
scheduler-response-WeightMode.json b87bc438cc66619e16edec4acef1dafb  -
scheduler-response-WeightModeWithAutoCreatedQueues-After.json 4265fb1c65813a44989f9f77cbd5e862  -
scheduler-response-WeightModeWithAutoCreatedQueues-Before.json a239664f30b71478991b0504a66dc4a5  -
scheduler-response.json 6e5b607d133ddf4e00eda23842b274db  -

# after
➜  /Users/tdomok/Work/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/webapp git:(YARN-11429) for f in *.json; do echo -n "$f "; cat $f | jq | md5sum; done
scheduler-response-AbsoluteMode.json 3cd84395f2864bbfcab55d1f81be5f44  -
scheduler-response-AbsoluteModeLegacyAutoCreation.json 4dbd90be628a52fa16eac0bde3774d6d  -
scheduler-response-PerUserResources.json eda777af4bf2f6cbfd3dc4b1a0ac945a  -
scheduler-response-PercentageMode.json 9a1dbd77cb034390092a553bfb04c078  -
scheduler-response-PercentageModeLegacyAutoCreation.json 9ca117ab46a4eb8be261650d26b17ae4  -
scheduler-response-WeightMode.json b87bc438cc66619e16edec4acef1dafb  -
scheduler-response-WeightModeWithAutoCreatedQueues-After.json 4265fb1c65813a44989f9f77cbd5e862  -
scheduler-response-WeightModeWithAutoCreatedQueues-Before.json a239664f30b71478991b0504a66dc4a5  -
scheduler-response.json 6e5b607d133ddf4e00eda23842b274db  -
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'YARN-11429. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

