### PR TITLE
HDFS-17123. Sort datanodeStorages when generating StorageBlockReport[] in method BPServiceActor#blockReport for future convenience.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/protocol/DatanodeStorage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/protocol/DatanodeStorage.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 /**
  * Class captures information of a storage in Datanode.
  */
-public class DatanodeStorage {
+public class DatanodeStorage implements Comparable<DatanodeStorage> {
   /** The state of the storage. */
   public enum State {
     NORMAL,
@@ -124,5 +124,10 @@ public class DatanodeStorage {
   @Override
   public int hashCode() {
     return getStorageID().hashCode();
+  }
+
+  @Override
+  public int compareTo(DatanodeStorage that) {
+    return getStorageID().compareTo(that.getStorageID());
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -412,7 +412,7 @@ class BPServiceActor implements Runnable {
     StorageBlockReport reports[] =
         new StorageBlockReport[perVolumeBlockLists.size()];
 
-    for(Map.Entry<DatanodeStorage, BlockListAsLongs> kvPair : perVolumeBlockLists.entrySet()) {
+    for (Map.Entry<DatanodeStorage, BlockListAsLongs> kvPair : perVolumeBlockLists.entrySet()) {
       BlockListAsLongs blockList = kvPair.getValue();
       reports[i++] = new StorageBlockReport(kvPair.getKey(), blockList);
       totalBlockCount += blockList.getNumberOfBlocks();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -38,6 +38,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 
@@ -2097,7 +2098,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
   @Override
   public Map<DatanodeStorage, BlockListAsLongs> getBlockReports(String bpid) {
     Map<DatanodeStorage, BlockListAsLongs> blockReportsMap =
-        new HashMap<DatanodeStorage, BlockListAsLongs>();
+        new TreeMap<DatanodeStorage, BlockListAsLongs>();
 
     Map<String, BlockListAsLongs.Builder> builders =
         new HashMap<String, BlockListAsLongs.Builder>();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
@@ -26,7 +26,6 @@ import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -837,7 +836,8 @@ public class SimulatedFSDataset implements FsDatasetSpi<FsVolumeSpi> {
   @Override
   public synchronized Map<DatanodeStorage, BlockListAsLongs> getBlockReports(
       String bpid) {
-    Map<DatanodeStorage, BlockListAsLongs> blockReports = new TreeMap<DatanodeStorage, BlockListAsLongs>();
+    Map<DatanodeStorage, BlockListAsLongs> blockReports =
+        new TreeMap<DatanodeStorage, BlockListAsLongs>();
     for (SimulatedStorage storage : storages) {
       blockReports.put(storage.getDnStorage(), getBlockReport(bpid, storage));
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
@@ -837,7 +837,7 @@ public class SimulatedFSDataset implements FsDatasetSpi<FsVolumeSpi> {
   @Override
   public synchronized Map<DatanodeStorage, BlockListAsLongs> getBlockReports(
       String bpid) {
-    Map<DatanodeStorage, BlockListAsLongs> blockReports = new HashMap<>();
+    Map<DatanodeStorage, BlockListAsLongs> blockReports = new TreeMap<DatanodeStorage, BlockListAsLongs>();
     for (SimulatedStorage storage : storages) {
       blockReports.put(storage.getDnStorage(), getBlockReport(bpid, storage));
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
@@ -195,7 +195,7 @@ public class ExternalDatasetImpl implements FsDatasetSpi<ExternalVolumeImpl> {
   @Override
   public Map<DatanodeStorage, BlockListAsLongs> getBlockReports(String bpid) {
     final Map<DatanodeStorage, BlockListAsLongs> result =
-	new HashMap<DatanodeStorage, BlockListAsLongs>();
+	new TreeMap<DatanodeStorage, BlockListAsLongs>();
 
     result.put(storage, BlockListAsLongs.EMPTY);
     return result;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
@@ -194,8 +194,8 @@ public class ExternalDatasetImpl implements FsDatasetSpi<ExternalVolumeImpl> {
 
   @Override
   public Map<DatanodeStorage, BlockListAsLongs> getBlockReports(String bpid) {
-    final Map<DatanodeStorage, BlockListAsLongs> result =
-	new TreeMap<DatanodeStorage, BlockListAsLongs>();
+    final Map<DatanodeStorage, BlockListAsLongs> result = 
+        new TreeMap<DatanodeStorage, BlockListAsLongs>();
 
     result.put(storage, BlockListAsLongs.EMPTY);
     return result;


### PR DESCRIPTION
### Description of PR
Currently in method blockReport(), it uses below code snippets to generate per datanode storage blocks:

```java
    for (Map.Entry<DatanodeStorage, BlockListAsLongs> kvPair : perVolumeBlockLists.entrySet()) {
      BlockListAsLongs blockList = kvPair.getValue();
      reports[i++] = new StorageBlockReport(kvPair.getKey(), blockList);
      totalBlockCount += blockList.getNumberOfBlocks();
    }
```
But the `perVolumeBlockLists` is a HashMap object, invocation of its entrySet() method will return an unordered Set.
Here we'd better sort datanodeStorages. By doing this, NameNode will handle block report storage by storage in a fixed order. Another advantage is that we perhaps use this order in datanode logic in the future.

### How to test
existing unit tests about block reports can test this modification. 
