### PR TITLE
YARN-11528. Lock triple-beam to the version compatible with node.js 12 to avoid compilation error.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/package.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/package.json
@@ -19,6 +19,9 @@
         "shelljs": "^0.2.6",
         "apidoc": "0.17.7"
     },
+    "resolutions": {
+        "triple-beam": "1.3.0"
+    },
     "scripts": {
         "prestart": "npm install & mvn clean package",
         "pretest": "npm install"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/YARN-11528

Recently released triple-beam 1.4 is not compatible with node.js 12.

```
[INFO] --- frontend-maven-plugin:1.11.2:yarn (yarn install) @ hadoop-yarn-applications-catalog-webapp ---
[INFO] testFailureIgnore property is ignored in non test phases
[INFO] Running 'yarn ' in /home/rocky/srcs/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/target
[INFO] yarn install v1.22.5
[INFO] info No lockfile found.
[INFO] [1/4] Resolving packages...
[INFO] warning angular-route@1.6.10: For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.
[INFO] warning angular@1.6.10: For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.
[INFO] [2/4] Fetching packages...
[INFO] error triple-beam@1.4.1: The engine "node" is incompatible with this module. Expected version ">= 14.0.0". Got "12.22.1"
[INFO] error Found incompatible module.
[info] error Found incompatible module.info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

Since upgrading node.js to 14 or above breaks yarn-ui and it will take a time to fix, I locked the version of  triple-beam in hadoop-yarn-applications-catalog-webapp side.