### PR TITLE
HADOOP-18764. fs.azure.buffer.dir to be under Yarn container path on yarn applications

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2165,9 +2165,11 @@ The switch to turn S3A auditing on or off.
 
   <property>
     <name>fs.azure.buffer.dir</name>
-    <value>${hadoop.tmp.dir}/abfs</value>
+    <value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/abfs</value>
     <description>Directory path for buffer files needed to upload data blocks
-      in AbfsOutputStream.</description>
+      in AbfsOutputStream.
+      Yarn container path will be used as default value on yarn applications,
+      otherwise fall back to hadoop.tmp.dir </description>
   </property>
 
 <property>


### PR DESCRIPTION
### Description of PR
fs.azure.buffer.dir to be under Yarn container path on yarn applications

### How was this patch tested?
`mvn -Dparallel-tests=abfs -DtestsThreadCount=8 -Dscale clean verify` on `us-west-2` bucket

Results:
```
[INFO] Results:
[INFO] 
[WARNING] Tests run: 141, Failures: 0, Errors: 0, Skipped: 4
```

```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   ITestAzureBlobFileSystemLease.testTwoCreate:142  Expected to find 'There is currently a lease on the resource and no lease ID was specified in the request' but got unexpected exception: org.apache.hadoop.fs.PathIOException: `abfs://abfs-testcontainer-1b46713f-9625-4c06-8ecb-64b39c8dff3d@mmtusw.dfs.core.windows.net/fork-0002/test/testTwoCreate617053501b77/testfile': Input/output error: Parallel access to the create path detected. Failing request to honor single writer semantics
	at org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem.checkException(AzureBlobFileSystem.java:1503)
	at org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem.create(AzureBlobFileSystem.java:334)
	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:1231)
	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:1208)
	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:1089)
	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:1076)
	at org.apache.hadoop.fs.azurebfs.ITestAzureBlobFileSystemLease.lambda$testTwoCreate$1(ITestAzureBlobFileSystemLease.java:144)
	at org.apache.hadoop.test.LambdaTestUtils.intercept(LambdaTestUtils.java:498)
	at org.apache.hadoop.test.LambdaTestUtils.intercept(LambdaTestUtils.java:384)
	at org.apache.hadoop.test.LambdaTestUtils.intercept(LambdaTestUtils.java:453)
	at org.apache.hadoop.fs.azurebfs.ITestAzureBlobFileSystemLease.testTwoCreate(ITestAzureBlobFileSystemLease.java:142)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
Caused by: Parallel access to the create path detected. Failing request to honor single writer semantics
	at org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore.conditionalCreateOverwriteFile(AzureBlobFileSystemStore.java:652)
	at org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore.createFile(AzureBlobFileSystemStore.java:563)
	at org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem.create(AzureBlobFileSystem.java:328)
	... 21 more

[ERROR]   ITestGetNameSpaceEnabled.testGetIsNamespaceEnabledWhenConfigIsFalse:98->unsetAndAssert:109 [getIsNamespaceEnabled should return the value configured for fs.azure.test.namespace.enabled] expected:<[fals]e> but was:<[tru]e>
[ERROR]   ITestGetNameSpaceEnabled.testGetIsNamespaceEnabledWhenConfigIsTrue:88->unsetAndAssert:109 [getIsNamespaceEnabled should return the value configured for fs.azure.test.namespace.enabled] expected:<[fals]e> but was:<[tru]e>
[ERROR]   ITestGetNameSpaceEnabled.testNonXNSAccount:77->Assert.assertFalse:65->Assert.assertTrue:42->Assert.fail:89 Expecting getIsNamespaceEnabled() return false
[INFO] 
[ERROR] Tests run: 581, Failures: 4, Errors: 0, Skipped: 107
```

```
[INFO] Results:
[INFO] 
[WARNING] Tests run: 339, Failures: 0, Errors: 0, Skipped: 41
```
Seeing failures unrelated to the patch specifically `ITestAzureBlobFileSystemLease.java` since the other failures seem config related.

Is this a known failure?
CC @steveloughran 
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

