### PR TITLE
YARN-11516. [Minor]Improve existsApplicationHomeSubCluster/existsReservationHomeSubCluster Log Level.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
@@ -806,7 +806,7 @@ public final class FederationStateStoreFacade {
         return true;
       }
     } catch (YarnException e) {
-      LOG.warn("get homeSubCluster by applicationId = {} error.", applicationId, e);
+      LOG.debug("get homeSubCluster by applicationId = {} error.", applicationId, e);
     }
     return false;
   }
@@ -893,7 +893,7 @@ public final class FederationStateStoreFacade {
         return true;
       }
     } catch (YarnException e) {
-      LOG.warn("get homeSubCluster by reservationId = {} error.", reservationId, e);
+      LOG.debug("get homeSubCluster by reservationId = {} error.", reservationId, e);
     }
     return false;
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: YARN-11516. Improve existsApplicationHomeSubCluster/existsReservationHomeSubCluster Log Level.

The method FederationStateStoreFacade#existsApplicationHomeSubCluster is used to determine whether an application has a HomeSubCluster assigned. If the HomeSubCluster is not found, we currently log a warning message. However, during the first submission of an application, it is normal for the corresponding HomeSubCluster not to exist. This warning message might mislead users into thinking that an exception occurred. To address this, we should change the logging format of this message to "debug".

FederationStateStoreFacade#existsReservationHomeSubCluster also needs to change the log level for the same reason.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

