### PR TITLE
HDFS-17137. Standby/Observer NameNode skip to handle redundant replica block logic when set decrease replication.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -4030,6 +4030,11 @@ public class BlockManager implements BlockStatsMXBean {
 
     // update neededReconstruction priority queues
     b.setReplication(newRepl);
+
+    // Process the block only when active NN is out of safe mode.
+    if (!isPopulatingReplQueues()) {
+      return;
+    }
     NumberReplicas num = countNodes(b);
     updateNeededReconstructions(b, 0, newRepl - oldRepl);
     if (shouldProcessExtraRedundancy(num, newRepl)) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyBlockManagement.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyBlockManagement.java
@@ -110,7 +110,7 @@ public class TestStandbyBlockManagement {
 
     // Create HA Cluster.
     try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
-        .nnTopology(MiniDFSNNTopology.simpleHATopology()).numDataNodes(10).build()) {
+        .nnTopology(MiniDFSNNTopology.simpleHATopology()).numDataNodes(4).build()) {
       cluster.waitActive();
       cluster.transitionToActive(0);
 
@@ -132,8 +132,8 @@ public class TestStandbyBlockManagement {
       // Create test file.
       Path file = new Path("/test");
       long fileLength = 512;
-      DFSTestUtil.createFile(fs, file, fileLength, (short) 8, 0L);
-      DFSTestUtil.waitReplication(fs, file, (short) 8);
+      DFSTestUtil.createFile(fs, file, fileLength, (short) 4, 0L);
+      DFSTestUtil.waitReplication(fs, file, (short) 4);
 
       // Set decrease 3 replication.
       fs.setReplication(file, (short) 3);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyBlockManagement.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyBlockManagement.java
@@ -97,4 +97,58 @@ public class TestStandbyBlockManagement {
     }
   }
 
+  /**
+   * Test Standby/Observer NameNode should not handle redundant replica block logic
+   * when set decrease replication.
+   * @throws Exception
+   */
+  @Test(timeout = 60000)
+  public void testNotHandleRedundantReplica() throws Exception {
+    Configuration conf = new Configuration();
+    HAUtil.setAllowStandbyReads(conf, true);
+    conf.setInt(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, 1);
+
+    // Create HA Cluster.
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .nnTopology(MiniDFSNNTopology.simpleHATopology()).numDataNodes(10).build()) {
+      cluster.waitActive();
+      cluster.transitionToActive(0);
+
+      NameNode nn1 = cluster.getNameNode(0);
+      assertEquals("ACTIVE", nn1.getNamesystem().getState().name());
+      NameNode nn2 = cluster.getNameNode(1);
+      assertEquals("STANDBY", nn2.getNamesystem().getState().name());
+
+      cluster.triggerHeartbeats();
+      // Sending the FBR.
+      cluster.triggerBlockReports();
+
+      // Default excessRedundancyMap size as 0.
+      assertEquals(0, nn1.getNamesystem().getBlockManager().getExcessBlocksCount());
+      assertEquals(0, nn2.getNamesystem().getBlockManager().getExcessBlocksCount());
+
+      FileSystem fs = HATestUtil.configureFailoverFs(cluster, conf);
+
+      // Create test file.
+      Path file = new Path("/test");
+      long fileLength = 512;
+      DFSTestUtil.createFile(fs, file, fileLength, (short) 8, 0L);
+      DFSTestUtil.waitReplication(fs, file, (short) 8);
+
+      // Set decrease 3 replication.
+      fs.setReplication(file, (short) 3);
+      HATestUtil.waitForStandbyToCatchUp(nn1, nn2);
+
+      // Make sure the DN has deleted the block and report to NNs.
+      cluster.triggerHeartbeats();
+      HATestUtil.waitForDNDeletions(cluster);
+      cluster.triggerDeletionReports();
+
+      DFSTestUtil.waitReplication(fs, file, (short) 3);
+
+      // Delete excess replica, active and standby nn excessRedundancyMap size as 0.
+      assertEquals(0, nn1.getNamesystem().getBlockManager().getExcessBlocksCount());
+      assertEquals(0, nn2.getNamesystem().getBlockManager().getExcessBlocksCount());
+    }
+  }
 }


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17137

Standby/Observer NameNode should not handle redundant replica block logic when set decrease replication.

At present, when call setReplication to execute the logic of decrease replication,

- ActiveNameNode will call the BlockManager#processExtraRedundancyBlock method to select the dn of the redundant replica , will add to the excessRedundancyMap and add to invalidateBlocks (RedundancyMonitor will be scheduled to delete the block on dn).

- Then the StandyNameNode or ObserverNameNode load editlog and apply the SetReplicationOp, if the dn of the replica to be deleted has not yet performed incremental block report,
here also will BlockManager#processExtraRedundancyBlock method be called here to select the dn of the redundant replica and add it to the excessRedundancyMap (here selected the redundant dn may be inconsistent with the dn selected in the active namenode).

In excessRedundancyMap exist dn maybe affects the dn decommission, resulting can not to complete decommission dn operation in Standy/ObserverNameNode.

The specific cases are as follows:
For example a file is 3 replica (d1,d2,d3) and call setReplication set file to 2 replica.

- ActiveNameNode select d1 with redundant replicas to add toexcessRedundancyMap and invalidateBlocks.

- StandyNameNode replays SetReplicationOp (at this time, d1 has not yet executed incremental block report), so here maybe selected redundant replica dn are inconsistent with ActiveNameNode, such as select d2 to add excessRedundancyMap.

- At this time, d1 completes deleting the block for incremental block report.

- The DN list for this block in ActiveNameNode includes d2 and d3 (delete d1 from in the excessRedundancyMap when processing the incremental block report ).

- The DN list for this block in StandyNameNode includes d2 and d3 (can not delete d2 from in the excessRedundancyMap when processing the incremental block report).

- At this time, execute the decommission operation on d3.

- ActiveNameNode will select a new node d4 to copy the replica, and d4 will run incrementally block report.

- The DN list for this block in ActiveNameNode includes d2 and d3(decommissioning status),d4, then d3 can to decommissioned normally.

- The DN list for this block in StandyNameNode is d3 (decommissioning status), d2 (redundant status), d4.
since the requirements for two live replica are not met, d3 cannot be decommissioned at this time.

Therefore, StandyNameNode or ObserverNameNode considers not process redundant replicas logic when call setReplication.



