### PR TITLE
HADOOP-18866. Refactor @Test(expected) with assertThrows

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestSSLFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestSSLFactory.java
@@ -27,6 +27,7 @@ import static org.apache.hadoop.security.ssl.SSLFactory.SSL_REQUIRE_CLIENT_CERT_
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.hadoop.conf.Configuration;
@@ -152,18 +153,20 @@ public class TestSSLFactory {
     assertNotEquals(conf, sslConfLoaded);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void clientMode() throws Exception {
     Configuration conf = createConfiguration(false, true);
     SSLFactory sslFactory = new SSLFactory(SSLFactory.Mode.CLIENT, conf);
-    try {
-      sslFactory.init();
-      Assert.assertNotNull(sslFactory.createSSLSocketFactory());
-      Assert.assertNotNull(sslFactory.getHostnameVerifier());
-      sslFactory.createSSLServerSocketFactory();
-    } finally {
-      sslFactory.destroy();
-    }
+    assertThrows(IllegalStateException.class, () -> {
+      try {
+        sslFactory.init();
+        Assert.assertNotNull(sslFactory.createSSLSocketFactory());
+        Assert.assertNotNull(sslFactory.getHostnameVerifier());
+        sslFactory.createSSLServerSocketFactory();
+      } finally {
+        sslFactory.destroy();
+      }
+    });
   }
 
   private void serverMode(boolean clientCert, boolean socket) throws Exception {
@@ -184,24 +187,32 @@ public class TestSSLFactory {
   }
 
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void serverModeWithoutClientCertsSocket() throws Exception {
-    serverMode(false, true);
+    assertThrows(IllegalStateException.class, () -> {
+      serverMode(false, true);
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void serverModeWithClientCertsSocket() throws Exception {
-    serverMode(true, true);
+    assertThrows(IllegalStateException.class, () -> {
+      serverMode(true, true);
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void serverModeWithoutClientCertsVerifier() throws Exception {
-    serverMode(false, false);
+    assertThrows(IllegalStateException.class, () -> {
+      serverMode(false, false);
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void serverModeWithClientCertsVerifier() throws Exception {
-    serverMode(true, false);
+    assertThrows(IllegalStateException.class, () -> {
+      serverMode(true, false);
+    });
   }
 
   private void runDelegatedTasks(SSLEngineResult result, SSLEngine engine)
@@ -357,16 +368,18 @@ public class TestSSLFactory {
     sslFactory.destroy();
   }
 
-  @Test(expected = GeneralSecurityException.class)
+  @Test
   public void invalidHostnameVerifier() throws Exception {
     Configuration conf = createConfiguration(false, true);
     conf.set(SSLFactory.SSL_HOSTNAME_VERIFIER_KEY, "foo");
     SSLFactory sslFactory = new SSLFactory(SSLFactory.Mode.CLIENT, conf);
-    try {
-      sslFactory.init();
-    } finally {
-      sslFactory.destroy();
-    }
+    assertThrows(GeneralSecurityException.class, () -> {
+      try {
+        sslFactory.init();
+      } finally {
+        sslFactory.destroy();
+      }
+    });
   }
 
   @Test


### PR DESCRIPTION
I am working on research that investigates test smell refactoring in which we identify alternative implementations of test cases, study how commonly used these refactorings are, and assess how acceptable they are in practice.

For example, the smell in [TestSSLFactory.java](https://github.com/apache/hadoop/commit/bd7dd286f301e6d5cc6cce6c4807de537d0751c6#diff-7d45b4721db053c54aaa9a8019a4780e36a0b092f2377a00abe8c5b3ae4fc3ec) occurs when exception handling can alternatively be implemented using assertion rather than annotation: using `assertThrows(IllegalStateException.class, () -> {...});` instead of `@Test(expected = IllegalStateException.class)`.

While there are many cases like this, we aim in this pull request to get your feedback on this particular test smell and its refactoring. Thanks in advance for your input.