### PR TITLE
fix hdfsThreadDestructor coredump

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/CryptoInputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/CryptoInputStream.java
@@ -740,6 +740,7 @@ public class CryptoInputStream extends FilterInputStream implements
     case StreamCapabilities.READAHEAD:
     case StreamCapabilities.DROPBEHIND:
     case StreamCapabilities.UNBUFFER:
+    case StreamCapabilities.READBYTEBUFFER:
       return true;
     default:
       return false;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StreamCapabilities.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StreamCapabilities.java
@@ -59,6 +59,12 @@ public interface StreamCapabilities {
    */
   String UNBUFFER = "in:unbuffer";
 
+    /**
+   * Stream read(ByteBuffer) capability implemented by
+   * {@link ByteBufferReadable#read(java.nio.ByteBuffer)}.
+   */
+  String READBYTEBUFFER = "in:readbytebuffer";
+  
   /**
    * Capabilities that a stream can support and be queried for.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -1779,6 +1779,7 @@ public class DFSInputStream extends FSInputStream
     case StreamCapabilities.READAHEAD:
     case StreamCapabilities.DROPBEHIND:
     case StreamCapabilities.UNBUFFER:
+    case StreamCapabilities.READBYTEBUFFER:
       return true;
     default:
       return false;

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/posix/thread_local_storage.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/posix/thread_local_storage.c
@@ -47,7 +47,7 @@ void hdfsThreadDestructor(void *v)
   jsize vmNum = 0;
   auto res = JNI_GetCreatedJavaVMs(&vm, 1, &vmNum);
   if (res != JNI_OK || vmNum <= 0) {
-    fprint(stderr, "JVM exits\n");
+    fprintf(stderr, "JVM exits\n");
     return;
   }
   ret = (*vm)->DetachCurrentThread(vm);

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/posix/thread_local_storage.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/posix/thread_local_storage.c
@@ -43,15 +43,17 @@ void hdfsThreadDestructor(void *v)
   jint ret;
 
   /* Detach the current thread from the JVM */
-  if (env) {
-    ret = (*env)->GetJavaVM(env, &vm);
-    if (ret) {
-      fprintf(stderr, "hdfsThreadDestructor: GetJavaVM failed with error %d\n",
-        ret);
-      (*env)->ExceptionDescribe(env);
-    } else {
-      (*vm)->DetachCurrentThread(vm);
-    }
+  /* Found created Java */
+  jsize vmNum = 0;
+  auto res = JNI_GetCreatedJavaVMs(&vm, 1, &vmNum);
+  if (res != JNI_OK || vmNum <= 0) {
+    fprint(stderr, "JVM exits\n");
+    return;
+  }
+  ret = (*vm)->DetachCurrentThread(vm);
+
+  if (ret != JNI_OK) {
+    fprintf(stderr, "hdfsThreadDestructor: Unable to detach thread from the JVM. Error code: %d\n", ret);
   }
 
   /* Free exception strings */

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfs_ext_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfs_ext_test.cc
@@ -503,7 +503,10 @@ TEST_F(HdfsExtTest, TestReadStats) {
   hdfsFileFreeReadStatistics(stats);
 
   EXPECT_EQ(0, hdfsCloseFile(fs, file));
-  EXPECT_EQ(0, errno);
+  // Since libhdfs is not guaranteed to set errno to 0 on successful
+  // operations, we disable this check for now, see HDFS-14325 for a
+  // long term solution to this problem
+  // EXPECT_EQ(0, errno);
 }
 
 //Testing working directory


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

