### PR TITLE
HDFS-17118 Fixed a couple checkstyle warnings in TestObserverReadProxyProvider

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -46,7 +46,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.event.Level;
@@ -59,8 +58,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -367,7 +366,7 @@ public class TestObserverReadProxyProvider {
 
     setupProxyProvider(1, NAMENODE_HA_STATE_PROBE_TIMEOUT_SHORT);
     final HAServiceState state = HAServiceState.STANDBY;
-    NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
+    @SuppressWarnings("unchecked") NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
         (NNProxyInfo<ClientProtocol>) mock(NNProxyInfo.class);
     Future<HAServiceState> task = mock(Future.class);
     when(task.get(anyLong(), any(TimeUnit.class))).thenReturn(state);
@@ -452,7 +451,7 @@ public class TestObserverReadProxyProvider {
   }
 
   /**
-   * Test GetHAServiceState when timeout is disabled (test the else { task.get() } code path)
+   * Test GetHAServiceState when timeout is disabled (test the else { task.get() } code path).
    */
   @Test
   public void testGetHAServiceStateWithoutTimeout() throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -366,9 +366,11 @@ public class TestObserverReadProxyProvider {
 
     setupProxyProvider(1, NAMENODE_HA_STATE_PROBE_TIMEOUT_SHORT);
     final HAServiceState state = HAServiceState.STANDBY;
-    @SuppressWarnings("unchecked") NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
+    @SuppressWarnings("unchecked")
+    NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
         (NNProxyInfo<ClientProtocol>) mock(NNProxyInfo.class);
-    @SuppressWarnings("unchecked") Future<HAServiceState> task = mock(Future.class);
+    @SuppressWarnings("unchecked")
+    Future<HAServiceState> task = mock(Future.class);
     when(task.get(anyLong(), any(TimeUnit.class))).thenReturn(state);
 
     HAServiceState state2 = proxyProvider.getHAServiceStateWithTimeout(dummyNNProxyInfo, task);
@@ -388,9 +390,11 @@ public class TestObserverReadProxyProvider {
     proxyLog.clearOutput();
 
     setupProxyProvider(1, NAMENODE_HA_STATE_PROBE_TIMEOUT_SHORT);
-    @SuppressWarnings("unchecked") NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
+    @SuppressWarnings("unchecked")
+    NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
         (NNProxyInfo<ClientProtocol>) Mockito.mock(NNProxyInfo.class);
-    @SuppressWarnings("unchecked") Future<HAServiceState> task = mock(Future.class);
+    @SuppressWarnings("unchecked")
+    Future<HAServiceState> task = mock(Future.class);
     TimeoutException e = new TimeoutException("Timeout");
     when(task.get(anyLong(), any(TimeUnit.class))).thenThrow(e);
 
@@ -412,9 +416,11 @@ public class TestObserverReadProxyProvider {
     proxyLog.clearOutput();
 
     setupProxyProvider(1, NAMENODE_HA_STATE_PROBE_TIMEOUT_SHORT);
-    @SuppressWarnings("unchecked") NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
+    @SuppressWarnings("unchecked")
+    NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
         (NNProxyInfo<ClientProtocol>) Mockito.mock(NNProxyInfo.class);
-    @SuppressWarnings("unchecked") Future<HAServiceState> task = mock(Future.class);
+    @SuppressWarnings("unchecked")
+    Future<HAServiceState> task = mock(Future.class);
     InterruptedException e = new InterruptedException("Interrupted");
     when(task.get(anyLong(), any(TimeUnit.class))).thenThrow(e);
 
@@ -435,9 +441,11 @@ public class TestObserverReadProxyProvider {
     proxyLog.clearOutput();
 
     setupProxyProvider(1, NAMENODE_HA_STATE_PROBE_TIMEOUT_SHORT);
-    @SuppressWarnings("unchecked") NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
+    @SuppressWarnings("unchecked")
+    NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
         (NNProxyInfo<ClientProtocol>) Mockito.mock(NNProxyInfo.class);
-    @SuppressWarnings("unchecked") Future<HAServiceState> task = mock(Future.class);
+    @SuppressWarnings("unchecked")
+    Future<HAServiceState> task = mock(Future.class);
     Exception e = new ExecutionException(new InterruptedException("Interrupted"));
     when(task.get(anyLong(), any(TimeUnit.class))).thenThrow(e);
 
@@ -459,9 +467,11 @@ public class TestObserverReadProxyProvider {
     setupProxyProvider(1, 0);
 
     final HAServiceState state = HAServiceState.STANDBY;
-    @SuppressWarnings("unchecked") NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
+    @SuppressWarnings("unchecked")
+    NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
         (NNProxyInfo<ClientProtocol>) mock(NNProxyInfo.class);
-    @SuppressWarnings("unchecked") Future<HAServiceState> task = mock(Future.class);
+    @SuppressWarnings("unchecked")
+    Future<HAServiceState> task = mock(Future.class);
     when(task.get()).thenReturn(state);
 
     HAServiceState state2 = proxyProvider.getHAServiceStateWithTimeout(dummyNNProxyInfo, task);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -368,7 +368,7 @@ public class TestObserverReadProxyProvider {
     final HAServiceState state = HAServiceState.STANDBY;
     @SuppressWarnings("unchecked") NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
         (NNProxyInfo<ClientProtocol>) mock(NNProxyInfo.class);
-    Future<HAServiceState> task = mock(Future.class);
+    @SuppressWarnings("unchecked") Future<HAServiceState> task = mock(Future.class);
     when(task.get(anyLong(), any(TimeUnit.class))).thenReturn(state);
 
     HAServiceState state2 = proxyProvider.getHAServiceStateWithTimeout(dummyNNProxyInfo, task);
@@ -388,9 +388,9 @@ public class TestObserverReadProxyProvider {
     proxyLog.clearOutput();
 
     setupProxyProvider(1, NAMENODE_HA_STATE_PROBE_TIMEOUT_SHORT);
-    NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
+    @SuppressWarnings("unchecked") NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
         (NNProxyInfo<ClientProtocol>) Mockito.mock(NNProxyInfo.class);
-    Future<HAServiceState> task = mock(Future.class);
+    @SuppressWarnings("unchecked") Future<HAServiceState> task = mock(Future.class);
     TimeoutException e = new TimeoutException("Timeout");
     when(task.get(anyLong(), any(TimeUnit.class))).thenThrow(e);
 
@@ -412,9 +412,9 @@ public class TestObserverReadProxyProvider {
     proxyLog.clearOutput();
 
     setupProxyProvider(1, NAMENODE_HA_STATE_PROBE_TIMEOUT_SHORT);
-    NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
+    @SuppressWarnings("unchecked") NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
         (NNProxyInfo<ClientProtocol>) Mockito.mock(NNProxyInfo.class);
-    Future<HAServiceState> task = mock(Future.class);
+    @SuppressWarnings("unchecked") Future<HAServiceState> task = mock(Future.class);
     InterruptedException e = new InterruptedException("Interrupted");
     when(task.get(anyLong(), any(TimeUnit.class))).thenThrow(e);
 
@@ -435,9 +435,9 @@ public class TestObserverReadProxyProvider {
     proxyLog.clearOutput();
 
     setupProxyProvider(1, NAMENODE_HA_STATE_PROBE_TIMEOUT_SHORT);
-    NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
+    @SuppressWarnings("unchecked") NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
         (NNProxyInfo<ClientProtocol>) Mockito.mock(NNProxyInfo.class);
-    Future<HAServiceState> task = mock(Future.class);
+    @SuppressWarnings("unchecked") Future<HAServiceState> task = mock(Future.class);
     Exception e = new ExecutionException(new InterruptedException("Interrupted"));
     when(task.get(anyLong(), any(TimeUnit.class))).thenThrow(e);
 
@@ -459,9 +459,9 @@ public class TestObserverReadProxyProvider {
     setupProxyProvider(1, 0);
 
     final HAServiceState state = HAServiceState.STANDBY;
-    NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
+    @SuppressWarnings("unchecked") NNProxyInfo<ClientProtocol> dummyNNProxyInfo =
         (NNProxyInfo<ClientProtocol>) mock(NNProxyInfo.class);
-    Future<HAServiceState> task = mock(Future.class);
+    @SuppressWarnings("unchecked") Future<HAServiceState> task = mock(Future.class);
     when(task.get()).thenReturn(state);
 
     HAServiceState state2 = proxyProvider.getHAServiceStateWithTimeout(dummyNNProxyInfo, task);


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

We noticed a few checkstyle warnings when backporting [HDFS-17030](https://issues.apache.org/jira/browse/HDFS-17030) from trunk to branch-3.3. The yetus build was not stable at that time and we did not notice the newly added checkstyle warnings. Fix them now.


### How was this patch tested?
- unit test for TestObserverReadProxyProvider

```
xinglin@xinglin-mn1 ~/p/h/t/hadoop-hdfs-project (HDFS-17118)> mvn test -Dtest=TestObserverReadProxyProvider
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.hdfs.server.namenode.ha.TestObserverReadProxyProvider
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.99 s - in org.apache.hadoop.hdfs.server.namenode.ha.TestObserverReadProxyProvider
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0
```

- mvn build for hadoop-hdfs.

```
xinglin@xinglin-mn1 ~/p/h/t/hadoop-hdfs-project (HDFS-17118)> mvn package -Dtar -Pdist -DskipTests -Dmaven.javadoc.failOnError=false
[INFO] Reactor Summary for Apache Hadoop HDFS Project 3.4.0-SNAPSHOT:
[INFO]
[INFO] Apache Hadoop HDFS Client .......................... SUCCESS [04:17 min]
[INFO] Apache Hadoop HDFS ................................. SUCCESS [03:33 min]
[INFO] Apache Hadoop HDFS Native Client ................... SUCCESS [  4.238 s]
[INFO] Apache Hadoop HttpFS ............................... SUCCESS [  6.406 s]
[INFO] Apache Hadoop HDFS-NFS ............................. SUCCESS [  3.799 s]
[INFO] Apache Hadoop HDFS-RBF ............................. SUCCESS [03:59 min]
[INFO] Apache Hadoop HDFS Project ......................... SUCCESS [  0.143 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12:04 min
[INFO] Finished at: 2023-07-23T23:03:01-07:00
[INFO] ------------------------------------------------------------------------
```


