### PR TITLE
HDFS-17079. Fix inccorect extraction of removeChildBool

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageReconstructor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageReconstructor.java
@@ -311,7 +311,7 @@ class OfflineImageReconstructor {
       if (str == null) {
         return false;
       }
-      return true;
+      return Boolean.parseBoolean(str);
     }
 
     String getRemainingKeyNames() {


### PR DESCRIPTION
### Description of PR

In OfflineImageReconstructor#removeChildBool, the value will always be recognized as "true" if the node is not null.

### How was this patch tested?

Not tested, quite simple bug.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

