### PR TITLE
HADOOP-18782 upgrade to snappy-java 1.1.10.1 due to CVEs

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -361,7 +361,7 @@ org.jetbrains.kotlin:kotlin-stdlib:1.4.10
 org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10
 org.lz4:lz4-java:1.7.1
 org.objenesis:objenesis:2.6
-org.xerial.snappy:snappy-java:1.0.5
+org.xerial.snappy:snappy-java:1.1.10.1
 org.yaml:snakeyaml:2.0
 org.wildfly.openssl:wildfly-openssl:1.1.3.Final
 

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -140,7 +140,7 @@
     <gson.version>2.9.0</gson.version>
     <metrics.version>3.2.4</metrics.version>
     <netty4.version>4.1.89.Final</netty4.version>
-    <snappy-java.version>1.1.8.2</snappy-java.version>
+    <snappy-java.version>1.1.10.1</snappy-java.version>
     <lz4-java.version>1.7.1</lz4-java.version>
 
     <!-- Maven protoc compiler -->


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

upgrade to snappy-java 1.1.10.1 due to CVEs

### How was this patch tested?

CI build

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

