### PR TITLE
HDFS-17153. Reconfig 'pipelineSupportSlownode' parameters for datanode.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeReconfiguration.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeReconfiguration.java
@@ -52,6 +52,7 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DISK_BALANCER_ENABLED;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DISK_BALANCER_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DISK_BALANCER_PLAN_VALID_INTERVAL;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DISK_BALANCER_PLAN_VALID_INTERVAL_DEFAULT;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_PIPELINE_SLOWNODE_ENABLED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -619,6 +620,14 @@ public class TestDataNodeReconfiguration {
           DFS_DATANODE_MIN_OUTLIER_DETECTION_NODES_DEFAULT);
       assertEquals(dn.getPeerMetrics().getSlowNodeDetector().getLowThresholdMs(),
           DFS_DATANODE_SLOWPEER_LOW_THRESHOLD_MS_DEFAULT);
+
+      LambdaTestUtils.intercept(ReconfigurationException.class,
+          "Could not change property dfs.pipeline.slownode from 'false' to 'text'",
+          () -> dn.reconfigureProperty(DFS_PIPELINE_SLOWNODE_ENABLED, "text"));
+
+      // Reset DFS_PIPELINE_SLOWNODE_ENABLED to true.
+      dn.reconfigureProperty(DFS_PIPELINE_SLOWNODE_ENABLED, "true");
+      assertTrue(dn.isPipelineSupportSlownode());
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -346,7 +346,7 @@ public class TestDFSAdmin {
     final List<String> outs = Lists.newArrayList();
     final List<String> errs = Lists.newArrayList();
     getReconfigurableProperties("datanode", address, outs, errs);
-    assertEquals(24, outs.size());
+    assertEquals(25, outs.size());
     assertEquals(DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY, outs.get(1));
   }
 


### PR DESCRIPTION
### Description of PR
**[HDFS-17153](https://issues.apache.org/jira/browse/HDFS-17153)**

Reference: [HDFS-16396](https://issues.apache.org/jira/browse/HDFS-16396)
In large clusters, rolling restart datanodes takes a long time. We can make 'pipelineSupportSlownode' parameters in datanode reconfigurable to facilitate cluster operation and maintenance.

### How was this patch tested?
UT



