### PR TITLE
HDFS-17081. Append ec file check if a block is replicated to at least the minimum replication need consider striped block

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -1696,7 +1696,7 @@ public class BlockManager implements BlockStatsMXBean {
   public boolean isSufficientlyReplicated(BlockInfo b) {
     // Compare against the lesser of the minReplication and number of live DNs.
     final int liveReplicas = countNodes(b).liveReplicas();
-    if (liveReplicas >= minReplication) {
+    if (hasMinStorage(b, liveReplicas)) {
       return true;
     }
     // getNumLiveDataNodes() is very expensive and we minimize its use by


### PR DESCRIPTION
### Description of PR

https://issues.apache.org/jira/browse/HDFS-17081

Append ec file check if a block is replicated to at least the minimum replication need consider ec block.

currently only the minimum replication of the replica is considered, the code is as follows:

/**
```
   * Check if a block is replicated to at least the minimum replication.
   */
  public boolean isSufficientlyReplicated(BlockInfo b) {
    // Compare against the lesser of the minReplication and number of live DNs.
    final int liveReplicas = countNodes(b).liveReplicas();
    if (liveReplicas >= minReplication) {
      return true;
    }
    // getNumLiveDataNodes() is very expensive and we minimize its use by
    // comparing with minReplication first.
    return liveReplicas >= getDatanodeManager().getNumLiveDataNodes();
  }
```