### PR TITLE
HADOOP-12677. DecompressorStream throws IndexOutOfBoundsException when calling skip(long)

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/DecompressorStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/DecompressorStream.java
@@ -199,9 +199,10 @@ public class DecompressorStream extends CompressionInputStream {
     checkStream();
 
     // Read 'n' bytes
-    int skipped = 0;
+    long skipped = 0;
     while (skipped < n) {
-      int len = Math.min(((int)n - skipped), skipBytes.length);
+      // len is between 0 and skipBytes.length, so downcast is safe
+      int len = (int)Math.min((n - skipped), skipBytes.length);
       len = read(skipBytes, 0, len);
       if (len == -1) {
         eof = true;


### PR DESCRIPTION
### Description of PR
Cast DecompressorStream.skip() properly.
Rebase an old patch.

### How was this patch tested?
Unit test

### For code changes:

- [ X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

