### PR TITLE
HDFS-17112. Show decommission duration in JMX and HTML.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -6664,6 +6664,8 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
           node.getLeavingServiceStatus().getOutOfServiceOnlyReplicas())
           .put("underReplicateInOpenFiles",
           node.getLeavingServiceStatus().getUnderReplicatedInOpenFiles())
+          .put("decommissionDuration",
+              monotonicNow() - node.getLeavingServiceStatus().getStartTime())
           .build();
       info.put(node.getXferAddrWithHostname(), innerinfo);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
@@ -406,6 +406,7 @@
       <th>Under replicated blocks</th>
       <th>Blocks with no live replicas</th>
       <th>Under Replicated Blocks <br/>In files under construction</th>
+      <th>Decommission duration</th>
     </tr>
   </thead>
   {#DecomNodes}
@@ -414,6 +415,7 @@
     <td>{underReplicatedBlocks}</td>
     <td>{decommissionOnlyReplicas}</td>
     <td>{underReplicateInOpenFiles}</td>
+    <td>{decommissionDuration}</td>
   </tr>
   {/DecomNodes}
 </table>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
@@ -415,7 +415,7 @@
     <td>{underReplicatedBlocks}</td>
     <td>{decommissionOnlyReplicas}</td>
     <td>{underReplicateInOpenFiles}</td>
-    <td>{decommissionDuration}</td>
+    <td>{decommissionDuration}ms</td>
   </tr>
   {/DecomNodes}
 </table>


### PR DESCRIPTION
### Description of PR

Expose decommission duration time in JMX page. It's a very useful info when decommissioning a batch of datanodes in a cluster.

