### PR TITLE
HDFS-17111. RBF: Optimize msync to only call nameservices that have observer reads enabled.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -212,7 +212,7 @@ public class RouterClientProtocol implements ClientProtocol {
    * @throws IOException If it cannot get the delegation token.
    */
   public Map<FederationNamespaceInfo, Token<DelegationTokenIdentifier>>
-  getDelegationTokens(Text renewer) throws IOException {
+      getDelegationTokens(Text renewer) throws IOException {
     rpcServer.checkOperation(NameNode.OperationCategory.WRITE, false);
     return null;
   }
@@ -265,7 +265,7 @@ public class RouterClientProtocol implements ClientProtocol {
       String clientName, EnumSetWritable<CreateFlag> flag,
       boolean createParent, short replication, long blockSize,
       CryptoProtocolVersion[] supportedVersions, String ecPolicyName,
-      String storagePolicy)
+      String storagePolicyName)
       throws IOException {
     rpcServer.checkOperation(NameNode.OperationCategory.WRITE);
 
@@ -287,7 +287,7 @@ public class RouterClientProtocol implements ClientProtocol {
             long.class, CryptoProtocolVersion[].class,
             String.class, String.class},
         new RemoteParam(), masked, clientName, flag, createParent,
-        replication, blockSize, supportedVersions, ecPolicyName, storagePolicy);
+        replication, blockSize, supportedVersions, ecPolicyName, storagePolicyName);
     final List<RemoteLocation> locations =
         rpcServer.getLocationsForPath(src, true);
     RemoteLocation createLocation = null;
@@ -1933,7 +1933,8 @@ public class RouterClientProtocol implements ClientProtocol {
     RemoteMethod method = new RemoteMethod("msync");
     Set<FederationNamespaceInfo> namespacesEligibleForObserverReads = new HashSet<>();
     for (FederationNamespaceInfo ns : allNamespaces) {
-      boolean isObserverReadEligible = rpcClient.isNamespaceObserverReadEligible(ns.getNameserviceId());
+      boolean isObserverReadEligible = rpcClient
+          .isNamespaceObserverReadEligible(ns.getNameserviceId());
       if (isObserverReadEligible) {
         namespacesEligibleForObserverReads.add(ns);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -144,7 +144,7 @@ public class RouterClientProtocol implements ClientProtocol {
   private volatile long serverDefaultsLastUpdate;
   private final long serverDefaultsValidityPeriod;
 
-  /** Caching the set of nameservices that are eligible for observer reads */
+  /** Caching the set of nameservices that are eligible for observer reads. */
   private final LoadingCache<Set<FederationNamespaceInfo>, Set<FederationNamespaceInfo>>
       crsNameservicesCache;
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdfs.server.federation.router;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_SERVER_DEFAULTS_VALIDITY_PERIOD_MS_DEFAULT;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_SERVER_DEFAULTS_VALIDITY_PERIOD_MS_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.FederationUtil.updateMountPointStatus;
-import java.util.HashSet;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.CryptoProtocolVersion;
 import org.apache.hadoop.fs.BatchedRemoteIterator.BatchedEntries;
@@ -1931,14 +1930,10 @@ public class RouterClientProtocol implements ClientProtocol {
     rpcServer.checkOperation(NameNode.OperationCategory.READ, true);
     Set<FederationNamespaceInfo> allNamespaces = namenodeResolver.getNamespaces();
     RemoteMethod method = new RemoteMethod("msync");
-    Set<FederationNamespaceInfo> namespacesEligibleForObserverReads = new HashSet<>();
-    for (FederationNamespaceInfo ns : allNamespaces) {
-      boolean isObserverReadEligible = rpcClient
-          .isNamespaceObserverReadEligible(ns.getNameserviceId());
-      if (isObserverReadEligible) {
-        namespacesEligibleForObserverReads.add(ns);
-      }
-    }
+    Set<FederationNamespaceInfo> namespacesEligibleForObserverReads = allNamespaces
+        .stream()
+        .filter(ns -> rpcClient.isNamespaceObserverReadEligible(ns.getNameserviceId()))
+        .collect(Collectors.toSet());
     rpcClient.invokeConcurrent(namespacesEligibleForObserverReads, method);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -211,7 +211,7 @@ public class RouterClientProtocol implements ClientProtocol {
    * @throws IOException If it cannot get the delegation token.
    */
   public Map<FederationNamespaceInfo, Token<DelegationTokenIdentifier>>
-      getDelegationTokens(Text renewer) throws IOException {
+  getDelegationTokens(Text renewer) throws IOException {
     rpcServer.checkOperation(NameNode.OperationCategory.WRITE, false);
     return null;
   }
@@ -264,7 +264,7 @@ public class RouterClientProtocol implements ClientProtocol {
       String clientName, EnumSetWritable<CreateFlag> flag,
       boolean createParent, short replication, long blockSize,
       CryptoProtocolVersion[] supportedVersions, String ecPolicyName,
-      String storagePolicyName)
+      String storagePolicy)
       throws IOException {
     rpcServer.checkOperation(NameNode.OperationCategory.WRITE);
 
@@ -286,7 +286,7 @@ public class RouterClientProtocol implements ClientProtocol {
             long.class, CryptoProtocolVersion[].class,
             String.class, String.class},
         new RemoteParam(), masked, clientName, flag, createParent,
-        replication, blockSize, supportedVersions, ecPolicyName, storagePolicyName);
+        replication, blockSize, supportedVersions, ecPolicyName, storagePolicy);
     final List<RemoteLocation> locations =
         rpcServer.getLocationsForPath(src, true);
     RemoteLocation createLocation = null;
@@ -1935,6 +1935,9 @@ public class RouterClientProtocol implements ClientProtocol {
         .stream()
         .filter(ns -> rpcClient.isNamespaceObserverReadEligible(ns.getNameserviceId()))
         .collect(Collectors.toSet());
+    if (namespacesEligibleForObserverReads.isEmpty()) {
+      return;
+    }
     rpcClient.invokeConcurrent(namespacesEligibleForObserverReads, method);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -1955,8 +1955,8 @@ public class RouterClientProtocol implements ClientProtocol {
   }
 
   /**
-   * Determines with nameservices has observer reads enabled.
-   * @return A set of nameservices eligible for observer reads.
+   * Determines which nameservices have observer reads enabled.
+   * @return A set of nameservices that are eligible for observer reads.
    * @throws IOException
    */
   private Set<FederationNamespaceInfo> getNameservicesEligibleForObserverReads()

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -1957,7 +1957,7 @@ public class RouterClientProtocol implements ClientProtocol {
   /**
    * Determines which nameservices have observer reads enabled.
    * @return A set of nameservices that are eligible for observer reads.
-   * @throws IOException
+   * @throws IOException If there is an error getting the nameservices.
    */
   private Set<FederationNamespaceInfo> getNameservicesEligibleForObserverReads()
       throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -1800,6 +1800,9 @@ public class RouterRpcClient {
    * @return whether the 'method' is a read-only operation.
    */
   private static boolean isReadCall(Method method) {
+    if (method == null) {
+      return false;
+    }
     if (!method.isAnnotationPresent(ReadOnly.class)) {
       return false;
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -1783,9 +1783,16 @@ public class RouterRpcClient {
   }
 
   private boolean isObserverReadEligible(String nsId, Method method) {
-    boolean isReadEnabledForNamespace =
-        observerReadEnabledDefault != observerReadEnabledOverrides.contains(nsId);
-    return isReadEnabledForNamespace && isReadCall(method);
+    return isReadCall(method) && isNamespaceObserverReadEligible(nsId);
+  }
+
+  /**
+   * Check if a namespace is eligible for observer reads.
+   * @param nsId namespaceID
+   * @return whether the 'namespace' has observer reads enabled.
+   */
+  boolean isNamespaceObserverReadEligible(String nsId) {
+    return observerReadEnabledDefault != observerReadEnabledOverrides.contains(nsId);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -892,4 +892,23 @@ public class TestObserverWithRouter {
     // There should only be one call to the namespace that has an observer.
     assertEquals("Only one call to the namespace with an observer", 1, rpcCountForActive);
   }
+
+  @EnumSource(ConfigSetting.class)
+  @ParameterizedTest
+  @Tag(SKIP_BEFORE_EACH_CLUSTER_STARTUP)
+  public void testMsyncWithNoNamespacesEligibleForCRS(ConfigSetting configSetting) throws Exception {
+    Configuration confOverride = new Configuration(false);
+    // Disable observer reads for all namespaces.
+    confOverride.setBoolean(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_DEFAULT_KEY, false);
+    startUpCluster(1, confOverride);
+    fileSystem = routerContext.getFileSystem(getConfToEnableObserverReads(configSetting));
+
+    // Send msync request
+    fileSystem.msync();
+
+    long rpcCountForActive = routerContext.getRouter().getRpcServer()
+        .getRPCMetrics().getActiveProxyOps();
+    // There should no calls to any namespace.
+    assertEquals("No calls to any namespace", 0, rpcCountForActive);
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -879,7 +879,8 @@ public class TestObserverWithRouter {
     Configuration confOverride = new Configuration(false);
     String namespaceWithObserverReadsDisabled = "ns0";
     // Disable observer reads for ns0
-    confOverride.set(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_OVERRIDES, namespaceWithObserverReadsDisabled);
+    confOverride.set(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_OVERRIDES,
+        namespaceWithObserverReadsDisabled);
     startUpCluster(1, confOverride);
     fileSystem = routerContext.getFileSystem(getConfToEnableObserverReads(configSetting));
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -874,12 +874,18 @@ public class TestObserverWithRouter {
 
   @EnumSource(ConfigSetting.class)
   @ParameterizedTest
+  @Tag(SKIP_BEFORE_EACH_CLUSTER_STARTUP)
   public void testMsyncOnlyToNamespacesWithObserver(ConfigSetting configSetting) throws Exception {
+    Configuration confOverride = new Configuration(false);
+    String namespaceWithObserverReadsDisabled = "ns0";
+    confOverride.set(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_OVERRIDES, namespaceWithObserverReadsDisabled);
+    startUpCluster(2, confOverride);
+
     fileSystem = routerContext.getFileSystem(getConfToEnableObserverReads(configSetting));
 
     // Switch observers in first nameservice to standbys.
-    cluster.switchToStandby(cluster.getNameservices().get(0), NAMENODES[2]);
-    cluster.switchToStandby(cluster.getNameservices().get(0), NAMENODES[3]);
+    cluster.switchToStandby(namespaceWithObserverReadsDisabled, NAMENODES[2]);
+    cluster.switchToStandby(namespaceWithObserverReadsDisabled, NAMENODES[3]);
 
     // Refresh namenode registrations.
     MockResolver mockResolver = (MockResolver) routerContext.getRouter().getNamenodeResolver();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -896,7 +896,8 @@ public class TestObserverWithRouter {
   @EnumSource(ConfigSetting.class)
   @ParameterizedTest
   @Tag(SKIP_BEFORE_EACH_CLUSTER_STARTUP)
-  public void testMsyncWithNoNamespacesEligibleForCRS(ConfigSetting configSetting) throws Exception {
+  public void testMsyncWithNoNamespacesEligibleForCRS(ConfigSetting configSetting)
+      throws Exception {
     Configuration confOverride = new Configuration(false);
     // Disable observer reads for all namespaces.
     confOverride.setBoolean(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_DEFAULT_KEY, false);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -904,7 +904,7 @@ public class TestObserverWithRouter {
     startUpCluster(1, confOverride);
     fileSystem = routerContext.getFileSystem(getConfToEnableObserverReads(configSetting));
 
-    // Send msync request
+    // Send msync request.
     fileSystem.msync();
 
     long rpcCountForActive = routerContext.getRouter().getRpcServer()


### PR DESCRIPTION
HDFS-17111. RBF: Optimize msync to only call nameservices that have observer reads enabled.
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Routers only need to msync to nameservices that have CRS configured.

The first commit would check if there is an namenode in the OBSERVER state. However, this may have tricky corner cases
that will lead to not msyncing if an observer goes down and then recovers.
For now I'll leverage the existing config for disabling observer reads on a per-namespace bases.

Checking if there is an OBSERVER present dynamically can be done in a separate ticket.

### How was this patch tested?
New unit test.

### For code changes:

- [ X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
