### PR TITLE
HADOOP-18789. Remove ozone from hadoop dev support.

### DIFF
--- a/dev-support/git-jira-validation/README.md
+++ b/dev-support/git-jira-validation/README.md
@@ -68,8 +68,8 @@ The script also requires below inputs:
    Exact fixVersion that we would like to compare all Jira's fixVersions
    with. e.g for 3.3.2 release, it should be 3.3.2.
 
-3. JIRA Project Name:
-   The exact name of Project as case-sensitive e.g HADOOP / OZONE
+3. JIRA Project Name (default Project Name: HADOOP):
+   The exact name of Project as case-sensitive.
 
 4. Path of project's working dir with release branch checked-in:
    Path of project from where we want to compare git hashes from. Local fork
@@ -84,7 +84,7 @@ The script also requires below inputs:
 
 Example of script execution:
 ```
-JIRA Project Name (e.g HADOOP / OZONE etc): HADOOP
+JIRA Project Name (default: HADOOP): HADOOP
 First commit hash to start excluding commits from history: fa4915fdbbbec434ab41786cb17b82938a613f16
 Fix Version: 3.3.2
 Jira server url (default: https://issues.apache.org/jira):

--- a/dev-support/git-jira-validation/git_jira_fix_version_check.py
+++ b/dev-support/git-jira-validation/git_jira_fix_version_check.py
@@ -30,7 +30,7 @@ import subprocess
 
 from jira import JIRA
 
-jira_project_name = input("JIRA Project Name (e.g HADOOP / OZONE etc): ") \
+jira_project_name = input("JIRA Project Name (default: HADOOP): ") \
                     or "HADOOP"
 # Define project_jira_keys with - appended. e.g for HADOOP Jiras,
 # project_jira_keys should include HADOOP-, HDFS-, YARN-, MAPREDUCE-


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Remove ozone at dev support script which has its own TLP now.

### How was this patch tested?
No.

### For code changes:

- [Y] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [N] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [N] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [N] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?