### PR TITLE
YARN-11486. Bugfix for the CapacityScheduler webpage.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/CapacitySchedulerPage.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/CapacitySchedulerPage.java
@@ -651,7 +651,7 @@ class CapacitySchedulerPage extends RmView {
           "      q = q.substr(q.lastIndexOf(':') + 2);",
           "      q = '^' + q.substr(q.lastIndexOf('.') + 1) + '$';",
           "    }",
-          "    $('#apps').dataTable().fnFilter(q, 4, true);",
+          "    $('#apps').dataTable().fnFilter(q, 5, true);",
           "  });",
           "  $('#cs').show();",
           "});").__().


### PR DESCRIPTION
**detail**:       https://issues.apache.org/jira/browse/YARN-11486

### **Describe**:
When a leaf queue(or subqueue) is clicked on the CapacityScheduler page, the application task information is not displayed. Besides, the FairScheduler page is normal.


![image](https://github.com/apache/hadoop/assets/65019264/2e36d932-582f-4b4c-945d-ceb121f02153)
![image](https://github.com/apache/hadoop/assets/65019264/47f05578-daba-459a-aef0-448e234dd420)


-----
### **Resolve**:
The $('#apps').dataTable().fnFilter used in the CapacitySchedulerPage is filtering based on the column with index value 4 (indexing starts from 0). However, in reality, the "Queue" column is located at index 5, causing the issue where clicking on a yarn sub-queue does not display its running jobs. Thanks to my team, especially Mr. Wang, for providing me with many hints and help.
![image](https://github.com/apache/hadoop/assets/65019264/335d9fb7-2ba3-4ba2-94ea-934667d8b5d2)

