### PR TITLE
YARN-11545. Fixed FS2CS ACL conversion when all users are allowed.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSConfigToCSConfigConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSConfigToCSConfigConverter.java
@@ -432,13 +432,13 @@ public class FSConfigToCSConfigConverter {
     AccessControlList adminAcls = access.get(AccessType.ADMINISTER_QUEUE);
 
     if (!submitAcls.getGroups().isEmpty() ||
-        !submitAcls.getUsers().isEmpty()) {
+        !submitAcls.getUsers().isEmpty() || submitAcls.isAllAllowed()) {
       capacitySchedulerConfig.set(PREFIX + queue + ".acl_submit_applications",
           submitAcls.getAclString());
     }
 
     if (!adminAcls.getGroups().isEmpty() ||
-        !adminAcls.getUsers().isEmpty()) {
+        !adminAcls.getUsers().isEmpty() || adminAcls.isAllAllowed()) {
       capacitySchedulerConfig.set(PREFIX + queue + ".acl_administer_queue",
           adminAcls.getAclString());
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSConfigToCSConfigConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSConfigToCSConfigConverter.java
@@ -263,9 +263,9 @@ public class TestFSConfigToCSConfigConverter {
         conf.get(PREFIX + "root.admins.alice.acl_administer_queue"));
 
     // root.users.john
-    assertEquals("root.users.john submit ACL", "john ",
+    assertEquals("root.users.john submit ACL", "*",
         conf.get(PREFIX + "root.users.john.acl_submit_applications"));
-    assertEquals("root.users.john admin ACL", "john ",
+    assertEquals("root.users.john admin ACL", "*",
         conf.get(PREFIX + "root.users.john.acl_administer_queue"));
 
     // root.users.joe

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/fair-scheduler-conversion.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/fair-scheduler-conversion.xml
@@ -33,8 +33,8 @@
                 <weight>1.0</weight>
                 <minResources>memory-mb=4096, vcores=1</minResources>
                 <schedulingPolicy>drf</schedulingPolicy>
-                <aclSubmitApps>john </aclSubmitApps>
-                <aclAdministerApps>john </aclAdministerApps>
+                <aclSubmitApps>*</aclSubmitApps>
+                <aclAdministerApps>*</aclAdministerApps>
                 <maxContainerAllocation>vcores=2,memory-mb=8192</maxContainerAllocation>
             </queue>
             <queue name="joe">


### PR DESCRIPTION
Change-Id: I755a21c6d300a7a831efa675819f20a35748c6b4

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Currently we only convert ACLs if users or groups are set. This should be extended to check if the "allAllowed" flag is set in the AcessControlList to be able to preserve * values also for the ACLs.

### How was this patch tested?
Locally and unit tests.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

