### PR TITLE
HADOOP-18780. Add tags 3.3/3.3.5 to the official Hadoop docker image.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,4 +24,4 @@ if [ ! -d "$DIR/build/apache-rat-0.15" ]; then
 	cd -
 fi
 java -jar $DIR/build/apache-rat-0.15/apache-rat-0.15.jar $DIR -e public -e apache-rat-0.15 -e .git -e .gitignore
-docker build -t apache/hadoop:3 .
+docker build -t apache/hadoop:3 -t apache/hadoop:3.3 -t apache/hadoop:3.3.5 .


### PR DESCRIPTION
### Description of PR
Add additional tags to the Hadoop docker images.

### How was this patch tested?
Manually tested locally.

> $ docker images apache/hadoop
> REPOSITORY      TAG       IMAGE ID       CREATED             SIZE
> apache/hadoop   3         ac9fc979c212   About an hour ago   1.64GB
> apache/hadoop   3.3       ac9fc979c212   About an hour ago   1.64GB
> apache/hadoop   3.3.5     ac9fc979c212   About an hour ago   1.64GB

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

