### PR TITLE
HADOOP-18806. Document missing property (ipc.server.read.threadpool.size) in core-default.xml

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2356,6 +2356,14 @@ The switch to turn S3A auditing on or off.
 </property>
 
 <property>
+  <name>ipc.server.read.threadpool.size</name>
+  <value>1</value>
+  <description>Indicates the number of threads in RPC server reading
+    from the socket.
+  </description>
+</property>
+
+<property>
   <name>ipc.maximum.data.length</name>
   <value>134217728</value>
   <description>This indicates the maximum IPC message length (bytes) that can be


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

I think `ipc.server.read.threadpool.size` is quite important configuration tuning point for scalability. But there is no mention about it in core-default.xml.
There are some articles about hadoop tuning configuration with it. (e.g. https://support.huawei.com/enterprise/en/knowledge/EKB1100015760)



### How was this patch tested?

It is just changed documentation.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?

