### PR TITLE
YARN-11533. CapacityScheduler CapacityConfigType changed in legacy queue allocation mode

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractCSQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractCSQueue.java
@@ -518,21 +518,27 @@ public abstract class AbstractCSQueue implements CSQueue {
 
       CapacityConfigType localType = CapacityConfigType.NONE;
 
-      // TODO: revisit this later
-      //  AbstractCSQueue.CapacityConfigType has only None, Percentage and Absolute mode
-      final Set<QueueCapacityVector.ResourceUnitCapacityType> definedCapacityTypes =
-          getConfiguredCapacityVector(label).getDefinedCapacityTypes();
-      if (definedCapacityTypes.size() == 1) {
-        QueueCapacityVector.ResourceUnitCapacityType next = definedCapacityTypes.iterator().next();
-        if (Objects.requireNonNull(next) == PERCENTAGE) {
-          localType = CapacityConfigType.PERCENTAGE;
-        } else if (next == QueueCapacityVector.ResourceUnitCapacityType.ABSOLUTE) {
-          localType = CapacityConfigType.ABSOLUTE_RESOURCE;
-        } else if (next == WEIGHT) {
+      if (queueContext.getConfiguration().isLegacyQueueMode()) {
+        localType = checkConfigTypeIsAbsoluteResource(
+                getQueuePath(), label) ? CapacityConfigType.ABSOLUTE_RESOURCE
+                : CapacityConfigType.PERCENTAGE;
+      } else {
+        // TODO: revisit this later
+        //  AbstractCSQueue.CapacityConfigType has only None, Percentage and Absolute mode
+        final Set<QueueCapacityVector.ResourceUnitCapacityType> definedCapacityTypes =
+                getConfiguredCapacityVector(label).getDefinedCapacityTypes();
+        if (definedCapacityTypes.size() == 1) {
+          QueueCapacityVector.ResourceUnitCapacityType next = definedCapacityTypes.iterator().next();
+          if (Objects.requireNonNull(next) == PERCENTAGE) {
+            localType = CapacityConfigType.PERCENTAGE;
+          } else if (next == QueueCapacityVector.ResourceUnitCapacityType.ABSOLUTE) {
+            localType = CapacityConfigType.ABSOLUTE_RESOURCE;
+          } else if (next == WEIGHT) {
+            localType = CapacityConfigType.PERCENTAGE;
+          }
+        } else { // Mixed type
           localType = CapacityConfigType.PERCENTAGE;
         }
-      } else { // Mixed type
-        localType = CapacityConfigType.PERCENTAGE;
       }
 
       if (this.capacityConfigType.equals(CapacityConfigType.NONE)) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/helper/CapacitySchedulerInfoHelper.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/helper/CapacitySchedulerInfoHelper.java
@@ -70,19 +70,35 @@ public class CapacitySchedulerInfoHelper {
   private CapacitySchedulerInfoHelper() {}
 
   public static String getMode(CSQueue queue) {
-    final Set<QueueCapacityVector.ResourceUnitCapacityType> definedCapacityTypes =
-        queue.getConfiguredCapacityVector(NO_LABEL).getDefinedCapacityTypes();
-    if (definedCapacityTypes.size() == 1) {
-      QueueCapacityVector.ResourceUnitCapacityType next = definedCapacityTypes.iterator().next();
-      if (Objects.requireNonNull(next) == PERCENTAGE) {
-        return "percentage";
-      } else if (next == QueueCapacityVector.ResourceUnitCapacityType.ABSOLUTE) {
+    if (((AbstractCSQueue) queue).getQueueContext().getConfiguration().isLegacyQueueMode()) {
+      if (queue.getCapacityConfigType() ==
+              AbstractCSQueue.CapacityConfigType.ABSOLUTE_RESOURCE) {
         return "absolute";
-      } else if (next == QueueCapacityVector.ResourceUnitCapacityType.WEIGHT) {
-        return "weight";
+      } else if (queue.getCapacityConfigType() ==
+              AbstractCSQueue.CapacityConfigType.PERCENTAGE) {
+        float weight = queue.getQueueCapacities().getWeight();
+        if (weight == -1) {
+          //-1 indicates we are not in weight mode
+          return "percentage";
+        } else {
+          return "weight";
+        }
       }
-    } else if (definedCapacityTypes.size() > 1) {
-      return "mixed";
+    } else {
+      final Set<QueueCapacityVector.ResourceUnitCapacityType> definedCapacityTypes =
+              queue.getConfiguredCapacityVector(NO_LABEL).getDefinedCapacityTypes();
+      if (definedCapacityTypes.size() == 1) {
+        QueueCapacityVector.ResourceUnitCapacityType next = definedCapacityTypes.iterator().next();
+        if (Objects.requireNonNull(next) == PERCENTAGE) {
+          return "percentage";
+        } else if (next == QueueCapacityVector.ResourceUnitCapacityType.ABSOLUTE) {
+          return "absolute";
+        } else if (next == QueueCapacityVector.ResourceUnitCapacityType.WEIGHT) {
+          return "weight";
+        }
+      } else if (definedCapacityTypes.size() > 1) {
+        return "mixed";
+      }
     }
 
     return "unknown";


### PR DESCRIPTION
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

