### PR TITLE
Hadoop 18826: [ABFS] Fix for Empty Relative Path Issue Leading to GetFileStatus("/") failure.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1663,7 +1663,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     Preconditions.checkNotNull(path, "path");
     String relPath = path.toUri().getPath();
     if (relPath.isEmpty()) {
-      // This means tha path passed y user is absolute path of root without "/"
+      // This means that path passed by user is absolute path of root without "/" at end.
       relPath = ROOT_PATH;
     }
     return relPath;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1661,7 +1661,12 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
   private String getRelativePath(final Path path) {
     Preconditions.checkNotNull(path, "path");
-    return path.toUri().getPath();
+    String relPath = path.toUri().getPath();
+    if (relPath.isEmpty()) {
+      // This means tha path passed y user is absolute path of root without "/"
+      relPath = ROOT_PATH;
+    }
+    return relPath;
   }
 
   private long parseContentLength(final String contentLength) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
@@ -85,11 +85,11 @@ public class ITestAzureBlobFileSystemFileStatus extends
       if (isDir) {
         assertEquals(errorInStatus + ": permission",
                 new FsPermission(DEFAULT_DIR_PERMISSION_VALUE), fileStatus.getPermission());
-        assertTrue(fileStatus.isDirectory());
+        assertTrue(errorInStatus + "not a directory", fileStatus.isDirectory());
       } else {
         assertEquals(errorInStatus + ": permission",
                 new FsPermission(DEFAULT_FILE_PERMISSION_VALUE), fileStatus.getPermission());
-        assertTrue(fileStatus.isFile());
+        assertTrue(errorInStatus + "not a file", fileStatus.isFile());
       }
     }
 
@@ -151,7 +151,7 @@ public class ITestAzureBlobFileSystemFileStatus extends
 
   @Test
   public void testFileStatusOnRoot() throws IOException {
-    AzureBlobFileSystem fs = this.getFileSystem();
+    AzureBlobFileSystem fs = getFileSystem();
 
     // Assert that passing relative root path works
     Path testPath = new Path("/");

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
@@ -18,7 +18,9 @@
 
 package org.apache.hadoop.fs.azurebfs;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.junit.Test;
@@ -155,7 +157,7 @@ public class ITestAzureBlobFileSystemFileStatus extends
     Path testPath = new Path("/");
     validateStatus(fs, testPath, true);
 
-    // Assert that passing absolute root path works2
+    // Assert that passing absolute root path works
     String testPathStr = makeQualified(testPath).toString();
     validateStatus(fs, new Path(testPathStr), true);
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
@@ -83,9 +83,11 @@ public class ITestAzureBlobFileSystemFileStatus extends
       if (isDir) {
         assertEquals(errorInStatus + ": permission",
                 new FsPermission(DEFAULT_DIR_PERMISSION_VALUE), fileStatus.getPermission());
+        assertTrue(fileStatus.isDirectory());
       } else {
         assertEquals(errorInStatus + ": permission",
                 new FsPermission(DEFAULT_FILE_PERMISSION_VALUE), fileStatus.getPermission());
+        assertTrue(fileStatus.isFile());
       }
     }
 
@@ -143,5 +145,23 @@ public class ITestAzureBlobFileSystemFileStatus extends
         minCreateStartTime < lastModifiedTime);
     assertTrue("lastModifiedTime should be before createEndTime",
         createEndTime > lastModifiedTime);
+  }
+
+  @Test
+  public void testFileStatusOnRoot() throws IOException {
+    AzureBlobFileSystem fs = this.getFileSystem();
+
+    // Assert that passing relative root path works
+    Path testPath = new Path("/");
+    validateStatus(fs, testPath, true);
+
+    // Assert that passing absolute root path works2
+    String testPathStr = makeQualified(testPath).toString();
+    validateStatus(fs, new Path(testPathStr), true);
+
+    // Assert that passing absolute root path without "/" works
+    testPathStr = testPathStr.substring(0, testPathStr.length() - 1);
+    validateStatus(fs, new Path(testPathStr), true);
+
   }
 }


### PR DESCRIPTION
### Description of PR
Jira Ticket: https://issues.apache.org/jira/browse/HADOOP-18826

Recently a bug was reported in ABFS getFileStatus() call (Refer to the Jira Ticket Above for more details).
Bug was only hit when getFileStatus() call was made on HNS account and the path passed was absolute path of the root without a "/" at the end. This is equivalent of having an empty relative path which was causing the issue.

This PR fixes the issue by appending a "/" at the end of empty relative path. This change will affect only those calls which are made on absolute path of the root without "/" at the end. 

### How was this patch tested?
Test case added for failing scenario. Complete test suite was run.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

------------------------
:::: AGGREGATED TEST RESULT ::::

HNS-OAuth
========================
[INFO] Results:
[INFO] 
[ERROR] Tests run: 141, Failures: 0, Errors: 0, Skipped: 5
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:329 » TestTimedOut test timed o...
[INFO] 
[ERROR] Tests run: 587, Failures: 0, Errors: 1, Skipped: 54
[INFO] Results:
[INFO] 
[WARNING] Tests run: 339, Failures: 0, Errors: 0, Skipped: 41

HNS-SharedKey
========================
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestAbfsClientThrottlingAnalyzer.testManySuccessAndErrorsAndWaiting:181->fuzzyValidate:64 The actual value 28 is not within the expected range: [5.60, 8.40].
[INFO] 
[ERROR] Tests run: 141, Failures: 1, Errors: 0, Skipped: 5
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:329 » TestTimedOut test timed o...
[INFO] 
[ERROR] Tests run: 587, Failures: 0, Errors: 1, Skipped: 54
[INFO] Results:
[INFO] 
[WARNING] Tests run: 339, Failures: 0, Errors: 0, Skipped: 41

NonHNS-SharedKey
========================
[INFO] Results:
[INFO]  
[ERROR] Tests run: 141, Failures: 0, Errors: 0, Skipped: 11
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   ITestAzureBlobFileSystemCheckAccess.testCheckAccessForAccountWithoutNS:181 Expecting org.apache.hadoop.security.AccessControlException with text "This request is not authorized to perform this operation using this permission.", 403 but got : "void"
[INFO] 
[ERROR] Tests run: 587, Failures: 1, Errors: 0, Skipped: 277
[INFO] Results:
[INFO] 
[WARNING] Tests run: 339, Failures: 0, Errors: 0, Skipped: 44

AppendBlob-HNS-OAuth
========================
[INFO] Results:
[INFO]
[ERROR] Tests run: 141, Failures: 0, Errors: 0, Skipped: 5
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:329 » TestTimedOut test timed o...
[INFO] 
[ERROR] Tests run: 587, Failures: 0, Errors: 1, Skipped: 54
[INFO] Results:
[INFO] 
[WARNING] Tests run: 339, Failures: 0, Errors: 0, Skipped: 41

Time taken: 79 mins 18 secs.

