### PR TITLE
Add documention for HDFS-17069.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -729,6 +729,7 @@
       You can use the following suffix (case insensitive):
       k(kilo), m(mega), g(giga), t(tera), p(peta), e(exa) to specify the size (such as 128k, 512m, 1g, etc.),
       Or provide complete size in bytes (such as 134217728 for 128 MB).
+      And it should be larger than 1m.
   </description>
 </property>
 


### PR DESCRIPTION
### Description of PR
HDFS-17069.
Add more documention for dfs.blocksize to make sure the  normal function.


### Test
This patch just modify `hdfs-default.xml`, and we add more doc for `dfs.blocksize`. So, there is no need to add more unit test for it.
