### PR TITLE
HDFS-17157: Transient network failure in lease recovery could be mitigated to ensure better consistency

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -2030,5 +2030,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final long DFS_LEASE_HARDLIMIT_DEFAULT =
       HdfsClientConfigKeys.DFS_LEASE_HARDLIMIT_DEFAULT;
 
+  // Block Recovery Policy
+  public static final String DFS_BLOCK_RECOVERY_EOF_RETRY_KEY = "dfs.block-recovery.retry.max.attempts";
+  public static final int DFS_BLOCK_RECOVERY_EOF_RETRY_DEFAULT = 3;
 
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
See [HDFS-17157](https://issues.apache.org/jira/browse/HDFS-17157) for details on the symptom and diagnostic.

The fix of [HDFS-17157](https://issues.apache.org/jira/browse/HDFS-17157) is implemented. In my local machine, it is able to pass all test cases.

I add some configurable retry mechanism to ZkDataBase#loadDataBase() to tolerate EOFException caused by possible transient network failure.

Any comments and suggestions would be appreciated.

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

