### PR TITLE
HADOOP-18870. CURATOR-599 change broke functionality introduced in HA…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
@@ -549,7 +549,17 @@ public final class ZKCuratorManager {
     public ZooKeeper newZooKeeper(String connectString, int sessionTimeout,
         Watcher watcher, boolean canBeReadOnly
     ) throws Exception {
-      ZKClientConfig zkClientConfig = new ZKClientConfig();
+      return this.newZooKeeper(connectString, sessionTimeout,
+      watcher, canBeReadOnly, new ZKClientConfig());
+    }
+
+    @Override
+    public ZooKeeper newZooKeeper(String connectString, int sessionTimeout,
+        Watcher watcher, boolean canBeReadOnly, ZKClientConfig zkClientConfig
+    ) throws Exception {
+      if (zkClientConfig == null) {
+        zkClientConfig = new ZKClientConfig();
+      }
       if (zkPrincipal != null) {
         LOG.info("Configuring zookeeper to use {} as the server principal",
             zkPrincipal);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/curator/TestZKCuratorManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/curator/TestZKCuratorManager.java
@@ -22,10 +22,15 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import javax.security.auth.login.AppConfigurationEntry;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
@@ -191,6 +196,36 @@ public class TestZKCuratorManager {
       // Remove global configuration
       System.clearProperty(ZKClientConfig.LOGIN_CONTEXT_NAME_KEY);
     }
+  }
+
+  @Test
+  public void testCuratorFrameworkFactory() throws Exception{
+    // By not explicitly calling the NewZooKeeper method validate that the Curator override works.
+    ZKClientConfig zkClientConfig = new ZKClientConfig();
+    Configuration conf = new Configuration();
+    conf.set(CommonConfigurationKeys.ZK_ADDRESS, this.server.getConnectString());
+    int numRetries = conf.getInt(CommonConfigurationKeys.ZK_NUM_RETRIES,
+        CommonConfigurationKeys.ZK_NUM_RETRIES_DEFAULT);
+    int zkSessionTimeout = conf.getInt(CommonConfigurationKeys.ZK_TIMEOUT_MS,
+        CommonConfigurationKeys.ZK_TIMEOUT_MS_DEFAULT);
+    int zkRetryInterval = conf.getInt(
+        CommonConfigurationKeys.ZK_RETRY_INTERVAL_MS,
+        CommonConfigurationKeys.ZK_RETRY_INTERVAL_MS_DEFAULT);
+    RetryNTimes retryPolicy = new RetryNTimes(numRetries, zkRetryInterval);
+
+    CuratorFramework client = CuratorFrameworkFactory.builder()
+        .connectString(conf.get(CommonConfigurationKeys.ZK_ADDRESS))
+        .zkClientConfig(zkClientConfig)
+        .sessionTimeoutMs(zkSessionTimeout).retryPolicy(retryPolicy)
+        .authorization(new ArrayList<>())
+        .zookeeperFactory(new ZKCuratorManager.HadoopZookeeperFactory(
+            "foo1", "bar1", "bar1.keytab", false,
+            new ZKCuratorManager.TruststoreKeystore(conf))
+
+        ).build();
+    client.start();
+    validateJaasConfiguration(ZKCuratorManager.HadoopZookeeperFactory.JAAS_CLIENT_ENTRY,
+        "bar1", "bar1.keytab", client.getZookeeperClient().getZooKeeper());
   }
 
   private void validateJaasConfiguration(String clientConfig, String principal, String keytab,


### PR DESCRIPTION
…DOOP-18139 and HADOOP-18709

With this fix the HadoopZookeeperFactory's newZooKeeper method override is taking effect again.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Curator change caused the newZooKeeper 4-parameter method-override to be inactive. Fixed it by routing it to a 5-parameter method-override and keeping the original functionality intact.

### How was this patch tested?
With unit a test and a local integration test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

