### PR TITLE
YARN-11551. RM format-conf-store should delete all the content of ZKConfigStore

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/ZKConfigurationStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/ZKConfigurationStore.java
@@ -64,6 +64,7 @@ public class ZKConfigurationStore extends YarnConfigurationStore {
   private static final String CONF_VERSION_PATH = "CONF_VERSION";
   private static final String NODEEXISTS_MSG = "Encountered NodeExists error."
       + " Skipping znode creation since another RM has already created it";
+  private String znodeParentPath;
   private String zkVersionPath;
   private String logsPath;
   private String confStorePath;
@@ -78,7 +79,7 @@ public class ZKConfigurationStore extends YarnConfigurationStore {
       RMContext rmContext) throws Exception {
     this.conf = config;
 
-    String znodeParentPath = conf.get(
+    this.znodeParentPath = conf.get(
         YarnConfiguration.RM_SCHEDCONF_STORE_ZK_PARENT_PATH,
         YarnConfiguration.DEFAULT_RM_SCHEDCONF_STORE_ZK_PARENT_PATH);
 
@@ -144,7 +145,7 @@ public class ZKConfigurationStore extends YarnConfigurationStore {
 
   @Override
   public void format() throws Exception {
-    zkManager.delete(confStorePath);
+    zkManager.delete(znodeParentPath);
   }
 
   @Override


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
To easily overcome the issue mentioned in [YARN-11075](https://issues.apache.org/jira/browse/YARN-11075) format-conf-store should delete everything under RM_SCHEDCONF_STORE_ZK_PARENT_PATH not just the CONF_STORE, because LOGS can contain elements that cannot be deserialized because of a missing serialVersionUID.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

