### PR TITLE
HDFS-17117. Print reconstructionQueuesInitProgress periodically when BlockManager processMisReplicatesAsync.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NamenodeBeanMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NamenodeBeanMetrics.java
@@ -884,6 +884,11 @@ public class NamenodeBeanMetrics
     return 0;
   }
 
+  @Override
+  public double getReconstructionQueuesInitProgress() {
+    return 0.0;
+  }
+
   private Router getRouter() throws IOException {
     if (this.router == null) {
       throw new IOException("Router is not initialized");

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NamenodeBeanMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NamenodeBeanMetrics.java
@@ -885,8 +885,8 @@ public class NamenodeBeanMetrics
   }
 
   @Override
-  public double getReconstructionQueuesInitProgress() {
-    return 0.0;
+  public float getReconstructionQueuesInitProgress() {
+    return 0;
   }
 
   private Router getRouter() throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -3889,10 +3889,10 @@ public class BlockManager implements BlockStatsMXBean {
         totalProcessed += processed;
         // there is a possibility that if any of the blocks deleted/added during
         // initialisation, then progress might be different.
-        reconstructionQueuesInitProgress = Math.min((double) totalProcessed
-            / totalBlocks, 1.0);
-        LOG.info("Reconstruction queues initialisation progress: {}, total number of blocks " +
-                "processed: {}/{}", reconstructionQueuesInitProgress, totalProcessed, totalBlocks);
+        if (totalBlocks > 0) { // here avoid metrics appear as NaN.
+          reconstructionQueuesInitProgress = Math.min((double) totalProcessed
+              / totalBlocks, 1.0);
+        }
 
         if (!blocksItr.hasNext()) {
           LOG.info("Total number of blocks            = {}", blocksMap.size());
@@ -3912,6 +3912,8 @@ public class BlockManager implements BlockStatsMXBean {
         }
       } finally {
         namesystem.writeUnlock("processMisReplicatesAsync");
+        LOG.info("Reconstruction queues initialisation progress: {}, total number of blocks " +
+            "processed: {}/{}", reconstructionQueuesInitProgress, totalProcessed, totalBlocks);
         // Make sure it is out of the write lock for sufficiently long time.
         Thread.sleep(sleepDuration);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -449,7 +449,7 @@ public class BlockManager implements BlockStatsMXBean {
   /**
    * Progress of the Reconstruction queues initialisation.
    */
-  private double reconstructionQueuesInitProgress = 0.0;
+  private float reconstructionQueuesInitProgress = 0.0f;
 
   /** for block replicas placement */
   private volatile BlockPlacementPolicies placementPolicies;
@@ -3890,8 +3890,8 @@ public class BlockManager implements BlockStatsMXBean {
         // there is a possibility that if any of the blocks deleted/added during
         // initialisation, then progress might be different.
         if (totalBlocks > 0) { // here avoid metrics appear as NaN.
-          reconstructionQueuesInitProgress = Math.min((double) totalProcessed
-              / totalBlocks, 1.0);
+          reconstructionQueuesInitProgress = Math.min((float) totalProcessed
+              / totalBlocks, 1.0f);
         }
 
         if (!blocksItr.hasNext()) {
@@ -3928,7 +3928,7 @@ public class BlockManager implements BlockStatsMXBean {
    * 
    * @return Returns values between 0 and 1 for the progress.
    */
-  public double getReconstructionQueuesInitProgress() {
+  public float getReconstructionQueuesInitProgress() {
     return reconstructionQueuesInitProgress;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -3891,6 +3891,8 @@ public class BlockManager implements BlockStatsMXBean {
         // initialisation, then progress might be different.
         reconstructionQueuesInitProgress = Math.min((double) totalProcessed
             / totalBlocks, 1.0);
+        LOG.info("Reconstruction queues initialisation progress: {}, total number of blocks " +
+                "processed: {}/{}", reconstructionQueuesInitProgress, totalProcessed, totalBlocks);
 
         if (!blocksItr.hasNext()) {
           LOG.info("Total number of blocks            = {}", blocksMap.size());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -4893,7 +4893,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
    */
   @Override // FSNamesystemMBean
   @Metric
-  public double getReconstructionQueuesInitProgress() {
+  public float getReconstructionQueuesInitProgress() {
     return blockManager.getReconstructionQueuesInitProgress();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -4889,6 +4889,15 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   }
 
   /**
+   * Get the progress of the reconstruction queues initialisation.
+   */
+  @Override // FSNamesystemMBean
+  @Metric
+  public double getReconstructionQueuesInitProgress() {
+    return blockManager.getReconstructionQueuesInitProgress();
+  }
+
+  /**
    * Returns the length of the wait Queue for the FSNameSystemLock.
    *
    * A larger number here indicates lots of threads are waiting for

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/FSNamesystemMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/FSNamesystemMBean.java
@@ -267,5 +267,5 @@ public interface FSNamesystemMBean {
    *
    * @return Returns values between 0 and 1 for the progress.
    */
-  double getReconstructionQueuesInitProgress();
+  float getReconstructionQueuesInitProgress();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/FSNamesystemMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/FSNamesystemMBean.java
@@ -263,7 +263,7 @@ public interface FSNamesystemMBean {
   int getPendingSPSPaths();
 
   /**
-   * Get the progress of the reconstruction queues initialisation
+   * Get the progress of the reconstruction queues initialisation.
    *
    * @return Returns values between 0 and 1 for the progress.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/FSNamesystemMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/FSNamesystemMBean.java
@@ -261,4 +261,11 @@ public interface FSNamesystemMBean {
    * @return The number of paths to be processed by sps.
    */
   int getPendingSPSPaths();
+
+  /**
+   * Get the progress of the reconstruction queues initialisation
+   *
+   * @return Returns values between 0 and 1 for the progress.
+   */
+  double getReconstructionQueuesInitProgress();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemMBean.java
@@ -246,9 +246,9 @@ public class TestFSNamesystemMBean {
       MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
       ObjectName mxbeanName =
           new ObjectName("Hadoop:service=NameNode,name=FSNamesystemState");
-      Double reconstructionQueuesInitProgress =
-          (Double) mbs.getAttribute(mxbeanName, "ReconstructionQueuesInitProgress");
-      assertEquals(0.0, reconstructionQueuesInitProgress.doubleValue(), 0);
+      float reconstructionQueuesInitProgress =
+          (float) mbs.getAttribute(mxbeanName, "ReconstructionQueuesInitProgress");
+      assertEquals(0.0, reconstructionQueuesInitProgress, 0);
 
       // create file.
       Path file = new Path("/test");
@@ -265,8 +265,8 @@ public class TestFSNamesystemMBean {
           100, 5 * 1000);
 
       reconstructionQueuesInitProgress =
-          (Double) mbs.getAttribute(mxbeanName, "ReconstructionQueuesInitProgress");
-      assertEquals(1.0, reconstructionQueuesInitProgress.doubleValue(), 0);
+          (float) mbs.getAttribute(mxbeanName, "ReconstructionQueuesInitProgress");
+      assertEquals(1.0, reconstructionQueuesInitProgress, 0);
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemMBean.java
@@ -241,7 +241,7 @@ public class TestFSNamesystemMBean {
       final FSNamesystem fsNamesystem = cluster.getNamesystem();
       final DistributedFileSystem fs = cluster.getFileSystem();
 
-      // validate init reconstructionQueuesInitProgress value.
+      // Validate init reconstructionQueuesInitProgress value.
       assertEquals(0.0, fsNamesystem.getReconstructionQueuesInitProgress(), 0);
       MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
       ObjectName mxbeanName =
@@ -250,16 +250,16 @@ public class TestFSNamesystemMBean {
           (float) mbs.getAttribute(mxbeanName, "ReconstructionQueuesInitProgress");
       assertEquals(0.0, reconstructionQueuesInitProgress, 0);
 
-      // create file.
+      // Create file.
       Path file = new Path("/test");
       long fileLength = 1024 * 1024 * 3;
       DFSTestUtil.createFile(fs, file, fileLength, (short) 1, 0L);
       DFSTestUtil.waitReplication(fs, file, (short) 1);
 
-      // restart nameNode to run processMisReplicatedBlocks.
+      // Restart nameNode to run processMisReplicatedBlocks.
       cluster.restartNameNode(true);
 
-      // validate reconstructionQueuesInitProgress value.
+      // Validate reconstructionQueuesInitProgress value.
       GenericTestUtils.waitFor(
           () -> cluster.getNamesystem().getReconstructionQueuesInitProgress() == 1.0,
           100, 5 * 1000);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemMBean.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 
@@ -33,9 +34,12 @@ import javax.management.ObjectName;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.metrics2.impl.ConfigBuilder;
 import org.apache.hadoop.metrics2.impl.TestMetricsConfig;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Test;
 import org.eclipse.jetty.util.ajax.JSON;
 
@@ -223,6 +227,46 @@ public class TestFSNamesystemMBean {
       if (cluster != null) {
         cluster.shutdown();
       }
+    }
+  }
+
+  /**
+   * Test metrics associated with reconstructionQueuesInitProgress.
+   */
+  @Test
+  public void testReconstructionQueuesInitProgressMetrics() throws Exception {
+    Configuration conf = new Configuration();
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build()) {
+      cluster.waitActive();
+      final FSNamesystem fsNamesystem = cluster.getNamesystem();
+      final DistributedFileSystem fs = cluster.getFileSystem();
+
+      // validate init reconstructionQueuesInitProgress value.
+      assertEquals(0.0, fsNamesystem.getReconstructionQueuesInitProgress(), 0);
+      MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+      ObjectName mxbeanName =
+          new ObjectName("Hadoop:service=NameNode,name=FSNamesystemState");
+      Double reconstructionQueuesInitProgress =
+          (Double) mbs.getAttribute(mxbeanName, "ReconstructionQueuesInitProgress");
+      assertEquals(0.0, reconstructionQueuesInitProgress.doubleValue(), 0);
+
+      // create file.
+      Path file = new Path("/test");
+      long fileLength = 1024 * 1024 * 3;
+      DFSTestUtil.createFile(fs, file, fileLength, (short) 1, 0L);
+      DFSTestUtil.waitReplication(fs, file, (short) 1);
+
+      // restart nameNode to run processMisReplicatedBlocks.
+      cluster.restartNameNode(true);
+
+      // validate reconstructionQueuesInitProgress value.
+      GenericTestUtils.waitFor(
+          () -> cluster.getNamesystem().getReconstructionQueuesInitProgress() == 1.0,
+          100, 5 * 1000);
+
+      reconstructionQueuesInitProgress =
+          (Double) mbs.getAttribute(mxbeanName, "ReconstructionQueuesInitProgress");
+      assertEquals(1.0, reconstructionQueuesInitProgress.doubleValue(), 0);
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemMBean.java
@@ -236,7 +236,7 @@ public class TestFSNamesystemMBean {
   @Test
   public void testReconstructionQueuesInitProgressMetrics() throws Exception {
     Configuration conf = new Configuration();
-    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build()) {
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).build()) {
       cluster.waitActive();
       final FSNamesystem fsNamesystem = cluster.getNamesystem();
       final DistributedFileSystem fs = cluster.getFileSystem();


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17117

BlockManager#processMisReplicatesAsync can periodically print reconstructionQueuesInitProgress, so that the admin can get the progress of the replication queues initialisation.
Ready to add logs and metrics.
