### PR TITLE
HDFS-17164. During rolling upgrade, datanode should copy-on-append when bumpReplicaGS.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/LocalReplica.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/LocalReplica.java
@@ -367,11 +367,22 @@ abstract public class LocalReplica extends ReplicaInfo {
   }
 
   @Override
-  public void bumpReplicaGS(long newGS) throws IOException {
+  public void bumpReplicaGS(long newGS, String trashDir) throws IOException {
     long oldGS = getGenerationStamp();
     final File oldmeta = getMetaFile();
     setGenerationStamp(newGS);
     final File newmeta = getMetaFile();
+
+    if (trashDir != null) {
+      // In order to support rollback in rolling upgrade,
+      // copy the original block/meta files to trash.
+      final String blockName = getBlockName();
+      final File blockFileInTrash = new File(trashDir, blockName);
+      final File metaFileInTrash = new File(trashDir,
+          DatanodeUtil.getMetaName(blockName, getGenerationStamp()));
+      copyBlockdata(blockFileInTrash.toURI());
+      copyMetadata(metaFileInTrash.toURI());
+    }
 
     // rename meta file to new GS
     if (LOG.isDebugEnabled()) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/LocalReplica.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/LocalReplica.java
@@ -378,10 +378,18 @@ abstract public class LocalReplica extends ReplicaInfo {
       // copy the original block/meta files to trash.
       final String blockName = getBlockName();
       final File blockFileInTrash = new File(trashDir, blockName);
-      final File metaFileInTrash = new File(trashDir,
-          DatanodeUtil.getMetaName(blockName, getGenerationStamp()));
-      copyBlockdata(blockFileInTrash.toURI());
-      copyMetadata(metaFileInTrash.toURI());
+
+      // If the block file already exists in trash,
+      // it is already copied.  Do not copy again.
+      if (!blockFileInTrash.exists()) {
+        getVolume().getFileIoProvider().mkdirsWithExistsCheck(
+            getVolume(), new File(trashDir));
+
+        final File metaFileInTrash = new File(trashDir,
+            DatanodeUtil.getMetaName(blockName, getGenerationStamp()));
+        copyBlockdata(blockFileInTrash.toURI());
+        copyMetadata(metaFileInTrash.toURI());
+      }
     }
 
     // rename meta file to new GS

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ProvidedReplica.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ProvidedReplica.java
@@ -291,7 +291,7 @@ public abstract class ProvidedReplica extends ReplicaInfo {
   }
 
   @Override
-  public void bumpReplicaGS(long newGS) throws IOException {
+  public void bumpReplicaGS(long newGS, String trashDir) throws IOException {
     throw new UnsupportedOperationException(
         "ProvidedReplica does not yet support writes");
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ReplicaInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ReplicaInfo.java
@@ -249,9 +249,11 @@ abstract public class ReplicaInfo extends Block
    * Its on-disk meta file name is renamed to be the new one too.
    *
    * @param newGS new generation stamp
+   * @param trashDir the trash directory in rolling upgrade
    * @throws IOException if the change fails
    */
-  abstract public void bumpReplicaGS(long newGS) throws IOException;
+  abstract public void bumpReplicaGS(long newGS, String trashDir)
+     throws IOException;
 
   abstract public ReplicaInfo getOriginalReplica();
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
@@ -321,6 +321,10 @@ class FsDatasetAsyncDiskService {
       final String blockName = replicaToDelete.getBlockName();
       final long genstamp = replicaToDelete.getGenerationStamp();
       File newBlockFile = new File(trashDirectory, blockName);
+      if (newBlockFile.exists()) {
+        // The files are already copied before and can be safely deleted.
+        return deleteFiles();
+      }
       File newMetaFile = new File(trashDirectory,
           DatanodeUtil.getMetaName(blockName, genstamp));
       try {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -1538,7 +1538,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
               replica = append(b.getBlockPoolId(), replicaInfo,
                                newGS, b.getNumBytes());
             } else { //RBW
-              replicaInfo.bumpReplicaGS(newGS);
+              bumpReplicaGS(b.getBlockPoolId(), replicaInfo, newGS);
               replica = (ReplicaInPipeline) replicaInfo;
             }
           } catch (IOException e) {
@@ -1554,6 +1554,12 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
     }
   }
 
+  private void bumpReplicaGS(String bpid, ReplicaInfo replica, long newGS)
+      throws IOException {
+    replica.bumpReplicaGS(newGS,
+        dataStorage.getTrashDirectoryForReplica(bpid, replica));
+  }
+
   @Override // FsDatasetSpi
   public Replica recoverClose(ExtendedBlock b, long newGS,
       long expectedBlockLen) throws IOException {
@@ -1566,7 +1572,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
           // check replica's state
           ReplicaInfo replicaInfo = recoverCheck(b, newGS, expectedBlockLen);
           // bump the replica's GS
-          replicaInfo.bumpReplicaGS(newGS);
+          bumpReplicaGS(b.getBlockPoolId(), replicaInfo, newGS);
           // finalize the replica if RBW
           if (replicaInfo.getState() == ReplicaState.RBW) {
             finalizeReplica(b.getBlockPoolId(), replicaInfo);
@@ -1745,7 +1751,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
         }
 
         // bump the replica's generation stamp to newGS
-        rbw.getReplicaInfo().bumpReplicaGS(newGS);
+        bumpReplicaGS(b.getBlockPoolId(), rbw.getReplicaInfo(), newGS);
       } catch (IOException e) {
         IOUtils.cleanupWithLogger(null, ref);
         throw e;
@@ -3155,7 +3161,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
     boolean copyOnTruncate = newBlockId > 0L && rur.getBlockId() != newBlockId;
     // bump rur's GS to be recovery id
     if(!copyOnTruncate) {
-      rur.bumpReplicaGS(recoveryId);
+      bumpReplicaGS(bpid, rur, recoveryId);
     }
 
     //update length

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestRollingUpgrade.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestRollingUpgrade.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.hdfs;
 import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
@@ -376,6 +378,115 @@ public class TestRollingUpgrade {
 
       startRollingUpgrade(foo, bar, file, data, cluster);
       rollbackRollingUpgrade(foo, bar, file, data, cluster);
+    }
+  }
+
+  private static void startRollingUpgrade(Path foo, Path bar,
+      Path fileToTruncate, Path fileToAppend, byte[] data, int oldLength,
+      MiniDFSCluster cluster) throws IOException {
+    LOG.info("startRollingUpgrade");
+    final DistributedFileSystem dfs = cluster.getFileSystem();
+
+    //start rolling upgrade
+    dfs.setSafeMode(SafeModeAction.ENTER);
+    dfs.rollingUpgrade(RollingUpgradeAction.PREPARE);
+    dfs.setSafeMode(SafeModeAction.LEAVE);
+
+    dfs.mkdirs(bar);
+    Assert.assertTrue(dfs.exists(foo));
+    Assert.assertTrue(dfs.exists(bar));
+
+    final int newLength = ThreadLocalRandom.current().nextInt(oldLength);
+    //truncate a file
+    dfs.truncate(fileToTruncate, newLength);
+    TestFileTruncate.checkBlockRecovery(fileToTruncate, dfs);
+    AppendTestUtil.checkFullFile(dfs, fileToTruncate, newLength, data);
+
+    //append a file
+    try (FSDataOutputStream out = dfs.append(fileToAppend)) {
+      out.write(data, oldLength, newLength);
+    }
+    AppendTestUtil.checkFullFile(dfs, fileToAppend, oldLength+newLength, data);
+  }
+
+
+  private static void rollback(Path foo, Path bar,
+      Path fileToTruncate, Path fileToAppend, Path fileNotClose,
+      byte[] data, int oldLength, MiniDFSCluster cluster)
+      throws Exception {
+    LOG.info("rollbackRollingUpgrade");
+    final List<DataNodeProperties> dnProperties = new ArrayList<>();
+    for(int i = 0; i < cluster.getDataNodes().size(); i++) {
+      dnProperties.add(cluster.stopDataNode(i));
+    }
+    cluster.restartNameNode(0, false, "-rollingUpgrade", "rollback");
+    for(DataNodeProperties dn : dnProperties) {
+      cluster.restartDataNode(dn, true);
+    }
+
+    final DistributedFileSystem dfs = cluster.getFileSystem();
+    for(boolean success = false; !success; ) {
+      try {
+        Assert.assertTrue(dfs.exists(foo));
+        success = true;
+      } catch (Throwable ignored) {
+      }
+      // retry until NN is ready.
+      LOG.info("sleep 1s and then retry");
+      Thread.sleep(1000);
+    }
+    Assert.assertFalse(dfs.exists(bar));
+
+    dfs.setSafeMode(SafeModeAction.FORCE_EXIT);
+    AppendTestUtil.checkFullFile(dfs, fileToTruncate, oldLength, data);
+    AppendTestUtil.checkFullFile(dfs, fileToAppend, oldLength, data);
+    AppendTestUtil.checkFullFile(dfs, fileNotClose, oldLength, data);
+  }
+
+  @Test
+  public void testRollbackAppend() throws Exception {
+    // start a cluster
+    final Configuration conf = getHdfsConfiguration();
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build()) {
+      cluster.waitActive();
+      final DistributedFileSystem dfs = cluster.getFileSystem();
+
+      final Path foo = new Path("/foo");
+      final Path bar = new Path("/bar");
+      dfs.mkdirs(foo);
+
+      final Path fileToTruncate = new Path(foo, "file-to-truncate");
+      final Path fileToAppend = new Path(foo, "file-to-append");
+      final Path fileNotClose = new Path(foo, "file-not-close");
+      final byte[] data = new byte[1024];
+      ThreadLocalRandom.current().nextBytes(data);
+      final int partOneLength = data.length / 3;
+      final int partTwoLength = 2 * data.length / 3;
+
+      try (FSDataOutputStream out = dfs.create(fileToTruncate)) {
+        out.write(data, 0, partOneLength);
+      }
+      try (FSDataOutputStream out = dfs.create(fileToAppend)) {
+        out.write(data, 0, partOneLength);
+      }
+
+      final FSDataOutputStream out = dfs.create(fileNotClose);
+      out.write(data, 0, partOneLength);
+      out.hsync();
+
+      waitForNullMxBean();
+      startRollingUpgrade(foo, bar, fileToTruncate, fileToAppend,
+          data, partOneLength, cluster);
+      checkMxBean();
+      dfs.rollEdits();
+      dfs.rollEdits();
+
+      out.write(data, partOneLength, partTwoLength);
+      out.close();
+
+      rollback(foo, bar, fileToTruncate, fileToAppend, fileNotClose,
+          data, partOneLength, cluster);
+      checkMxBeanIsNull();
     }
   }
 


### PR DESCRIPTION
### Description of PR

During rolling upgrade, datanode create a trash directory for each block pool. Then a block deletion becomes moving the block to trash.

For bumpReplicaGS, it will rename the meta file and then continue writing to the block file. It should copy the original block file and the original meta file to trash in order to support rollback.

See https://issues.apache.org/jira/browse/HDFS-17164

### How was this patch tested?

Added a new unit test.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ NA ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ NA ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ NA ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
