### PR TITLE
HDFS-17051. Fix wrong time unit in TestFileAppend4#recoverFile

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileAppend4.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileAppend4.java
@@ -106,9 +106,9 @@ public class TestFileAppend4 {
 
     // set the soft limit to be 1 second so that the
     // namenode triggers lease recovery upon append request
-    cluster.setLeasePeriod(1,
+    cluster.setLeasePeriod(1000,
         conf.getLong(DFSConfigKeys.DFS_LEASE_HARDLIMIT_KEY,
-            DFSConfigKeys.DFS_LEASE_HARDLIMIT_DEFAULT));
+            DFSConfigKeys.DFS_LEASE_HARDLIMIT_DEFAULT) * 1000);
 
     // Trying recovery
     int tries = 60;


### PR DESCRIPTION
### Description of PR
At TestFIleAppend4.java the method `recoverFile` 
`// set the soft limit to be 1 second so that the

  // namenode triggers lease recovery upon append request   

    cluster.setLeasePeriod(1,   

    conf.getLong(DFSConfigKeys.DFS_LEASE_HARDLIMIT_KEY,   

     DFSConfigKeys.DFS_LEASE_HARDLIMIT_DEFAULT));`

The notation mean setLeasePeriod of soft limit to be 1 second, but current set the soft limit to be 1ms.
### How was this patch tested?


### For code changes:

issue: https://issues.apache.org/jira/browse/HDFS-17051

