### PR TITLE
HADOOP-18767. Fix warn logger when creating WeakReferenceMap

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/WeakReferenceMap.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/WeakReferenceMap.java
@@ -219,7 +219,7 @@ public class WeakReferenceMap<K, V> {
       // between the put() and the get()
       resolvedStrongRef = resolve(retrievedWeakRef);
       if (resolvedStrongRef == null) {
-        referenceLostDuringCreation.warn("reference to %s lost during creation", key);
+        referenceLostDuringCreation.warn("reference to {} lost during creation", key);
         noteLost(key);
       }
     } while (resolvedStrongRef == null);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
WeakReferenceMap.create(K key) logs once at warning level if a reference to a key was lost during creation.
It logs key incorrectly. Fixed the logger so that key is also emitted by the log line.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

