### PR TITLE
HDFS-17084. Utilize StringTable for numerable XAttributes

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -3241,8 +3241,32 @@ public abstract class FileSystem extends Configured
    */
   public void setXAttr(Path path, String name, byte[] value)
       throws IOException {
-    setXAttr(path, name, value, EnumSet.of(XAttrSetFlag.CREATE,
-        XAttrSetFlag.REPLACE));
+    setXAttr(path, name, value, false);
+  }
+
+  /**
+   * Set an xattr of a file or directory.
+   * The name must be prefixed with the namespace followed by ".". For example,
+   * "user.attr".
+   * <p>
+   * Refer to the HDFS extended attributes user documentation for details.
+   *
+   * @param path Path to modify
+   * @param name xattr name.
+   * @param value xattr value.
+   * @param enumValue if value is enumerable
+   * @throws IOException IO failure
+   * @throws UnsupportedOperationException if the operation is unsupported
+   *         (default outcome).
+   */
+  public void setXAttr(Path path, String name, byte[] value, boolean enumValue)
+          throws IOException {
+    EnumSet<XAttrSetFlag> flags = EnumSet.of(XAttrSetFlag.CREATE,
+            XAttrSetFlag.REPLACE);
+    if (enumValue) {
+      flags.add(XAttrSetFlag.ENUM_VALUE);
+    }
+    setXAttr(path, name, value, flags);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FilterFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FilterFileSystem.java
@@ -627,6 +627,12 @@ public class FilterFileSystem extends FileSystem {
   }
 
   @Override
+  public void setXAttr(Path path, String name, byte[] value, boolean numerable)
+      throws IOException {
+    fs.setXAttr(path, name, value, numerable);
+  }
+
+  @Override
   public void setXAttr(Path path, String name, byte[] value,
       EnumSet<XAttrSetFlag> flag) throws IOException {
     fs.setXAttr(path, name, value, flag);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/XAttrSetFlag.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/XAttrSetFlag.java
@@ -38,7 +38,13 @@ public enum XAttrSetFlag {
    * Replace a existing xattr.
    * If the xattr does not exist, exception will be thrown.
    */
-  REPLACE((short) 0x02);
+  REPLACE((short) 0x02),
+
+  /**
+   * Value is enumerable.
+   * Value will be stored efficiently.
+   */
+  ENUM_VALUE((short) 0x04);
 
   private final short flag;
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/XAttrCommands.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/XAttrCommands.java
@@ -133,7 +133,7 @@ class XAttrCommands extends FsCommand {
    */
   public static class SetfattrCommand extends FsCommand {
     public static final String NAME = SET_FATTR;
-    public static final String USAGE = "{-n name [-v value] | -x name} <path>";
+    public static final String USAGE = "{-n name [-v value [-e]] | -x name} <path>";
     public static final String DESCRIPTION =
       "Sets an extended attribute name and value for a file or directory.\n" +
       "-n name: The extended attribute name.\n" +
@@ -143,19 +143,27 @@ class XAttrCommands extends FsCommand {
       "argument is prefixed with 0x or 0X, then it is taken as a hexadecimal " +
       "number. If the argument begins with 0s or 0S, then it is taken as a " +
       "base64 encoding.\n" +
+      "-e: if set, means the value is enumerable, HDFS will try to store it " +
+      "efficiently.\n" +
       "-x name: Remove the extended attribute.\n" +
       "<path>: The file or directory.\n";
 
     private String name = null;
     private byte[] value = null;
     private String xname = null;
+    private boolean enumValue = false;
 
     @Override
     protected void processOptions(LinkedList<String> args) throws IOException {
       name = StringUtils.popOptionWithArgument("-n", args);
       String v = StringUtils.popOptionWithArgument("-v", args);
+      enumValue = StringUtils.popOption("-e", args);
       if (v != null) {
         value = XAttrCodec.decodeValue(v);
+      }
+      if (enumValue && v == null) {
+        throw new HadoopIllegalArgumentException(
+                "Can not specify '-e' when '-v' is empty.");
       }
       xname = StringUtils.popOptionWithArgument("-x", args);
 
@@ -179,7 +187,7 @@ class XAttrCommands extends FsCommand {
     @Override
     protected void processPath(PathData item) throws IOException {
       if (name != null) {
-        item.fs.setXAttr(item.path, name, value);
+        item.fs.setXAttr(item.path, name, value, enumValue);
       } else if (xname != null) {
         item.fs.removeXAttr(item.path, xname);
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/XAttrCommands.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/XAttrCommands.java
@@ -135,18 +135,18 @@ class XAttrCommands extends FsCommand {
     public static final String NAME = SET_FATTR;
     public static final String USAGE = "{-n name [-v value [-e]] | -x name} <path>";
     public static final String DESCRIPTION =
-      "Sets an extended attribute name and value for a file or directory.\n" +
-      "-n name: The extended attribute name.\n" +
-      "-v value: The extended attribute value. There are three different " +
-      "encoding methods for the value. If the argument is enclosed in double " +
-      "quotes, then the value is the string inside the quotes. If the " +
-      "argument is prefixed with 0x or 0X, then it is taken as a hexadecimal " +
-      "number. If the argument begins with 0s or 0S, then it is taken as a " +
-      "base64 encoding.\n" +
-      "-e: if set, means the value is enumerable, HDFS will try to store it " +
-      "efficiently.\n" +
-      "-x name: Remove the extended attribute.\n" +
-      "<path>: The file or directory.\n";
+        "Sets an extended attribute name and value for a file or directory.\n" +
+        "-n name: The extended attribute name.\n" +
+        "-v value: The extended attribute value. There are three different " +
+        "encoding methods for the value. If the argument is enclosed in double " +
+        "quotes, then the value is the string inside the quotes. If the " +
+        "argument is prefixed with 0x or 0X, then it is taken as a hexadecimal " +
+        "number. If the argument begins with 0s or 0S, then it is taken as a " +
+        "base64 encoding.\n" +
+        "-e: if set, means the value is enumerable, HDFS will try to store it " +
+        "efficiently.\n" +
+        "-x name: Remove the extended attribute.\n" +
+        "<path>: The file or directory.\n";
 
     private String name = null;
     private byte[] value = null;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHarFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHarFileSystem.java
@@ -198,7 +198,7 @@ public class TestHarFileSystem {
     public void setXAttr(Path path, String name, byte[] value)
         throws IOException;
 
-    public void setXAttr(Path path, String name, byte[] value, boolean numerable)
+    void setXAttr(Path path, String name, byte[] value, boolean numerable)
         throws IOException;
 
     public void setXAttr(Path path, String name, byte[] value,

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHarFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHarFileSystem.java
@@ -198,6 +198,9 @@ public class TestHarFileSystem {
     public void setXAttr(Path path, String name, byte[] value)
         throws IOException;
 
+    public void setXAttr(Path path, String name, byte[] value, boolean numerable)
+        throws IOException;
+
     public void setXAttr(Path path, String name, byte[] value,
         EnumSet<XAttrSetFlag> flag) throws IOException;
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/fs/XAttr.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/fs/XAttr.java
@@ -91,8 +91,8 @@ public class XAttr {
       return this;
     }
 
-    public Builder setEnumerable(boolean numerable) {
-      this.numerable = numerable;
+    public Builder setEnumerable(boolean isNumerable) {
+      this.numerable = isNumerable;
       return this;
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/fs/XAttr.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/fs/XAttr.java
@@ -68,11 +68,13 @@ public class XAttr {
   private final NameSpace ns;
   private final String name;
   private final byte[] value;
+  private final boolean enumerable;
 
   public static class Builder {
     private NameSpace ns = NameSpace.USER;
     private String name;
     private byte[] value;
+    private boolean numerable;
 
     public Builder setNameSpace(NameSpace ns) {
       this.ns = ns;
@@ -89,15 +91,21 @@ public class XAttr {
       return this;
     }
 
+    public Builder setEnumerable(boolean numerable) {
+      this.numerable = numerable;
+      return this;
+    }
+
     public XAttr build() {
-      return new XAttr(ns, name, value);
+      return new XAttr(ns, name, value, numerable);
     }
   }
 
-  private XAttr(NameSpace ns, String name, byte[] value) {
+  private XAttr(NameSpace ns, String name, byte[] value, boolean enumerable) {
     this.ns = ns;
     this.name = name;
     this.value = value;
+    this.enumerable = enumerable;
   }
 
   public NameSpace getNameSpace() {
@@ -112,12 +120,17 @@ public class XAttr {
     return value;
   }
 
+  public boolean isEnumerable() {
+    return enumerable;
+  }
+
   @Override
   public int hashCode() {
     return new HashCodeBuilder(811, 67)
         .append(name)
         .append(ns)
         .append(value)
+        .append(enumerable)
         .toHashCode();
   }
 
@@ -133,6 +146,7 @@ public class XAttr {
         .append(ns, rhs.ns)
         .append(name, rhs.name)
         .append(value, rhs.value)
+        .append(enumerable, rhs.enumerable)
         .isEquals();
   }
 
@@ -152,12 +166,13 @@ public class XAttr {
     return new EqualsBuilder()
         .append(ns, rhs.ns)
         .append(name, rhs.name)
+        .append(isEnumerable(), rhs.isEnumerable())
         .isEquals();
   }
 
   @Override
   public String toString() {
-    return "XAttr [ns=" + ns + ", name=" + name + ", value="
+    return "XAttr [ns=" + ns + ", name=" + name + ", enumerable-" + enumerable + ", value="
         + Arrays.toString(value) + "]";
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -2906,7 +2906,7 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
       EnumSet<XAttrSetFlag> flag) throws IOException {
     checkOpen();
     try (TraceScope ignored = newPathTraceScope("setXAttr", src)) {
-      namenode.setXAttr(src, XAttrHelper.buildXAttr(name, value), flag);
+      namenode.setXAttr(src, XAttrHelper.buildXAttr(name, value, flag), flag);
     } catch (RemoteException re) {
       throw re.unwrapRemoteException(AccessControlException.class,
           FileNotFoundException.class,

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/XAttrHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/XAttrHelper.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
@@ -24,6 +25,7 @@ import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.fs.XAttr;
 import org.apache.hadoop.fs.XAttr.NameSpace;
+import org.apache.hadoop.fs.XAttrSetFlag;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.StringUtils;
 
@@ -47,6 +49,10 @@ public class XAttrHelper {
    * Both name and namespace are case sensitive.
    */
   public static XAttr buildXAttr(String name, byte[] value) {
+    return buildXAttr(name, value, null);
+  }
+
+  public static XAttr buildXAttr(String name, byte[] value, final EnumSet<XAttrSetFlag> flag) {
     Preconditions.checkNotNull(name, "XAttr name cannot be null.");
 
     final int prefixIndex = name.indexOf(".");
@@ -78,8 +84,13 @@ public class XAttrHelper {
           "prefixed with user/trusted/security/system/raw, followed by a '.'");
     }
 
+    boolean isNumerable = false;
+    if (flag != null && flag.contains(XAttrSetFlag.ENUM_VALUE)) {
+      isNumerable = true;
+    }
+
     return (new XAttr.Builder()).setNameSpace(ns).setName(name.
-        substring(prefixIndex + 1)).setValue(value).build();
+        substring(prefixIndex + 1)).setValue(value).setEnumerable(isNumerable).build();
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelperClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelperClient.java
@@ -1106,6 +1106,9 @@ public class PBHelperClient {
     if (a.getValue() != null) {
       builder.setValue(getByteString(a.getValue()));
     }
+    if (a.isEnumerable()) {
+      builder.setEnumerable(true);
+    }
     return builder.build();
   }
 
@@ -1352,6 +1355,9 @@ public class PBHelperClient {
     }
     if (flag.contains(XAttrSetFlag.REPLACE)) {
       value |= XAttrSetFlagProto.XATTR_REPLACE.getNumber();
+    }
+    if (flag.contains(XAttrSetFlag.ENUM_VALUE)) {
+      value |= XAttrSetFlagProto.XATTR_ENUMERABLE.getNumber();
     }
     return value;
   }
@@ -2929,6 +2935,10 @@ public class PBHelperClient {
         XAttrSetFlagProto.XATTR_REPLACE_VALUE) {
       result.add(XAttrSetFlag.REPLACE);
     }
+    if ((flag & XAttrSetFlagProto.XATTR_ENUMERABLE.getNumber()) ==
+        XAttrSetFlagProto.XATTR_ENUMERABLE.getNumber()) {
+      result.add(XAttrSetFlag.ENUM_VALUE);
+    }
     return result;
   }
 
@@ -2940,6 +2950,9 @@ public class PBHelperClient {
     }
     if (a.hasValue()) {
       builder.setValue(a.getValue().toByteArray());
+    }
+    if (a.hasEnumerable()) {
+      builder.setEnumerable(a.getEnumerable());
     }
     return builder.build();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/xattr.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/xattr.proto
@@ -33,11 +33,13 @@ message XAttrProto {
   required XAttrNamespaceProto namespace = 1;
   required string name = 2;
   optional bytes value = 3;
+  optional bool enumerable = 4;
 }
   
 enum XAttrSetFlagProto {
   XATTR_CREATE     = 0x01;
   XATTR_REPLACE    = 0x02;
+  XATTR_ENUMERABLE = 0x04;
 }
 
 message SetXAttrRequestProto {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogOp.java
@@ -5587,7 +5587,10 @@ public abstract class FSEditLogOp {
       XMLUtils.addSaxString(contentHandler, "NAMESPACE",
           xAttr.getNameSpace().toString());
       XMLUtils.addSaxString(contentHandler, "NAME", xAttr.getName());
-      XMLUtils.addSaxString(contentHandler, "NUMERABLE", String.valueOf(xAttr.isEnumerable()));
+      if (xAttr.isEnumerable()) {
+        XMLUtils.addSaxString(contentHandler, "NUMERABLE",
+            String.valueOf(xAttr.isEnumerable()));
+      }
       if (xAttr.getValue() != null) {
         try {
           XMLUtils.addSaxString(contentHandler, "VALUE",
@@ -5611,7 +5614,8 @@ public abstract class FSEditLogOp {
     for (Stanza a: stanzas) {
       XAttr.Builder builder = new XAttr.Builder();
       builder.setNameSpace(XAttr.NameSpace.valueOf(a.getValue("NAMESPACE"))).
-          setName(a.getValue("NAME")).setEnumerable(Boolean.parseBoolean(a.getValue("NUMERABLE")));
+          setName(a.getValue("NAME")).
+          setEnumerable(Boolean.parseBoolean(a.getValueOrNull("NUMERABLE")));
       String v = a.getValueOrNull("VALUE");
       if (v != null) {
         try {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogOp.java
@@ -5587,6 +5587,7 @@ public abstract class FSEditLogOp {
       XMLUtils.addSaxString(contentHandler, "NAMESPACE",
           xAttr.getNameSpace().toString());
       XMLUtils.addSaxString(contentHandler, "NAME", xAttr.getName());
+      XMLUtils.addSaxString(contentHandler, "NUMERABLE", String.valueOf(xAttr.isEnumerable()));
       if (xAttr.getValue() != null) {
         try {
           XMLUtils.addSaxString(contentHandler, "VALUE",
@@ -5610,7 +5611,7 @@ public abstract class FSEditLogOp {
     for (Stanza a: stanzas) {
       XAttr.Builder builder = new XAttr.Builder();
       builder.setNameSpace(XAttr.NameSpace.valueOf(a.getValue("NAMESPACE"))).
-          setName(a.getValue("NAME"));
+          setName(a.getValue("NAME")).setEnumerable(Boolean.parseBoolean(a.getValue("NUMERABLE")));
       String v = a.getValueOrNull("VALUE");
       if (v != null) {
         try {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatPBINode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatPBINode.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hdfs.server.namenode;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/SerialNumberManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/SerialNumberManager.java
@@ -30,7 +30,7 @@ public enum SerialNumberManager {
   GLOBAL(),
   USER(PermissionStatusFormat.USER, AclEntryStatusFormat.NAME),
   GROUP(PermissionStatusFormat.GROUP, AclEntryStatusFormat.NAME),
-  XATTR(XAttrFormat.NAME);
+  XATTR(XAttrFormat.NAME, XAttrValueFormat.VALUE);
 
   private static final SerialNumberManager[] values = values();
   private static final int maxEntryBits;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/XAttrFeature.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/XAttrFeature.java
@@ -50,7 +50,8 @@ public class XAttrFeature implements INode.Feature {
       ImmutableList.Builder<XAttr> b = null;
       for (XAttr attr : xAttrs) {
         if (attr.getValue() == null ||
-            attr.getValue().length <= PACK_THRESHOLD) {
+            attr.getValue().length <= PACK_THRESHOLD ||
+            attr.isEnumerable()) {
           toPack.add(attr);
         } else {
           if (b == null) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/XAttrFormat.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/XAttrFormat.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.hdfs.util.LongBitFormat;
  * incompatible.
  *
  */
-@SuppressWarnings("checkstyle:PatternVariableName")
+@SuppressWarnings("checkstyle:MemberName")
 public enum XAttrFormat implements LongBitFormat.Enum {
   RESERVED(null, 4),
   NUMERABLE(RESERVED.BITS, 1),

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/XAttrFormat.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/XAttrFormat.java
@@ -19,13 +19,11 @@ package org.apache.hadoop.hdfs.server.namenode;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.hadoop.fs.XAttr;
-import org.apache.hadoop.fs.XAttrCodec;
 import org.apache.hadoop.hdfs.XAttrHelper;
 
 import org.apache.hadoop.util.Preconditions;
@@ -39,7 +37,7 @@ import org.apache.hadoop.hdfs.util.LongBitFormat;
  * incompatible.
  *
  */
-
+@SuppressWarnings("checkstyle:PatternVariableName")
 public enum XAttrFormat implements LongBitFormat.Enum {
   RESERVED(null, 4),
   NUMERABLE(RESERVED.BITS, 1),
@@ -242,7 +240,8 @@ public enum XAttrFormat implements LongBitFormat.Enum {
           }
         } else {
           out.write(Ints.toByteArray(
-                  SerialNumberManager.XATTR.getSerialNumber(new String(a.getValue(), StandardCharsets.UTF_8))));
+              SerialNumberManager.XATTR.getSerialNumber(
+                  new String(a.getValue(), StandardCharsets.UTF_8))));
         }
       }
     } catch (IOException e) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/XAttrValueFormat.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/XAttrValueFormat.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.namenode;
+
+import org.apache.hadoop.hdfs.util.LongBitFormat;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Class to pack XAttrs Value.<br>
+ *
+ * Note:  this format is used both in-memory and on-disk.  Changes will be
+ * incompatible.
+ *
+ */
+
+public enum XAttrValueFormat implements LongBitFormat.Enum {
+  VALUE(null, 24);
+
+  private final LongBitFormat BITS;
+
+  XAttrValueFormat(LongBitFormat previous, int length) {
+    BITS = new LongBitFormat(name(), previous, length, 0);
+  }
+
+  @Override
+  public int getLength() {
+    return BITS.getLength();
+  }
+
+  public static byte[] getValue(int record) {
+    int nid = (int)VALUE.BITS.retrieve(record);
+    return SerialNumberManager.XATTR.getString(nid).getBytes(StandardCharsets.UTF_8);
+  }
+
+  static int toInt(byte[] value) {
+    int vid = SerialNumberManager.XATTR.getSerialNumber(new String(value, StandardCharsets.UTF_8));
+    long res = 0L;
+    res = VALUE.BITS.combine(vid, res);
+    return (int)res;
+  }
+
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/fsimage.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/fsimage.proto
@@ -119,10 +119,12 @@ message INodeSection {
      * so only 2 bits were needed. At that time, this bit was reserved. When a
      * 5th namespace was created (raw) this bit became used as a 3rd namespace
      * bit.
-     * [27:32) -- reserved for future uses.
+     * [27:28) -- indicating if the value is enumerable
+     * [28:32) -- reserved for future uses.
      */
     required fixed32 name = 1;
     optional bytes value = 2;
+    optional fixed32 valueInt = 3;
   }
   
   message XAttrFeatureProto {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
@@ -322,7 +322,7 @@ public class TestOfflineImageViewer {
       // as UTF8
       hdfs.setXAttr(xattr, "user.a4", new byte[]{ -0x3d, 0x28 });
       // Set enumerable attribute
-      hdfs.setXAttr(xattr, "user.a5", new byte[]{ 0x37, 0x38, 0x39 }, true);
+      hdfs.setXAttr(xattr, "user.a5", new byte[]{0x37, 0x38, 0x39}, true);
       writtenFiles.put(xattr.toString(), hdfs.getFileStatus(xattr));
       // Set ACLs
       hdfs.setAcl(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
@@ -321,6 +321,8 @@ public class TestOfflineImageViewer {
       // OIV should be able to handle XAttr values that can't be expressed
       // as UTF8
       hdfs.setXAttr(xattr, "user.a4", new byte[]{ -0x3d, 0x28 });
+      // Set enumerable attribute
+      hdfs.setXAttr(xattr, "user.a5", new byte[]{ 0x37, 0x38, 0x39 }, true);
       writtenFiles.put(xattr.toString(), hdfs.getFileStatus(xattr));
       // Set ACLs
       hdfs.setAcl(


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Currently only the name of XAttr will utilize SerialNumber's StringTable to store values, for values they are stored as "byte[]".

If the XAttr values are numerable, StringTable could be used for efficiency.

This ticket is to let users create numerable attributes.

JIRA ticket: https://issues.apache.org/jira/browse/HDFS-17084

### How was this patch tested?

unit test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

