### PR TITLE
HDFS-17116. RBF:  Update invoke millisecond time as monotonicNow() in RouterSafemodeService

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterSafemodeService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterSafemodeService.java
@@ -17,11 +17,10 @@
  */
 package org.apache.hadoop.hdfs.server.federation.router;
 
-import static org.apache.hadoop.util.Time.now;
+import static org.apache.hadoop.util.Time.monotonicNow;
 
 import java.util.concurrent.TimeUnit;
 
-import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.server.federation.store.StateStoreService;
 import org.slf4j.Logger;
@@ -73,7 +72,7 @@ public class RouterSafemodeService extends PeriodicService {
   private long startupTime;
 
   /** The time the Router enters safe mode in milliseconds. */
-  private long enterSafeModeTime = now();
+  private long enterSafeModeTime = monotonicNow();
 
 
   /**
@@ -107,7 +106,7 @@ public class RouterSafemodeService extends PeriodicService {
    */
   private void enter() {
     LOG.info("Entering safe mode");
-    enterSafeModeTime = now();
+    enterSafeModeTime = monotonicNow();
     safeMode = true;
     router.updateRouterState(RouterServiceState.SAFEMODE);
   }
@@ -117,7 +116,7 @@ public class RouterSafemodeService extends PeriodicService {
    */
   private void leave() {
     // Cache recently updated, leave safemode
-    long timeInSafemode = now() - enterSafeModeTime;
+    long timeInSafemode = monotonicNow() - enterSafeModeTime;
     LOG.info("Leaving safe mode after {} milliseconds", timeInSafemode);
     RouterMetrics routerMetrics = router.getRouterMetrics();
     if (routerMetrics == null) {
@@ -151,7 +150,7 @@ public class RouterSafemodeService extends PeriodicService {
     LOG.info("Enter safe mode after {} ms without reaching the State Store",
         this.staleInterval);
 
-    this.startupTime = now();
+    this.startupTime = monotonicNow();
 
     // Initializing the RPC server in safe mode, it will disable it later
     enter();
@@ -161,17 +160,11 @@ public class RouterSafemodeService extends PeriodicService {
 
   @Override
   public void periodicInvoke() {
-    long now = now();
+    long now = monotonicNow();
     long delta = now - startupTime;
     if (delta < startupInterval) {
       LOG.info("Delaying safemode exit for {} milliseconds...",
           this.startupInterval - delta);
-      if (delta < 0) {
-        LOG.warn("Negative startup interval detected, resetting startupTime and " +
-            "enterSafeModeTime.");
-        startupTime = now();
-        enterSafeModeTime = now();
-      }
       return;
     }
     StateStoreService stateStore = router.getStateStore();
@@ -187,10 +180,5 @@ public class RouterSafemodeService extends PeriodicService {
       // Cache recently updated, leave safe mode
       leave();
     }
-  }
-
-  @VisibleForTesting
-  public void setStartupTime(long startupTime) {
-    this.startupTime = startupTime;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/StateStoreService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/StateStoreService.java
@@ -435,7 +435,7 @@ public class StateStoreService extends CompositeService {
     }
     if (success) {
       // Uses local time, not driver time.
-      this.cacheLastUpdateTime = Time.now();
+      this.cacheLastUpdateTime = Time.monotonicNow();
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterSafemode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterSafemode.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
-import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
@@ -129,37 +128,13 @@ public class TestRouterSafemode {
 
     assertTrue(router.getSafemodeService().isInSafeMode());
     verifyRouter(RouterServiceState.SAFEMODE);
+
     // Wait for initial time in milliseconds
     long interval =
         conf.getTimeDuration(DFS_ROUTER_SAFEMODE_EXTENSION,
             TimeUnit.SECONDS.toMillis(2), TimeUnit.MILLISECONDS) +
         conf.getTimeDuration(DFS_ROUTER_CACHE_TIME_TO_LIVE_MS,
             TimeUnit.SECONDS.toMillis(1), TimeUnit.MILLISECONDS);
-    Thread.sleep(interval);
-
-    assertFalse(router.getSafemodeService().isInSafeMode());
-    verifyRouter(RouterServiceState.RUNNING);
-  }
-
-  @Test
-  public void testRouterExitSafemodeResetUpTime()
-      throws InterruptedException, IllegalStateException, IOException {
-
-    Calendar calendar = Calendar.getInstance();
-    // Get the future times, add one day to the current date.
-    calendar.add(Calendar.DAY_OF_MONTH, 1);
-    long timestampAfterOneDay = calendar.getTimeInMillis();
-    router.getSafemodeService().setStartupTime(timestampAfterOneDay);
-
-    assertTrue(router.getSafemodeService().isInSafeMode());
-    verifyRouter(RouterServiceState.SAFEMODE);
-
-    // Wait for initial time in milliseconds
-    long interval =
-        conf.getTimeDuration(DFS_ROUTER_SAFEMODE_EXTENSION,
-            TimeUnit.SECONDS.toMillis(2), TimeUnit.MILLISECONDS) +
-            conf.getTimeDuration(DFS_ROUTER_CACHE_TIME_TO_LIVE_MS,
-                TimeUnit.SECONDS.toMillis(1), TimeUnit.MILLISECONDS) * 2;
     Thread.sleep(interval);
 
     assertFalse(router.getSafemodeService().isInSafeMode());


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17116

The following exceptions occurred in our online environment:

1. After the machine restarts, the system time is abnormal, is a time in the future
2. After starting the router, there is log "safemode exit for 24981702 milliseconds...", which has been in the safemode state,this is mainly because the startupTime is recorded as the future system time when router is started at this time, and the system time returns to normal soon, resulting in a negative delta, at this time, the service can only be restored by restart the router service.

The relevant logs are:

```
2023-07-15 03:15:49,276 INFO  ipc.Server xxx
2023-07-15 11:21:03,785 INFO  router.DFSRouter (LogAdapter.java:info(51)) [main] - STARTUP_MSG:
/************************************************************
STARTUP_MSG: Starting Router
...
2023-07-15 11:21:51,325 INFO xxx
2023-07-15 03:22:00,257 INFO xxx
2023-07-15 03:22:29,829 INFO router.RouterSafemodeService (RouterSafemodeService.java:periodicInvoke(167)) [RouterSafemodeService-0] - Delaying safemode exit for 28761777 milliseconds...
```

Maybe we can be compatible with this case at the code level, can invoke monotonicNow() to calculate the delta.