### PR TITLE
HDFS-17166. RBF: Throwing NoNamenodesAvailableException for a long time, when failover

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/ActiveNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/ActiveNamenodeResolver.java
@@ -146,4 +146,12 @@ public interface ActiveNamenodeResolver {
    * @param routerId Unique string identifier for the router.
    */
   void setRouterId(String routerId);
+
+  /**
+   * Shuffle cache, to ensure that the current nn will not be accessed first next time
+   *
+   * @param nsId name service id
+   * @param namenode namenode contexts
+   */
+  void shuffleCache(String nsId, FederationNamenodeContext namenode);
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/ActiveNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/ActiveNamenodeResolver.java
@@ -148,10 +148,11 @@ public interface ActiveNamenodeResolver {
   void setRouterId(String routerId);
 
   /**
-   * Shuffle cache, to ensure that the current nn will not be accessed first next time.
+   * Rotate cache, make the current namenode have the lowest priority,
+   * to ensure that the current namenode will not be accessed first next time.
    *
    * @param nsId name service id
    * @param namenode namenode contexts
    */
-  void shuffleCache(String nsId, FederationNamenodeContext namenode);
+  void rotateCache(String nsId, FederationNamenodeContext namenode);
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/ActiveNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/ActiveNamenodeResolver.java
@@ -148,7 +148,7 @@ public interface ActiveNamenodeResolver {
   void setRouterId(String routerId);
 
   /**
-   * Shuffle cache, to ensure that the current nn will not be accessed first next time
+   * Shuffle cache, to ensure that the current nn will not be accessed first next time.
    *
    * @param nsId name service id
    * @param namenode namenode contexts

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/ActiveNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/ActiveNamenodeResolver.java
@@ -153,6 +153,7 @@ public interface ActiveNamenodeResolver {
    *
    * @param nsId name service id
    * @param namenode namenode contexts
+   * @param listObserversFirst Observer read case, observer NN will be ranked first
    */
-  void rotateCache(String nsId, FederationNamenodeContext namenode);
+  void rotateCache(String nsId, FederationNamenodeContext namenode, boolean listObserversFirst);
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
@@ -485,10 +485,12 @@ public class MembershipNamenodeResolver
    *
    * @param nsId name service id
    * @param namenode namenode contexts
+   * @param listObserversFirst Observer read case, observer NN will be ranked first
    */
   @Override
-  public synchronized void rotateCache(String nsId, FederationNamenodeContext namenode) {
-    cacheNS.compute(Pair.of(nsId, false), (ns, namenodeContexts) -> {
+  public synchronized void rotateCache(
+          String nsId, FederationNamenodeContext namenode, boolean listObserversFirst) {
+    cacheNS.compute(Pair.of(nsId, listObserversFirst), (ns, namenodeContexts) -> {
       if (namenodeContexts == null || namenodeContexts.size() <= 1) {
         return namenodeContexts;
       }
@@ -509,9 +511,8 @@ public class MembershipNamenodeResolver
         List<FederationNamenodeContext> rotatedNnContexts = new ArrayList<>(namenodeContexts);
         Collections.rotate(rotatedNnContexts, -1);
         return rotatedNnContexts;
-      }else {
-        return namenodeContexts;
       }
+      return namenodeContexts;
     });
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
@@ -499,7 +499,7 @@ public class MembershipNamenodeResolver
        * If the first nn in the cache is active, the active nn priority cannot be lowered.
        * This happens when other threads have already updated the cache.
        */
-      if(firstNamenodeContext.getState().equals(ACTIVE)){
+      if (firstNamenodeContext.getState().equals(ACTIVE)) {
         return namenodeContexts;
       }
       /*
@@ -507,7 +507,7 @@ public class MembershipNamenodeResolver
        * that needs to be lowered in priority, there is no need to rotate.
        * This happens when other threads have already rotated the cache.
        */
-      if(firstNamenodeContext.getRpcAddress().equals(namenode.getRpcAddress())){
+      if (firstNamenodeContext.getRpcAddress().equals(namenode.getRpcAddress())) {
         List<FederationNamenodeContext> rotatedNnContexts = new ArrayList<>(namenodeContexts);
         Collections.rotate(rotatedNnContexts, -1);
         return rotatedNnContexts;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
@@ -488,7 +488,7 @@ public class MembershipNamenodeResolver
    * @param listObserversFirst Observer read case, observer NN will be ranked first
    */
   @Override
-  public synchronized void rotateCache(
+  public void rotateCache(
       String nsId, FederationNamenodeContext namenode, boolean listObserversFirst) {
     cacheNS.compute(Pair.of(nsId, listObserversFirst), (ns, namenodeContexts) -> {
       if (namenodeContexts == null || namenodeContexts.size() <= 1) {
@@ -510,6 +510,10 @@ public class MembershipNamenodeResolver
       if (firstNamenodeContext.getRpcAddress().equals(namenode.getRpcAddress())) {
         List<FederationNamenodeContext> rotatedNnContexts = new ArrayList<>(namenodeContexts);
         Collections.rotate(rotatedNnContexts, -1);
+        String firstNamenodeId = namenodeContexts.get(0).getNamenodeId();
+        LOG.info("Rotate cache of pair <ns: {}, observer first: {}>, put namenode: {} in the " +
+            "first position of the cache and namenode: {} in the last position of the cache",
+            nsId, listObserversFirst, firstNamenodeId, namenode.getNamenodeId());
         return rotatedNnContexts;
       }
       return namenodeContexts;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
@@ -489,7 +489,7 @@ public class MembershipNamenodeResolver
    */
   @Override
   public synchronized void rotateCache(
-          String nsId, FederationNamenodeContext namenode, boolean listObserversFirst) {
+      String nsId, FederationNamenodeContext namenode, boolean listObserversFirst) {
     cacheNS.compute(Pair.of(nsId, listObserversFirst), (ns, namenodeContexts) -> {
       if (namenodeContexts == null || namenodeContexts.size() <= 1) {
         return namenodeContexts;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -599,10 +599,8 @@ public class RouterRpcClient {
           }
           LOG.error("Cannot get available namenode for {} {} error: {}",
               nsId, rpcAddress, ioe.getMessage());
-          if (this.namenodeResolver != null) {
-            this.namenodeResolver.rotateCache(nsId, namenode, shouldUseObserver);
-            LOG.info("Rotate cache of pair: <ns: {}, observer use: {}>", nsId, shouldUseObserver);
-          }
+          // Rotate cache so that client can retry the next namenode in the cache
+          this.namenodeResolver.rotateCache(nsId, namenode, shouldUseObserver);
           // Throw RetriableException so that client can retry
           throw new RetriableException(ioe);
         } else {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -599,6 +599,9 @@ public class RouterRpcClient {
           }
           LOG.error("Cannot get available namenode for {} {} error: {}",
               nsId, rpcAddress, ioe.getMessage());
+          if (this.namenodeResolver != null) {
+            this.namenodeResolver.shuffleCache(nsId, namenode);
+          }
           // Throw RetriableException so that client can retry
           throw new RetriableException(ioe);
         } else {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -600,7 +600,7 @@ public class RouterRpcClient {
           LOG.error("Cannot get available namenode for {} {} error: {}",
               nsId, rpcAddress, ioe.getMessage());
           if (this.namenodeResolver != null) {
-            this.namenodeResolver.shuffleCache(nsId, namenode);
+            this.namenodeResolver.rotateCache(nsId, namenode);
           }
           // Throw RetriableException so that client can retry
           throw new RetriableException(ioe);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -600,7 +600,7 @@ public class RouterRpcClient {
           LOG.error("Cannot get available namenode for {} {} error: {}",
               nsId, rpcAddress, ioe.getMessage());
           if (this.namenodeResolver != null) {
-            this.namenodeResolver.rotateCache(nsId, namenode);
+            this.namenodeResolver.rotateCache(nsId, namenode, shouldUseObserver);
           }
           // Throw RetriableException so that client can retry
           throw new RetriableException(ioe);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -601,6 +601,7 @@ public class RouterRpcClient {
               nsId, rpcAddress, ioe.getMessage());
           if (this.namenodeResolver != null) {
             this.namenodeResolver.rotateCache(nsId, namenode, shouldUseObserver);
+            LOG.info("Rotate cache of pair: <ns: {}, observer use: {}>", nsId, shouldUseObserver);
           }
           // Throw RetriableException so that client can retry
           throw new RetriableException(ioe);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
@@ -134,7 +134,7 @@ public class MiniRouterDFSCluster {
 
   protected static final long DEFAULT_HEARTBEAT_INTERVAL_MS =
       TimeUnit.SECONDS.toMillis(5);
-  public static final long DEFAULT_CACHE_INTERVAL_MS =
+  protected static final long DEFAULT_CACHE_INTERVAL_MS =
       TimeUnit.SECONDS.toMillis(5);
   /** Heartbeat interval in milliseconds. */
   private long heartbeatInterval;
@@ -1201,5 +1201,9 @@ public class MiniRouterDFSCluster {
     } catch (Exception e) {
       throw new IOException("Cannot wait for the namenodes", e);
     }
+  }
+
+  public long getCacheFlushInterval() {
+    return cacheFlushInterval;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
@@ -1203,6 +1203,11 @@ public class MiniRouterDFSCluster {
     }
   }
 
+  /**
+   * Get cache flush interval in milliseconds.
+   *
+   * @return Cache flush interval in milliseconds.
+   */
   public long getCacheFlushInterval() {
     return cacheFlushInterval;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
@@ -134,7 +134,7 @@ public class MiniRouterDFSCluster {
 
   protected static final long DEFAULT_HEARTBEAT_INTERVAL_MS =
       TimeUnit.SECONDS.toMillis(5);
-  protected static final long DEFAULT_CACHE_INTERVAL_MS =
+  public static final long DEFAULT_CACHE_INTERVAL_MS =
       TimeUnit.SECONDS.toMillis(5);
   /** Heartbeat interval in milliseconds. */
   private long heartbeatInterval;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
@@ -398,7 +398,8 @@ public class MockResolver
   }
 
   @Override
-  public void rotateCache(String nsId, FederationNamenodeContext namenode) {
+  public void rotateCache(
+          String nsId, FederationNamenodeContext namenode, boolean listObserversFirst) {
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
@@ -398,7 +398,7 @@ public class MockResolver
   }
 
   @Override
-  public void shuffleCache(String nsId, FederationNamenodeContext namenode) {
+  public void rotateCache(String nsId, FederationNamenodeContext namenode) {
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
@@ -397,6 +397,10 @@ public class MockResolver
   public void setRouterId(String router) {
   }
 
+  @Override
+  public void shuffleCache(String nsId, FederationNamenodeContext namenode) {
+  }
+
   /**
    * Mocks the availability of default namespace.
    * @param b if true default namespace is unset.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
@@ -399,7 +399,7 @@ public class MockResolver
 
   @Override
   public void rotateCache(
-          String nsId, FederationNamenodeContext namenode, boolean listObserversFirst) {
+      String nsId, FederationNamenodeContext namenode, boolean listObserversFirst) {
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterClientRejectOverload.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterClientRejectOverload.java
@@ -17,10 +17,13 @@
  */
 package org.apache.hadoop.hdfs.server.federation.router;
 
+import static org.apache.hadoop.ha.HAServiceProtocol.HAServiceState.ACTIVE;
+import static org.apache.hadoop.ha.HAServiceProtocol.HAServiceState.STANDBY;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.simulateSlowNamenode;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.simulateThrowExceptionRouterRpcServer;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.transitionClusterNSToStandby;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.transitionClusterNSToActive;
+import static org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.DEFAULT_CACHE_INTERVAL_MS;
 import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -42,16 +45,19 @@ import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.ClientProtocol;
+import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
 import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.RouterContext;
 import org.apache.hadoop.hdfs.server.federation.RouterConfigBuilder;
 import org.apache.hadoop.hdfs.server.federation.StateStoreDFSCluster;
 import org.apache.hadoop.hdfs.server.federation.metrics.FederationRPCMetrics;
+import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeContext;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ipc.StandbyException;
 import org.apache.hadoop.test.GenericTestUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hadoop.util.Time;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -356,6 +362,72 @@ public class TestRouterClientRejectOverload {
     // Router 0 failures do not change
     assertEquals(originalRouter0Failures, rpcMetrics0.getProxyOpNoNamenodes());
   }
+
+  /**
+   * When failover occurs, the router may record that the ns has no active namenode.
+   * Only when the router updates the cache next time can the memory status be updated,
+   * causing the router to report NoNamenodesAvailableException for a long time
+   */
+  @Test
+  public void testNoNamenodesAvailableLongTimeWhenNsFailover() throws Exception {
+    setupCluster(false, true);
+    transitionClusterNSToStandby(cluster);
+    for (RouterContext routerContext : cluster.getRouters()) {
+      // Manually trigger the heartbeat
+      Collection<NamenodeHeartbeatService> heartbeatServices = routerContext
+              .getRouter().getNamenodeHeartbeatServices();
+      for (NamenodeHeartbeatService service : heartbeatServices) {
+        service.periodicInvoke();
+      }
+      // Update service cache
+      routerContext.getRouter().getStateStore().refreshCaches(true);
+    }
+    // Record the time after the router first updated the cache
+    long firstLoadTime = Time.now();
+    List<MiniRouterDFSCluster.NamenodeContext> namenodes = cluster.getNamenodes();
+
+    // Make sure all namenodes are in standby state
+    for (MiniRouterDFSCluster.NamenodeContext namenodeContext : namenodes) {
+      assertTrue(namenodeContext.getNamenode().getNameNodeState() == STANDBY.ordinal());
+    }
+
+    Configuration conf = cluster.getRouterClientConf();
+    // Set dfs.client.failover.random.order false, to pick 1st router at first
+    conf.setBoolean("dfs.client.failover.random.order", false);
+
+    DFSClient routerClient = new DFSClient(new URI("hdfs://fed"), conf);
+
+    for (RouterContext routerContext : cluster.getRouters()) {
+      // Get the second namenode in the router cache and make it active
+      List<? extends FederationNamenodeContext> ns0 = routerContext.getRouter().getNamenodeResolver().getNamenodesForNameserviceId("ns0", false);
+      String nsId = ns0.get(1).getNamenodeId();
+      cluster.switchToActive("ns0", nsId);
+      // Manually trigger the heartbeat, but the router does not manually load the cache
+      Collection<NamenodeHeartbeatService> heartbeatServices = routerContext
+              .getRouter().getNamenodeHeartbeatServices();
+      for (NamenodeHeartbeatService service : heartbeatServices) {
+        service.periodicInvoke();
+      }
+      assertTrue(cluster.getNamenode("ns0", nsId).getNamenode().getNameNodeState() == ACTIVE.ordinal());
+    }
+
+    // Get router0 metrics
+    FederationRPCMetrics rpcMetrics0 = cluster.getRouters().get(0)
+            .getRouter().getRpcServer().getRPCMetrics();
+    // Original failures
+    long originalRouter0Failures = rpcMetrics0.getProxyOpNoNamenodes();
+
+    // At this time, the router has recorded 2 standby namenodes in memory, and the first accessed namenode is indeed standby,
+    // then an NoNamenodesAvailableException will be reported for the first access, and the next access will be successful
+    routerClient.getFileInfo("/");
+    long successReadTime = Time.now();
+    assertEquals(originalRouter0Failures + 1, rpcMetrics0.getProxyOpNoNamenodes());
+
+    // access the active namenode without waiting for the router to update the cache,
+    // even if there are 2 standby states recorded in the router memory
+    assertTrue(successReadTime - firstLoadTime < DEFAULT_CACHE_INTERVAL_MS);
+  }
+
 
   @Test
   public void testAsyncCallerPoolMetrics() throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterClientRejectOverload.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterClientRejectOverload.java
@@ -23,7 +23,6 @@ import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.simul
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.simulateThrowExceptionRouterRpcServer;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.transitionClusterNSToStandby;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.transitionClusterNSToActive;
-import static org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.DEFAULT_CACHE_INTERVAL_MS;
 import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -388,8 +387,7 @@ public class TestRouterClientRejectOverload {
 
     // Make sure all namenodes are in standby state
     for (MiniRouterDFSCluster.NamenodeContext namenodeContext : namenodes) {
-      assertEquals(STANDBY.ordinal(),
-              namenodeContext.getNamenode().getNameNodeState());
+      assertEquals(STANDBY.ordinal(), namenodeContext.getNamenode().getNameNodeState());
     }
 
     Configuration conf = cluster.getRouterClientConf();
@@ -436,7 +434,7 @@ public class TestRouterClientRejectOverload {
      * access the active namenode without waiting for the router to update the cache,
      * even if there are 2 standby states recorded in the router memory.
      */
-    assertTrue(successReadTime - firstLoadTime < DEFAULT_CACHE_INTERVAL_MS);
+    assertTrue(successReadTime - firstLoadTime < cluster.getCacheFlushInterval());
   }
 
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Provides a description of the bug, the cause of the bug and steps to reproduce it：https://issues.apache.org/jira/browse/HDFS-17166
### How was this patch tested?
**1. Unit testing**
- please see: TestRouterClientRejectOverload.testNoNamenodesAvailableLongTimeWhenNsFailover()

**2. Comparison test in real environment**
- Suppose we have 2 clients [c1 c2], 2 routers  [r1 r2] and a ns [ns60], the ns has 2 nn [nn6001  nn6002]
- If both nn6001 and nn6002 are in standby state, the priority of nn6002 is higher than nn6001, 
- r1 uses the package that fixing the bug, r2 uses the original package which has the bug
- c1 loops to send requests to r1, and c2 loops to send requests to r2, the request is related to ns60
- Make both nn6001 and nn6002 in standby state
- After the router reports that nn is in standby state, switch nn6001 to active
 14:15:24 nn6001 is active

- Check the log of router r1, after nn6001 switches to active, only NoNamenodesAvailableException is printed once

- Check the log of router r2, and print NoNamenodesAvailableException for more than one minute after nn6001 switches to active

- At 14:16:25, the client c2 accessing the router with the bug could not get the data, and the client c1 accessing the router after the bug was fixed could get the data normally:
  
c2's log:unable to access normally
c1's log:display the result correctly

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

