### PR TITLE
HDFS-17141. Optimize the default parameters for the FileUtil.isRegularFile() method

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
@@ -629,7 +629,7 @@ public class FileUtil {
   }
 
   public static boolean isRegularFile(File file) {
-    return isRegularFile(file, true);
+    return isRegularFile(file, false);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
@@ -1607,12 +1607,12 @@ public class TestFileUtil {
     FileOutputStream os = new FileOutputStream(tmpFile);
     os.write(data);
     os.close();
-    assertTrue(FileUtil.isRegularFile(tmpFile));
+    assertTrue(FileUtil.isRegularFile(tmpFile, true));
 
     // create a symlink to file
     File link = new File(del, "reg2");
     FileUtil.symLink(tmpFile.toString(), link.toString());
-    assertFalse(FileUtil.isRegularFile(link, false));
+    assertFalse(FileUtil.isRegularFile(link));
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DirectoryScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DirectoryScanner.java
@@ -544,8 +544,8 @@ public class DirectoryScanner implements Runnable {
         }
 
         // Block and meta must be regular file
-        boolean isRegular = FileUtil.isRegularFile(info.getBlockFile(), false) &&
-                FileUtil.isRegularFile(info.getMetaFile(), false);
+        boolean isRegular = FileUtil.isRegularFile(info.getBlockFile()) &&
+                FileUtil.isRegularFile(info.getMetaFile());
         if (!isRegular) {
           statsRecord.mismatchBlocks++;
           addDifference(diffRecord, statsRecord, info);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -2737,8 +2737,8 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
           Block.getGenerationStamp(diskMetaFile.getName()) :
           HdfsConstants.GRANDFATHER_GENERATION_STAMP;
 
-      final boolean isRegular = FileUtil.isRegularFile(diskMetaFile, false) &&
-          FileUtil.isRegularFile(diskFile, false);
+      final boolean isRegular = FileUtil.isRegularFile(diskMetaFile) &&
+          FileUtil.isRegularFile(diskFile);
 
       if (vol.getStorageType() == StorageType.PROVIDED) {
         if (memBlockInfo == null) {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HDFS-17141. Optimize the default parameters for the FileUtil.isRegularFile() method.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

