### PR TITLE
YARN-9877 - Intermittent TIME_OUT of LogAggregationReport

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
@@ -1088,7 +1088,7 @@ public class RMAppImpl implements RMApp, Recoverable {
       // otherwise, add it to ranNodes for further process
       app.ranNodes.add(nodeAddedEvent.getNodeId());
 
-      if (!nodeAddedEvent.isFromAcquiredState()) {
+      if (!nodeAddedEvent.isInAcquiredState()) {
         app.logAggregation.addReportIfNecessary(
             nodeAddedEvent.getNodeId(), app.getApplicationId());
       } else {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
@@ -1092,10 +1092,8 @@ public class RMAppImpl implements RMApp, Recoverable {
         app.logAggregation.addReportIfNecessary(
             nodeAddedEvent.getNodeId(), app.getApplicationId());
       } else {
-        LOG.warn(String.format("Not considering container for log aggregation "
-                + "while app is transitioning from ACQUIRED directly to RELEASED "
-                + "for nodeId: %s and appId: %s",
-            nodeAddedEvent.getNodeId(), app.getApplicationId()));
+        LOG.debug("Not considering node for log aggregation yet. nodeId: {}, appId: {}",
+            nodeAddedEvent.getNodeId(), app.getApplicationId());
       }
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
@@ -1088,12 +1088,13 @@ public class RMAppImpl implements RMApp, Recoverable {
       // otherwise, add it to ranNodes for further process
       app.ranNodes.add(nodeAddedEvent.getNodeId());
 
-      if (!nodeAddedEvent.isInAcquiredState()) {
+      if (!nodeAddedEvent.isCreatedFromAcquiredState()) {
         app.logAggregation.addReportIfNecessary(
             nodeAddedEvent.getNodeId(), app.getApplicationId());
       } else {
         LOG.warn(String.format("Not considering container for log aggregation "
-                + "while it is in an ACQUIRED state for nodeId: %s and appId: %s",
+                + "while app is transitioning from ACQUIRED directly to RELEASED "
+                + "for nodeId: %s and appId: %s",
             nodeAddedEvent.getNodeId(), app.getApplicationId()));
       }
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
@@ -1088,13 +1088,13 @@ public class RMAppImpl implements RMApp, Recoverable {
       // otherwise, add it to ranNodes for further process
       app.ranNodes.add(nodeAddedEvent.getNodeId());
 
-      app.logAggregation.addReportIfNecessary(
-          nodeAddedEvent.getNodeId(), app.getApplicationId());
-
       if (!nodeAddedEvent.isFromAcquiredState()) {
         app.logAggregation.addReportIfNecessary(
             nodeAddedEvent.getNodeId(), app.getApplicationId());
-        }
+      } else {
+        LOG.warn(String.format("Log aggregation will be skipped for nodeId: %s and appId: %s",
+            nodeAddedEvent.getNodeId(), app.getApplicationId()));
+      }
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
@@ -1090,6 +1090,11 @@ public class RMAppImpl implements RMApp, Recoverable {
 
       app.logAggregation.addReportIfNecessary(
           nodeAddedEvent.getNodeId(), app.getApplicationId());
+
+      if (!nodeAddedEvent.isFromAcquiredState()) {
+        app.logAggregation.addReportIfNecessary(
+            nodeAddedEvent.getNodeId(), app.getApplicationId());
+        }
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
@@ -1092,7 +1092,8 @@ public class RMAppImpl implements RMApp, Recoverable {
         app.logAggregation.addReportIfNecessary(
             nodeAddedEvent.getNodeId(), app.getApplicationId());
       } else {
-        LOG.warn(String.format("Log aggregation will be skipped for nodeId: %s and appId: %s",
+        LOG.warn(String.format("Not considering container for log aggregation "
+                + "while it is in an ACQUIRED state for nodeId: %s and appId: %s",
             nodeAddedEvent.getNodeId(), app.getApplicationId()));
       }
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppRunningOnNodeEvent.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppRunningOnNodeEvent.java
@@ -23,13 +23,23 @@ import org.apache.hadoop.yarn.api.records.NodeId;
 
 public class RMAppRunningOnNodeEvent extends RMAppEvent {
   private final NodeId node;
+  private final boolean fromAcquiredState;
 
   public RMAppRunningOnNodeEvent(ApplicationId appId, NodeId node) {
+    this(appId, node, false);
+  }
+
+  public RMAppRunningOnNodeEvent(ApplicationId appId, NodeId node, boolean fromAcquiredState) {
     super(appId, RMAppEventType.APP_RUNNING_ON_NODE);
     this.node = node;
+    this.fromAcquiredState = fromAcquiredState;
   }
   
   public NodeId getNodeId() {
     return node;
+  }
+
+  public boolean isFromAcquiredState() {
+    return fromAcquiredState;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppRunningOnNodeEvent.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppRunningOnNodeEvent.java
@@ -23,23 +23,23 @@ import org.apache.hadoop.yarn.api.records.NodeId;
 
 public class RMAppRunningOnNodeEvent extends RMAppEvent {
   private final NodeId node;
-  private final boolean fromAcquiredState;
+  private final boolean inAcquiredState;
 
   public RMAppRunningOnNodeEvent(ApplicationId appId, NodeId node) {
     this(appId, node, false);
   }
 
-  public RMAppRunningOnNodeEvent(ApplicationId appId, NodeId node, boolean fromAcquiredState) {
+  public RMAppRunningOnNodeEvent(ApplicationId appId, NodeId node, boolean inAcquiredState) {
     super(appId, RMAppEventType.APP_RUNNING_ON_NODE);
     this.node = node;
-    this.fromAcquiredState = fromAcquiredState;
+    this.inAcquiredState = inAcquiredState;
   }
   
   public NodeId getNodeId() {
     return node;
   }
 
-  public boolean isFromAcquiredState() {
-    return fromAcquiredState;
+  public boolean isInAcquiredState() {
+    return inAcquiredState;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppRunningOnNodeEvent.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppRunningOnNodeEvent.java
@@ -30,7 +30,9 @@ public class RMAppRunningOnNodeEvent extends RMAppEvent {
   }
 
   public RMAppRunningOnNodeEvent(
-      ApplicationId appId, NodeId node, boolean createdFromAcquiredState
+      ApplicationId appId,
+      NodeId node,
+      boolean createdFromAcquiredState
   ) {
     super(appId, RMAppEventType.APP_RUNNING_ON_NODE);
     this.node = node;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppRunningOnNodeEvent.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppRunningOnNodeEvent.java
@@ -23,23 +23,25 @@ import org.apache.hadoop.yarn.api.records.NodeId;
 
 public class RMAppRunningOnNodeEvent extends RMAppEvent {
   private final NodeId node;
-  private final boolean inAcquiredState;
+  private final boolean createdFromAcquiredState;
 
   public RMAppRunningOnNodeEvent(ApplicationId appId, NodeId node) {
     this(appId, node, false);
   }
 
-  public RMAppRunningOnNodeEvent(ApplicationId appId, NodeId node, boolean inAcquiredState) {
+  public RMAppRunningOnNodeEvent(
+      ApplicationId appId, NodeId node, boolean createdFromAcquiredState
+  ) {
     super(appId, RMAppEventType.APP_RUNNING_ON_NODE);
     this.node = node;
-    this.inAcquiredState = inAcquiredState;
+    this.createdFromAcquiredState = createdFromAcquiredState;
   }
   
   public NodeId getNodeId() {
     return node;
   }
 
-  public boolean isInAcquiredState() {
-    return inAcquiredState;
+  public boolean isCreatedFromAcquiredState() {
+    return createdFromAcquiredState;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmcontainer/RMContainerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmcontainer/RMContainerImpl.java
@@ -606,7 +606,7 @@ public class RMContainerImpl implements RMContainer {
 
       // Tell the app
       container.eventHandler.handle(new RMAppRunningOnNodeEvent(container
-          .getApplicationAttemptId().getApplicationId(), container.nodeId));
+          .getApplicationAttemptId().getApplicationId(), container.nodeId, false));
 
       // Opportunistic containers move directly from NEW to ACQUIRED
       if (container.getState() == RMContainerState.NEW) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmcontainer/RMContainerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmcontainer/RMContainerImpl.java
@@ -606,7 +606,7 @@ public class RMContainerImpl implements RMContainer {
 
       // Tell the app
       container.eventHandler.handle(new RMAppRunningOnNodeEvent(container
-          .getApplicationAttemptId().getApplicationId(), container.nodeId, false));
+          .getApplicationAttemptId().getApplicationId(), container.nodeId, true));
 
       // Opportunistic containers move directly from NEW to ACQUIRED
       if (container.getState() == RMContainerState.NEW) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/TestRMAppTransitions.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/TestRMAppTransitions.java
@@ -965,13 +965,13 @@ public class TestRMAppTransitions {
 
   @Test
   public void testAcquiredReleased() throws IOException {
-    RMApp application = testCreateAppAccepted(null);
+    RMApp application = testCreateAppSubmittedNoRecovery(null);
     NodeId nodeId = NodeId.newInstance("host", 1234);
     application.handle(
         new RMAppRunningOnNodeEvent(application.getApplicationId(), nodeId, true));
     Map<NodeId, LogAggregationReport> logAggregationReportsForApp =
         application.getLogAggregationReportsForApp();
-    assertEquals(1, logAggregationReportsForApp.size());
+    assertEquals(0, logAggregationReportsForApp.size());
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/TestRMAppTransitions.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/TestRMAppTransitions.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.yarn.api.records.impl.pb.ApplicationSubmissionContextPB
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.event.DrainDispatcher;
 import org.apache.hadoop.yarn.event.EventHandler;
+import org.apache.hadoop.yarn.server.api.protocolrecords.LogAggregationReport;
 import org.apache.hadoop.yarn.server.resourcemanager.ApplicationMasterService;
 import org.apache.hadoop.yarn.server.resourcemanager.RMAppManagerEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.RMAppManagerEventType;
@@ -960,6 +961,17 @@ public class TestRMAppTransitions {
     rmDispatcher.await();
     assertAppState(RMAppState.ACCEPTED, application);
     assertAppStateLaunchTimeSaved(1234L);
+  }
+
+  @Test
+  public void testAcquiredReleased() throws IOException {
+    RMApp application = testCreateAppAccepted(null);
+    NodeId nodeId = NodeId.newInstance("host", 1234);
+    application.handle(
+        new RMAppRunningOnNodeEvent(application.getApplicationId(), nodeId, true));
+    Map<NodeId, LogAggregationReport> logAggregationReportsForApp =
+        application.getLogAggregationReportsForApp();
+    assertEquals(1, logAggregationReportsForApp.size());
   }
 
   @Test


### PR DESCRIPTION
In case of ACQUIRED -> RELEASED transition the LOG aggregation will time out for container.
(Based on  @adamantal works, thanks for it.)

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

