### PR TITLE
HDFS-17076. Remove the unused method isSlownodeByNameserviceId in DataNode

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockPoolManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockPoolManager.java
@@ -308,13 +308,6 @@ class BlockPoolManager {
     return bpByNameserviceId;
   }
 
-  boolean isSlownodeByNameserviceId(String nsId) {
-    if (bpByNameserviceId.containsKey(nsId)) {
-      return bpByNameserviceId.get(nsId).isSlownode();
-    }
-    return false;
-  }
-
   boolean isSlownodeByBlockPoolId(String bpId) {
     if (bpByBlockPoolId.containsKey(bpId)) {
       return bpByBlockPoolId.get(bpId).isSlownode();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -4240,10 +4240,6 @@ public class DataNode extends ReconfigurableBase
     return dataSetLockManager;
   }
 
-  boolean isSlownodeByNameserviceId(String nsId) {
-    return blockPoolManager.isSlownodeByNameserviceId(nsId);
-  }
-
   boolean isSlownodeByBlockPoolId(String bpId) {
     return blockPoolManager.isSlownodeByBlockPoolId(bpId);
   }


### PR DESCRIPTION
### How was this patch tested?
https://issues.apache.org/jira/browse/HDFS-17076

Remove the unused method isSlownodeByNameserviceId() in DataNode.