### PR TITLE
HADOOP-18867. Upgrade ZooKeeper to 3.6.4.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1421,10 +1421,6 @@
             <artifactId>kerby-config</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.apache.yetus</groupId>
-            <artifactId>audience-annotations</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
           </exclusion>
@@ -1728,6 +1724,10 @@
             <artifactId>jdk.tools</artifactId>
             <groupId>jdk.tools</groupId>
           </exclusion>
+          <exclusion>
+            <groupId>org.apache.yetus</groupId>
+            <artifactId>audience-annotations</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -1746,6 +1746,10 @@
           <exclusion>
             <groupId>jdk.tools</groupId>
             <artifactId>jdk.tools</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.yetus</groupId>
+            <artifactId>audience-annotations</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -1769,6 +1773,10 @@
           <exclusion>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.yetus</groupId>
+            <artifactId>audience-annotations</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -97,7 +97,7 @@
     <hadoop-thirdparty-shaded-protobuf-prefix>${hadoop-thirdparty-shaded-prefix}.protobuf</hadoop-thirdparty-shaded-protobuf-prefix>
     <hadoop-thirdparty-shaded-guava-prefix>${hadoop-thirdparty-shaded-prefix}.com.google.common</hadoop-thirdparty-shaded-guava-prefix>
 
-    <zookeeper.version>3.6.3</zookeeper.version>
+    <zookeeper.version>3.6.4</zookeeper.version>
     <curator.version>5.2.0</curator.version>
     <findbugs.version>3.0.5</findbugs.version>
     <dnsjava.version>3.4.0</dnsjava.version>
@@ -1419,6 +1419,10 @@
           <exclusion>
             <groupId>org.apache.kerby</groupId>
             <artifactId>kerby-config</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.yetus</groupId>
+            <artifactId>audience-annotations</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-18867

While ZooKeeper 3.6 is already EOL, we can upgrade to the final release of the ZooKeeper 3.6 as short-term fix until bumping to ZooKeeper 3.7 or later. Dependency convergence error must be addressed on `-Dhbase.profile=2.0`.

```
$ mvn clean install -Dzookeeper.version=3.6.4 -Dhbase.profile=2.0 -DskipTests
Dependency convergence error for org.apache.yetus:audience-annotations:jar:0.13.0:compile paths to dependency are:
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-common:jar:3.4.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-common:test-jar:tests:3.4.0-SNAPSHOT:test
    +-org.apache.zookeeper:zookeeper:jar:3.6.4:compile
      +-org.apache.zookeeper:zookeeper-jute:jar:3.6.4:compile
        +-org.apache.yetus:audience-annotations:jar:0.13.0:compile
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-common:jar:3.4.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-common:test-jar:tests:3.4.0-SNAPSHOT:test
    +-org.apache.zookeeper:zookeeper:jar:3.6.4:compile
      +-org.apache.yetus:audience-annotations:jar:0.13.0:compile
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-common:jar:3.4.0-SNAPSHOT
  +-org.apache.hbase:hbase-common:jar:2.2.4:compile
    +-org.apache.yetus:audience-annotations:jar:0.5.0:compile
```