### PR TITLE
HDFS-17161: Adding test for StripedBlockReader#createBlockReader leak…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeFaultInjector.java
@@ -21,8 +21,10 @@ import org.apache.hadoop.classification.VisibleForTesting;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 
+import java.io.Closeable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.Socket;
 import java.nio.ByteBuffer;
 
 /**
@@ -162,4 +164,14 @@ public class DataNodeFaultInjector {
    * Just delay delete replica a while.
    */
   public void delayDeleteReplica() {}
+
+  /**
+   *  Used as a hook to throw IOException
+   *  when create block-reader
+   *  Also check the socket is not leaked
+   */
+  public void collectSocket(Socket s) {}
+
+  public void injectIOException() throws IOException {}
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeFaultInjector.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.classification.VisibleForTesting;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 
-import java.io.Closeable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.Socket;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockReader.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.security.token.block.BlockTokenIdentifier;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.datanode.DataNodeFaultInjector;
+import org.apache.hadoop.hdfs.server.datanode.FaultInjectorFileIoEvents;
 import org.apache.hadoop.hdfs.util.StripedBlockUtil.BlockReadStats;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.net.NetUtils;
@@ -125,6 +126,7 @@ class StripedBlockReader {
          * TODO: add proper tracer
          */
       peer = newConnectedPeer(block, dnAddr, blockToken, source);
+      DataNodeFaultInjector.get().injectIOException();
       if (peer.isLocal()) {
         this.isLocal = true;
       }
@@ -155,6 +157,7 @@ class StripedBlockReader {
           sock, datanode.getDataEncryptionKeyFactoryForBlock(b),
           blockToken, datanodeId, socketTimeout);
       success = true;
+      DataNodeFaultInjector.get().collectSocket(sock);
       return peer;
     } finally {
       if (!success) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestReconstructStripedFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestReconstructStripedFile.java
@@ -754,12 +754,12 @@ public class TestReconstructStripedFile {
     try {
       shutdownDataNode(dataNode);
       final int attempts = 60;
-      // Wait Until the injection is injected
+      // Wait Until the IOException is injected
       for (int i = 0; i < attempts; i++) {
         if (injected.get()) {
           break;
         }
-        if (i == 59) {
+        if (i == (attempts - 1)) {
           Assert.fail("Should have injected the IOException");
         }
         Thread.sleep(1000);
@@ -775,7 +775,7 @@ public class TestReconstructStripedFile {
         if (allReleased) {
           break;
         }
-        if (i == 59) {
+        if (i == (attempts - 1)) {
           Assert.fail("The socket is still not released");
         }
         Thread.sleep(1000);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestReconstructStripedFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestReconstructStripedFile.java
@@ -21,8 +21,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,10 +34,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.*;
 
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
@@ -687,6 +687,99 @@ public class TestReconstructStripedFile {
       // before HDFS-15240, NPE will cause reconstruction fail(test timeout)
       StripedFileTestUtil
           .waitForReconstructionFinished(file, fs, groupSize);
+    } finally {
+      DataNodeFaultInjector.set(oldInjector);
+    }
+  }
+
+  @Test(timeout = 120000)
+  public void testSocketLeakInReconstruction() throws Exception {
+    assumeTrue("Ignore case where num parity units <= 1",
+            ecPolicy.getNumParityUnits() > 1);
+    int stripedBufferSize = conf.getInt(
+            DFSConfigKeys.DFS_DN_EC_RECONSTRUCTION_STRIPED_READ_BUFFER_SIZE_KEY,
+            cellSize);
+    ErasureCodingPolicy policy = ecPolicy;
+    fs.enableErasureCodingPolicy(policy.getName());
+    fs.getClient().setErasureCodingPolicy("/", policy.getName());
+
+    // StripedBlockReconstructor#reconstruct will loop 2 times
+    final int fileLen = stripedBufferSize * 2 * ecPolicy.getNumDataUnits();
+    String fileName = "/timeout-read-block";
+    Path file = new Path(fileName);
+    writeFile(fs, fileName, fileLen);
+    fs.getFileBlockLocations(file, 0, fileLen);
+
+    LocatedBlocks locatedBlocks =
+            StripedFileTestUtil.getLocatedBlocks(file, fs);
+    Assert.assertEquals(1, locatedBlocks.getLocatedBlocks().size());
+    // The file only has one block group
+    LocatedBlock lblock = locatedBlocks.get(0);
+    DatanodeInfo[] datanodeinfos = lblock.getLocations();
+
+    // to reconstruct first block
+    DataNode dataNode = cluster.getDataNode(datanodeinfos[0].getIpcPort());
+
+    int stripedReadTimeoutInMills = conf.getInt(
+            DFSConfigKeys.DFS_DN_EC_RECONSTRUCTION_STRIPED_READ_TIMEOUT_MILLIS_KEY,
+            DFSConfigKeys.
+                    DFS_DN_EC_RECONSTRUCTION_STRIPED_READ_TIMEOUT_MILLIS_DEFAULT);
+    Assert.assertTrue(
+            DFSConfigKeys.DFS_DN_EC_RECONSTRUCTION_STRIPED_READ_TIMEOUT_MILLIS_KEY
+                    + " must be greater than 2000",
+            stripedReadTimeoutInMills > 2000);
+
+    DataNodeFaultInjector oldInjector = DataNodeFaultInjector.get();
+
+    ConcurrentMap<Integer,Socket> socketInUse = new ConcurrentHashMap<>();
+    AtomicBoolean injected = new AtomicBoolean(false);
+
+    DataNodeFaultInjector ioInjector = new DataNodeFaultInjector() {
+      private final AtomicInteger counter = new AtomicInteger(0);
+      
+      @Override
+      public void collectSocket(Socket s) {
+        socketInUse.put(counter.incrementAndGet(),s);
+      }
+
+      @Override
+      public void injectIOException() throws IOException {
+        if (injected.compareAndSet(false,true)) {
+          throw new IOException("Inject Error");
+        }
+      }
+    };
+    DataNodeFaultInjector.set(ioInjector);
+
+    try {
+      shutdownDataNode(dataNode);
+      final int attempts = 60;
+      // Wait Until the injection is injected
+      for (int i = 0; i < attempts; i++) {
+        if (injected.get()) {
+          break;
+        }
+        if (i == 59) {
+          Assert.fail("Should have injected the IOException");
+        }
+        Thread.sleep(1000);
+      }
+      // Wait Until the socket is released
+      for (int i = 0; i < attempts; i++) {
+        boolean allReleased = true;
+        for (Socket s : socketInUse.values()) {
+          if (!s.isClosed()) {
+            allReleased = false;
+          }
+        }
+        if (allReleased) {
+          break;
+        }
+        if (i == 59) {
+          Assert.fail("The socket is still not released");
+        }
+        Thread.sleep(1000);
+      }
     } finally {
       DataNodeFaultInjector.set(oldInjector);
     }


### PR DESCRIPTION
…s socket on IOException

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
In [HDFS-13039](https://issues.apache.org/jira/browse/HDFS-13039), it is proposed a situation in which an IOException during StripedBlockReader#createBlockReader has potential to leak the socket. However, in [HDFS-13039](https://issues.apache.org/jira/browse/HDFS-13039), the test patch is still missed. Then in this case, we add a unit test to reproduce that. From the test results, when the patch in HDFS-13039 is removed, the test would failed while the test could pass when the patch is added back.

Any comments and suggestions would be appreciated.

### How was this patch tested?
The case itself is about a unit test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

