### PR TITLE
YARN-11505. [Federation] Add Steps To Set up a Test Cluster.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
@@ -385,3 +385,269 @@ The output from this particular example job should be something like:
 
 The state of the job can also be tracked on the Router Web UI at `routerhost:8089`.
 Note that no change in the code or recompilation of the input jar was required to use federation. Also, the output of this job is the exact same as it would be when run without federation. Also, in order to get the full benefit of federation, use a large enough number of mappers such that more than one cluster is required. That number happens to be 16 in the case of the above example.
+
+How to build a Test Federation Cluster
+--------------------
+
+The purpose of this document is to help users quickly set up a testing environment for YARN Federation. With this testing environment, users can utilize the core functionality of YARN Federation. This is the simplest test cluster setup (based on Linux) with only essential configurations (YARN non-HA mode). We require 3 machines, and each machine should have at least <4C, 8GB> of resources. We only cover YARN configuration in this document. For information on configuring HDFS and ZooKeeper, please refer to other documentation sources.
+
+Test Environment Description:
+- We need to build a HDFS test environment, this part can refer to HDFS documentation.
+- We need two YARN clusters, each YARN cluster has one RM and one NM, The RM and NM on the same node.
+- We need one ZK cluster(We only need one ZooKeeper node.), this part can refer to Zookeeper documentation.
+- We need one Router and one Client.
+
+Example of Machine-Role Mapping(Exclude HDFS):
+
+| Machine   | Role          | 
+|:----------|:--------------|
+| Machine A | RM1\NM1\ZK1   |                                                  |
+| Machine B | RM2\NM2       |
+| Machine C | Router\Client |
+
+### YARN-1(ClusterTest-Yarn1)
+
+####  RM-1 
+
+> For the ResourceManager, we need to configure the following option:
+
+```
+
+<!-- YARN cluster-id -->
+<property>
+  <name>yarn.resourcemanager.cluster-id</name>
+  <value>ClusterTest-Yarn1</value>
+</property>
+
+<!--
+  We can choose to use FairScheduler or CapacityScheduler. Different schedulers have different configuration.
+  FairScheduler: org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler
+  CapacityScheduler: org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler
+-->
+<property>
+  <name>yarn.resourcemanager.scheduler.class</name>
+  <value>org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler</value>
+</property>
+
+<!-- 
+ This configuration option is used to specify the configuration file for FairScheduler. 
+ If we are using CapacityScheduler, we don't need to configure this option.
+-->
+<property>
+  <name>yarn.scheduler.fair.allocation.file</name>
+  <value>/path/fair-scheduler.xml</value>
+</property>
+
+<!-- Enable YARN Federation mode -->
+<property>
+  <name>yarn.federation.enabled</name>
+  <value>true</value>
+</property>
+
+<!-- We use ZooKeeper to query/store Federation information. -->
+<property>
+  <name>yarn.federation.state-store.class</name>
+  <value>org.apache.hadoop.yarn.server.federation.store.impl.ZookeeperFederationStateStore</value>
+</property>
+
+<!-- ZK Address. -->
+<property>
+  <name>hadoop.zk.address</name>
+  <value>zkHost:zkPort</value>
+</property>
+
+```
+
+> Start RM
+
+```
+$HADOOP_HOME/bin/yarn --daemon start resourcemanager
+```
+
+#### NM-1
+
+> For the NodeManager, we need to configure the following option:
+
+```
+<!-- YARN cluster-id -->
+<property>
+  <name>yarn.resourcemanager.cluster-id</name>
+  <value>ClusterTest-Yarn1</value>
+</property>
+
+<!-- local dir -->
+<property>
+  <name>yarn.nodemanager.local-dirs</name>
+  <value>path/local</value>
+</property>
+
+<!-- log dir -->
+<property>
+  <name>yarn.nodemanager.log-dirs</name>
+  <value>path/logdir</value>
+</property>
+
+<!-- Enable YARN Federation mode -->
+<property>
+  <name>yarn.federation.enabled</name>
+  <value>true</value>
+</property>
+
+<!-- Disenable YARN Federation FailOver -->
+<property>
+  <name>yarn.federation.failover.enabled</name>
+  <value>false</value>
+</property>
+
+<!-- Enable YARN Federation Non-HA Mode -->
+<property>
+  <name>yarn.federation.non-ha.enabled</name>
+  <value>true</value>
+</property>
+
+<!-- We use ZooKeeper to query/store Federation information. -->
+<property>
+  <name>yarn.federation.state-store.class</name>
+  <value>org.apache.hadoop.yarn.server.federation.store.impl.ZookeeperFederationStateStore</value>
+</property>
+
+<!-- ZK Address. -->
+<property>
+  <name>hadoop.zk.address</name>
+  <value>zkHost:zkPort</value>
+</property>
+
+<!-- Enable AmRmProxy. -->
+<property>
+  <name>yarn.nodemanager.amrmproxy.enabled</name>
+  <value>true</value>
+</property>
+
+<!-- interceptors to be run at the amrmproxy -->
+<property>
+  <name>yarn.nodemanager.amrmproxy.interceptor-class.pipeline</name>
+  <value>org.apache.hadoop.yarn.server.nodemanager.amrmproxy.FederationInterceptor</value>
+</property>
+```
+
+> Start NM
+
+```
+$HADOOP_HOME/bin/yarn --daemon start nodemanager
+```
+
+### YARN-2(ClusterTest-Yarn2)
+
+#### RM-2
+
+The RM of the `YARN-2` cluster is configured the same as the RM of `YARN-1` except for the `cluster-id`
+
+```
+<property>
+  <name>yarn.resourcemanager.cluster-id</name>
+  <value>ClusterTest-Yarn2</value>
+</property>
+```
+
+#### NM-2
+
+The NM of the `YARN-2` cluster is configured the same as the RM of `YARN-1` except for the `cluster-id`
+
+```
+<property>
+  <name>yarn.resourcemanager.cluster-id</name>
+  <value>ClusterTest-Yarn2</value>
+</property>
+```
+
+After we have finished configuring the `YARN-2` cluster, we can proceed with starting the `YARN-2` cluster.
+
+### ROUTER
+
+> For the Router, we need to configure the following option:
+
+```
+<!-- Enable YARN Federation mode -->
+<property>
+  <name>yarn.federation.enabled</name>
+  <value>true</value>
+</property>
+
+<!-- We use ZooKeeper to query/store Federation information. -->
+<property>
+  <name>yarn.federation.state-store.class</name>
+  <value>org.apache.hadoop.yarn.server.federation.store.impl.ZookeeperFederationStateStore</value>
+</property>
+
+<!-- ZK Address. -->
+<property>
+  <name>hadoop.zk.address</name>
+  <value>zkHost:zkPort</value>
+</property>
+
+<!-- Configure the FederationClientInterceptor -->
+<property>
+  <name>yarn.router.clientrm.interceptor-class.pipeline</name>
+  <value>org.apache.hadoop.yarn.server.router.clientrm.FederationClientInterceptor</value>
+</property>
+
+<!-- Configure the FederationInterceptorREST -->
+<property>
+  <name>yarn.router.webapp.interceptor-class.pipeline</name>
+  <value>org.apache.hadoop.yarn.server.router.webapp.FederationInterceptorREST</value>
+</property>
+
+<!-- Configure the FederationRMAdminInterceptor -->
+<property>
+  <name>yarn.router.rmadmin.interceptor-class.pipeline</name>
+  <value>org.apache.hadoop.yarn.server.router.rmadmin.FederationRMAdminInterceptor</value>
+</property>
+```
+
+> Start Router
+
+```
+$HADOOP_HOME/bin/yarn --daemon start router
+```
+
+### YARN-CLIENT
+
+> For the Yarn-Client, we need to configure the following option:
+
+```
+
+<!-- Enable YARN Federation mode -->
+<property>
+  <name>yarn.federation.enabled</name>
+  <value>true</value>
+</property>
+
+<!-- Disenable YARN Federation FailOver -->
+<property>
+  <name>yarn.federation.failover.enabled</name>
+  <value>false</value>
+</property>
+
+<!-- Configure yarn.resourcemanager.address, 
+   We need to set it to the router address -->
+<property>
+  <name>yarn.resourcemanager.address</name>
+  <value>router-1-Host:8050</value>
+</property>
+
+<!-- Configure yarn.resourcemanager.admin.address, 
+   We need to set it to the router address -->
+<property>
+  <name>yarn.resourcemanager.admin.address</name>
+  <value>router-1-Host:8052</value>
+</property>
+
+<!-- Configure yarn.resourcemanager.scheduler.address, 
+   We need to set it to the AMRMProxy address -->
+<property>
+  <name>yarn.resourcemanager.scheduler.address</name>
+  <value>localhost:8049</value>
+</property>
+```
+
+After we build the test cluster, we can try to submit MR Jobs or Spark Jobs.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
@@ -392,26 +392,26 @@ How to build a Test Federation Cluster
 The purpose of this document is to help users quickly set up a testing environment for YARN Federation. With this testing environment, users can utilize the core functionality of YARN Federation. This is the simplest test cluster setup (based on Linux) with only essential configurations (YARN non-HA mode). We require 3 machines, and each machine should have at least <4C, 8GB> of resources. We only cover YARN configuration in this document. For information on configuring HDFS and ZooKeeper, please refer to other documentation sources.
 
 Test Environment Description:
-- We need to build a HDFS test environment, this part can refer to HDFS documentation.
+- We need to build a HDFS test environment, this part can refer to HDFS documentation. [HDFS SingleCluster](../../hadoop-project-dist/hadoop-common/SingleCluster.html)
 - We need two YARN clusters, each YARN cluster has one RM and one NM, The RM and NM on the same node.
-- We need one ZK cluster(We only need one ZooKeeper node.), this part can refer to Zookeeper documentation.
+- We need one ZK cluster(We only need one ZooKeeper node.), this part can refer to Zookeeper documentation. [ZookeeperStarted](https://zookeeper.apache.org/doc/current/zookeeperStarted.html)
 - We need one Router and one Client.
 
 Example of Machine-Role Mapping(Exclude HDFS):
 
-| Machine   | Role          | 
+| Machine   | Role          |
 |:----------|:--------------|
-| Machine A | RM1\NM1\ZK1   |                                                  |
+| Machine A | RM1\NM1\ZK1   |
 | Machine B | RM2\NM2       |
 | Machine C | Router\Client |
 
 ### YARN-1(ClusterTest-Yarn1)
 
-####  RM-1 
+####  RM-1
 
-> For the ResourceManager, we need to configure the following option:
+- For the ResourceManager, we need to configure the following option:
 
-```
+```xml
 
 <!-- YARN cluster-id -->
 <property>
@@ -429,8 +429,8 @@ Example of Machine-Role Mapping(Exclude HDFS):
   <value>org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler</value>
 </property>
 
-<!-- 
- This configuration option is used to specify the configuration file for FairScheduler. 
+<!--
+ This configuration option is used to specify the configuration file for FairScheduler.
  If we are using CapacityScheduler, we don't need to configure this option.
 -->
 <property>
@@ -458,7 +458,7 @@ Example of Machine-Role Mapping(Exclude HDFS):
 
 ```
 
-> Start RM
+- Start RM
 
 ```
 $HADOOP_HOME/bin/yarn --daemon start resourcemanager
@@ -466,9 +466,9 @@ $HADOOP_HOME/bin/yarn --daemon start resourcemanager
 
 #### NM-1
 
-> For the NodeManager, we need to configure the following option:
+- For the NodeManager, we need to configure the following option:
 
-```
+```xml
 <!-- YARN cluster-id -->
 <property>
   <name>yarn.resourcemanager.cluster-id</name>
@@ -530,7 +530,7 @@ $HADOOP_HOME/bin/yarn --daemon start resourcemanager
 </property>
 ```
 
-> Start NM
+- Start NM
 
 ```
 $HADOOP_HOME/bin/yarn --daemon start nodemanager
@@ -542,7 +542,7 @@ $HADOOP_HOME/bin/yarn --daemon start nodemanager
 
 The RM of the `YARN-2` cluster is configured the same as the RM of `YARN-1` except for the `cluster-id`
 
-```
+```xml
 <property>
   <name>yarn.resourcemanager.cluster-id</name>
   <value>ClusterTest-Yarn2</value>
@@ -553,7 +553,7 @@ The RM of the `YARN-2` cluster is configured the same as the RM of `YARN-1` exce
 
 The NM of the `YARN-2` cluster is configured the same as the RM of `YARN-1` except for the `cluster-id`
 
-```
+```xml
 <property>
   <name>yarn.resourcemanager.cluster-id</name>
   <value>ClusterTest-Yarn2</value>
@@ -562,11 +562,11 @@ The NM of the `YARN-2` cluster is configured the same as the RM of `YARN-1` exce
 
 After we have finished configuring the `YARN-2` cluster, we can proceed with starting the `YARN-2` cluster.
 
-### ROUTER
+### Router
 
-> For the Router, we need to configure the following option:
+- For the Router, we need to configure the following option:
 
-```
+```xml
 <!-- Enable YARN Federation mode -->
 <property>
   <name>yarn.federation.enabled</name>
@@ -604,17 +604,17 @@ After we have finished configuring the `YARN-2` cluster, we can proceed with sta
 </property>
 ```
 
-> Start Router
+- Start Router
 
 ```
 $HADOOP_HOME/bin/yarn --daemon start router
 ```
 
-### YARN-CLIENT
+### Yarn-Client
 
-> For the Yarn-Client, we need to configure the following option:
+- For the Yarn-Client, we need to configure the following option:
 
-```
+```xml
 
 <!-- Enable YARN Federation mode -->
 <property>
@@ -628,26 +628,24 @@ $HADOOP_HOME/bin/yarn --daemon start router
   <value>false</value>
 </property>
 
-<!-- Configure yarn.resourcemanager.address, 
+<!-- Configure yarn.resourcemanager.address,
    We need to set it to the router address -->
 <property>
   <name>yarn.resourcemanager.address</name>
   <value>router-1-Host:8050</value>
 </property>
 
-<!-- Configure yarn.resourcemanager.admin.address, 
+<!-- Configure yarn.resourcemanager.admin.address,
    We need to set it to the router address -->
 <property>
   <name>yarn.resourcemanager.admin.address</name>
   <value>router-1-Host:8052</value>
 </property>
 
-<!-- Configure yarn.resourcemanager.scheduler.address, 
+<!-- Configure yarn.resourcemanager.scheduler.address,
    We need to set it to the AMRMProxy address -->
 <property>
   <name>yarn.resourcemanager.scheduler.address</name>
   <value>localhost:8049</value>
 </property>
 ```
-
-After we build the test cluster, we can try to submit MR Jobs or Spark Jobs.


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11505. [Federation] Add Steps To Set up a Test Cluster.

According to the current YARN Federation documentation, users have difficulties setting up a test cluster (due to too many configurations that are needed). This JIRA will improve the documentation so that users can quickly set up a YARN Federation test cluster by following the steps in the documentation.

We can check this link:
https://issues.apache.org/jira/secure/attachment/13059110/Federation-v2-1.png

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

