### PR TITLE
HADOOP-18876. ABFS: Change default from disk to bytebuffer for fs.azure.data.blocks.buffer

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -85,7 +85,7 @@ public final class ConfigurationKeys {
   /**
    * What data block buffer to use.
    * <br>
-   * Options include: "disk"(Default), "array", and "bytebuffer".
+   * Options include: "disk", "array", and "bytebuffer"(Default).
    * <br>
    * Default is {@link FileSystemConfigurations#DATA_BLOCKS_BUFFER_DEFAULT}.
    * Value: {@value}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -132,11 +132,13 @@ public final class FileSystemConfigurations {
    */
   public static final String DATA_BLOCKS_BUFFER_DISK = "disk";
 
+  public static final String DATA_BLOCKS_BYTEBUFFER = "bytebuffer";
+
   /**
    * Default buffer option: {@value}.
    */
   public static final String DATA_BLOCKS_BUFFER_DEFAULT =
-      DATA_BLOCKS_BUFFER_DISK;
+          DATA_BLOCKS_BYTEBUFFER;
 
   /**
    * IO rate limit. Value: {@value}


### PR DESCRIPTION
Change default from disk to bytebuffer for fs.azure.data.blocks.buffer.

Derived from numerous workload runs, the data presented accentuates a noteworthy performance enhancement. The utilization of ByteBuffer for **reading operations** showcased a remarkable improvement of approximately **64.83%** in contrast to conventional disk-based reading. Furthermore, the integration of ByteBuffer for **write operations** resulted in a significant efficiency gain of about **60.75%**. These findings underscore the consistent and substantial advantages of embracing ByteBuffer as the default choice, particularly in light of the performance issues associated with disk operations.