### PR TITLE
HDFS-17122. Rectify the table length discrepancy in the DataNode UI

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.js
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.js
@@ -378,6 +378,7 @@
                 });
             }
           });
+          $("#table-datanodes").width('100%');
           renderHistogram(data);
           $('#ui-tabs a[href="#tab-datanode"]').tab('show');
         });


### PR DESCRIPTION
JIRA: HDFS-17122. Rectify the table length discrepancy in the DataNode UI

The hidden column settings in table-datanodes.dataTable have caused an error in the calculation of table length in dataTable.

![image](https://github.com/apache/hadoop/assets/54506205/99d5ea59-0b6b-4e4a-b8fb-cf714485b266)

Certainly, it would be advisable to set the width of #table-datanodes to 100% in order to accommodate the hidden columns.

![image](https://github.com/apache/hadoop/assets/54506205/d8a7ec33-f8b4-4046-b257-8f63dcf0100d)
