### PR TITLE
HDFS-17162. RBF: Add missing comments in StateStoreService

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/StateStoreService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/StateStoreService.java
@@ -64,6 +64,12 @@ import org.apache.hadoop.classification.VisibleForTesting;
  * <li>File {@link
  * org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreFileImpl
  * StateStoreFileImpl}
+ * <li>FileSystem {@link
+ * org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreFileSystemImpl
+ * StateStoreFileSystemImpl}
+ * <li>MySQL {@link
+ * org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreMySQLImpl
+ * StateStoreMySQLImpl}
  * <li>ZooKeeper {@link
  * org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl
  * StateStoreZooKeeperImpl}


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Small doc fix. StateStoreService lacks an introduction to StateStoreFileSystemImpl and StateStoreMySQLImpl .

### How was this patch tested?
No need test, it is doc fix.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

