### PR TITLE
HADOOP-18679. Add API for bulk/paged object deletion

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/BulkDelete.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/BulkDelete.java
@@ -67,7 +67,8 @@ import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsTo
  * <p>
  * Be aware that on some stores (AWS S3) each object listed in a bulk delete counts
  * against the write IOPS limit; large page sizes are counterproductive here.
- * @see <a href="https://issues.apache.org/jira/browse/HADOOP-16823">HADOOP-16823.Large DeleteObject requests are their own Thundering Herd</a>
+ * @see <a href="https://issues.apache.org/jira/browse/HADOOP-16823">HADOOP-16823.
+ *  Large DeleteObject requests are their own Thundering Herd</a>
  * <p>
  * Progress callback: the callback may come from any thread, further work may or may
  * not be blocked during the callback's processing in application code.
@@ -86,7 +87,8 @@ public interface BulkDelete {
 
   /**
    * Initiate a bulk delete operation.
-   * @param base base path for the delete; all files MUST be under this path
+   * @param base base path for the delete; it must belong to the FS and
+   *               all files MUST be under this path
    * @param files iterator of files. If Closeable, it will be closed once complete
    * @return a builder for the operation
    * @throws UnsupportedOperationException not supported.
@@ -236,7 +238,7 @@ public interface BulkDelete {
      * An exception covering at least one of the failures
      * encountered.
      */
-    private final IOException exception;
+    private final Exception exception;
 
     /**
      * Number of files deleted.
@@ -263,7 +265,7 @@ public interface BulkDelete {
 
     public Outcome(final boolean successful,
         final boolean aborted,
-        final IOException exception,
+        final Exception exception,
         final int deleted,
         final int failures,
         final int pageCount,
@@ -282,7 +284,7 @@ public interface BulkDelete {
       return successful;
     }
 
-    public IOException getException() {
+    public Exception getException() {
       return exception;
     }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/BulkDelete.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/BulkDelete.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+
+/**
+ * Interface for bulk file delete operations.
+ * <p>
+ * The expectation is that the iterator-provided list of paths
+ * will be batched into pages and submitted to the remote filesystem/store
+ * for bulk deletion, possibly in parallel.
+ * <p>
+ * A remote iterator provides the list of paths to delete; all must be under
+ * the base path.
+ * <p>
+ * The iterator may be a {@code Closeable} and if so, it will be closed on
+ * completion, irrespective of the outcome.
+ * <p>
+ * The iterator may be an {@code IOStatisticsSource} and if so, its statistics
+ * will be included in the statistics of the {@link Outcome}.
+ * <p>
+ * If the iterator's methods raise any exception, the delete will fail fast;
+ * no more files will be submitted for deletion.
+ * <p>
+ * If a bulk delete call fails, then the next progress report will include
+ * information about the failure; the callback can decide whether to continue
+ * or not. The default callback is {@link #FAIL_FAST}, which will trigger
+ * a fast failure.
+ *
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Unstable
+public interface BulkDelete {
+
+  /**
+   * Initiate a bulk delete operation.
+   * @param base base path for the delete; all files MUST be under this path
+   * @param files iterator of files. If Closeable, it will be closed once complete
+   * @return a builder for the operation
+   * @throws UnsupportedOperationException not supported.
+   * @throws IOException IO failure on initial builder creation.
+   */
+  Builder bulkDelete(Path base, RemoteIterator<Path> files)
+      throws UnsupportedOperationException, IOException;
+
+  /**
+   * Builder for the operation;
+   * The {@link #build()} method will initiate the operation, possibly
+   * blocking, possibly in a separate thread, possibly in a pool
+   * of threads.
+   */
+  interface Builder
+      extends FSBuilder<CompletableFuture<BulkDelete.Outcome>, Builder> {
+
+    /**
+     * Add a progress callback.
+     * @param deleteProgress progress callback
+     * @return the builder
+     */
+    Builder withProgress(DeleteProgress deleteProgress);
+
+  }
+
+  /**
+   * Path capability for bulk delete.
+   */
+  String CAPABILITY_BULK_DELETE = "fs.capability.bulk.delete";
+
+  /**
+   * Numeric hint about page size, "preferred" rather than "required".
+   * Implementations will ignore this if it is out of their supported/preferred
+   * range.
+   */
+  String OPT_PAGE_SIZE = "fs.option.bulkdelete.page.size";
+
+  /**
+   * Callback for progress; allows for a delete
+   * to be aborted (best effort).
+   * There are no guarantees as to which thread this will be called from.
+   */
+  interface DeleteProgress {
+
+    /**
+     * Report progress.
+     * @param update update to report
+     * @return true if the operation should continue, false to abort.
+     */
+    boolean report(ProgressReport update);
+  }
+
+  /**
+   * Progress update data.
+   */
+  class ProgressReport {
+
+    /**
+     * Number of files deleted.
+     */
+    private final int deleteCount;
+
+    /**
+     * List of files which were deleted.
+     */
+    private final List<Path> successes;
+
+    /**
+     * List of files which failed to delete.
+     * This may be empty, but will never be null.
+     */
+    private final List<Path> failures;
+
+    /**
+     * An exception covering at least one of the failures
+     * encountered.
+     */
+    private final IOException exception;
+
+    public ProgressReport(final int deleteCount,
+        final List<Path> successes,
+        final List<Path> failures,
+        final IOException exception) {
+      this.deleteCount = deleteCount;
+      this.successes = successes;
+      this.failures = failures;
+      this.exception = exception;
+    }
+
+    public int getDeleteCount() {
+      return deleteCount;
+    }
+
+    public List<Path> getSuccesses() {
+      return successes;
+    }
+
+    public List<Path> getFailures() {
+      return failures;
+    }
+  }
+
+  /**
+   * Result of a bulk delete operation.
+   */
+  class Outcome implements IOStatisticsSource {
+
+    /**
+     * Did the operation succeed?
+     */
+    private final boolean successful;
+
+    /**
+     * An exception covering at least one of the failures
+     * encountered.
+     */
+    private final IOException exception;
+
+    /**
+     * Number of files deleted.
+     */
+    private final int deleteCount;
+
+    /**
+     * Number of delete pages submitted to the store.
+     */
+    private final int pageCount;
+
+    /**
+     * List of files which failed to delete.
+     * This may be empty, but will never be null.
+     * If the operation failed fast, it will not
+     * include those files which were not submitted
+     */
+    private final List<Path> failures;
+
+    /**
+     * IO Statistics.
+     * This will include any statistics supplied by
+     * the iterator.
+     */
+    private final IOStatistics iostats;
+
+    public Outcome(final boolean successful,
+        final IOException exception,
+        final int deleteCount,
+        final int pageCount,
+        final List<Path> failures,
+        final IOStatistics iostats) {
+
+      this.successful = successful;
+      this.exception = exception;
+      this.deleteCount = deleteCount;
+      this.pageCount = pageCount;
+      this.failures = failures;
+      this.iostats = iostats;
+    }
+
+    public boolean successful() {
+      return successful;
+    }
+
+    public IOException getException() {
+      return exception;
+    }
+
+    public int getDeleteCount() {
+      return deleteCount;
+    }
+
+    public List<Path> getFailures() {
+      return failures;
+    }
+
+    @Override
+    public IOStatistics getIOStatistics() {
+      return iostats;
+    }
+
+    @Override
+    public String toString() {
+      return "Outcome{" +
+          "successful=" + successful +
+          ", deleteCount=" + deleteCount +
+          ", failures=" + failures +
+          ", iostats=" + iostats +
+          '}';
+    }
+  }
+
+  /**
+   * A fail fast policy: if there are any failures, abort.
+   * This is the default until any other progress callback
+   * is set in the builder.
+   */
+  DeleteProgress FAIL_FAST = (report -> report.failures.isEmpty());
+
+  /**
+   * Continue if there are any failures.
+   */
+  DeleteProgress CONTINUE = (report -> true);
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/BulkDelete.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/BulkDelete.java
@@ -27,6 +27,8 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsSource;
 
+import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsToPrettyString;
+
 /**
  * Interface for bulk file delete operations.
  * <p>
@@ -37,6 +39,13 @@ import org.apache.hadoop.fs.statistics.IOStatisticsSource;
  * A remote iterator provides the list of paths to delete; all must be under
  * the base path.
  * <p>
+ * There is no guarantee order of execution.
+ * Implementations may shuffle paths before posting requests.
+ * <p>
+ * Callers MUST have no expectation that parent directories will exist after the
+ * operation completes; if an object store needs to explicitly look for and create
+ * directory markers, that step will be omitted.
+ * <p>
  * The iterator may be a {@code Closeable} and if so, it will be closed on
  * completion, irrespective of the outcome.
  * <p>
@@ -46,11 +55,30 @@ import org.apache.hadoop.fs.statistics.IOStatisticsSource;
  * If the iterator's methods raise any exception, the delete will fail fast;
  * no more files will be submitted for deletion.
  * <p>
+ * The {@link #OPT_BACKGROUND} boolean option is a hint to prioritise other work
+ * over the delete; use it for background cleanup, compaction etc.
+ * <p>
+ * no guarantee of page size being greater than 1, or even constant through
+ * the entire operation. The {@link #OPT_PAGE_SIZE} option can be used as
+ * a hint.
+ * Most object stores may have a maximum page size; if a larger size is requested,
+ * you will always get something at or below that limit (i.e. it is not an
+ * error to ask for more than the limit)
+ * <p>
+ * Be aware that on some stores (AWS S3) each object listed in a bulk delete counts
+ * against the write IOPS limit; large page sizes are counterproductive here.
+ * @see <a href="https://issues.apache.org/jira/browse/HADOOP-16823">HADOOP-16823.Large DeleteObject requests are their own Thundering Herd</a>
+ * <p>
+ * Progress callback: the callback may come from any thread, further work may or may
+ * not be blocked during the callback's processing in application code.
+ * <p>
  * If a bulk delete call fails, then the next progress report will include
  * information about the failure; the callback can decide whether to continue
  * or not. The default callback is {@link #FAIL_FAST}, which will trigger
  * a fast failure.
- *
+ * <p>
+ * After a progress callback requests abort, active operations MAY continue.
+ * The {@link ProgressReport#aborting} flag indicates this.
  */
 @InterfaceAudience.Public
 @InterfaceStability.Unstable
@@ -98,6 +126,14 @@ public interface BulkDelete {
   String OPT_PAGE_SIZE = "fs.option.bulkdelete.page.size";
 
   /**
+   * Is this a background operation?
+   * If so, a lower write rate may be used so that it doesn't interfere
+   * with higher priority workloads -such as through rate limiting
+   * and/or the use of smaller page sizes.
+   */
+  String OPT_BACKGROUND = "fs.option.bulkdelete.background";
+
+  /**
    * Callback for progress; allows for a delete
    * to be aborted (best effort).
    * There are no guarantees as to which thread this will be called from.
@@ -113,7 +149,7 @@ public interface BulkDelete {
   }
 
   /**
-   * Progress update data.
+   * Delete progress report.
    */
   class ProgressReport {
 
@@ -139,14 +175,24 @@ public interface BulkDelete {
      */
     private final IOException exception;
 
+    /**
+     * Has an abort been requested from a previous progress report?
+     * If a progress report is delivered with this flag, it indicates
+     * that the abort has been requested, and that this report is
+     * from a page which was submitted before the abort request.
+     */
+    private final boolean aborting;
+
     public ProgressReport(final int deleteCount,
         final List<Path> successes,
         final List<Path> failures,
-        final IOException exception) {
+        final IOException exception,
+        final boolean aborting) {
       this.deleteCount = deleteCount;
       this.successes = successes;
       this.failures = failures;
       this.exception = exception;
+      this.aborting = aborting;
     }
 
     public int getDeleteCount() {
@@ -160,6 +206,14 @@ public interface BulkDelete {
     public List<Path> getFailures() {
       return failures;
     }
+
+    public IOException getException() {
+      return exception;
+    }
+
+    public boolean isAborting() {
+      return aborting;
+    }
   }
 
   /**
@@ -169,8 +223,14 @@ public interface BulkDelete {
 
     /**
      * Did the operation succeed?
+     * That is: delete all files without any failures?
      */
     private final boolean successful;
+
+    /**
+     * Wast the operation aborted?
+     */
+    private final boolean aborted;
 
     /**
      * An exception covering at least one of the failures
@@ -181,20 +241,18 @@ public interface BulkDelete {
     /**
      * Number of files deleted.
      */
-    private final int deleteCount;
+    private final int deleted;
+
+    /**
+     * Number of files which failed to delete.
+     */
+    private final int failures;
 
     /**
      * Number of delete pages submitted to the store.
      */
     private final int pageCount;
 
-    /**
-     * List of files which failed to delete.
-     * This may be empty, but will never be null.
-     * If the operation failed fast, it will not
-     * include those files which were not submitted
-     */
-    private final List<Path> failures;
 
     /**
      * IO Statistics.
@@ -204,15 +262,17 @@ public interface BulkDelete {
     private final IOStatistics iostats;
 
     public Outcome(final boolean successful,
+        final boolean aborted,
         final IOException exception,
-        final int deleteCount,
+        final int deleted,
+        final int failures,
         final int pageCount,
-        final List<Path> failures,
         final IOStatistics iostats) {
 
       this.successful = successful;
+      this.aborted = aborted;
       this.exception = exception;
-      this.deleteCount = deleteCount;
+      this.deleted = deleted;
       this.pageCount = pageCount;
       this.failures = failures;
       this.iostats = iostats;
@@ -226,11 +286,11 @@ public interface BulkDelete {
       return exception;
     }
 
-    public int getDeleteCount() {
-      return deleteCount;
+    public int getDeleted() {
+      return deleted;
     }
 
-    public List<Path> getFailures() {
+    public int getFailures() {
       return failures;
     }
 
@@ -243,9 +303,9 @@ public interface BulkDelete {
     public String toString() {
       return "Outcome{" +
           "successful=" + successful +
-          ", deleteCount=" + deleteCount +
+          ", deleteCount=" + deleted +
           ", failures=" + failures +
-          ", iostats=" + iostats +
+          ", iostats=" + ioStatisticsToPrettyString(iostats) +
           '}';
     }
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/BulkDeleteSupport.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/BulkDeleteSupport.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.impl;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nonnull;
+
+import org.apache.hadoop.fs.BulkDelete;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Support for bulk delete operations.
+ */
+public final class BulkDeleteSupport {
+
+  /**
+   * Builder implementation; takes a callback for the actual operation.
+   */
+  public static class BulkDeleteBinding
+      extends AbstractFSBuilderImpl<CompletableFuture<BulkDelete.Outcome>, BulkDelete.Builder>
+      implements BulkDelete.Builder {
+
+    private final RemoteIterator<Path> files;
+
+    private final BulkDeleteBuilderCallbacks callbacks;
+
+    private BulkDelete.DeleteProgress deleteProgress;
+
+    public BulkDeleteBinding(
+        @Nonnull final Path path,
+        @Nonnull RemoteIterator<Path> files,
+        @Nonnull BulkDeleteBuilderCallbacks callbacks) {
+      super(path);
+      this.files = requireNonNull(files);
+      this.callbacks = requireNonNull(callbacks);
+    }
+
+    @Override
+    public BulkDelete.Builder withProgress(final BulkDelete.DeleteProgress deleteProgress) {
+      this.deleteProgress = deleteProgress;
+      return this;
+    }
+
+    @Override
+    public BulkDelete.Builder getThisBuilder() {
+      return this;
+    }
+
+    public RemoteIterator<Path> getFiles() {
+      return files;
+    }
+
+    public BulkDelete.DeleteProgress getDeleteProgress() {
+      return deleteProgress;
+    }
+
+    @Override
+    public CompletableFuture<BulkDelete.Outcome> build()
+        throws IllegalArgumentException, IOException {
+      return null;
+    }
+  }
+
+  /**
+   * Callbacks for the builder.
+   */
+  public interface BulkDeleteBuilderCallbacks {
+    CompletableFuture<BulkDelete.Outcome> initiateBulkDelete(
+        BulkDeleteBinding builder) throws IOException;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StoreStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StoreStatisticNames.java
@@ -47,6 +47,9 @@ public final class StoreStatisticNames {
   public static final String OP_APPEND = "op_append";
 
   /** {@value}. */
+  public static final String OP_BULK_DELETE = "op_bulk-delete";
+
+  /** {@value}. */
   public static final String OP_COPY_FROM_LOCAL_FILE =
       "op_copy_from_local_file";
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
@@ -103,6 +103,10 @@ public enum Statistic {
       StoreStatisticNames.OP_ACCESS,
       "Calls of access()",
       TYPE_DURATION),
+  INVOCATION_BULK_DELETE(
+      StoreStatisticNames.OP_BULK_DELETE,
+      "Calls of bulk delete()",
+      TYPE_COUNTER),
   INVOCATION_COPY_FROM_LOCAL_FILE(
       StoreStatisticNames.OP_COPY_FROM_LOCAL_FILE,
       "Calls of copyFromLocalFile()",

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/BulkDeleteApiOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/BulkDeleteApiOperation.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import com.amazonaws.AmazonClientException;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+
+import org.apache.hadoop.fs.BulkDelete;
+import org.apache.hadoop.fs.InvalidRequestException;
+import org.apache.hadoop.fs.impl.BulkDeleteSupport;
+import org.apache.hadoop.fs.s3a.Retries;
+import org.apache.hadoop.fs.store.audit.AuditSpan;
+import org.apache.hadoop.util.functional.FutureIO;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.emptyStatistics;
+import static org.apache.hadoop.util.functional.RemoteIterators.mappingRemoteIterator;
+import static org.apache.hadoop.util.functional.RemoteIterators.toList;
+
+/**
+ * Implementation of the public bulk delete API.
+ * Iterates through the list of files, initiating bulk delete calls.
+ */
+public class BulkDeleteApiOperation
+    extends ExecutingStoreOperation<CompletableFuture<BulkDelete.Outcome>> {
+
+
+  private final BulkDeleteSupport.BulkDeleteBinding binding;
+
+
+  /**
+   * Number of entries in a page.
+   */
+  private final int pageSize;
+
+  private final BulkDeleteApiOperationCallbacks callbacks;
+
+  public BulkDeleteApiOperation(
+      final StoreContext storeContext,
+      final AuditSpan auditSpan,
+      final BulkDeleteSupport.BulkDeleteBinding binding,
+      final int pageSize,
+      final BulkDeleteApiOperationCallbacks callbacks) {
+    super(storeContext, auditSpan);
+    this.binding = requireNonNull(binding);
+    this.pageSize = pageSize;
+    this.callbacks = requireNonNull(callbacks);
+  }
+
+  @Override
+  public CompletableFuture<BulkDelete.Outcome> execute() throws IOException {
+    // initial POC does a large blocking call.
+    return FutureIO.eval(() -> {
+      final StoreContext context = getStoreContext();
+      final List<ObjectIdentifier> keysToDelete =
+          toList(mappingRemoteIterator(binding.getFiles(),
+              p -> ObjectIdentifier.builder().key(context.pathToKey(p)).build()));
+
+      boolean successful = true;
+      Exception exception = null;
+      try {
+        callbacks.removeKeys(keysToDelete);
+      } catch (IOException e) {
+        successful = false;
+        exception = e;
+      }
+      return new BulkDelete.Outcome(
+          successful,
+          false,
+          exception,
+          keysToDelete.size(),
+          0,
+          1,
+          emptyStatistics());
+    });
+  }
+
+  public interface BulkDeleteApiOperationCallbacks {
+
+    /**
+     * Remove keys from the store.
+     * @param keysToDelete collection of keys to delete on the s3-backend.
+     * if empty, no request is made of the object store.
+     * @throws InvalidRequestException if the request was rejected due to
+     * a mistaken attempt to delete the root directory.
+     * @throws MultiObjectDeleteException one or more of the keys could not
+     * be deleted in a multiple object delete operation.
+     * @throws IOException other IO Exception.
+     */
+    @Retries.RetryRaw
+    void removeKeys(List<ObjectIdentifier> keysToDelete)
+        throws MultiObjectDeleteException, IOException;
+  }
+}


### PR DESCRIPTION
Initial pass at writing an API for bulk deletes,
targeting S3 and any store with paged delete support.

Minimal design of a RemoteIterator to provide the list of paths to delete; a progress report will be provided after pages are deleted so as to provide an update of files deleted, and a way for the application code to abort an ongoing delete -such as after a failure.

### Aspects of implementation to make clear in markdown spec

* no guarantee of page size being > 1; or constant through entire operation.
* after progress callback requests abort, more operations may continue (should we include an "aborting" flag?)
* no guarantee order of execution. implementations may shuffle paths before posting.
* no expectation that parent directories will exist after the operation completes; if an object store needs to explicitly look for and create directory markers, that step will be omitted.
* background option is a hint to prioritise over other write operations vs add an interval between pages/different page size
* callback: guarantee of thread callback comes from or whether it blocks further work
* any exception raised by the iterator is an unrecoverable failure. unsubmitted paths may/may not be submitted before reporting the failure
* no timeouts on iterator next()/hasNext().

### How was this patch tested?

No tests yet; working on API first.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

