### PR TITLE
HADOOP-18869: [ABFS] Fixing Behavior of a File System APIs on root path

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -121,6 +121,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.BLOCK_UPLOAD_ACTIVE_BLOCKS_DEFAULT;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.DATA_BLOCKS_BUFFER_DEFAULT;
 import static org.apache.hadoop.fs.azurebfs.constants.InternalConstants.CAPABILITY_SAFE_READAHEAD;
+import static org.apache.hadoop.fs.azurebfs.services.AbfsErrors.ERR_CREATE_ON_ROOT;
 import static org.apache.hadoop.fs.impl.PathCapabilitiesSupport.validatePathCapabilityArgs;
 import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.logIOStatisticsAtLevel;
 import static org.apache.hadoop.util.functional.RemoteIterators.filteringRemoteIterator;
@@ -328,7 +329,7 @@ public class AzureBlobFileSystem extends FileSystem
     if (f.isRoot()) {
       throw new AbfsRestOperationException(HTTP_CONFLICT,
           AzureServiceErrorCode.PATH_CONFLICT.getErrorCode(),
-          "Cannot create file on the root path",
+          ERR_CREATE_ON_ROOT,
           null);
     }
 
@@ -358,7 +359,7 @@ public class AzureBlobFileSystem extends FileSystem
     if (f.isRoot()) {
       throw new AbfsRestOperationException(HTTP_CONFLICT,
           AzureServiceErrorCode.PATH_CONFLICT.getErrorCode(),
-          "Cannot create file on the root path",
+          ERR_CREATE_ON_ROOT,
           null);
     }
     final Path parent = f.getParent();

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -978,15 +978,25 @@ public class AzureBlobFileSystem extends FileSystem
       TracingContext tracingContext = new TracingContext(clientCorrelationId,
           fileSystemId, FSOperationType.SET_ATTR, true, tracingHeaderFormat,
           listener);
-      Hashtable<String, String> properties = abfsStore
-          .getPathStatus(qualifiedPath, tracingContext);
+      Hashtable<String, String> properties;
       String xAttrName = ensureValidAttributeName(name);
+
+      if (path.isRoot()) {
+        properties = abfsStore.getFilesystemProperties(tracingContext);
+      } else {
+        properties = abfsStore.getPathStatus(qualifiedPath, tracingContext);
+      }
+
       boolean xAttrExists = properties.containsKey(xAttrName);
       XAttrSetFlag.validate(name, xAttrExists, flag);
 
       String xAttrValue = abfsStore.decodeAttribute(value);
       properties.put(xAttrName, xAttrValue);
-      abfsStore.setPathProperties(qualifiedPath, properties, tracingContext);
+      if (path.isRoot()) {
+        abfsStore.setFilesystemProperties(properties, tracingContext);
+      } else {
+        abfsStore.setPathProperties(qualifiedPath, properties, tracingContext);
+      }
     } catch (AzureBlobFileSystemException ex) {
       checkException(path, ex);
     }
@@ -1018,9 +1028,15 @@ public class AzureBlobFileSystem extends FileSystem
       TracingContext tracingContext = new TracingContext(clientCorrelationId,
           fileSystemId, FSOperationType.GET_ATTR, true, tracingHeaderFormat,
           listener);
-      Hashtable<String, String> properties = abfsStore
-          .getPathStatus(qualifiedPath, tracingContext);
+      Hashtable<String, String> properties;
       String xAttrName = ensureValidAttributeName(name);
+
+      if (path.isRoot()) {
+        properties = abfsStore.getFilesystemProperties(tracingContext);
+      } else {
+        properties = abfsStore.getPathStatus(qualifiedPath, tracingContext);
+      }
+
       if (properties.containsKey(xAttrName)) {
         String xAttrValue = properties.get(xAttrName);
         value = abfsStore.encodeAttribute(xAttrValue);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -494,7 +494,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       final Hashtable<String, String> properties, TracingContext tracingContext)
       throws AzureBlobFileSystemException {
     try (AbfsPerfInfo perfInfo = startTracking("setPathProperties", "setPathProperties")){
-      LOG.debug("setFilesystemProperties for filesystem: {} path: {} with properties: {}",
+      LOG.debug("setPathProperties for filesystem: {} path: {} with properties: {}",
               client.getFileSystem(),
               path,
               properties);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsErrors.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsErrors.java
@@ -48,6 +48,6 @@ public final class AbfsErrors {
       + "operation";
   public static final String ERR_NO_LEASE_THREADS = "Lease desired but no lease threads "
       + "configured, set " + FS_AZURE_LEASE_THREADS;
-
+  public static final String ERR_CREATE_ON_ROOT = "Cannot create file over root path";
   private AbfsErrors() {}
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
-import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.test.GenericTestUtils;
@@ -154,18 +153,22 @@ public class ITestAzureBlobFileSystemCreate extends
     final AzureBlobFileSystem fs = getFileSystem();
     Path testFile = path(AbfsHttpConstants.ROOT_PATH);
     try {
-      fs.create(testFile, true);
-      fail("Should've thrown AbfsRestOperationException");
+      intercept(AbfsRestOperationException.class, () ->
+          fs.create(testFile, true));
     } catch (AbfsRestOperationException e) {
-      Assertions.assertThat(e.getStatusCode()).describedAs(
-          "Request should fail with 409 Conflict").isEqualTo(HTTP_CONFLICT);
+      Assertions.assertThat(e.getStatusCode())
+          .describedAs("Request should fail with 409 Conflict")
+          .isEqualTo(HTTP_CONFLICT);
     }
     try {
-      fs.createNonRecursive(testFile, FsPermission.getDefault(), false, 1024, (short) 1, 1024, null);
-      fail("Should've thrown AbfsRestOperationException");
+      intercept(AbfsRestOperationException.class, () ->
+          fs.createNonRecursive(testFile, FsPermission.getDefault(),
+              false, 1024, (short) 1, 1024, null));
+
     } catch (AbfsRestOperationException e) {
-      Assertions.assertThat(e.getStatusCode()).describedAs(
-          "Request should fail with 409 Conflict").isEqualTo(HTTP_CONFLICT);
+      Assertions.assertThat(e.getStatusCode())
+          .describedAs("Request should fail with 409 Conflict")
+          .isEqualTo(HTTP_CONFLICT);
     }
   }
 
@@ -213,7 +216,8 @@ public class ITestAzureBlobFileSystemCreate extends
         // the exception raised in close() must be in the caught exception's
         // suppressed list
         Throwable[] suppressed = fnfe.getSuppressed();
-        assertEquals("suppressed count", 1, suppressed.length);
+        Assertions.assertThat(suppressed.length)
+            .describedAs("suppressed count should be 1").isEqualTo(1);
         Throwable inner = suppressed[0];
         if (!(inner instanceof IOException)) {
           throw inner;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Field;
 import java.util.EnumSet;
 import java.util.UUID;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import org.apache.hadoop.conf.Configuration;
@@ -33,6 +34,8 @@ import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.test.GenericTestUtils;
@@ -144,6 +147,26 @@ public class ITestAzureBlobFileSystemCreate extends
     fs.createNonRecursive(testFile, true, 1024, (short) 1, 1024, null)
         .close();
     assertIsFile(fs, testFile);
+  }
+
+  @Test
+  public void testCreateOnRoot() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    Path testFile = path(AbfsHttpConstants.ROOT_PATH);
+    try {
+      fs.create(testFile, true);
+      fail("Should've thrown AbfsRestOperationException");
+    } catch (AbfsRestOperationException e) {
+      Assertions.assertThat(e.getStatusCode()).describedAs(
+          "Request should fail with 409 Conflict").isEqualTo(HTTP_CONFLICT);
+    }
+    try {
+      fs.createNonRecursive(testFile, FsPermission.getDefault(), false, 1024, (short) 1, 1024, null);
+      fail("Should've thrown AbfsRestOperationException");
+    } catch (AbfsRestOperationException e) {
+      Assertions.assertThat(e.getStatusCode()).describedAs(
+          "Request should fail with 409 Conflict").isEqualTo(HTTP_CONFLICT);
+    }
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -152,23 +152,19 @@ public class ITestAzureBlobFileSystemCreate extends
   public void testCreateOnRoot() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
     Path testFile = path(AbfsHttpConstants.ROOT_PATH);
-    try {
-      intercept(AbfsRestOperationException.class, () ->
-          fs.create(testFile, true));
-    } catch (AbfsRestOperationException e) {
-      Assertions.assertThat(e.getStatusCode())
-          .describedAs("Request should fail with 409 Conflict")
-          .isEqualTo(HTTP_CONFLICT);
+    AbfsRestOperationException ex = intercept(AbfsRestOperationException.class, () ->
+        fs.create(testFile, true));
+    if (ex.getStatusCode() != HTTP_CONFLICT) {
+      // Request should fail with 409.
+      throw ex;
     }
-    try {
-      intercept(AbfsRestOperationException.class, () ->
-          fs.createNonRecursive(testFile, FsPermission.getDefault(),
-              false, 1024, (short) 1, 1024, null));
 
-    } catch (AbfsRestOperationException e) {
-      Assertions.assertThat(e.getStatusCode())
-          .describedAs("Request should fail with 409 Conflict")
-          .isEqualTo(HTTP_CONFLICT);
+    ex = intercept(AbfsRestOperationException.class, () ->
+        fs.createNonRecursive(testFile, FsPermission.getDefault(),
+            false, 1024, (short) 1, 1024, null));
+    if (ex.getStatusCode() != HTTP_CONFLICT) {
+      // Request should fail with 409.
+      throw ex;
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/resources/abfs.xml
+++ b/hadoop-tools/hadoop-azure/src/test/resources/abfs.xml
@@ -19,7 +19,7 @@
 <configuration xmlns:xi="http://www.w3.org/2001/XInclude">
     <property>
         <name>fs.contract.test.root-tests-enabled</name>
-        <value>false</value>
+        <value>true</value>
     </property>
 
     <property>


### PR DESCRIPTION
### Description of PR
Jira Ticket: https://issues.apache.org/jira/browse/HADOOP-18869 

Following changes are included in this PR:
1. HDFS.create() was failing on root path with Invalid URL. As a fix a check is added to avoid network call if root path is passed. Instead, an Exception will be thrown with relevant message.
2. HDFS.createNonRecursive() was failing on root path with NullPointerException. As a fix a check is added to avoid network call if root path is passed. Instead, an Exception will be thrown with relevant message.
3. HDFS.getXAttr() was failing for root path with Invalid URL. As a fix support for setting File System Properties added if root path is passed.
4. HDFS.setXAttr() was failing for root path with Invalid URL. As a fix support for getting File System Properties added if root path is passed.
5. Tests for getsetXAttr() were trying to set Unicode characters in attribute value encoded in ISO_8859-1 which does not support unicode, hence the value set by setXAttr() were going as undefined character. getXAttr() also retrieved them as undefined characters only. As a fix, assertions were changed to compare the both encoded and decoded values.
Also, ABFS used DFS endpoint to interact with Azure services. As per the official documentation, these operations on DFS endpoint supports only ASCII characters. As a ix tests were modified to work only with ASCII characters.

### How was this patch tested?
Existing tests were modified and more tests were added.
Whole test suite was ran to verify the changes. Test results pasted below.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

