### PR TITLE
HDFS-17066: RBF: The construction of the trash path in the downstream nameservice should be based on src locations.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -86,6 +86,10 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
   public static final int
       DFS_ROUTER_METRICS_TOP_NUM_TOKEN_OWNERS_KEY_DEFAULT = 10;
 
+  public static final String DFS_ROUTER_TRASH_PATH_CREATED_BY_MOUNT_POINT =
+          FEDERATION_ROUTER_PREFIX + "trash-path.created-by.mount-point";
+  public static final boolean DFS_ROUTER_TRASH_PATH_CREATED_BY_MOUNT_POINT_DEFAULT = false;
+
   // HDFS Router heartbeat
   public static final String DFS_ROUTER_HEARTBEAT_ENABLE =
       FEDERATION_ROUTER_PREFIX + "heartbeat.enable";

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -674,6 +674,15 @@
   </property>
 
   <property>
+    <name>dfs.federation.router.trash-path.created-by.mount-point</name>
+    <value>false</value>
+    <description>
+      Set to true to use the mount point to create trash path
+      when path is the trail associated with the Trash.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.federation.router.keytab.file</name>
     <value></value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
@@ -46,6 +46,7 @@ import java.net.URISyntaxException;
 import java.util.Collections;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_TRASH_PATH_CREATED_BY_MOUNT_POINT;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
@@ -70,6 +71,8 @@ public class TestRouterTrash {
   private static String ns1;
   private static final String MOUNT_POINT = "/home/data";
   private static final String FILE = MOUNT_POINT + "/file1";
+  private static final String DST_PATH = "/home/dst_data";
+  private static final String DST_FILE = DST_PATH + "/file1";
   private static final String TRASH_ROOT = "/user/" + TEST_USER + "/.Trash";
   private static final String CURRENT = "/Current";
 
@@ -274,6 +277,81 @@ public class TestRouterTrash {
     fileStatuses = nnFs.listStatus(
         new Path(TRASH_ROOT + CURRENT + MOUNT_POINT));
     assertEquals(2, fileStatuses.length);
+  }
+
+  private void deleteToTrashExistMountPoint() throws IOException,
+          URISyntaxException, InterruptedException {
+    MountTable addEntry = MountTable.newInstance(MOUNT_POINT,
+            Collections.singletonMap(ns0, DST_PATH));
+    assertTrue(addMountTable(addEntry));
+
+    // current user client
+    DFSClient client = nnContext.getClient();
+    client.setOwner("/", TEST_USER, TEST_USER);
+    UserGroupInformation ugi = UserGroupInformation.
+            createRemoteUser(TEST_USER);
+    // test user client
+    client = nnContext.getClient(ugi);
+    client.mkdirs(DST_PATH, new FsPermission("777"), true);
+    assertTrue(client.exists(DST_PATH));
+    // create test file
+    client.create(DST_FILE, true);
+
+    Path filePath = new Path(FILE);
+    FileStatus[] fileStatuses = routerFs.listStatus(filePath);
+    assertEquals(1, fileStatuses.length);
+    assertEquals(TEST_USER, fileStatuses[0].getOwner());
+
+    // move to Trash.
+    Configuration routerConf = routerContext.getConf();
+    FileSystem fs =
+            DFSTestUtil.getFileSystemAs(ugi, routerConf);
+    Trash trash = new Trash(fs, routerConf);
+    assertTrue(trash.moveToTrash(filePath));
+  }
+
+  @Test
+  public void testTrashPathStructure() throws IOException,
+          URISyntaxException, InterruptedException {
+    // Trash path created by dst_path by default.
+    deleteToTrashExistMountPoint();
+    FileStatus[] fileStatuses = nnFs.listStatus(
+            new Path(TRASH_ROOT + CURRENT + DST_PATH));
+    assertEquals(1, fileStatuses.length);
+    assertTrue(nnFs.exists(new Path(TRASH_ROOT + CURRENT + DST_FILE)));
+
+    // Re-build and start a federated cluster with dfs.federation.router.trash-path.created-by.mount-point=true.
+    tearDown();
+    cluster = new StateStoreDFSCluster(false, 2);
+    Configuration conf = new RouterConfigBuilder()
+            .stateStore()
+            .admin()
+            .rpc()
+            .http()
+            .build();
+    conf.set(FS_TRASH_INTERVAL_KEY, "100");
+    conf.setBoolean(DFS_ROUTER_TRASH_PATH_CREATED_BY_MOUNT_POINT, true);
+    cluster.addRouterOverrides(conf);
+    cluster.startCluster();
+    cluster.startRouters();
+    cluster.waitClusterUp();
+
+    ns0 = cluster.getNameservices().get(0);
+    ns1 = cluster.getNameservices().get(1);
+
+    routerContext = cluster.getRandomRouter();
+    routerFs = routerContext.getFileSystem();
+    nnContext = cluster.getNamenode(ns0, null);
+    nnFs = nnContext.getFileSystem();
+    Router router = routerContext.getRouter();
+    mountTable = (MountTableResolver) router.getSubclusterResolver();
+
+    // Trash path created by mount_point.
+    deleteToTrashExistMountPoint();
+    fileStatuses = nnFs.listStatus(
+            new Path(TRASH_ROOT + CURRENT + MOUNT_POINT));
+    assertEquals(1, fileStatuses.length);
+    assertTrue(nnFs.exists(new Path(TRASH_ROOT + CURRENT + FILE)));
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
@@ -280,16 +280,16 @@ public class TestRouterTrash {
   }
 
   private void deleteToTrashExistMountPoint() throws IOException,
-          URISyntaxException, InterruptedException {
+      URISyntaxException, InterruptedException {
     MountTable addEntry = MountTable.newInstance(MOUNT_POINT,
-            Collections.singletonMap(ns0, DST_PATH));
+        Collections.singletonMap(ns0, DST_PATH));
     assertTrue(addMountTable(addEntry));
 
     // current user client
     DFSClient client = nnContext.getClient();
     client.setOwner("/", TEST_USER, TEST_USER);
     UserGroupInformation ugi = UserGroupInformation.
-            createRemoteUser(TEST_USER);
+        createRemoteUser(TEST_USER);
     // test user client
     client = nnContext.getClient(ugi);
     client.mkdirs(DST_PATH, new FsPermission("777"), true);
@@ -305,18 +305,18 @@ public class TestRouterTrash {
     // move to Trash.
     Configuration routerConf = routerContext.getConf();
     FileSystem fs =
-            DFSTestUtil.getFileSystemAs(ugi, routerConf);
+        DFSTestUtil.getFileSystemAs(ugi, routerConf);
     Trash trash = new Trash(fs, routerConf);
     assertTrue(trash.moveToTrash(filePath));
   }
 
   @Test
   public void testTrashPathStructure() throws IOException,
-          URISyntaxException, InterruptedException {
+      URISyntaxException, InterruptedException {
     // Trash path created by dst_path by default.
     deleteToTrashExistMountPoint();
     FileStatus[] fileStatuses = nnFs.listStatus(
-            new Path(TRASH_ROOT + CURRENT + DST_PATH));
+        new Path(TRASH_ROOT + CURRENT + DST_PATH));
     assertEquals(1, fileStatuses.length);
     assertTrue(nnFs.exists(new Path(TRASH_ROOT + CURRENT + DST_FILE)));
 
@@ -324,11 +324,11 @@ public class TestRouterTrash {
     tearDown();
     cluster = new StateStoreDFSCluster(false, 2);
     Configuration conf = new RouterConfigBuilder()
-            .stateStore()
-            .admin()
-            .rpc()
-            .http()
-            .build();
+        .stateStore()
+        .admin()
+        .rpc()
+        .http()
+        .build();
     conf.set(FS_TRASH_INTERVAL_KEY, "100");
     conf.setBoolean(DFS_ROUTER_TRASH_PATH_CREATED_BY_MOUNT_POINT, true);
     cluster.addRouterOverrides(conf);
@@ -349,7 +349,7 @@ public class TestRouterTrash {
     // Trash path created by mount_point.
     deleteToTrashExistMountPoint();
     fileStatuses = nnFs.listStatus(
-            new Path(TRASH_ROOT + CURRENT + MOUNT_POINT));
+        new Path(TRASH_ROOT + CURRENT + MOUNT_POINT));
     assertEquals(1, fileStatuses.length);
     assertTrue(nnFs.exists(new Path(TRASH_ROOT + CURRENT + FILE)));
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

