### PR TITLE
HDFS-17120. Support snapshot diff based copylisting for flat paths.

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
@@ -122,6 +122,10 @@ public final class DistCpConstants {
   /* DistCp CopyListing class override param */
   public static final String CONF_LABEL_COPY_LISTING_CLASS = "distcp.copy.listing.class";
 
+  /* Traverse directory from diff recursively and add paths to the copyList if true */
+  public static final String CONF_LABEL_DIFF_COPY_LISTING_TRAVERSE_DIRECTORY =
+      "distcp.diff.copy.listing.traverse.directory";
+
   /**
    *  DistCp Filter class override param.
    */

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/GlobbedCopyListing.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/GlobbedCopyListing.java
@@ -61,7 +61,7 @@ public class GlobbedCopyListing extends CopyListing {
    * @param pathToListingFile The location at which the copy-listing file
    *                           is to be created.
    * @param context The distcp context with associated input options.
-   * @throws IOException
+   * @throws IOException if unable to construct the fileList
    */
   @Override
   public void doBuildListing(Path pathToListingFile, DistCpContext context)

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/RegexCopyFilter.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/RegexCopyFilter.java
@@ -50,6 +50,7 @@ public class RegexCopyFilter extends CopyFilter {
   /**
    * Constructor, sets up a File object to read filter patterns from and
    * the List to store the patterns.
+   * @param filtersFilename name of the filtersFile
    */
   protected RegexCopyFilter(String filtersFilename) {
     filtersFile = new File(filtersFilename);

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestCopyListing.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestCopyListing.java
@@ -182,16 +182,14 @@ public class TestCopyListing extends SimpleCopyListing {
     try {
       fs = FileSystem.get(getConf());
       buildListingUsingSnapshotDiff(fs, configuration, distCpSync, listingFile);
-    } catch (IOException e) {
-      LOG.error("Exception encountered in test", e);
-      Assert.fail("Test failed " + e.getMessage());
     } finally {
       TestDistCpUtils.delete(fs, "/tmp");
     }
   }
 
   @Test(timeout=10000)
-  public void testDiffBasedSimpleCopyListingWithoutTraverseDirectory() {
+  public void testDiffBasedSimpleCopyListingWithoutTraverseDirectory()
+      throws IOException {
     FileSystem fs = null;
     Configuration configuration = getConf();
     DistCpSync distCpSync = Mockito.mock(DistCpSync.class);
@@ -202,9 +200,6 @@ public class TestCopyListing extends SimpleCopyListing {
     try {
       fs = FileSystem.get(getConf());
       buildListingUsingSnapshotDiff(fs, configuration, distCpSync, listingFile);
-    } catch (IOException e) {
-      LOG.error("Exception encountered in test", e);
-      Assert.fail("Test failed " + e.getMessage());
     } finally {
       TestDistCpUtils.delete(fs, "/tmp");
     }

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestCopyListing.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestCopyListing.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.tools;
 
 import static org.mockito.Mockito.*;
 
+import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.Path;
@@ -165,6 +167,77 @@ public class TestCopyListing extends SimpleCopyListing {
     } finally {
       TestDistCpUtils.delete(fs, "/tmp");
     }
+  }
+
+  @Test(expected = DuplicateFileException.class, timeout = 10000)
+  public void testDiffBasedSimpleCopyListing() throws IOException {
+    FileSystem fs = null;
+    Configuration configuration = getConf();
+    DistCpSync distCpSync = Mockito.mock(DistCpSync.class);
+    Path listingFile = new Path("/tmp/list");
+    // Throws DuplicateFileException as it recursively traverses src3 directory
+    // and also adds 3.txt,4.txt twice
+    configuration.setBoolean(
+        DistCpConstants.CONF_LABEL_DIFF_COPY_LISTING_TRAVERSE_DIRECTORY, true);
+    try {
+      fs = FileSystem.get(getConf());
+      buildListingUsingSnapshotDiff(fs, configuration, distCpSync, listingFile);
+    } catch (IOException e) {
+      LOG.error("Exception encountered in test", e);
+      Assert.fail("Test failed " + e.getMessage());
+    } finally {
+      TestDistCpUtils.delete(fs, "/tmp");
+    }
+  }
+
+  @Test(timeout=10000)
+  public void testDiffBasedSimpleCopyListingWithoutTraverseDirectory() {
+    FileSystem fs = null;
+    Configuration configuration = getConf();
+    DistCpSync distCpSync = Mockito.mock(DistCpSync.class);
+    Path listingFile = new Path("/tmp/list");
+    // no exception expected in this case
+    configuration.setBoolean(
+        DistCpConstants.CONF_LABEL_DIFF_COPY_LISTING_TRAVERSE_DIRECTORY, false);
+    try {
+      fs = FileSystem.get(getConf());
+      buildListingUsingSnapshotDiff(fs, configuration, distCpSync, listingFile);
+    } catch (IOException e) {
+      LOG.error("Exception encountered in test", e);
+      Assert.fail("Test failed " + e.getMessage());
+    } finally {
+      TestDistCpUtils.delete(fs, "/tmp");
+    }
+  }
+
+  private void buildListingUsingSnapshotDiff(FileSystem fs,
+      Configuration configuration, DistCpSync distCpSync, Path listingFile)
+      throws IOException {
+    List<Path> srcPaths = new ArrayList<>();
+    srcPaths.add(new Path("/tmp/in"));
+    TestDistCpUtils.createFile(fs, "/tmp/in/src1/1.txt");
+    TestDistCpUtils.createFile(fs, "/tmp/in/src2/1.txt");
+    TestDistCpUtils.createFile(fs, "/tmp/in/src3/3.txt");
+    TestDistCpUtils.createFile(fs, "/tmp/in/src3/4.txt");
+    Path target = new Path("/tmp/out");
+    // adding below flags useDiff & sync only to enable context.shouldUseSnapshotDiff()
+    final DistCpOptions options =
+        new DistCpOptions.Builder(srcPaths, target).withUseDiff("snap1",
+            "snap2").withSyncFolder(true).build();
+    // Create a dummy DiffInfo List that contains a directory + paths inside
+    // that directory as part of the diff.
+    ArrayList<DiffInfo> diffs = new ArrayList<>();
+    diffs.add(new DiffInfo(new Path("/tmp/in/src3/"), new Path("/tmp/in/src3/"),
+        SnapshotDiffReport.DiffType.CREATE));
+    diffs.add(new DiffInfo(new Path("/tmp/in/src3/3.txt"),
+        new Path("/tmp/in/src3/3.txt"), SnapshotDiffReport.DiffType.CREATE));
+    diffs.add(new DiffInfo(new Path("/tmp/in/src3/4.txt"),
+        new Path("/tmp/in/src3/4.txt"), SnapshotDiffReport.DiffType.CREATE));
+    Mockito.when(distCpSync.prepareDiffListForCopyListing()).thenReturn(diffs);
+    final DistCpContext context = new DistCpContext(options);
+    CopyListing listing =
+        new SimpleCopyListing(configuration, CREDENTIALS, distCpSync);
+    listing.buildListing(listingFile, context);
   }
 
   @Test


### PR DESCRIPTION
### Description of PR
Currently for Diff-based copyListing that is used during the distcpSync step of an incremental copy by default the SimpleCopyListing implementation is used.  In it's implementation it iterates through the DiffReport and if the DiffType is Create and the path is a directory, it recursively traverses the directory and adds the subpaths to the resultant copyList.

This works fine for implementations of snapshotDiff that include only top-level directories as part of its DiffReport . Suppose a snapshotDiff implementation outputs only flat paths that include both the directory and sub-directory subpath in its DiffReport, it will lead to duplicate paths in the copyList and throws DuplicateFileException.

This PR adds a flag` traverseDirectories` in SimpleCopyListing to solve this . If diff has flat paths, one can set this flag to false 
There is no impact to existing behaviour as the default value of this flag is true.

https://issues.apache.org/jira/browse/HDFS-17120

### How was this patch tested?
### For code changes:
Added Unit tests

