### PR TITLE
HDFS-17148. RBF: SQLDelegationTokenSecretManager must cleanup expired tokens in SQL

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
@@ -759,7 +759,7 @@ extends AbstractDelegationTokenIdentifier>
     Set<TokenIdent> expiredTokens = new HashSet<>();
     synchronized (this) {
       Iterator<Map.Entry<TokenIdent, DelegationTokenInformation>> i =
-          getTokensForCleanup().entrySet().iterator();
+          getCandidateTokensForCleanup().entrySet().iterator();
       while (i.hasNext()) {
         Map.Entry<TokenIdent, DelegationTokenInformation> entry = i.next();
         long renewDate = entry.getValue().getRenewDate();
@@ -774,7 +774,7 @@ extends AbstractDelegationTokenIdentifier>
     logExpireTokens(expiredTokens);
   }
 
-  protected Map<TokenIdent, DelegationTokenInformation> getTokensForCleanup() {
+  protected Map<TokenIdent, DelegationTokenInformation> getCandidateTokensForCleanup() {
     return this.currentTokens;
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
@@ -190,6 +190,14 @@ extends AbstractDelegationTokenIdentifier>
     return currentTokens.size();
   }
 
+  /**
+   * Interval for tokens to be renewed.
+   * @return Renew interval in milliseconds.
+   */
+  protected long getTokenRenewInterval() {
+    return this.tokenRenewInterval;
+  }
+
   /** 
    * Add a previously used master key to cache (when NN restarts), 
    * should be called before activate().
@@ -751,7 +759,7 @@ extends AbstractDelegationTokenIdentifier>
     Set<TokenIdent> expiredTokens = new HashSet<>();
     synchronized (this) {
       Iterator<Map.Entry<TokenIdent, DelegationTokenInformation>> i =
-          currentTokens.entrySet().iterator();
+          getTokensForCleanup().entrySet().iterator();
       while (i.hasNext()) {
         Map.Entry<TokenIdent, DelegationTokenInformation> entry = i.next();
         long renewDate = entry.getValue().getRenewDate();
@@ -764,6 +772,10 @@ extends AbstractDelegationTokenIdentifier>
     }
     // don't hold lock on 'this' to avoid edit log updates blocking token ops
     logExpireTokens(expiredTokens);
+  }
+
+  protected Map<TokenIdent, DelegationTokenInformation> getTokensForCleanup() {
+    return this.currentTokens;
   }
 
   protected void logExpireTokens(

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/SQLDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/SQLDelegationTokenSecretManager.java
@@ -53,7 +53,7 @@ public abstract class SQLDelegationTokenSecretManager<TokenIdent
       + "token.seqnum.batch.size";
   public static final int DEFAULT_SEQ_NUM_BATCH_SIZE = 10;
   public static final String SQL_DTSM_TOKEN_MAX_CLEANUP_RESULTS = SQL_DTSM_CONF_PREFIX
-      + "token.token.max.cleanup.results";
+      + "token.max.cleanup.results";
   public static final int SQL_DTSM_TOKEN_MAX_CLEANUP_RESULTS_DEFAULT = 10000;
   public static final String SQL_DTSM_TOKEN_LOADING_CACHE_EXPIRATION = SQL_DTSM_CONF_PREFIX
       + "token.loading.cache.expiration";

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/SQLDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/SQLDelegationTokenSecretManager.java
@@ -459,7 +459,7 @@ public abstract class SQLDelegationTokenSecretManager<TokenIdent
   protected abstract byte[] selectTokenInfo(int sequenceNum, byte[] tokenIdentifier)
       throws SQLException;
   protected abstract Map<byte[], byte[]> selectStaleTokenInfos(long maxModifiedTime,
-      int topResults) throws SQLException;
+      int maxResults) throws SQLException;
   protected abstract void insertToken(int sequenceNum, byte[] tokenIdentifier, byte[] tokenInfo)
       throws SQLException;
   protected abstract void updateToken(int sequenceNum, byte[] tokenIdentifier, byte[] tokenInfo)

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/SQLDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/SQLDelegationTokenSecretManager.java
@@ -183,6 +183,7 @@ public abstract class SQLDelegationTokenSecretManager<TokenIdent
       Map<byte[], byte[]> tokenInfoBytesList = selectTokenInfos(maxModifiedTime,
           this.maxTokenCleanupResults);
 
+      LOG.info("Found {} tokens for cleanup", tokenInfoBytesList.size());
       for (Map.Entry<byte[], byte[]> tokenInfoBytes : tokenInfoBytesList.entrySet()) {
         TokenIdent tokenIdent = createTokenIdent(tokenInfoBytes.getKey());
         DelegationTokenInformation tokenInfo = createTokenInfo(tokenInfoBytes.getValue());

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/SQLDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/SQLDelegationTokenSecretManager.java
@@ -24,6 +24,8 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.classification.VisibleForTesting;
@@ -50,6 +52,9 @@ public abstract class SQLDelegationTokenSecretManager<TokenIdent
   private static final String SQL_DTSM_TOKEN_SEQNUM_BATCH_SIZE = SQL_DTSM_CONF_PREFIX
       + "token.seqnum.batch.size";
   public static final int DEFAULT_SEQ_NUM_BATCH_SIZE = 10;
+  public static final String SQL_DTSM_TOKEN_MAX_CLEANUP_RESULTS = SQL_DTSM_CONF_PREFIX
+      + "token.token.max.cleanup.results";
+  public static final int SQL_DTSM_TOKEN_MAX_CLEANUP_RESULTS_DEFAULT = 10000;
   public static final String SQL_DTSM_TOKEN_LOADING_CACHE_EXPIRATION = SQL_DTSM_CONF_PREFIX
       + "token.loading.cache.expiration";
   public static final long SQL_DTSM_TOKEN_LOADING_CACHE_EXPIRATION_DEFAULT =
@@ -62,6 +67,9 @@ public abstract class SQLDelegationTokenSecretManager<TokenIdent
   // A new batch is requested once the sequenceNums available to a secret manager are
   // exhausted, including during initialization.
   private final int seqNumBatchSize;
+
+  // Number of tokens to obtain from SQL during the cleanup process.
+  private final int maxTokenCleanupResults;
 
   // Last sequenceNum in the current batch that has been allocated to a token.
   private int currentSeqNum;
@@ -82,6 +90,8 @@ public abstract class SQLDelegationTokenSecretManager<TokenIdent
 
     this.seqNumBatchSize = conf.getInt(SQL_DTSM_TOKEN_SEQNUM_BATCH_SIZE,
         DEFAULT_SEQ_NUM_BATCH_SIZE);
+    this.maxTokenCleanupResults = conf.getInt(SQL_DTSM_TOKEN_MAX_CLEANUP_RESULTS,
+        SQL_DTSM_TOKEN_MAX_CLEANUP_RESULTS_DEFAULT);
 
     long cacheExpirationMs = conf.getTimeDuration(SQL_DTSM_TOKEN_LOADING_CACHE_EXPIRATION,
         SQL_DTSM_TOKEN_LOADING_CACHE_EXPIRATION_DEFAULT, TimeUnit.MILLISECONDS);
@@ -151,6 +161,38 @@ public abstract class SQLDelegationTokenSecretManager<TokenIdent
     getTokenInfo(id);
 
     return super.cancelToken(token, canceller);
+  }
+
+  /**
+   * Obtain a list of tokens that will be considered for cleanup, based on the last
+   * time the token was updated in SQL. This list may include tokens that are not
+   * expired and should not be deleted (e.g. if the token was last renewed using a
+   * higher renewal interval).
+   * The number of results is limited to reduce performance impact. Some level of
+   * contention is expected when multiple routers run cleanup simultaneously.
+   * @return Map of tokens that have not been updated in SQL after the token renewal
+   *         period.
+   */
+  @Override
+  protected Map<TokenIdent, DelegationTokenInformation> getTokensForCleanup() {
+    Map<TokenIdent, DelegationTokenInformation> tokens = new HashMap<>();
+    try {
+      // Query SQL for tokens that haven't been updated after
+      // the last token renewal period.
+      long maxModifiedTime = Time.now() - getTokenRenewInterval();
+      Map<byte[], byte[]> tokenInfoBytesList = selectTokenInfos(maxModifiedTime,
+          this.maxTokenCleanupResults);
+
+      for (Map.Entry<byte[], byte[]> tokenInfoBytes : tokenInfoBytesList.entrySet()) {
+        TokenIdent tokenIdent = createTokenIdent(tokenInfoBytes.getKey());
+        DelegationTokenInformation tokenInfo = createTokenInfo(tokenInfoBytes.getValue());
+        tokens.put(tokenIdent, tokenInfo);
+      }
+    } catch (IOException | SQLException e) {
+      LOG.error("Failed to get all tokens in SQL secret manager", e);
+    }
+
+    return tokens;
   }
 
   /**
@@ -414,6 +456,8 @@ public abstract class SQLDelegationTokenSecretManager<TokenIdent
 
   // Token operations in SQL database
   protected abstract byte[] selectTokenInfo(int sequenceNum, byte[] tokenIdentifier)
+      throws SQLException;
+  protected abstract Map<byte[], byte[]> selectTokenInfos(long maxModifiedTime, int topResults)
       throws SQLException;
   protected abstract void insertToken(int sequenceNum, byte[] tokenIdentifier, byte[] tokenInfo)
       throws SQLException;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/security/token/SQLDelegationTokenSecretManagerImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/security/token/SQLDelegationTokenSecretManagerImpl.java
@@ -23,6 +23,9 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier;
@@ -147,6 +150,26 @@ public class SQLDelegationTokenSecretManagerImpl
         }
       }
       return null;
+    });
+  }
+
+  @Override
+  protected Map<byte[], byte[]> selectTokenInfos(long maxModifiedTime, int maxResults)
+      throws SQLException {
+    return retryHandler.execute(() -> {
+      try (Connection connection = connectionFactory.getConnection();
+          PreparedStatement statement = connection.prepareStatement(
+              "SELECT tokenIdentifier, tokenInfo FROM Tokens WHERE modifiedTime < ?")) {
+        statement.setTimestamp(1, new Timestamp(maxModifiedTime));
+        statement.setMaxRows(maxResults);
+        ResultSet result = statement.executeQuery();
+        Map<byte[], byte[]> results = new HashMap<>();
+        while (result.next()) {
+          results.put(result.getBytes("tokenIdentifier"),
+              result.getBytes("tokenInfo"));
+        }
+        return results;
+      }
     });
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/security/token/SQLDelegationTokenSecretManagerImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/security/token/SQLDelegationTokenSecretManagerImpl.java
@@ -154,7 +154,7 @@ public class SQLDelegationTokenSecretManagerImpl
   }
 
   @Override
-  protected Map<byte[], byte[]> selectTokenInfos(long maxModifiedTime, int maxResults)
+  protected Map<byte[], byte[]> selectStaleTokenInfos(long maxModifiedTime, int maxResults)
       throws SQLException {
     return retryHandler.execute(() -> {
       try (Connection connection = connectionFactory.getConnection();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/security/token/SQLDelegationTokenSecretManagerImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/security/token/SQLDelegationTokenSecretManagerImpl.java
@@ -162,13 +162,14 @@ public class SQLDelegationTokenSecretManagerImpl
               "SELECT tokenIdentifier, tokenInfo FROM Tokens WHERE modifiedTime < ?")) {
         statement.setTimestamp(1, new Timestamp(maxModifiedTime));
         statement.setMaxRows(maxResults);
-        ResultSet result = statement.executeQuery();
-        Map<byte[], byte[]> results = new HashMap<>();
-        while (result.next()) {
-          results.put(result.getBytes("tokenIdentifier"),
-              result.getBytes("tokenInfo"));
+        try (ResultSet result = statement.executeQuery()) {
+          Map<byte[], byte[]> results = new HashMap<>();
+          while (result.next()) {
+            results.put(result.getBytes("tokenIdentifier"),
+                result.getBytes("tokenInfo"));
+          }
+          return results;
         }
-        return results;
       }
     });
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/security/token/TestSQLDelegationTokenSecretManagerImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/security/token/TestSQLDelegationTokenSecretManagerImpl.java
@@ -218,7 +218,7 @@ public class TestSQLDelegationTokenSecretManagerImpl {
         try {
           // Constantly renew token so it doesn't expire.
           tokenManager.renewToken(token1, "foo");
-          
+
           // Wait for cleanup to happen so expired token is deleted from SQL.
           return !isTokenInSQL(secretManager, tokenId2);
         } catch (IOException | SQLException e) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/security/token/TestSQLDelegationTokenSecretManagerImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/security/token/TestSQLDelegationTokenSecretManagerImpl.java
@@ -30,12 +30,15 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier;
+import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenSecretManager;
 import org.apache.hadoop.security.token.delegation.SQLDelegationTokenSecretManager;
+import org.apache.hadoop.security.token.delegation.web.DelegationTokenIdentifier;
 import org.apache.hadoop.security.token.delegation.web.DelegationTokenManager;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
@@ -52,6 +55,7 @@ public class TestSQLDelegationTokenSecretManagerImpl {
   private static final String CONNECTION_URL = "jdbc:derby:memory:TokenStore";
   private static final int TEST_MAX_RETRIES = 3;
   private static final int TOKEN_EXPIRATION_SECONDS = 1;
+  private static final int TOKEN_EXPIRATION_SCAN_SECONDS = 1;
   private static Configuration conf;
 
   @Before
@@ -75,6 +79,7 @@ public class TestSQLDelegationTokenSecretManagerImpl {
     conf.set(SQLConnectionFactory.CONNECTION_DRIVER, "org.apache.derby.jdbc.EmbeddedDriver");
     conf.setInt(SQLSecretManagerRetriableHandlerImpl.MAX_RETRIES, TEST_MAX_RETRIES);
     conf.setInt(SQLSecretManagerRetriableHandlerImpl.RETRY_SLEEP_TIME_MS, 10);
+    conf.setInt(DelegationTokenManager.REMOVAL_SCAN_INTERVAL, TOKEN_EXPIRATION_SCAN_SECONDS);
   }
 
   @AfterClass
@@ -188,6 +193,62 @@ public class TestSQLDelegationTokenSecretManagerImpl {
     }
   }
 
+  @Test
+  public void testRemoveExpiredTokens() throws Exception {
+    DelegationTokenManager tokenManager = createTokenManager(getShortLivedTokenConf());
+
+    try {
+      TestDelegationTokenSecretManager secretManager =
+          (TestDelegationTokenSecretManager) tokenManager.getDelegationTokenSecretManager();
+
+      // Create token to be constantly renewed.
+      Token token1 = tokenManager.createToken(UserGroupInformation.getCurrentUser(), "foo");
+      AbstractDelegationTokenIdentifier tokenId1 =
+          (AbstractDelegationTokenIdentifier) token1.decodeIdentifier();
+
+      // Create token expected to expire soon.
+      long expirationTime2 = Time.now();
+      AbstractDelegationTokenIdentifier tokenId2 = storeToken(secretManager, 2, expirationTime2);
+
+      // Create token not expected to expire soon.
+      long expirationTime3 = Time.now() + TimeUnit.SECONDS.toMillis(TOKEN_EXPIRATION_SECONDS) * 10;
+      AbstractDelegationTokenIdentifier tokenId3 = storeToken(secretManager, 3, expirationTime3);
+
+      GenericTestUtils.waitFor(() -> {
+        try {
+          // Constantly renew token so it doesn't expire.
+          tokenManager.renewToken(token1, "foo");
+          
+          // Wait for cleanup to happen so expired token is deleted from SQL.
+          return !isTokenInSQL(secretManager, tokenId2);
+        } catch (IOException | SQLException e) {
+          throw new RuntimeException(e);
+        }
+      }, 100, 6000);
+
+      Assert.assertTrue("Renewed token must not be cleaned up",
+          isTokenInSQL(secretManager, tokenId1));
+      Assert.assertTrue("Token with future expiration must not be cleaned up",
+          isTokenInSQL(secretManager, tokenId3));
+    } finally {
+      stopTokenManager(tokenManager);
+    }
+  }
+
+  private AbstractDelegationTokenIdentifier storeToken(
+      TestDelegationTokenSecretManager secretManager, int sequenceNum, long expirationTime)
+      throws IOException {
+    AbstractDelegationTokenIdentifier tokenId = new DelegationTokenIdentifier(new Text("Test"));
+    tokenId.setOwner(new Text("foo"));
+    tokenId.setSequenceNumber(sequenceNum);
+
+    AbstractDelegationTokenSecretManager.DelegationTokenInformation tokenInfo =
+        new AbstractDelegationTokenSecretManager.DelegationTokenInformation(expirationTime, null);
+    secretManager.storeToken(tokenId, tokenInfo);
+
+    return tokenId;
+  }
+
   private Configuration getShortLivedTokenConf() {
     Configuration shortLivedConf = new Configuration(conf);
     shortLivedConf.setTimeDuration(
@@ -201,13 +262,12 @@ public class TestSQLDelegationTokenSecretManagerImpl {
       TestDelegationTokenSecretManager secretManager, AbstractDelegationTokenIdentifier tokenId,
       boolean expectedInSQL) throws SQLException {
     secretManager.removeExpiredStoredToken(tokenId);
-    byte[] tokenInfo = secretManager.selectTokenInfo(tokenId.getSequenceNumber(),
-        tokenId.getBytes());
-    if (expectedInSQL) {
-      Assert.assertNotNull("Verify token exists in database", tokenInfo);
-    } else {
-      Assert.assertNull("Verify token was removed from database", tokenInfo);
-    }
+    Assert.assertEquals(expectedInSQL, isTokenInSQL(secretManager, tokenId));
+  }
+
+  private boolean isTokenInSQL(TestDelegationTokenSecretManager secretManager,
+      AbstractDelegationTokenIdentifier tokenId) throws SQLException {
+    return secretManager.selectTokenInfo(tokenId.getSequenceNumber(), tokenId.getBytes()) != null;
   }
 
   @Test
@@ -540,6 +600,11 @@ public class TestSQLDelegationTokenSecretManagerImpl {
 
     public void removeExpiredStoredToken(TokenIdentifier tokenId) {
       super.removeExpiredStoredToken((AbstractDelegationTokenIdentifier) tokenId);
+    }
+
+    public void storeToken(AbstractDelegationTokenIdentifier ident,
+        DelegationTokenInformation tokenInfo) throws IOException {
+      super.storeToken(ident, tokenInfo);
     }
 
     public void setReadOnly(boolean readOnly) {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: HDFS-17148. RBF: SQLDelegationTokenSecretManager must cleanup expired tokens in SQL

These changes update the SQLDelegationTokenSecretManager to cleanup expired tokens found in SQL. Currently, AbstractDelegationTokenSecretManagers only cleanup tokens in its memory cache. The SQLDelegationTokenSecretManager was recently updated to use a LoadingCache with a short TTL, so most expired tokens won't be present in memory.

During token cleanup, the SQLDelegationTokenSecretManager will query SQL for a list of tokens that have not been updated recently, based on the modifiedTime column. We will limit the amount of results returned to prevent performance impact on SQL. Once the list is returned, the ExpiredTokenRemover will evaluate if the tokens are actually expired and delete them from SQL if so.

### How was this patch tested?
Added unit test for different token cleanup scenarios:
1. Having an expired token in SQL. which should be deleted
2. Having a token with a long renewal time, which should not be deleted
3. Having a token recently renewed, which should not be deleted

### For code changes:

- [Y] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [Y] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [Y] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [Y] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

