### PR TITLE
YARN-11542. Fix NegativeArraySizeException in IFile's readRawValue me…

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/IFile.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/IFile.java
@@ -58,6 +58,8 @@ import org.slf4j.LoggerFactory;
 public class IFile {
   private static final Logger LOG = LoggerFactory.getLogger(IFile.class);
   public static final int EOF_MARKER = -1; // End of File Marker
+
+  private static final int ARRAY_MAX_SIZE = Integer.MAX_VALUE - 8;
   
   /**
    * <code>IFile.Writer</code> to write out intermediate map-outputs. 
@@ -433,8 +435,11 @@ public class IFile {
     }
     
     public void nextRawValue(DataInputBuffer value) throws IOException {
+      long targetSizeLong = currentValueLength + (currentValueLength >> 1);
+      int targetSize = (int) Math.min(targetSizeLong, ARRAY_MAX_SIZE);
+      
       final byte[] valBytes = (value.getData().length < currentValueLength)
-        ? new byte[currentValueLength << 1]
+        ? new byte[targetSize]
         : value.getData();
       int i = readData(valBytes, 0, currentValueLength);
       if (i != currentValueLength) {


### PR DESCRIPTION
…thod

Change-Id: Ie943e06fe287ed08abd51060bacd58b05a465811

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
We are using bit shifting to double the byte array in IFile's nextRawValue method to store the byte values in it. With large dataset it can easily happen that we shift the leftmost bit when we are calculating the size of the array, which can lead to a negative number as the array size, causing the NegativeArraySizeException.

It would be safer to expand the backing array with a 1.5x factor, and have a check not to extend Integer's max value during that.

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

