### PR TITLE
HDFS-17130. Blocks on IN_MAINTENANCE DNs should be sorted properly in LocatedBlocks.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
@@ -134,7 +134,7 @@ public class DFSUtil {
 
   /**
    * Comparator for sorting DataNodeInfo[] based on
-   * decommissioned and entering_maintenance states.
+   * decommissioned, in_maintenance, decommissioning and entering_maintenance states.
    */
   public static class ServiceComparator implements Comparator<DatanodeInfo> {
     @Override
@@ -146,7 +146,14 @@ public class DFSUtil {
         return -1;
       }
 
-      // Decommissioning nodes will be placed before decommissioned nodes.
+      // IN_MAINTENANCE nodes will be placed before decommissioned nodes.
+      if (a.isInMaintenance()) {
+        return b.isInMaintenance() ? 0 : 1;
+      } else if (b.isInMaintenance()) {
+        return -1;
+      }
+
+      // Decommissioning nodes will be placed before IN_MAINTENANCE nodes.
       if (a.isDecommissionInProgress()) {
         return b.isDecommissionInProgress() ? 0 : 1;
       } else if (b.isDecommissionInProgress()) {
@@ -166,9 +173,10 @@ public class DFSUtil {
 
   /**
    * Comparator for sorting DataNodeInfo[] based on
-   * slow, stale, entering_maintenance, decommissioning and decommissioned states.
+   * slow, stale, entering_maintenance, decommissioning, in_maintenance and decommissioned states.
    * Order: live {@literal ->} slow {@literal ->} stale {@literal ->}
-   * entering_maintenance {@literal ->} decommissioning {@literal ->} decommissioned
+   * entering_maintenance {@literal ->} decommissioning {@literal ->}
+   * in_maintenance {@literal ->} decommissioned
    */
   @InterfaceAudience.Private 
   public static class StaleAndSlowComparator extends ServiceComparator {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -512,6 +512,7 @@ public class DatanodeManager {
 
   private boolean isInactive(DatanodeInfo datanode) {
     return datanode.isDecommissioned() ||
+        datanode.isInMaintenance() ||
         datanode.isDecommissionInProgress() ||
         datanode.isEnteringMaintenance() ||
         (avoidStaleDataNodesForRead && datanode.isStale(staleInterval));
@@ -542,7 +543,8 @@ public class DatanodeManager {
   /**
    * Sort the non-striped located blocks by the distance to the target host.
    *
-   * For striped blocks, it will only move decommissioned/decommissioning/stale/slow
+   * For striped blocks, it will only move decommissioned/in_maintenance
+   * /decommissioning/stale/slow
    * nodes to the bottom. For example, assume we have storage list:
    * d0, d1, d2, d3, d4, d5, d6, d7, d8, d9
    * mapping to block indices:
@@ -572,7 +574,7 @@ public class DatanodeManager {
   }
 
   /**
-   * Move decommissioned/decommissioning/entering_maintenance/stale/slow
+   * Move decommissioned/in_maintenance/decommissioning/entering_maintenance/stale/slow
    * datanodes to the bottom. After sorting it will
    * update block indices and block tokens respectively.
    *
@@ -591,7 +593,8 @@ public class DatanodeManager {
       locToToken.put(di[i], lsb.getBlockTokens()[i]);
     }
     // Arrange the order of datanodes as follows:
-    // live(in-service) -> stale -> entering_maintenance -> decommissioning -> decommissioned
+    // live(in-service) -> stale -> entering_maintenance -> decommissioning
+    // -> in_maintenance -> decommissioned
     Arrays.sort(di, comparator);
 
     // must update cache since we modified locations array
@@ -605,7 +608,7 @@ public class DatanodeManager {
   }
 
   /**
-   * Move decommissioned/decommissioning/entering_maintenance/stale/slow
+   * Move decommissioned/in_maintenance/decommissioning/entering_maintenance/stale/slow
    * datanodes to the bottom. Also, sort nodes by network
    * distance.
    *
@@ -638,7 +641,8 @@ public class DatanodeManager {
 
     DatanodeInfoWithStorage[] di = lb.getLocations();
     // Arrange the order of datanodes as follows:
-    // live(in-service) -> stale -> entering_maintenance -> decommissioning -> decommissioned
+    // live(in-service) -> stale -> entering_maintenance -> decommissioning
+    // -> in_maintenance -> decommissioned
     Arrays.sort(di, comparator);
 
     // Sort nodes by network distance only for located blocks

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSortLocatedBlock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSortLocatedBlock.java
@@ -125,13 +125,13 @@ public class TestSortLocatedBlock {
    *
    * After sorting the expected datanodes list will be:
    * live -> slow -> stale -> staleAndSlow ->
-   * entering_maintenance -> decommissioning -> decommissioned.
+   * entering_maintenance -> decommissioning -> in_maintenance -> decommissioned.
    *
    * avoidStaleDataNodesForRead=true && avoidSlowDataNodesForRead=true
-   * d6 -> d5 -> d4 -> d3 -> d2 -> d1 -> d0
+   * d6 -> d5 -> d4 -> d3 -> d2 -> d1 -> d7 -> d0
    */
   @Test(timeout = 30000)
-  public void testAviodStaleAndSlowDatanodes() throws IOException {
+  public void testAvoidStaleAndSlowDatanodes() throws IOException {
     DatanodeManager dm = mockDatanodeManager(true, true);
     DatanodeInfo[] locs = mockDatanodes(dm);
 
@@ -148,7 +148,7 @@ public class TestSortLocatedBlock {
     DatanodeInfoWithStorage[] locations = locatedBlock.getLocations();
 
     // assert location order:
-    // live -> stale -> entering_maintenance -> decommissioning -> decommissioned
+    // live -> stale -> entering_maintenance -> decommissioning -> in_maintenance -> decommissioned
     // live
     assertEquals(locs[6].getIpAddr(), locations[0].getIpAddr());
     // slow
@@ -161,8 +161,10 @@ public class TestSortLocatedBlock {
     assertEquals(locs[2].getIpAddr(), locations[4].getIpAddr());
     // decommissioning
     assertEquals(locs[1].getIpAddr(), locations[5].getIpAddr());
+    // in_maintenance
+    assertEquals(locs[7].getIpAddr(), locations[6].getIpAddr());
     // decommissioned
-    assertEquals(locs[0].getIpAddr(), locations[6].getIpAddr());
+    assertEquals(locs[0].getIpAddr(), locations[7].getIpAddr());
   }
 
   /**
@@ -171,13 +173,13 @@ public class TestSortLocatedBlock {
    *
    * After sorting the expected datanodes list will be:
    * (live <-> slow) -> (stale <-> staleAndSlow) ->
-   * entering_maintenance -> decommissioning -> decommissioned.
+   * entering_maintenance -> decommissioning -> in_maintenance -> decommissioned.
    *
    * avoidStaleDataNodesForRead=true && avoidSlowDataNodesForRead=false
-   * (d6 <-> d5) -> (d4 <-> d3) -> d2 -> d1 -> d0
+   * (d6 <-> d5) -> (d4 <-> d3) -> d2 -> d1 -> d7 -> d0
    */
   @Test(timeout = 30000)
-  public void testAviodStaleDatanodes() throws IOException {
+  public void testAvoidStaleDatanodes() throws IOException {
     DatanodeManager dm = mockDatanodeManager(true, false);
     DatanodeInfo[] locs = mockDatanodes(dm);
 
@@ -209,8 +211,10 @@ public class TestSortLocatedBlock {
     assertEquals(locs[2].getIpAddr(), locations[4].getIpAddr());
     // decommissioning
     assertEquals(locs[1].getIpAddr(), locations[5].getIpAddr());
+    // in_maintenance
+    assertEquals(locs[7].getIpAddr(), locations[6].getIpAddr());
     // decommissioned
-    assertEquals(locs[0].getIpAddr(), locations[6].getIpAddr());
+    assertEquals(locs[0].getIpAddr(), locations[7].getIpAddr());
   }
 
   /**
@@ -219,13 +223,13 @@ public class TestSortLocatedBlock {
    *
    * After sorting the expected datanodes list will be:
    * (live <-> stale) -> (slow <-> staleAndSlow) ->
-   * entering_maintenance -> decommissioning -> decommissioned.
+   * entering_maintenance -> decommissioning -> in_maintenance -> decommissioned.
    *
    * avoidStaleDataNodesForRead=false && avoidSlowDataNodesForRead=true
-   * (d6 -> d4) -> (d5 <-> d3) -> d2 -> d1 -> d0
+   * (d6 -> d4) -> (d5 <-> d3) -> d2 -> d1 -> d7 -> d0
    */
   @Test(timeout = 30000)
-  public void testAviodSlowDatanodes() throws IOException {
+  public void testAvoidSlowDatanodes() throws IOException {
     DatanodeManager dm = mockDatanodeManager(false, true);
     DatanodeInfo[] locs = mockDatanodes(dm);
 
@@ -257,8 +261,10 @@ public class TestSortLocatedBlock {
     assertEquals(locs[2].getIpAddr(), locations[4].getIpAddr());
     // decommissioning
     assertEquals(locs[1].getIpAddr(), locations[5].getIpAddr());
+    // in_maintenance
+    assertEquals(locs[7].getIpAddr(), locations[6].getIpAddr());
     // decommissioned
-    assertEquals(locs[0].getIpAddr(), locations[6].getIpAddr());
+    assertEquals(locs[0].getIpAddr(), locations[7].getIpAddr());
   }
 
   /**
@@ -267,10 +273,10 @@ public class TestSortLocatedBlock {
    *
    * After sorting the expected datanodes list will be:
    * (live <-> stale <-> slow <-> staleAndSlow) ->
-   * entering_maintenance -> decommissioning -> decommissioned.
+   * entering_maintenance -> decommissioning -> in_maintenance -> decommissioned.
    *
    * avoidStaleDataNodesForRead=false && avoidSlowDataNodesForRead=false
-   * (d6 <-> d5 <-> d4 <-> d3) -> d2 -> d1 -> d0
+   * (d6 <-> d5 <-> d4 <-> d3) -> d2 -> d1 -> d7 -> d0
    */
   @Test(timeout = 30000)
   public void testWithServiceComparator() throws IOException {
@@ -297,7 +303,8 @@ public class TestSortLocatedBlock {
     DatanodeInfoWithStorage[] locations = locatedBlock.getLocations();
 
     // assert location order:
-    // live/slow/stale -> entering_maintenance -> decommissioning -> decommissioned.
+    // live/slow/stale -> entering_maintenance -> decommissioning
+    // -> in_maintenance -> decommissioned.
     // live/slow/stale
     assertTrue(list.contains(locations[0]) &&
         list.contains(locations[1]) &&
@@ -307,8 +314,10 @@ public class TestSortLocatedBlock {
     assertEquals(locs[2].getIpAddr(), locations[4].getIpAddr());
     // decommissioning
     assertEquals(locs[1].getIpAddr(), locations[5].getIpAddr());
+    // in_maintenance
+    assertEquals(locs[7].getIpAddr(), locations[6].getIpAddr());
     // decommissioned
-    assertEquals(locs[0].getIpAddr(), locations[6].getIpAddr());
+    assertEquals(locs[0].getIpAddr(), locations[7].getIpAddr());
   }
 
   /**
@@ -320,9 +329,10 @@ public class TestSortLocatedBlock {
    * d4 - stale
    * d5 - slow
    * d6 - live(in-service)
+   * d7 - in_maintenance
    */
   private static DatanodeInfo[] mockDatanodes(DatanodeManager dm) {
-    int totalDns = 7;
+    int totalDns = 8;
     DatanodeInfo[] locs = new DatanodeInfo[totalDns];
 
     // create datanodes
@@ -346,6 +356,7 @@ public class TestSortLocatedBlock {
         DFSConfigKeys.DFS_NAMENODE_STALE_DATANODE_INTERVAL_DEFAULT * 1000 - 1);
     // set slow state
     dm.addSlowPeers(locs[5].getDatanodeUuid());
+    locs[7].setInMaintenance();
 
     return locs;
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Blocks on IN_MAINTENANCE DNs should be sorted properly in LocatedBlocks.

### How was this patch tested?
Unit Test

