### PR TITLE
HADOOP-18788: Support lz4 highCompressor level.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeys.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeys.java
@@ -184,6 +184,13 @@ public class CommonConfigurationKeys extends CommonConfigurationKeysPublic {
   public static final boolean IO_COMPRESSION_CODEC_LZ4_USELZ4HC_DEFAULT =
       false;
 
+  /** Compression Level for Lz4 highCompressor */
+  public static final String IO_COMPRESSION_CODEC_LZ4_HC_LEVEL_KEY =
+          "io.compression.codec.lz4.hc.level";
+
+  /** Default value for IO_COMPRESSION_CODEC_LZ4_HC_LEVEL_KEY */
+  public static final int IO_COMPRESSION_CODEC_LZ4_HC_LEVEL_DEFAULT = 9;
+
 
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/Lz4Codec.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/Lz4Codec.java
@@ -116,7 +116,10 @@ public class Lz4Codec implements Configurable, CompressionCodec {
     boolean useLz4HC = conf.getBoolean(
         CommonConfigurationKeys.IO_COMPRESSION_CODEC_LZ4_USELZ4HC_KEY,
         CommonConfigurationKeys.IO_COMPRESSION_CODEC_LZ4_USELZ4HC_DEFAULT);
-    return new Lz4Compressor(bufferSize, useLz4HC);
+    int compressionLevel = conf.getInt(
+            CommonConfigurationKeys.IO_COMPRESSION_CODEC_LZ4_HC_LEVEL_KEY,
+            CommonConfigurationKeys.IO_COMPRESSION_CODEC_LZ4_HC_LEVEL_DEFAULT);
+    return new Lz4Compressor(bufferSize, useLz4HC, compressionLevel);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/lz4/Lz4Compressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/lz4/Lz4Compressor.java
@@ -38,6 +38,7 @@ public class Lz4Compressor implements Compressor {
   private static final Logger LOG =
       LoggerFactory.getLogger(Lz4Compressor.class.getName());
   private static final int DEFAULT_DIRECT_BUFFER_SIZE = 64 * 1024;
+  private static final int DEFAULT_HC_LEVEL = 9;
 
   private int directBufferSize;
   private Buffer compressedDirectBuf = null;
@@ -60,13 +61,13 @@ public class Lz4Compressor implements Compressor {
    * @param useLz4HC use high compression ratio version of lz4, 
    *                 which trades CPU for compression ratio.
    */
-  public Lz4Compressor(int directBufferSize, boolean useLz4HC) {
+  public Lz4Compressor(int directBufferSize, boolean useLz4HC, int compressionLevel) {
     this.directBufferSize = directBufferSize;
 
     try {
       LZ4Factory lz4Factory = LZ4Factory.fastestInstance();
       if (useLz4HC) {
-        lz4Compressor = lz4Factory.highCompressor();
+        lz4Compressor = lz4Factory.highCompressor(compressionLevel);
       } else {
         lz4Compressor = lz4Factory.fastCompressor();
       }
@@ -93,7 +94,7 @@ public class Lz4Compressor implements Compressor {
    * @param directBufferSize size of the direct buffer to be used.
    */
   public Lz4Compressor(int directBufferSize) {
-    this(directBufferSize, false);
+    this(directBufferSize, false, DEFAULT_HC_LEVEL);
   }
 
   /**


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The Hadoop's LZ4 compression codec now depends on lz4-java. There two type of compressor in lz4, `fastCompressor` and `highCompressor`. The default lz4 compressor in hadoop is fastCompressor, we also can use highCompressor by using config `IO_COMPRESSION_CODEC_LZ4_USELZ4HC_DEFAULT`

 

When we want to use highCompressor in hadoop, we only can use the default compression level, which is level 9. while highCompressor in lz4-java supports compression level from 1 to 17.

 

This PR add a configuration to let users to choose different compresssionLevel for lz4 highCompressor.

### How was this patch tested?
UT

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

