### PR TITLE
YARN-11517. Improve Federation#RouterCLI DeregisterSubCluster Code.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/QueueCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/QueueCLI.java
@@ -49,7 +49,7 @@ public class QueueCLI extends YarnCLI {
 
   public static final String ALLTAG = "all";
 
-  public static void main(String[] args) throws Exception {
+  public static void main(String[]  args) throws Exception {
     QueueCLI cli = new QueueCLI();
     cli.setSysOutPrintStream(System.out);
     cli.setSysErrPrintStream(System.err);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/QueueCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/QueueCLI.java
@@ -49,7 +49,7 @@ public class QueueCLI extends YarnCLI {
 
   public static final String ALLTAG = "all";
 
-  public static void main(String[]  args) throws Exception {
+  public static void main(String[] args) throws Exception {
     QueueCLI cli = new QueueCLI();
     cli.setSysOutPrintStream(System.out);
     cli.setSysErrPrintStream(System.err);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
@@ -63,8 +63,10 @@ public class RouterCLI extends Configured implements Tool {
   private static final int EXIT_ERROR = -1;
 
   // Command1: deregisterSubCluster
-  // Title information
-  List<String> DEREGISTER_SUBCLUSTER_HEADER = Arrays.asList(
+  private static final String DEREGISTER_SUBCLUSTER_TITLE =
+      "Yarn Federation Deregister SubCluster";
+  // Columns information
+  private static final List<String> DEREGISTER_SUBCLUSTER_HEADER = Arrays.asList(
       "SubCluster Id", "Deregister State", "Last HeartBeatTime", "Information", "SubCluster State");
   // Constant
   private static final String OPTION_SC = "sc";
@@ -176,18 +178,31 @@ public class RouterCLI extends Configured implements Tool {
     ToolRunner.printGenericCommandUsage(System.err);
   }
 
+  /**
+   * According to the parameter Deregister SubCluster.
+   *
+   * @param args parameter array.
+   * @return If the Deregister SubCluster operation is successful,
+   * it will return 0. Otherwise, it will return -1.
+   *
+   * @throws IOException raised on errors performing I/O.
+   * @throws YarnException exceptions from yarn servers.
+   * @throws ParseException Exceptions thrown during parsing of a command-line.
+   */
   private int handleDeregisterSubCluster(String[] args)
       throws IOException, YarnException, ParseException {
 
+    // Prepare Options.
     Options opts = new Options();
     opts.addOption("deregisterSubCluster", false,
-        "Deregister YARN SubCluster if its heartbeat timeout exceeds half an hour.");
+        "Deregister YARN subCluster, if subCluster Heartbeat Timeout.");
     Option subClusterOpt = new Option(OPTION_SC, OPTION_SUBCLUSTERID, true,
-        "The sub-cluster can be specified using either the '-sc' or '--subCluster' option. " +
-         " If a sub-cluster fails to report a heartbeat for more than half an hour, it will be marked as 'SC_LOST'.");
+        "The subCluster can be specified using either the '-sc' or '--subCluster' option. " +
+         " If the subCluster's Heartbeat Timeout, it will be marked as 'SC_LOST'.");
     subClusterOpt.setOptionalArg(true);
     opts.addOption(subClusterOpt);
 
+    // Parse command line arguments.
     CommandLine cliParser;
     try {
       cliParser = new GnuParser().parse(opts, args);
@@ -197,6 +212,7 @@ public class RouterCLI extends Configured implements Tool {
       return EXIT_ERROR;
     }
 
+    // Try to parse the subClusterId.
     String subClusterId = null;
     if (cliParser.hasOption(OPTION_SC) || cliParser.hasOption(OPTION_SUBCLUSTERID)) {
       subClusterId = cliParser.getOptionValue(OPTION_SC);
@@ -205,6 +221,8 @@ public class RouterCLI extends Configured implements Tool {
       }
     }
 
+    // If subClusterId is not empty, try deregisterSubCluster subCluster,
+    // otherwise try deregisterSubCluster all subCluster.
     if (StringUtils.isNotBlank(subClusterId)) {
       return deregisterSubCluster(subClusterId);
     } else {
@@ -220,7 +238,7 @@ public class RouterCLI extends Configured implements Tool {
     DeregisterSubClusterRequest request =
         DeregisterSubClusterRequest.newInstance(subClusterId);
     DeregisterSubClusterResponse response = adminProtocol.deregisterSubCluster(request);
-    FormattingCLIUtils formattingCLIUtils = new FormattingCLIUtils("Yarn Federation Deregister SubCluster")
+    FormattingCLIUtils formattingCLIUtils = new FormattingCLIUtils(DEREGISTER_SUBCLUSTER_TITLE)
         .addHeaders(DEREGISTER_SUBCLUSTER_HEADER);
     List<DeregisterSubClusters> deregisterSubClusters = response.getDeregisterSubClusters();
     deregisterSubClusters.forEach(deregisterSubCluster -> {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestRouterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestRouterCLI.java
@@ -103,15 +103,17 @@ public class TestRouterCLI {
 
   @Test
   public void testHelp() throws Exception {
-    PrintStream oldOutPrintStream = System.out;
-    PrintStream oldErrPrintStream = System.err;
     ByteArrayOutputStream dataOut = new ByteArrayOutputStream();
     ByteArrayOutputStream dataErr = new ByteArrayOutputStream();
     System.setOut(new PrintStream(dataOut));
     System.setErr(new PrintStream(dataErr));
 
     String[] args = {"-help"};
+    rmAdminCLI.run(args);
     assertEquals(0, rmAdminCLI.run(args));
+
+    args = new String[]{"-help", "-deregisterSubCluster"};
+    rmAdminCLI.run(args);
   }
 
   @Test
@@ -120,7 +122,10 @@ public class TestRouterCLI {
     ByteArrayOutputStream dataOut = new ByteArrayOutputStream();
     System.setOut(new PrintStream(dataOut));
     oldOutPrintStream.println(dataOut);
-    String[] args = {"-deregisterSubCluster", "-c", "SC-1"};
+    String[] args = {"-deregisterSubCluster", "-sc", "SC-1"};
+    assertEquals(0, rmAdminCLI.run(args));
+
+    args = new String[]{"-deregisterSubCluster", "--subClusterId", "SC-1"};
     assertEquals(0, rmAdminCLI.run(args));
   }
 
@@ -134,10 +139,17 @@ public class TestRouterCLI {
     String[] args = {"-deregisterSubCluster"};
     assertEquals(0, rmAdminCLI.run(args));
 
-    args = new String[]{"-deregisterSubCluster", "-c"};
+    args = new String[]{"-deregisterSubCluster", "-sc"};
     assertEquals(0, rmAdminCLI.run(args));
 
-    args = new String[]{"-deregisterSubCluster", "-c", ""};
+    args = new String[]{"-deregisterSubCluster", "--sc", ""};
     assertEquals(0, rmAdminCLI.run(args));
+
+    args = new String[]{"-deregisterSubCluster", "--subClusterId"};
+    assertEquals(0, rmAdminCLI.run(args));
+
+    args = new String[]{"-deregisterSubCluster", "--subClusterId", ""};
+    assertEquals(0, rmAdminCLI.run(args));
+
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/FederationRMAdminInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/FederationRMAdminInterceptor.java
@@ -879,8 +879,6 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
       SubClusterState subClusterState = subClusterInfo.getState();
       long lastHeartBeat = subClusterInfo.getLastHeartBeat();
       Date lastHeartBeatDate = new Date(lastHeartBeat);
-      String heartBeatTimeOut =
-          conf.get(YarnConfiguration.ROUTER_SUBCLUSTER_EXPIRATION_TIME, "30m");
       deregisterSubClusters = DeregisterSubClusters.newInstance(
           reqSubClusterId, "NONE", lastHeartBeatDate.toString(),
           "Normal Heartbeat", subClusterState.name());
@@ -897,7 +895,8 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
           if (deregisterSubClusterFlag) {
             deregisterSubClusters.setDeregisterState("SUCCESS");
             deregisterSubClusters.setSubClusterState("SC_LOST");
-            deregisterSubClusters.setInformation("Heartbeat Time >= " + heartBeatTimeOut);
+            deregisterSubClusters.setInformation("Heartbeat Time >= " +
+                heartbeatExpirationMillis / (1000 * 60) + "minutes");
           } else {
             deregisterSubClusters.setDeregisterState("FAILED");
             deregisterSubClusters.setInformation("DeregisterSubClusters Failed.");
@@ -905,9 +904,9 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
         }
       } else {
         deregisterSubClusters.setDeregisterState("FAILED");
-        deregisterSubClusters.setInformation("Heartbeat Time < " + heartBeatTimeOut +
-            "DeregisterSubCluster does not need to be executed");
-        LOG.warn("SubCluster {} in State {} does not need to update state.",
+        deregisterSubClusters.setInformation("The subCluster is Unusable, " +
+            "So it can't be Deregistered");
+        LOG.warn("The SubCluster {} is Unusable (SubClusterState:{}), So it can't be Deregistered",
             subClusterId, subClusterState);
       }
       return deregisterSubClusters;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/FederationRMAdminInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/FederationRMAdminInterceptor.java
@@ -870,7 +870,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
    */
   private DeregisterSubClusters deregisterSubCluster(String reqSubClusterId) {
 
-    DeregisterSubClusters deregisterSubClusters = null;
+    DeregisterSubClusters deregisterSubClusters;
 
     try {
       // Step1. Get subCluster information.
@@ -879,9 +879,11 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
       SubClusterState subClusterState = subClusterInfo.getState();
       long lastHeartBeat = subClusterInfo.getLastHeartBeat();
       Date lastHeartBeatDate = new Date(lastHeartBeat);
-
+      String heartBeatTimeOut =
+          conf.get(YarnConfiguration.ROUTER_SUBCLUSTER_EXPIRATION_TIME, "30m");
       deregisterSubClusters = DeregisterSubClusters.newInstance(
-              reqSubClusterId, "UNKNOWN", lastHeartBeatDate.toString(), "", subClusterState.name());
+          reqSubClusterId, "NONE", lastHeartBeatDate.toString(),
+          "Normal Heartbeat", subClusterState.name());
 
       // Step2. Deregister subCluster.
       if (subClusterState.isUsable()) {
@@ -891,11 +893,11 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
         long heartBearTimeInterval = Time.now() - lastHeartBeat;
         if (heartBearTimeInterval - heartbeatExpirationMillis < 0) {
           boolean deregisterSubClusterFlag =
-                  federationFacade.deregisterSubCluster(subClusterId, SubClusterState.SC_LOST);
+              federationFacade.deregisterSubCluster(subClusterId, SubClusterState.SC_LOST);
           if (deregisterSubClusterFlag) {
             deregisterSubClusters.setDeregisterState("SUCCESS");
             deregisterSubClusters.setSubClusterState("SC_LOST");
-            deregisterSubClusters.setInformation("Heartbeat Time >= 30 minutes.");
+            deregisterSubClusters.setInformation("Heartbeat Time >= " + heartBeatTimeOut);
           } else {
             deregisterSubClusters.setDeregisterState("FAILED");
             deregisterSubClusters.setInformation("DeregisterSubClusters Failed.");
@@ -903,16 +905,16 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
         }
       } else {
         deregisterSubClusters.setDeregisterState("FAILED");
-        deregisterSubClusters.setInformation("Heartbeat Time < 30 minutes. " +
+        deregisterSubClusters.setInformation("Heartbeat Time < " + heartBeatTimeOut +
             "DeregisterSubCluster does not need to be executed");
         LOG.warn("SubCluster {} in State {} does not need to update state.",
-                subClusterId, subClusterState);
+            subClusterId, subClusterState);
       }
       return deregisterSubClusters;
     } catch (YarnException e) {
       LOG.error("SubCluster {} DeregisterSubCluster Failed", reqSubClusterId, e);
       deregisterSubClusters = DeregisterSubClusters.newInstance(
-              reqSubClusterId, "FAILED", "UNKNOWN", e.getMessage(), "UNKNOWN");
+          reqSubClusterId, "FAILED", "UNKNOWN", e.getMessage(), "UNKNOWN");
       return deregisterSubClusters;
     }
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11517. Improve Federation#RouterCLI deregisterSubCluster Code.

In this pr, we have made improvements to the code of RouterCLI#DeregisterSubCluster, enhancing its readability. Additionally, we have optimized the output infomation style by presenting the data in a tabular format.

<img width="953" alt="image" src="https://github.com/apache/hadoop/assets/55643692/ca929e92-a456-4fac-91b4-2d6a48e3cf3d">


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

