### PR TITLE
YARN-11504. [Addendum] [Federation] YARN Federation Supports Non-HA mode

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/RMProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/RMProxy.java
@@ -130,8 +130,11 @@ public class RMProxy<T> {
   protected static <T> T createRMProxyFederation(final Configuration configuration,
       final Class<T> protocol, RMProxy<T> instance) throws IOException {
     YarnConfiguration yarnConf = new YarnConfiguration(configuration);
-    RetryPolicy retryPolicy = createRetryPolicy(yarnConf, isFailoverEnabled(yarnConf));
-    return newProxyInstanceFederation(yarnConf, protocol, instance, retryPolicy);
+    if (isFederationNonHAEnabled(yarnConf)) {
+      RetryPolicy retryPolicy = createRetryPolicy(yarnConf, isFailoverEnabled(yarnConf));
+      return newProxyInstanceFederation(yarnConf, protocol, instance, retryPolicy);
+    }
+    return createRMProxy(configuration, protocol, instance);
   }
 
   protected static <T> T newProxyInstanceFederation(final YarnConfiguration conf,


### PR DESCRIPTION
### Description of PR
When I was submitting (#5716) the PR, I found that junit reported an error, I took a closer look at this piece of code, and we should consider the logic for compatibility with HA


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

