### PR TITLE
HADOOP-18845. Add ability to configure s3 connection ttl

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -25,6 +25,8 @@ import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 
 import java.util.concurrent.TimeUnit;
 
+import com.amazonaws.ClientConfiguration;
+
 /**
  * Constants used with the {@link S3AFileSystem}.
  *
@@ -153,6 +155,11 @@ public final class Constants {
   // number of simultaneous connections to s3
   public static final String MAXIMUM_CONNECTIONS = "fs.s3a.connection.maximum";
   public static final int DEFAULT_MAXIMUM_CONNECTIONS = 96;
+
+  // Expiration time of s3 http connection from the connection pool.
+  // See {@code com.amazonaws.ClientConfiguration#setConnectionTTL}
+  public static final String CONNECTION_TTL = "fs.s3a.connection.ttl";
+  public static final long DEFAULT_CONNECTION_TTL = ClientConfiguration.DEFAULT_CONNECTION_TTL;
 
   // connect to s3 over ssl?
   public static final String SECURE_CONNECTIONS =

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -156,10 +156,16 @@ public final class Constants {
   public static final String MAXIMUM_CONNECTIONS = "fs.s3a.connection.maximum";
   public static final int DEFAULT_MAXIMUM_CONNECTIONS = 96;
 
-  // Expiration time of s3 http connection from the connection pool.
-  // See {@code com.amazonaws.ClientConfiguration#setConnectionTTL}
+  /**
+   * Configuration option to configure expiration time of
+   * s3 http connection from the connection pool in milliseconds: {@value}.
+   */
   public static final String CONNECTION_TTL = "fs.s3a.connection.ttl";
-  public static final long DEFAULT_CONNECTION_TTL = ClientConfiguration.DEFAULT_CONNECTION_TTL;
+
+  /**
+   * Default value for {@value CONNECTION_TTL}: {@value}.
+   */
+  public static final long DEFAULT_CONNECTION_TTL = 5 * 60 * 1000;
 
   // connect to s3 over ssl?
   public static final String SECURE_CONNECTIONS =

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -25,8 +25,6 @@ import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 
 import java.util.concurrent.TimeUnit;
 
-import com.amazonaws.ClientConfiguration;
-
 /**
  * Constants used with the {@link S3AFileSystem}.
  *
@@ -163,9 +161,9 @@ public final class Constants {
   public static final String CONNECTION_TTL = "fs.s3a.connection.ttl";
 
   /**
-   * Default value for {@value CONNECTION_TTL}: {@value}.
+   * Default value for {@code CONNECTION_TTL}: {@value}.
    */
-  public static final long DEFAULT_CONNECTION_TTL = 5 * 60 * 1000;
+  public static final long DEFAULT_CONNECTION_TTL = 5 * 60_000;
 
   // connect to s3 over ssl?
   public static final String SECURE_CONNECTIONS =

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Invoker.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Invoker.java
@@ -462,7 +462,7 @@ public class Invoker {
     do {
       try {
         if (retryCount > 0) {
-          LOG.debug("retry #{}", retryCount);
+          LOG.debug("{} retry #{}", text, retryCount);
         }
         // execute the operation, returning if successful
         return operation.apply();
@@ -471,7 +471,8 @@ public class Invoker {
       }
       // you only get here if the operation didn't complete
       // normally, hence caught != null
-
+      LOG.debug("{} ; {}, ", text, caught.toString());
+      LOG.trace("{}", caught);
       // translate the exception into an IOE for the retry logic
       IOException translated;
       if (caught instanceof IOException) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Invoker.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Invoker.java
@@ -472,7 +472,7 @@ public class Invoker {
       // you only get here if the operation didn't complete
       // normally, hence caught != null
       LOG.debug("{} ; {}, ", text, caught.toString());
-      LOG.trace("{}", caught);
+      LOG.trace("", caught);
       // translate the exception into an IOE for the retry logic
       IOException translated;
       if (caught instanceof IOException) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -1299,10 +1299,6 @@ public final class S3AUtils {
       ClientConfiguration awsConf) throws IOException {
     awsConf.setMaxConnections(intOption(conf, MAXIMUM_CONNECTIONS,
         DEFAULT_MAXIMUM_CONNECTIONS, 1));
-    // To discuss?
-    // what if user set the value to 0?
-    // Should we reduce the value to Integer.MAX_VALUE if user sets greater than that.
-
     awsConf.setConnectionTTL(longOption(conf, CONNECTION_TTL,
             DEFAULT_CONNECTION_TTL, -1));
     initProtocolSettings(conf, awsConf);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -1299,6 +1299,12 @@ public final class S3AUtils {
       ClientConfiguration awsConf) throws IOException {
     awsConf.setMaxConnections(intOption(conf, MAXIMUM_CONNECTIONS,
         DEFAULT_MAXIMUM_CONNECTIONS, 1));
+    // To discuss?
+    // what if user set the value to 0?
+    // Should we reduce the value to Integer.MAX_VALUE if user sets greater than that.
+
+    awsConf.setConnectionTTL(longOption(conf, CONNECTION_TTL,
+            DEFAULT_CONNECTION_TTL, -1));
     initProtocolSettings(conf, awsConf);
     awsConf.setMaxErrorRetry(intOption(conf, MAX_ERROR_RETRIES,
         DEFAULT_MAX_ERROR_RETRIES, 0));

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
@@ -1782,9 +1782,9 @@ will attempt to retry the operation; it may just be a transient event. If there
 are many such exceptions in logs, it may be a symptom of connectivity or network
 problems.
 
-The above error could be because of a stale http connections.Default value in AWS
-SDK is set to -1 (infinite) which means connection will be reused indefinitely.
-We have introduced a new config fs.s3a.connection.ttl to configure this.
+The above error could be because of a stale http connections. The default value in AWS
+SDK is set to -1 (infinite) which means the connection will be reused indefinitely.
+We have introduced a new config `fs.s3a.connection.ttl` to configure this.
 Tuning this setting down (together with an appropriately-low setting for Java's DNS cache TTL)
 ensures that your application will quickly rotate over to new IP addresses when the
 service begins announcing them through DNS, at the cost of having to re-establish new

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
@@ -1782,6 +1782,23 @@ will attempt to retry the operation; it may just be a transient event. If there
 are many such exceptions in logs, it may be a symptom of connectivity or network
 problems.
 
+Above error could be because of a stale http connections. By default, connections
+in the http connection pool are reused indefinitely. To discard connections after 
+a specific period of time please configure fs.s3a.connection.ttl.
+
+```xml
+<property>
+  <name>fs.s3a.connection.ttl</name>
+  <value>-1</value>
+  <description>
+      Expiration time for a connection in the connection pool in milliseconds.
+      When a connection is retrieved from the connection pool,
+      this parameter is checked to see if the connection can be reused. 
+      Default value is set to -1 (infinite) which means connection 
+      will be reused indefinitely.
+  </description>
+</property>
+```
 ### `AWSBadRequestException` IllegalLocationConstraintException/The unspecified location constraint is incompatible
 
 ```

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
@@ -1782,20 +1782,23 @@ will attempt to retry the operation; it may just be a transient event. If there
 are many such exceptions in logs, it may be a symptom of connectivity or network
 problems.
 
-Above error could be because of a stale http connections. By default, connections
-in the http connection pool are reused indefinitely. To discard connections after 
-a specific period of time please configure fs.s3a.connection.ttl.
+The above error could be because of a stale http connections.Default value in AWS
+SDK is set to -1 (infinite) which means connection will be reused indefinitely.
+We have introduced a new config fs.s3a.connection.ttl to configure this.
+Tuning this setting down (together with an appropriately-low setting for Java's DNS cache TTL)
+ensures that your application will quickly rotate over to new IP addresses when the
+service begins announcing them through DNS, at the cost of having to re-establish new
+connections more frequently.
 
 ```xml
 <property>
   <name>fs.s3a.connection.ttl</name>
-  <value>-1</value>
+  <value>300000</value>
   <description>
       Expiration time for a connection in the connection pool in milliseconds.
       When a connection is retrieved from the connection pool,
-      this parameter is checked to see if the connection can be reused. 
-      Default value is set to -1 (infinite) which means connection 
-      will be reused indefinitely.
+      this parameter is checked to see if the connection can be reused.
+      Default value is 5 minutes.
   </description>
 </property>
 ```

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
@@ -515,25 +515,25 @@ public class ITestS3AConfiguration {
 
   @Test(timeout = 10_000L)
   public void testConnectTtlPropagation() throws Exception {
-    Configuration config = new Configuration();
+    Configuration config = new Configuration(false);
     ClientConfiguration awsConf  = new ClientConfiguration();
     initConnectionSettings(config, awsConf);
     Assertions.assertThat(awsConf.getConnectionTTL())
-            .describedAs(String.format("connection ttl should be set to default value as" +
-                    " %s is not set", CONNECTION_TTL))
+            .describedAs("connection ttl should be set to default value as" +
+                    " %s is not set", CONNECTION_TTL)
             .isEqualTo(DEFAULT_CONNECTION_TTL);
     long connectionTtlTestVal = 1000;
     config.setLong(CONNECTION_TTL, connectionTtlTestVal);
     initConnectionSettings(config, awsConf);
     Assertions.assertThat(awsConf.getConnectionTTL())
-            .describedAs(String.format("%s not propagated to aws conf", CONNECTION_TTL))
+            .describedAs("%s not propagated to aws conf", CONNECTION_TTL)
             .isEqualTo(connectionTtlTestVal);
 
     long connectionTtlTestVal1 = -1;
     config.setLong(CONNECTION_TTL, connectionTtlTestVal1);
     initConnectionSettings(config, awsConf);
     Assertions.assertThat(awsConf.getConnectionTTL())
-            .describedAs(String.format("%s not propagated to aws conf", CONNECTION_TTL))
+            .describedAs("%s not propagated to aws conf", CONNECTION_TTL)
             .isEqualTo(connectionTtlTestVal1);
 
     long connectionTtlTestVal2 = -100;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.s3native.S3xLoginHelper;
 import org.apache.hadoop.test.GenericTestUtils;
+
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -509,6 +511,23 @@ public class ITestS3AConfiguration {
     fs = S3ATestUtils.createTestFileSystem(config);
     Configuration updated = fs.getConf();
     assertOptionEquals(updated, "fs.s3a.propagation", "propagated");
+  }
+
+  @Test(timeout = 10_000L)
+  public void testConnectTtlPropagation() throws Exception {
+    Configuration config = new Configuration();
+    ClientConfiguration awsConf  = new ClientConfiguration();
+    initConnectionSettings(config, awsConf);
+    Assertions.assertThat(awsConf.getConnectionTTL())
+            .describedAs(String.format("connection ttl should be set to default value as" +
+                    " %s is not set", CONNECTION_TTL))
+            .isEqualTo(DEFAULT_CONNECTION_TTL);
+    long connectionTtlTestVal = 1000;
+    config.setLong(CONNECTION_TTL, connectionTtlTestVal);
+    initConnectionSettings(config, awsConf);
+    Assertions.assertThat(awsConf.getConnectionTTL())
+            .describedAs(String.format("%s not propagated to aws conf", CONNECTION_TTL))
+            .isEqualTo(connectionTtlTestVal);
   }
 
   @Test(timeout = 10_000L)

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
@@ -528,6 +528,17 @@ public class ITestS3AConfiguration {
     Assertions.assertThat(awsConf.getConnectionTTL())
             .describedAs(String.format("%s not propagated to aws conf", CONNECTION_TTL))
             .isEqualTo(connectionTtlTestVal);
+
+    long connectionTtlTestVal1 = -1;
+    config.setLong(CONNECTION_TTL, connectionTtlTestVal1);
+    initConnectionSettings(config, awsConf);
+    Assertions.assertThat(awsConf.getConnectionTTL())
+            .describedAs(String.format("%s not propagated to aws conf", CONNECTION_TTL))
+            .isEqualTo(connectionTtlTestVal1);
+
+    long connectionTtlTestVal2 = -100;
+    config.setLong(CONNECTION_TTL, connectionTtlTestVal2);
+    intercept(IllegalArgumentException.class, () -> initConnectionSettings(config, awsConf));
   }
 
   @Test(timeout = 10_000L)


### PR DESCRIPTION

### Description of PR
Introducing fs.s3a.connection.ttl configuration which can be configured to expire old HTTP connection after specified period of time.

### How was this patch tested?
Tests in progress. Added a new test. 

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

