### PR TITLE
YARN-11513: Applications submitted to ambiguous queue fail during recovery if "Specified" Placement Rule is used

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMAppManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMAppManager.java
@@ -1056,7 +1056,7 @@ public class RMAppManager implements EventHandler<RMAppManagerEvent>,
       LOG.info("Placed application with ID " + context.getApplicationId() +
           " in queue: " + placementContext.getQueue() +
           ", original submission queue was: " + context.getQueue());
-      context.setQueue(placementContext.getQueue());
+      context.setQueue(placementContext.getFullQueuePath());
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
@@ -283,7 +283,7 @@ public class TestAppManager extends AppManagerTestBase{
     setupDispatcher(rmContext, conf);
   }
 
-  private static PlacementManager createMockPlacementManager(
+  public static PlacementManager createMockPlacementManager(
       String userRegex, String placementQueue, String placementParentQueue
   ) throws YarnException {
     PlacementManager placementMgr = mock(PlacementManager.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestWorkPreservingRMRestart.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestWorkPreservingRMRestart.java
@@ -1654,16 +1654,19 @@ public class TestWorkPreservingRMRestart extends ParameterizedSchedulerTestBase 
   //   Test behavior of an app if two same name leaf queue with different queuePath
   //   during work preserving rm restart with %specified mapping Placement Rule.
   //   Test case does following:
-  //1. Submit an apps to queue root.p1.test.
-  //2. During the applications is running, restart the rm and
+  //1. Submit an apps to queue root.joe.test.
+  //2. While the applications is running, restart the rm and
   //   check whether the app submitted to the queue it was submitted initially.
   //3. Verify that application running successfully.
   @Test(timeout = 60000)
   public void testQueueRecoveryOnRMWorkPreservingRestart() throws Exception {
+    if (getSchedulerType() != SchedulerType.CAPACITY) {
+      return;
+    }
     CapacitySchedulerConfiguration csConf = new CapacitySchedulerConfiguration(conf);
 
     csConf.setQueues(
-            CapacitySchedulerConfiguration.ROOT, new String[] { "default", "joe", "john" });
+            CapacitySchedulerConfiguration.ROOT, new String[] {"default", "joe", "john"});
     csConf.setCapacity(
             CapacitySchedulerConfiguration.ROOT + "." + "joe", 25);
     csConf.setCapacity(
@@ -1719,8 +1722,8 @@ public class TestWorkPreservingRMRestart extends ParameterizedSchedulerTestBase 
               PlacementManager placementManager,
               ApplicationSubmissionContext context, String user,
               boolean isRecovery) throws YarnException {
-            return super
-                .placeApplication(newMockRMContext.getQueuePlacementManager(), context, user, isRecovery);
+            return super.placeApplication(
+                    newMockRMContext.getQueuePlacementManager(), context, user, isRecovery);
           }
         };
       }


### PR DESCRIPTION
Change-Id: Ic4e5efb7fab323768efe5626dc312d40b4a8a755

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

