### PR TITLE
MAPREDUCE-7442. Exception message is not intusive when accessing the WebUI

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/ConfBlock.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/ConfBlock.java
@@ -113,7 +113,7 @@ public class ConfBlock extends HtmlBlock {
           __();
     } catch(IOException e) {
       LOG.error("Error while reading "+confPath, e);
-      html.p().__("Sorry got an error while reading conf file. ", confPath);
+      html.p().__("Sorry got an error while reading conf file. ", confPath).__();
     }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
fix the bug is issue [MAPREDUCE-7442](https://issues.apache.org/jira/browse/MAPREDUCE-7442)
this PR fix the bug that exception message is not intusive when accessing the job configuration web UI.

### How was this patch tested?
I rebuild the project, and restart our own Hadoop cluster, then we can the exception message on the webpage of the job configuration, and here is the picture:
![image](https://github.com/apache/hadoop/assets/62563545/7fb5f9ab-b839-4535-9684-792ea7449760)


### For code changes:

I changed the file
 hadoop/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/ConfBlock.java, line116.

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

