### PR TITLE
HDFS-17045. File renamed from a snapshottable dir to a non-snapshottable dir cannot be deleted.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeReference.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeReference.java
@@ -831,17 +831,17 @@ public abstract class INodeReference extends INode {
      *
      * @param context to {@link ReclaimContext#getSnapshotIdToBeDeleted()}
      */
-    private boolean shouldDestroy(ReclaimContext context) {
+    private void shouldDestroy(ReclaimContext context) {
       final int snapshotToBeDeleted = context.getSnapshotIdToBeDeleted();
-      if (dstSnapshotId < snapshotToBeDeleted) {
-        return true;
+      if (snapshotToBeDeleted == Snapshot.CURRENT_STATE_ID
+          || snapshotToBeDeleted > dstSnapshotId) {
+        return;
       }
       LOG.warn("Try to destroy a DstReference with dstSnapshotId = {}"
           + " >= snapshotToBeDeleted = {}", dstSnapshotId, snapshotToBeDeleted);
       LOG.warn("    dstRef: {}", toDetailString());
       final INode r = getReferredINode().asReference().getReferredINode();
       LOG.warn("  referred: {}", r.toDetailString());
-      return false;
     }
 
     /**
@@ -857,9 +857,7 @@ public abstract class INodeReference extends INode {
      */
     @Override
     public void destroyAndCollectBlocks(ReclaimContext reclaimContext) {
-      if (!shouldDestroy(reclaimContext)) {
-        return;
-      }
+      shouldDestroy(reclaimContext);
 
       // since we count everything of the subtree for the quota usage of a
       // dst reference node, here we should just simply do a quota computation.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
@@ -163,6 +163,7 @@ public class TestRenameWithSnapshots {
     
     hdfs.delete(bar, false);
     Assert.assertEquals(1, withCount.getReferenceCount());
+    restartClusterAndCheckImage(true);
   }
   
   private static boolean existsInDiffReport(List<DiffReportEntry> entries,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
@@ -197,6 +197,7 @@ public class TestRenameWithSnapshots {
     assertTrue(existsInDiffReport(entries, DiffType.MODIFY, "", null));
     assertTrue(existsInDiffReport(entries, DiffType.CREATE, file2.getName(),
         null));
+    restartClusterAndCheckImage(true);
   }
 
   /**
@@ -219,6 +220,7 @@ public class TestRenameWithSnapshots {
     assertTrue(existsInDiffReport(entries, DiffType.MODIFY, "", null));
     assertTrue(existsInDiffReport(entries, DiffType.RENAME, file1.getName(),
         file2.getName()));
+    restartClusterAndCheckImage(true);
   }
 
   @Test (timeout=60000)


### PR DESCRIPTION
### Description of PR

Change the `shouldDestroy` method to returning `void`.  For the detail of this bug, see HDFS-17045.

### How was this patch tested?

Added some checks on an existing test.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

