### PR TITLE
HADOOP-18794. ipc.server.handler.queue.size missing from core-default.xml

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2322,6 +2322,15 @@ The switch to turn S3A auditing on or off.
 </property>
 
 <property>
+  <name>ipc.server.handler.queue.size</name>
+  <value>100</value>
+  <description>
+    Indicates how many calls per handler are allowed in the queue. This value can
+    determine the maximum call queue size by multiplying the number of handler threads.
+  </description>
+</property>
+
+<property>
   <name>ipc.server.listen.queue.size</name>
   <value>256</value>
   <description>Indicates the length of the listen queue for servers accepting


### PR DESCRIPTION
JIRA: [HADOOP-18794](https://issues.apache.org/jira/browse/HADOOP-18794). ipc.server.handler.queue.size missing from core-default.xml.