### PR TITLE
HADOOP-18817.Upgrade version of aws-java-sdk-bundle to 1.12.368 avoid verify error.

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -215,7 +215,7 @@ com.aliyun:aliyun-java-sdk-kms:2.11.0
 com.aliyun:aliyun-java-sdk-ram:3.1.0
 com.aliyun:aliyun-java-sdk-sts:3.0.0
 com.aliyun.oss:aliyun-sdk-oss:3.13.2
-com.amazonaws:aws-java-sdk-bundle:1.12.367
+com.amazonaws:aws-java-sdk-bundle:1.12.368
 com.cedarsoftware:java-util:1.9.0
 com.cedarsoftware:json-io:2.5.1
 com.fasterxml.jackson.core:jackson-annotations:2.12.7

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -182,7 +182,7 @@
     <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <surefire.fork.timeout>900</surefire.fork.timeout>
-    <aws-java-sdk.version>1.12.367</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.368</aws-java-sdk.version>
     <hsqldb.version>2.7.1</hsqldb.version>
     <frontend-maven-plugin.version>1.11.2</frontend-maven-plugin.version>
     <jasmine-maven-plugin.version>2.1</jasmine-maven-plugin.version>


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The compilation failed when I packaged through the maven command 
`mvn clean install -DskipTests -Dtar -Pdist -Pnative  
`

report an error: 

```
[WARNING]
Dependency convergence error for com.amazonaws:aws-java-sdk-simpleworkflow:1.12.367 paths to dependency are:
+-org.apache.hadoop:hadoop-aws:3.3.6
  +-com.amazonaws:aws-java-sdk-bundle:1.12.367
    +-com.amazonaws:aws-java-sdk:1.12.367
      +-com.amazonaws:aws-java-sdk-simpleworkflow:1.12.367

and

+-org.apache.hadoop:hadoop-aws:3.3.6
  +-com.amazonaws:aws-java-sdk-bundle:1.12.367
    +-com.amazonaws:aws-java-sdk:1.12.367
      +-com.amazonaws:aws-java-sdk-swf-libraries:1.11.22
        +-com.amazonaws:aws-java-sdk-simpleworkflow:1.11.22
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.DependencyConvergence failed with message:
 Failed while enforcing releasability. See above detailed error message. 
```
 
com.amazonaws:aws-java-sdk-swf-libraries are not required


### How was this patch tested?

unit test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

