### PR TITLE
HADOOP-18769. Upgrade hadoop3 docker scripts to use 3.3.6.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM apache/hadoop-runner
-ARG HADOOP_URL=https://dlcdn.apache.org/hadoop/common/hadoop-3.3.5/hadoop-3.3.5.tar.gz
+ARG HADOOP_URL=https://dlcdn.apache.org/hadoop/common/hadoop-3.3.6/hadoop-3.3.6.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && curl -LSs -o hadoop.tar.gz $HADOOP_URL && tar zxf hadoop.tar.gz && rm hadoop.tar.gz && mv hadoop* hadoop && rm -rf /opt/hadoop/share/doc
 WORKDIR /opt/hadoop

--- a/build.sh
+++ b/build.sh
@@ -24,4 +24,4 @@ if [ ! -d "$DIR/build/apache-rat-0.15" ]; then
 	cd -
 fi
 java -jar $DIR/build/apache-rat-0.15/apache-rat-0.15.jar $DIR -e public -e apache-rat-0.15 -e .git -e .gitignore
-docker build -t apache/hadoop:3 -t apache/hadoop:3.3 -t apache/hadoop:3.3.5 .
+docker build -t apache/hadoop:3 .


### PR DESCRIPTION
### Description of PR
Upate apache/hadoop docker image to build using Hadoop 3.3.6.

### How was this patch tested?
Ran locally.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

