### PR TITLE
HDFS-17062. HA NameNode Web UI should show last HA Transition time

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
@@ -196,6 +196,9 @@
 {#fsn}
   <tr><th>Last Checkpoint Time</th><td>{@if cond="{LastCheckpointTime} === 0"}Never{:else}{LastCheckpointTime|date_tostring}{/if}</td></tr>
 {/fsn}
+{#nnstat}
+  <tr><th>Last HA Transition Time</th><td>{@if cond="{LastHATransitionTime} === 0"}Never{:else}{LastHATransitionTime|date_tostring}{/if}</td></tr>
+{/nnstat}
 {#ecstat}
   <tr><th>Enabled Erasure Coding Policies</th><td>{EnabledEcPolicies}</td></tr>
 {/ecstat}


### PR DESCRIPTION

### Description of PR
NameNode web UI should show LastHATransitionTime.   

When NN happened failover request by zkfc because fsn holding lock for too long. We can know the exact time, then filter logs based on time. 

### How was this patch tested?

issue: https://issues.apache.org/jira/browse/HDFS-17062
![image](https://github.com/apache/hadoop/assets/32935220/4cbd4108-0106-4388-bdcb-28155eb015a2)
![image](https://github.com/apache/hadoop/assets/32935220/7224966a-d409-4089-a050-7019144939d3)


