### PR TITLE
HADOOP-18764. fs.azure.buffer.dir to be under Yarn container path on yarn applications 

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2133,9 +2133,11 @@ The switch to turn S3A auditing on or off.
 
   <property>
     <name>fs.azure.buffer.dir</name>
-    <value>${hadoop.tmp.dir}/abfs</value>
+    <value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/abfs</value>
     <description>Directory path for buffer files needed to upload data blocks
-      in AbfsOutputStream.</description>
+      in AbfsOutputStream.
+      Yarn container path will be used as default value on yarn applications,
+      otherwise fall back to hadoop.tmp.dir </description>
   </property>
 
 <property>


### PR DESCRIPTION
Changing fs.azure.buffer.dir for azure so things clean up better in long-lived yarn clusters.

Contributed by: Mehakmeet Singh

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
backport to branch-3.3 from #5737 

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

