### PR TITLE
YARN-11435. [Router] FederationStateStoreFacade is not reinitialized with Router conf.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestFederationRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestFederationRMFailoverProxyProvider.java
@@ -77,7 +77,7 @@ public class TestFederationRMFailoverProxyProvider {
 
     stateStore = spy(new MemoryFederationStateStore());
     stateStore.init(conf);
-    FederationStateStoreFacade.getInstance().reinitialize(stateStore, conf);
+    FederationStateStoreFacade.getInstance(conf).reinitialize(stateStore, conf);
     verify(stateStore, times(0))
         .getSubClusters(any(GetSubClustersInfoRequest.class));
   }
@@ -180,7 +180,7 @@ public class TestFederationRMFailoverProxyProvider {
           .getSubClusters(any(GetSubClustersInfoRequest.class));
 
       // Force flush cache, so that it will pick up the new RM address
-      FederationStateStoreFacade.getInstance().getSubCluster(subClusterId,
+      FederationStateStoreFacade.getInstance(conf).getSubCluster(subClusterId,
           true);
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/failover/FederationRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/failover/FederationRMFailoverProxyProvider.java
@@ -76,7 +76,7 @@ public class FederationRMFailoverProxyProvider<T>
     String clusterId = configuration.get(YarnConfiguration.RM_CLUSTER_ID);
     Preconditions.checkNotNull(clusterId, "Missing RM ClusterId");
     this.subClusterId = SubClusterId.newInstance(clusterId);
-    this.facade = FederationStateStoreFacade.getInstance();
+    this.facade = FederationStateStoreFacade.getInstance(configuration);
     if (configuration instanceof YarnConfiguration) {
       this.conf = (YarnConfiguration) configuration;
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
@@ -105,8 +105,7 @@ public final class FederationStateStoreFacade {
   private static final Logger LOG =
       LoggerFactory.getLogger(FederationStateStoreFacade.class);
 
-  private static final FederationStateStoreFacade FACADE =
-      new FederationStateStoreFacade();
+  private static volatile FederationStateStoreFacade facade;
 
   private static Random rand = new Random(System.currentTimeMillis());
 
@@ -115,8 +114,8 @@ public final class FederationStateStoreFacade {
   private SubClusterResolver subclusterResolver;
   private FederationCache federationCache;
 
-  private FederationStateStoreFacade() {
-    initializeFacadeInternal(new Configuration());
+  private FederationStateStoreFacade(Configuration conf) {
+    initializeFacadeInternal(conf);
   }
 
   private void initializeFacadeInternal(Configuration config) {
@@ -199,7 +198,50 @@ public final class FederationStateStoreFacade {
    * @return the singleton {@link FederationStateStoreFacade} instance
    */
   public static FederationStateStoreFacade getInstance() {
-    return FACADE;
+    return getInstanceInternal(new Configuration());
+  }
+
+  /**
+   * Returns the singleton instance of the FederationStateStoreFacade object.
+   *
+   * @param conf configuration.
+   * @return the singleton {@link FederationStateStoreFacade} instance
+   */
+  public static FederationStateStoreFacade getInstance(Configuration conf) {
+    return getInstanceInternal(conf);
+  }
+
+  /**
+   * Returns the singleton instance of the FederationStateStoreFacade object.
+   *
+   * @param conf configuration.
+   * @return the singleton {@link FederationStateStoreFacade} instance
+   */
+  private static FederationStateStoreFacade getInstanceInternal(Configuration conf){
+    if (facade != null) {
+      return facade;
+    }
+    generateStateStoreFacade(conf);
+    return facade;
+  }
+
+  /**
+   * Generate the singleton instance of the FederationStateStoreFacade object.
+   *
+   * @param conf configuration.
+   */
+  private static void generateStateStoreFacade(Configuration conf){
+    if (facade == null) {
+      synchronized (FederationStateStoreFacade.class) {
+        if (facade == null) {
+          Configuration yarnConf = new Configuration();
+          if (conf != null) {
+            yarnConf = conf;
+          }
+          facade = new FederationStateStoreFacade(yarnConf);
+        }
+      }
+    }
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/cache/TestFederationCache.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/cache/TestFederationCache.java
@@ -60,13 +60,14 @@ public class TestFederationCache {
   private Configuration conf;
   private FederationStateStore stateStore;
   private FederationStateStoreTestUtil stateStoreTestUtil;
-  private FederationStateStoreFacade facade = FederationStateStoreFacade.getInstance();
+  private FederationStateStoreFacade facade;
 
   public TestFederationCache(Class cacheClassName) {
     conf = new Configuration();
     conf.setInt(YarnConfiguration.FEDERATION_CACHE_TIME_TO_LIVE_SECS, 1);
     conf.setClass(YarnConfiguration.FEDERATION_FACADE_CACHE_CLASS,
         cacheClassName, FederationCache.class);
+    facade = FederationStateStoreFacade.getInstance(conf);
   }
 
   @Before

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/BaseFederationPoliciesTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/BaseFederationPoliciesTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.protocolrecords.ReservationSubmissionRequest;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
@@ -75,7 +76,8 @@ public abstract class BaseFederationPoliciesTest {
         .newInstance("queue1", getPolicy().getClass().getCanonicalName(), buf));
     fpc.setFederationSubclusterResolver(
         FederationPoliciesTestUtil.initResolver());
-    fpc.setFederationStateStoreFacade(FederationPoliciesTestUtil.initFacade());
+    Configuration conf = new Configuration();
+    fpc.setFederationStateStoreFacade(FederationPoliciesTestUtil.initFacade(conf));
     getPolicy().reinitialize(fpc);
   }
 
@@ -100,7 +102,8 @@ public abstract class BaseFederationPoliciesTest {
         .newInstance("queue1", "WrongPolicyName", buf));
     fpc.setFederationSubclusterResolver(
         FederationPoliciesTestUtil.initResolver());
-    fpc.setFederationStateStoreFacade(FederationPoliciesTestUtil.initFacade());
+    Configuration conf = new Configuration();
+    fpc.setFederationStateStoreFacade(FederationPoliciesTestUtil.initFacade(conf));
     getPolicy().reinitialize(fpc);
   }
 
@@ -212,9 +215,9 @@ public abstract class BaseFederationPoliciesTest {
   public FederationStateStoreFacade getMemoryFacade() throws YarnException {
 
     // setting up a store and its facade (with caching off)
-    FederationStateStoreFacade fedFacade = FederationStateStoreFacade.getInstance();
     YarnConfiguration conf = new YarnConfiguration();
     conf.setInt(YarnConfiguration.FEDERATION_CACHE_TIME_TO_LIVE_SECS, 0);
+    FederationStateStoreFacade fedFacade = FederationStateStoreFacade.getInstance(conf);
     FederationStateStore store = new MemoryFederationStateStore();
     store.init(conf);
     fedFacade.reinitialize(store, conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/TestFederationPolicyInitializationContextValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/TestFederationPolicyInitializationContextValidator.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.server.federation.policies;
 
 import java.nio.ByteBuffer;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.server.federation.policies.amrmproxy.FederationAMRMProxyPolicy;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyInitializationException;
 import org.apache.hadoop.yarn.server.federation.policies.manager.FederationPolicyManager;
@@ -45,7 +46,8 @@ public class TestFederationPolicyInitializationContextValidator {
 
   @Before
   public void setUp() throws Exception {
-    goodFacade = FederationPoliciesTestUtil.initFacade();
+    Configuration conf = new Configuration();
+    goodFacade = FederationPoliciesTestUtil.initFacade(conf);
     goodConfig = new MockPolicyManager().serializeConf();
     goodSR = FederationPoliciesTestUtil.initResolver();
     goodHome = SubClusterId.newInstance("homesubcluster");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/TestRouterPolicyFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/TestRouterPolicyFacade.java
@@ -62,10 +62,9 @@ public class TestRouterPolicyFacade {
   public void setup() throws YarnException {
 
     // setting up a store and its facade (with caching off)
-    FederationStateStoreFacade fedFacade =
-        FederationStateStoreFacade.getInstance();
     YarnConfiguration conf = new YarnConfiguration();
     conf.set(YarnConfiguration.FEDERATION_CACHE_TIME_TO_LIVE_SECS, "0");
+    FederationStateStoreFacade fedFacade = FederationStateStoreFacade.getInstance(conf);
     store = new MemoryFederationStateStore();
     store.init(conf);
     fedFacade.reinitialize(store, conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/BasePolicyManagerTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/BasePolicyManagerTest.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.yarn.server.federation.policies.manager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyInitializationContext;
 import org.apache.hadoop.yarn.server.federation.policies.amrmproxy.FederationAMRMProxyPolicy;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyInitializationException;
@@ -72,13 +73,14 @@ public abstract class BasePolicyManagerTest {
       Class expAMRMProxyPolicy, Class expRouterPolicy) throws Exception {
 
     // serializeConf it in a context
+    Configuration conf = new Configuration();
     SubClusterPolicyConfiguration fpc = wfp.serializeConf();
     fpc.setType(policyManagerType.getCanonicalName());
     FederationPolicyInitializationContext context =
         new FederationPolicyInitializationContext();
     context.setSubClusterPolicyConfiguration(fpc);
     context
-        .setFederationStateStoreFacade(FederationPoliciesTestUtil.initFacade());
+        .setFederationStateStoreFacade(FederationPoliciesTestUtil.initFacade(conf));
     context.setFederationSubclusterResolver(
         FederationPoliciesTestUtil.initResolver());
     context.setHomeSubcluster(SubClusterId.newInstance("homesubcluster"));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/utils/FederationPoliciesTestUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/utils/FederationPoliciesTestUtil.java
@@ -123,7 +123,7 @@ public final class FederationPoliciesTestUtil {
     fpc.setSubClusterPolicyConfiguration(SubClusterPolicyConfiguration
         .newInstance("queue1", policy.getClass().getCanonicalName(), buf));
     FederationStateStoreFacade facade = FederationStateStoreFacade
-        .getInstance();
+        .getInstance(conf);
     FederationStateStore fss = mock(FederationStateStore.class);
 
     if (activeSubclusters == null) {
@@ -242,9 +242,8 @@ public final class FederationPoliciesTestUtil {
 
   public static FederationStateStoreFacade initFacade(
       List<SubClusterInfo> subClusterInfos, SubClusterPolicyConfiguration
-      policyConfiguration) throws YarnException {
-    FederationStateStoreFacade goodFacade = FederationStateStoreFacade
-        .getInstance();
+      policyConfiguration, Configuration conf) throws YarnException {
+    FederationStateStoreFacade goodFacade = FederationStateStoreFacade.getInstance(conf);
     FederationStateStore fss = mock(FederationStateStore.class);
     GetSubClustersInfoResponse response = GetSubClustersInfoResponse
         .newInstance(subClusterInfos);
@@ -276,8 +275,20 @@ public final class FederationPoliciesTestUtil {
    * @throws YarnException in case the initialization is not successful.
    */
   public static FederationStateStoreFacade initFacade() throws YarnException {
+    return initFacade(new Configuration());
+  }
+
+  /**
+   * Initialiaze a main-memory {@link FederationStateStoreFacade} used for
+   * testing, wiht a mock resolver.
+   *
+   * @param conf Configuration.
+   * @return the facade.
+   * @throws YarnException in case the initialization is not successful.
+   */
+  public static FederationStateStoreFacade initFacade(Configuration conf) throws YarnException {
     SubClusterPolicyConfiguration policyConfiguration =
         SubClusterPolicyConfiguration.newInstance(null, null, null);
-    return initFacade(new ArrayList<>(), policyConfiguration);
+    return initFacade(new ArrayList<>(), policyConfiguration, conf);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/utils/TestFederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/utils/TestFederationStateStoreFacade.java
@@ -80,8 +80,8 @@ public class TestFederationStateStoreFacade {
   private Configuration conf;
   private FederationStateStore stateStore;
   private FederationStateStoreTestUtil stateStoreTestUtil;
-  private FederationStateStoreFacade facade =
-      FederationStateStoreFacade.getInstance();
+  private FederationStateStoreFacade facade;
+
   private Boolean isCachingEnabled;
 
   public TestFederationStateStoreFacade(Boolean isCachingEnabled) {
@@ -90,6 +90,7 @@ public class TestFederationStateStoreFacade {
       conf.setInt(YarnConfiguration.FEDERATION_CACHE_TIME_TO_LIVE_SECS, 0);
     }
     this.isCachingEnabled = isCachingEnabled;
+    facade = FederationStateStoreFacade.getInstance(conf);
   }
 
   @Before

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/main/java/org/apache/hadoop/yarn/server/globalpolicygenerator/GlobalPolicyGenerator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/main/java/org/apache/hadoop/yarn/server/globalpolicygenerator/GlobalPolicyGenerator.java
@@ -112,7 +112,7 @@ public class GlobalPolicyGenerator extends CompositeService {
   @Override
   protected void serviceInit(Configuration conf) throws Exception {
     // Set up the context
-    this.gpgContext.setStateStoreFacade(FederationStateStoreFacade.getInstance());
+    this.gpgContext.setStateStoreFacade(FederationStateStoreFacade.getInstance(conf));
     GPGPolicyFacade gpgPolicyFacade =
         new GPGPolicyFacade(this.gpgContext.getStateStoreFacade(), conf);
     this.gpgContext.setPolicyFacade(gpgPolicyFacade);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/TestGPGPolicyFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/TestGPGPolicyFacade.java
@@ -53,8 +53,7 @@ public class TestGPGPolicyFacade {
 
   private Configuration conf;
   private FederationStateStore stateStore;
-  private FederationStateStoreFacade facade =
-      FederationStateStoreFacade.getInstance();
+  private FederationStateStoreFacade facade;
   private GPGPolicyFacade policyFacade;
 
   private Set<SubClusterId> subClusterIds;
@@ -70,6 +69,7 @@ public class TestGPGPolicyFacade {
     subClusterIds.add(SubClusterId.newInstance("sc0"));
     subClusterIds.add(SubClusterId.newInstance("sc1"));
     subClusterIds.add(SubClusterId.newInstance("sc2"));
+    facade = FederationStateStoreFacade.getInstance(conf);
   }
 
   @Before

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/policygenerator/TestPolicyGenerator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/policygenerator/TestPolicyGenerator.java
@@ -87,8 +87,7 @@ public class TestPolicyGenerator {
 
   private Configuration conf;
   private FederationStateStore stateStore;
-  private FederationStateStoreFacade facade =
-      FederationStateStoreFacade.getInstance();
+  private FederationStateStoreFacade facade;
 
   private List<SubClusterId> subClusterIds;
   private Map<SubClusterId, SubClusterInfo> subClusterInfos;
@@ -102,10 +101,11 @@ public class TestPolicyGenerator {
   public TestPolicyGenerator() {
     conf = new Configuration();
     conf.setInt(YarnConfiguration.FEDERATION_CACHE_TIME_TO_LIVE_SECS, 0);
-
+    facade = FederationStateStoreFacade.getInstance(conf);
     gpgContext = new GPGContextImpl();
     gpgContext.setPolicyFacade(new GPGPolicyFacade(facade, conf));
     gpgContext.setStateStoreFacade(facade);
+
   }
 
   @Before

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/secure/AbstractGlobalPolicyGeneratorTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/secure/AbstractGlobalPolicyGeneratorTest.java
@@ -136,7 +136,7 @@ public abstract class AbstractGlobalPolicyGeneratorTest {
     assertNull("GPG is already running", gpg);
     MemoryFederationStateStore stateStore = new MemoryFederationStateStore();
     stateStore.init(conf);
-    FederationStateStoreFacade.getInstance().reinitialize(stateStore, conf);
+    FederationStateStoreFacade.getInstance(conf).reinitialize(stateStore, conf);
     UserGroupInformation.setConfiguration(conf);
     gpg = new GlobalPolicyGenerator();
     gpg.init(conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/subclustercleaner/TestSubClusterCleaner.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/subclustercleaner/TestSubClusterCleaner.java
@@ -63,7 +63,7 @@ public class TestSubClusterCleaner {
     stateStore = new MemoryFederationStateStore();
     stateStore.init(conf);
 
-    facade = FederationStateStoreFacade.getInstance();
+    facade = FederationStateStoreFacade.getInstance(conf);
     facade.reinitialize(stateStore, conf);
 
     gpgContext = new GPGContextImpl();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/AMRMProxyService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/AMRMProxyService.java
@@ -145,7 +145,7 @@ public class AMRMProxyService extends CompositeService implements
           RegistryOperations.class);
       addService(this.registry);
     }
-    this.federationFacade = FederationStateStoreFacade.getInstance();
+    this.federationFacade = FederationStateStoreFacade.getInstance(conf);
     this.federationEnabled =
         conf.getBoolean(YarnConfiguration.FEDERATION_ENABLED,
             YarnConfiguration.DEFAULT_FEDERATION_ENABLED);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
@@ -335,7 +335,7 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
     this.lastAllocateResponse
         .setResponseId(AMRMClientUtils.PRE_REGISTER_RESPONSE_ID);
 
-    this.federationFacade = FederationStateStoreFacade.getInstance();
+    this.federationFacade = FederationStateStoreFacade.getInstance(conf);
     this.subClusterResolver = this.federationFacade.getSubClusterResolver();
 
     // AMRMProxyPolicy will be initialized in registerApplicationMaster

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
@@ -118,7 +118,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
     stateStore = new MemoryFederationStateStore();
     stateStore.init(getConf());
-    FederationStateStoreFacade.getInstance().reinitialize(stateStore,
+    FederationStateStoreFacade.getInstance(getConf()).reinitialize(stateStore,
         getConf());
 
     nmStateStore = new NMMemoryStateStoreService();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptorSecure.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptorSecure.java
@@ -144,7 +144,7 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
 
     stateStore = new MemoryFederationStateStore();
     stateStore.init(conf);
-    FederationStateStoreFacade.getInstance().reinitialize(stateStore, conf);
+    FederationStateStoreFacade.getInstance(conf).reinitialize(stateStore, conf);
 
     nmStateStore = new NMMemoryStateStoreService();
     nmStateStore.init(conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/cleaner/SubClusterCleaner.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/cleaner/SubClusterCleaner.java
@@ -44,7 +44,7 @@ public class SubClusterCleaner implements Runnable {
   private long heartbeatExpirationMillis;
 
   public SubClusterCleaner(Configuration conf) {
-    federationFacade = FederationStateStoreFacade.getInstance();
+    federationFacade = FederationStateStoreFacade.getInstance(conf);
     this.heartbeatExpirationMillis =
         conf.getTimeDuration(YarnConfiguration.ROUTER_SUBCLUSTER_EXPIRATION_TIME,
         YarnConfiguration.DEFAULT_ROUTER_SUBCLUSTER_EXPIRATION_TIME, TimeUnit.MILLISECONDS);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -212,7 +212,7 @@ public class FederationClientInterceptor
   public void init(String userName) {
     super.init(userName);
 
-    federationFacade = FederationStateStoreFacade.getInstance();
+    federationFacade = FederationStateStoreFacade.getInstance(getConf());
     rand = new Random(System.currentTimeMillis());
 
     int numMinThreads = getNumMinThreads(getConf());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterClientRMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterClientRMService.java
@@ -629,7 +629,7 @@ public class RouterClientRMService extends AbstractService
         TimeUnit.MILLISECONDS);
 
     return new RouterDelegationTokenSecretManager(secretKeyInterval,
-        tokenMaxLifetime, tokenRenewInterval, removeScanInterval);
+        tokenMaxLifetime, tokenRenewInterval, removeScanInterval, conf);
   }
 
   @VisibleForTesting

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/FederationRMAdminInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/FederationRMAdminInterceptor.java
@@ -130,7 +130,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
     this.executorService = new ThreadPoolExecutor(numThreads, numThreads,
         0L, TimeUnit.MILLISECONDS, workQueue, threadFactory);
 
-    federationFacade = FederationStateStoreFacade.getInstance();
+    federationFacade = FederationStateStoreFacade.getInstance(this.getConf());
     this.conf = this.getConf();
     this.adminRMProxies = new ConcurrentHashMap<>();
     routerMetrics = RouterMetrics.getMetrics();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/RMAdminProtocolMethod.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/RMAdminProtocolMethod.java
@@ -63,7 +63,7 @@ public class RMAdminProtocolMethod extends FederationMethodWrapper {
   public <R> Collection<R> invokeConcurrent(FederationRMAdminInterceptor interceptor,
       Class<R> clazz, String subClusterId) throws YarnException {
     this.rmAdminInterceptor = interceptor;
-    this.federationFacade = FederationStateStoreFacade.getInstance();
+    this.federationFacade = FederationStateStoreFacade.getInstance(interceptor.getConf());
     this.configuration = interceptor.getConf();
     if (StringUtils.isNotBlank(subClusterId)) {
       return invoke(clazz, subClusterId);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/security/RouterDelegationTokenSecretManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/security/RouterDelegationTokenSecretManager.java
@@ -67,6 +67,7 @@ public class RouterDelegationTokenSecretManager
    * @param delegationTokenRenewInterval       how often the tokens must be renewed
    *                                           in milliseconds
    * @param delegationTokenRemoverScanInterval how often the tokens are scanned
+   * @param conf Configuration.
    */
   public RouterDelegationTokenSecretManager(long delegationKeyUpdateInterval,
       long delegationTokenMaxLifetime, long delegationTokenRenewInterval,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/security/RouterDelegationTokenSecretManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/security/RouterDelegationTokenSecretManager.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.yarn.server.router.security;
 
 import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenSecretManager;
 import org.apache.hadoop.security.token.delegation.DelegationKey;
 import org.apache.hadoop.security.token.delegation.RouterDelegationTokenSupport;
@@ -69,10 +70,10 @@ public class RouterDelegationTokenSecretManager
    */
   public RouterDelegationTokenSecretManager(long delegationKeyUpdateInterval,
       long delegationTokenMaxLifetime, long delegationTokenRenewInterval,
-      long delegationTokenRemoverScanInterval) {
+      long delegationTokenRemoverScanInterval, Configuration conf) {
     super(delegationKeyUpdateInterval, delegationTokenMaxLifetime,
         delegationTokenRenewInterval, delegationTokenRemoverScanInterval);
-    this.federationFacade = FederationStateStoreFacade.getInstance(null);
+    this.federationFacade = FederationStateStoreFacade.getInstance(conf);
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/security/RouterDelegationTokenSecretManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/security/RouterDelegationTokenSecretManager.java
@@ -72,7 +72,7 @@ public class RouterDelegationTokenSecretManager
       long delegationTokenRemoverScanInterval) {
     super(delegationKeyUpdateInterval, delegationTokenMaxLifetime,
         delegationTokenRenewInterval, delegationTokenRemoverScanInterval);
-    this.federationFacade = FederationStateStoreFacade.getInstance();
+    this.federationFacade = FederationStateStoreFacade.getInstance(null);
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/AboutBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/AboutBlock.java
@@ -63,7 +63,7 @@ public class AboutBlock extends RouterBlock {
    * @param isEnabled true, federation is enabled; false, federation is not enabled.
    */
   private void initYarnRouterBasicInformation(boolean isEnabled) {
-    FederationStateStoreFacade facade = FederationStateStoreFacade.getInstance();
+    FederationStateStoreFacade facade = FederationStateStoreFacade.getInstance(router.getConfig());
     RouterInfo routerInfo = new RouterInfo(router);
     String lastStartTime =
         DateFormatUtils.format(routerInfo.getStartedOn(), DATE_PATTERN);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/AppsBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/AppsBlock.java
@@ -104,7 +104,7 @@ public class AppsBlock extends RouterBlock {
   private AppsInfo getSubClusterAppsInfo(String subCluster, String states) {
     try {
       SubClusterId subClusterId = SubClusterId.newInstance(subCluster);
-      FederationStateStoreFacade facade = FederationStateStoreFacade.getInstance();
+      FederationStateStoreFacade facade = FederationStateStoreFacade.getInstance(this.conf);
       SubClusterInfo subClusterInfo = facade.getSubCluster(subClusterId);
 
       if (subClusterInfo != null) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
@@ -188,7 +188,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
 
     super.init(user);
 
-    federationFacade = FederationStateStoreFacade.getInstance();
+    federationFacade = FederationStateStoreFacade.getInstance(getConf());
 
     final Configuration conf = this.getConf();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/NodeLabelsBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/NodeLabelsBlock.java
@@ -73,7 +73,8 @@ public class NodeLabelsBlock extends RouterBlock {
   private NodeLabelsInfo getSubClusterNodeLabelsInfo(String subCluster) {
     try {
       SubClusterId subClusterId = SubClusterId.newInstance(subCluster);
-      FederationStateStoreFacade facade = FederationStateStoreFacade.getInstance();
+      FederationStateStoreFacade facade =
+          FederationStateStoreFacade.getInstance(router.getConfig());
       SubClusterInfo subClusterInfo = facade.getSubCluster(subClusterId);
 
       if (subClusterInfo != null) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/NodesBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/NodesBlock.java
@@ -90,7 +90,8 @@ public class NodesBlock extends RouterBlock {
   private NodesInfo getSubClusterNodesInfo(String subCluster) {
     try {
       SubClusterId subClusterId = SubClusterId.newInstance(subCluster);
-      FederationStateStoreFacade facade = FederationStateStoreFacade.getInstance();
+      FederationStateStoreFacade facade =
+          FederationStateStoreFacade.getInstance(this.router.getConfig());
       SubClusterInfo subClusterInfo = facade.getSubCluster(subClusterId);
 
       if (subClusterInfo != null) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/RouterBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/RouterBlock.java
@@ -51,7 +51,7 @@ public abstract class RouterBlock extends HtmlBlock {
     super(ctx);
     this.ctx = ctx;
     this.router = router;
-    this.facade = FederationStateStoreFacade.getInstance();
+    this.facade = FederationStateStoreFacade.getInstance(router.getConfig());
     this.conf = this.router.getConfig();
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/cleaner/TestSubClusterCleaner.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/cleaner/TestSubClusterCleaner.java
@@ -57,7 +57,7 @@ public class TestSubClusterCleaner {
     stateStore = new MemoryFederationStateStore();
     stateStore.init(conf);
 
-    facade = FederationStateStoreFacade.getInstance();
+    facade = FederationStateStoreFacade.getInstance(conf);
     facade.reinitialize(stateStore, conf);
 
     cleaner = new SubClusterCleaner(conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
@@ -191,7 +191,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     stateStore = new MemoryFederationStateStore();
     stateStore.init(this.getConf());
-    FederationStateStoreFacade.getInstance().reinitialize(stateStore, getConf());
+    FederationStateStoreFacade.getInstance(getConf()).reinitialize(stateStore, getConf());
     stateStoreUtil = new FederationStateStoreTestUtil(stateStore);
 
     interceptor.setConf(this.getConf());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
@@ -110,7 +110,7 @@ public class TestFederationClientInterceptorRetry
 
     stateStore = new MemoryFederationStateStore();
     stateStore.init(this.getConf());
-    FederationStateStoreFacade.getInstance().reinitialize(stateStore,
+    FederationStateStoreFacade.getInstance(getConf()).reinitialize(stateStore,
         getConf());
     stateStoreUtil = new FederationStateStoreTestUtil(stateStore);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestableFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestableFederationClientInterceptor.java
@@ -245,6 +245,6 @@ public class TestableFederationClientInterceptor
         TimeUnit.MILLISECONDS);
 
     return new RouterDelegationTokenSecretManager(secretKeyInterval,
-        tokenMaxLifetime, tokenRenewInterval, removeScanInterval);
+        tokenMaxLifetime, tokenRenewInterval, removeScanInterval, conf);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/TestFederationRMAdminInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/TestFederationRMAdminInterceptor.java
@@ -120,8 +120,8 @@ public class TestFederationRMAdminInterceptor extends BaseRouterRMAdminTest {
     // Initialize facade & stateSore
     stateStore = new MemoryFederationStateStore();
     stateStore.init(this.getConf());
-    facade = FederationStateStoreFacade.getInstance();
-    facade.reinitialize(stateStore, getConf());
+    facade = FederationStateStoreFacade.getInstance(this.getConf());
+    facade.reinitialize(stateStore, this.getConf());
     stateStoreUtil = new FederationStateStoreTestUtil(stateStore);
 
     // Initialize interceptor

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/AbstractSecureRouterTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/AbstractSecureRouterTest.java
@@ -183,7 +183,7 @@ public abstract class AbstractSecureRouterTest {
     assertNull("Router is already running", router);
     MemoryFederationStateStore stateStore = new MemoryFederationStateStore();
     stateStore.init(getConf());
-    FederationStateStoreFacade.getInstance().reinitialize(stateStore, getConf());
+    FederationStateStoreFacade.getInstance(getConf()).reinitialize(stateStore, getConf());
     UserGroupInformation.setConfiguration(conf);
     router = new Router();
     router.init(conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/MockRouter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/MockRouter.java
@@ -50,7 +50,7 @@ public class MockRouter extends Router {
         YarnConfiguration.DEFAULT_FEDERATION_ENABLED);
 
     if (isEnabled) {
-      facade = FederationStateStoreFacade.getInstance();
+      facade = FederationStateStoreFacade.getInstance(configuration);
       initTestFederationSubCluster();
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
@@ -215,7 +215,8 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
         RM_DELEGATION_TOKEN_REMOVE_SCAN_INTERVAL_KEY,
         RM_DELEGATION_TOKEN_REMOVE_SCAN_INTERVAL_DEFAULT, TimeUnit.MILLISECONDS);
     RouterDelegationTokenSecretManager tokenSecretManager = new RouterDelegationTokenSecretManager(
-        secretKeyInterval, tokenMaxLifetime, tokenRenewInterval, removeScanInterval);
+        secretKeyInterval, tokenMaxLifetime, tokenRenewInterval, removeScanInterval,
+        this.getConf());
     tokenSecretManager.startThreads();
     routerClientRMService.setRouterDTSecretManager(tokenSecretManager);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
@@ -188,7 +188,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     stateStore = new MemoryFederationStateStore();
     stateStore.init(this.getConf());
-    FederationStateStoreFacade.getInstance().reinitialize(stateStore,
+    FederationStateStoreFacade.getInstance(this.getConf()).reinitialize(stateStore,
         this.getConf());
     stateStoreUtil = new FederationStateStoreTestUtil(stateStore);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorRESTRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorRESTRetry.java
@@ -93,7 +93,7 @@ public class TestFederationInterceptorRESTRetry
 
     stateStore = new MemoryFederationStateStore();
     stateStore.init(conf);
-    FederationStateStoreFacade.getInstance().reinitialize(stateStore,
+    FederationStateStoreFacade.getInstance(conf).reinitialize(stateStore,
         getConf());
     stateStoreUtil = new FederationStateStoreTestUtil(stateStore);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebAppProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebAppProxy.java
@@ -153,7 +153,7 @@ public class TestRouterWebAppProxy {
             newApplicationReport(appId4, YarnApplicationState.FINISHED, proxyAppUrl4, null)));
 
     // Initial federation store.
-    FederationStateStoreFacade facade = FederationStateStoreFacade.getInstance();
+    FederationStateStoreFacade facade = FederationStateStoreFacade.getInstance(conf);
     facade.getStateStore()
         .registerSubCluster(SubClusterRegisterRequest.newInstance(subClusterInfo1));
     facade.getStateStore()

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/FedAppReportFetcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/FedAppReportFetcher.java
@@ -50,7 +50,7 @@ public class FedAppReportFetcher extends AppReportFetcher {
   public FedAppReportFetcher(Configuration conf) {
     super(conf);
     subClusters = new ConcurrentHashMap<>();
-    federationFacade = FederationStateStoreFacade.getInstance();
+    federationFacade = FederationStateStoreFacade.getInstance(conf);
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestFedAppReportFetcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestFedAppReportFetcher.java
@@ -77,7 +77,7 @@ public class TestFedAppReportFetcher {
     conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.APPLICATION_HISTORY_ENABLED, isAHSEnabled);
 
-    FederationStateStoreFacade fedFacade = FederationStateStoreFacade.getInstance();
+    FederationStateStoreFacade fedFacade = FederationStateStoreFacade.getInstance(this.conf);
     FederationStateStore fss = new MemoryFederationStateStore();
     fss.init(conf);
     fedFacade.reinitialize(fss, conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServletFed.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServletFed.java
@@ -192,7 +192,7 @@ public class TestWebAppProxyServletFed {
             .newInstance(newApplicationReport(appId4, YarnApplicationState.FINISHED, null)));
 
     // Initial federation store.
-    FederationStateStoreFacade facade = FederationStateStoreFacade.getInstance();
+    FederationStateStoreFacade facade = FederationStateStoreFacade.getInstance(conf);
     facade.getStateStore()
         .registerSubCluster(SubClusterRegisterRequest.newInstance(subClusterInfo1));
     facade.getStateStore()


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11435. [Router] FederationStateStoreFacade is not reinitialized with Router conf.

When implementing the FederationStateStoreFacade, we opted for the singleton pattern. However, our FederationStateStoreFacade singleton implementation used a newly created Configuration when creating the singleton, without considering the configuration differences of the calling class. In this PR, we have refactored this portion of the code using the Double Checked Locking method of the singleton pattern, allowing the FederationStateStoreFacade to be aware of the configuration differences of the calling class.

### How was this patch tested?

Junit Test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

