### PR TITLE
YARN-11433. Router's main() should support generic options.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/main/java/org/apache/hadoop/yarn/server/globalpolicygenerator/GlobalPolicyGenerator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/main/java/org/apache/hadoop/yarn/server/globalpolicygenerator/GlobalPolicyGenerator.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.security.AuthenticationFilterInitializer;
 import org.apache.hadoop.security.HttpCrossOriginFilterInitializer;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.service.CompositeService;
+import org.apache.hadoop.util.GenericOptionsParser;
 import org.apache.hadoop.util.JvmPauseMonitor;
 import org.apache.hadoop.util.ShutdownHookManager;
 import org.apache.hadoop.util.StringUtils;
@@ -290,7 +291,9 @@ public class GlobalPolicyGenerator extends CompositeService {
 
   public static void main(String[] argv) {
     try {
-      startGPG(argv, new YarnConfiguration());
+      YarnConfiguration conf = new YarnConfiguration();
+      new GenericOptionsParser(conf, argv);
+      startGPG(argv, conf);
     } catch (Throwable t) {
       LOG.error("Error starting global policy generator", t);
       System.exit(-1);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/main/java/org/apache/hadoop/yarn/server/globalpolicygenerator/GlobalPolicyGenerator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/main/java/org/apache/hadoop/yarn/server/globalpolicygenerator/GlobalPolicyGenerator.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.server.globalpolicygenerator;
 
 import java.io.IOException;
+import java.io.PrintStream;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -292,8 +293,17 @@ public class GlobalPolicyGenerator extends CompositeService {
   public static void main(String[] argv) {
     try {
       YarnConfiguration conf = new YarnConfiguration();
-      new GenericOptionsParser(conf, argv);
-      startGPG(argv, conf);
+      GenericOptionsParser hParser = new GenericOptionsParser(conf, argv);
+      argv = hParser.getRemainingArgs();
+      if (argv.length > 1) {
+        if (argv[0].equals("-format-policy-store")) {
+          // TODO: YARN-11561. [Federation] GPG Supports Format PolicyStateStore.
+        } else {
+          printUsage(System.err);
+        }
+      } else {
+        startGPG(argv, conf);
+      }
     } catch (Throwable t) {
       LOG.error("Error starting global policy generator", t);
       System.exit(-1);
@@ -307,5 +317,9 @@ public class GlobalPolicyGenerator extends CompositeService {
   @VisibleForTesting
   public WebApp getWebApp() {
     return webApp;
+  }
+
+  private static void printUsage(PrintStream out) {
+    out.println("Usage: yarn gpg [-format-policy-store]");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/main/java/org/apache/hadoop/yarn/server/globalpolicygenerator/GlobalPolicyGenerator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/main/java/org/apache/hadoop/yarn/server/globalpolicygenerator/GlobalPolicyGenerator.java
@@ -298,6 +298,7 @@ public class GlobalPolicyGenerator extends CompositeService {
       if (argv.length > 1) {
         if (argv[0].equals("-format-policy-store")) {
           // TODO: YARN-11561. [Federation] GPG Supports Format PolicyStateStore.
+          System.err.println("format-policy-store is not yet supported.");
         } else {
           printUsage(System.err);
         }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/TestGlobalPolicyGenerator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/TestGlobalPolicyGenerator.java
@@ -72,7 +72,7 @@ public class TestGlobalPolicyGenerator {
     assertTrue(dataErr.toString().contains(
         "Usage: yarn gpg [-format-policy-store]"));
   }
-  
+
   @Test
   public void testUserProvidedUGIConf() throws Exception {
     String errMsg = "Invalid attribute value for " +

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/TestGlobalPolicyGenerator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/TestGlobalPolicyGenerator.java
@@ -24,8 +24,12 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit test for GlobalPolicyGenerator.
@@ -54,5 +58,16 @@ public class TestGlobalPolicyGenerator {
       List<Service> services = gpg.getServices();
       return (services.size() == 1 && gpg.getWebApp() != null);
     }, 100, 5000);
+  }
+
+  @Test
+  public void testGPGCLI() {
+    ByteArrayOutputStream dataOut = new ByteArrayOutputStream();
+    ByteArrayOutputStream dataErr = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(dataOut));
+    System.setErr(new PrintStream(dataErr));
+    GlobalPolicyGenerator.main(new String[]{"-help", "-format-policy-store"});
+    assertTrue(dataErr.toString().contains(
+        "Usage: yarn gpg [-format-policy-store]"));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
@@ -256,7 +256,8 @@ public class Router extends CompositeService {
           // TODO: YARN-11548. [Federation] Router Supports Format FederationStateStore.
           System.err.println("format-state-store is not yet supported.");
         } else if (argv[0].equals("-remove-application-from-state-store") && argv.length == 2) {
-          // TODO: YARN-11547. [Federation] Router Supports Remove individual application records from FederationStateStore.
+          // TODO: YARN-11547. [Federation]
+          //  Router Supports Remove individual application records from FederationStateStore.
           System.err.println("remove-application-from-state-store is not yet supported.");
         } else {
           printUsage(System.err);
@@ -314,6 +315,7 @@ public class Router extends CompositeService {
   }
 
   private static void printUsage(PrintStream out) {
-    out.println("Usage: yarn router [-format-state-store] | [-remove-application-from-state-store <appId>]");
+    out.println("Usage: yarn router [-format-state-store] | " +
+        "[-remove-application-from-state-store <appId>]");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.metrics2.source.JvmMetrics;
 import org.apache.hadoop.security.HttpCrossOriginFilterInitializer;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.service.CompositeService;
+import org.apache.hadoop.util.GenericOptionsParser;
 import org.apache.hadoop.util.JvmPauseMonitor;
 import org.apache.hadoop.util.ShutdownHookManager;
 import org.apache.hadoop.util.StringUtils;
@@ -245,6 +246,8 @@ public class Router extends CompositeService {
     StringUtils.startupShutdownMessage(Router.class, argv, LOG);
     Router router = new Router();
     try {
+
+      new GenericOptionsParser(conf, argv);
 
       // Remove the old hook if we are rebooting.
       if (null != routerShutdownHook) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
@@ -252,8 +252,10 @@ public class Router extends CompositeService {
       if (argv.length > 1) {
         if (argv[0].equals("-format-state-store")) {
           // TODO: YARN-11548. [Federation] Router Supports Format FederationStateStore.
+          System.err.println("format-state-store is not yet supported.");
         } else if (argv[0].equals("-remove-application-from-state-store") && argv.length == 2) {
           // TODO: YARN-11547. [Federation] Router Supports Remove individual application records from FederationStateStore.
+          System.err.println("remove-application-from-state-store is not yet supported.");
         } else {
           printUsage(System.err);
         }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.server.router;
 
 import java.io.IOException;
+import java.io.PrintStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -246,20 +247,26 @@ public class Router extends CompositeService {
     StringUtils.startupShutdownMessage(Router.class, argv, LOG);
     Router router = new Router();
     try {
-
-      new GenericOptionsParser(conf, argv);
-
-      // Remove the old hook if we are rebooting.
-      if (null != routerShutdownHook) {
-        ShutdownHookManager.get().removeShutdownHook(routerShutdownHook);
+      GenericOptionsParser hParser = new GenericOptionsParser(conf, argv);
+      argv = hParser.getRemainingArgs();
+      if (argv.length > 1) {
+        if (argv[0].equals("-format-state-store")) {
+          // TODO: YARN-11548. [Federation] Router Supports Format FederationStateStore.
+        } else if (argv[0].equals("-remove-application-from-state-store") && argv.length == 2) {
+          // TODO: YARN-11547. [Federation] Router Supports Remove individual application records from FederationStateStore.
+        } else {
+          printUsage(System.err);
+        }
+      } else {
+        // Remove the old hook if we are rebooting.
+        if (null != routerShutdownHook) {
+          ShutdownHookManager.get().removeShutdownHook(routerShutdownHook);
+        }
+        routerShutdownHook = new CompositeServiceShutdownHook(router);
+        ShutdownHookManager.get().addShutdownHook(routerShutdownHook, SHUTDOWN_HOOK_PRIORITY);
+        router.init(conf);
+        router.start();
       }
-
-      routerShutdownHook = new CompositeServiceShutdownHook(router);
-      ShutdownHookManager.get().addShutdownHook(routerShutdownHook,
-          SHUTDOWN_HOOK_PRIORITY);
-
-      router.init(conf);
-      router.start();
     } catch (Throwable t) {
       LOG.error("Error starting Router", t);
       System.exit(-1);
@@ -300,5 +307,9 @@ public class Router extends CompositeService {
   @VisibleForTesting
   public FedAppReportFetcher getFetcher() {
     return fetcher;
+  }
+
+  private static void printUsage(PrintStream out) {
+    out.println("Usage: yarn router [-format-state-store] | [-remove-application-from-state-store <appId>]");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouter.java
@@ -401,6 +401,7 @@ public class TestRouter {
     System.setErr(new PrintStream(dataErr));
     Router.main(new String[]{"-help", "-format-state-store"});
     assertTrue(dataErr.toString().contains(
-        "Usage: yarn router [-format-state-store] | [-remove-application-from-state-store <appId>]"));
+        "Usage: yarn router [-format-state-store] | " +
+        "[-remove-application-from-state-store <appId>]"));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouter.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.yarn.server.router;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.apache.hadoop.conf.Configuration;
@@ -42,7 +43,9 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.Collection;
 import java.util.HashMap;
@@ -377,4 +380,14 @@ public class TestRouter {
     }
   }
 
+  @Test
+  public void testRouterCLI() {
+    ByteArrayOutputStream dataOut = new ByteArrayOutputStream();
+    ByteArrayOutputStream dataErr = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(dataOut));
+    System.setErr(new PrintStream(dataErr));
+    Router.main(new String[]{"-help", "-format-state-store"});
+    assertTrue(dataErr.toString().contains(
+        "Usage: yarn router [-format-state-store] | [-remove-application-from-state-store <appId>]"));
+  }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: YARN-11433. Router's main() should support generic options.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

