### PR TITLE
HDFS-17167. Add config to startup NameNode as Observer

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1177,6 +1177,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final String  DFS_NAMENODE_PLUGINS_KEY = "dfs.namenode.plugins";
   public static final String  DFS_WEB_UGI_KEY = "dfs.web.ugi";
   public static final String  DFS_NAMENODE_STARTUP_KEY = "dfs.namenode.startup";
+  public static final String  DFS_NAMENODE_OBSERVER_ENABLED_KEY = "dfs.namenode.observer.enabled";
+  public static final boolean DFS_NAMENODE_OBSERVER_ENABLED_DEFAULT = false;
   public static final String  DFS_DATANODE_KEYTAB_FILE_KEY = "dfs.datanode.keytab.file";
   public static final String  DFS_DATANODE_KERBEROS_PRINCIPAL_KEY =
       HdfsClientConfigKeys.DFS_DATANODE_KERBEROS_PRINCIPAL_KEY;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/BackupNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/BackupNode.java
@@ -435,7 +435,7 @@ public class BackupNode extends NameNode {
   }
 
   @Override
-  protected HAState createHAState(StartupOption startOpt) {
+  protected HAState createHAState(Configuration conf) {
     return new BackupState();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -1172,7 +1172,7 @@ public class NameNode extends ReconfigurableBase implements
           DFS_NAMENODE_OBSERVER_ENABLED_DEFAULT)
         || startOpt == StartupOption.OBSERVER) {
       // Set Observer state using config instead of startup option
-      // This allows other startup options to be used when starting observer
+      // This allows other startup options to be used when starting observer.
       // e.g. rollingUpgrade
       return OBSERVER_STATE;
     } else {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -163,6 +163,8 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_LIFELINE_RPC_BIN
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_METRICS_LOGGER_PERIOD_SECONDS_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_METRICS_LOGGER_PERIOD_SECONDS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_NAME_DIR_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_OBSERVER_ENABLED_DEFAULT;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_OBSERVER_ENABLED_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_PLUGINS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_RPC_BIND_HOST_KEY;
@@ -1125,7 +1127,7 @@ public class NameNode extends ReconfigurableBase implements
           + " this namenode/service.", clientNamenodeAddress);
     }
     this.haEnabled = HAUtil.isHAEnabled(conf, nsId);
-    state = createHAState(getStartupOption(conf));
+    state = createHAState(conf);
     this.allowStaleStandbyReads = HAUtil.shouldAllowStandbyReads(conf);
     this.haContext = createHAContext();
     try {
@@ -1161,11 +1163,17 @@ public class NameNode extends ReconfigurableBase implements
     }
   }
 
-  protected HAState createHAState(StartupOption startOpt) {
+  protected HAState createHAState(Configuration conf) {
+    StartupOption startOpt = getStartupOption(conf);
     if (!haEnabled || startOpt == StartupOption.UPGRADE
         || startOpt == StartupOption.UPGRADEONLY) {
       return ACTIVE_STATE;
-    } else if (startOpt == StartupOption.OBSERVER) {
+    } else if (conf.getBoolean(DFS_NAMENODE_OBSERVER_ENABLED_KEY,
+          DFS_NAMENODE_OBSERVER_ENABLED_DEFAULT)
+        || startOpt == StartupOption.OBSERVER) {
+      // Set Observer state using config instead of startup option
+      // This allows other startup options to be used when starting observer
+      // e.g. rollingUpgrade
       return OBSERVER_STATE;
     } else {
       return STANDBY_STATE;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -2802,6 +2802,15 @@
 </property>
 
 <property>
+  <name>dfs.namenode.observer.enabled</name>
+  <value>false</value>
+  <description>
+    This causes NameNode on startup to become an observer node if
+    set to true, otherwise startup is no different.
+  </description>
+</property>
+
+<property>
   <name>dfs.namenode.enable.retrycache</name>
   <value>true</value>
   <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/HATestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/HATestUtil.java
@@ -58,6 +58,7 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HA_LOGROLL_PERIOD_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HA_NAMENODES_KEY_PREFIX;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HA_TAILEDITS_INPROGRESS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_OBSERVER_ENABLED_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY;
 import static org.apache.hadoop.hdfs.DFSUtil.createUri;
 
@@ -232,7 +233,7 @@ public abstract class HATestUtil {
     }
 
     MiniQJMHACluster.Builder qjmBuilder = new MiniQJMHACluster.Builder(conf)
-        .setNumNameNodes(2 + numObservers);
+        .setNumNameNodes(2);
     qjmBuilder.getDfsBuilder().numDataNodes(numDataNodes)
         .simulatedCapacities(simulatedCapacities)
         .racks(racks);
@@ -242,8 +243,9 @@ public abstract class HATestUtil {
     dfsCluster.transitionToActive(0);
     dfsCluster.waitActive(0);
 
+    conf.setBoolean(DFS_NAMENODE_OBSERVER_ENABLED_KEY, true);
     for (int i = 0; i < numObservers; i++) {
-      dfsCluster.transitionToObserver(2 + i);
+      dfsCluster.addNameNode(conf, dfsCluster.getNameNodePort());
     }
     return qjmhaCluster;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/HATestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/HATestUtil.java
@@ -58,7 +58,6 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HA_LOGROLL_PERIOD_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HA_NAMENODES_KEY_PREFIX;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HA_TAILEDITS_INPROGRESS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY;
-import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_OBSERVER_ENABLED_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY;
 import static org.apache.hadoop.hdfs.DFSUtil.createUri;
 
@@ -233,7 +232,7 @@ public abstract class HATestUtil {
     }
 
     MiniQJMHACluster.Builder qjmBuilder = new MiniQJMHACluster.Builder(conf)
-        .setNumNameNodes(2);
+        .setNumNameNodes(2 + numObservers);
     qjmBuilder.getDfsBuilder().numDataNodes(numDataNodes)
         .simulatedCapacities(simulatedCapacities)
         .racks(racks);
@@ -243,9 +242,8 @@ public abstract class HATestUtil {
     dfsCluster.transitionToActive(0);
     dfsCluster.waitActive(0);
 
-    conf.setBoolean(DFS_NAMENODE_OBSERVER_ENABLED_KEY, true);
     for (int i = 0; i < numObservers; i++) {
-      dfsCluster.addNameNode(conf, dfsCluster.getNameNodePort());
+      dfsCluster.transitionToObserver(2 + i);
     }
     return qjmhaCluster;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
@@ -236,25 +236,29 @@ public class TestObserverNode {
         .setBoolean(DFS_NAMENODE_OBSERVER_ENABLED_KEY, false);
     dfsCluster.restartNameNode(nnIdx);
 
+    // Verify that the NameNode is not in Observer state
     dfsCluster.waitNameNodeUp(nnIdx);
     assertTrue("The NameNode started as Observer despite "
         + DFS_NAMENODE_OBSERVER_ENABLED_KEY + " being false",
         dfsCluster.getNameNode(nnIdx).isStandbyState());
 
-    Path testPath2 = new Path(testPath, "test2");
-
     dfs.mkdir(testPath, FsPermission.getDefault());
     assertSentTo(0);
 
+    // The first request goes to the active because it has not refreshed yet;
+    // the second would go to the observer if it was not in standby
     dfsCluster.rollEditLogAndTail(0);
+    dfs.getFileStatus(testPath);
     dfs.getFileStatus(testPath);
     assertSentTo(0);
 
-    // Add a new namenode with the observer startup option as true
+    Path testPath2 = new Path(testPath, "test2");
+    // Restart the NameNode with the observer startup option as true
     dfsCluster.getConfiguration(nnIdx)
         .setBoolean(DFS_NAMENODE_OBSERVER_ENABLED_KEY, true);
     dfsCluster.restartNameNode(nnIdx);
 
+    // Check that the NameNode is in Observer state
     dfsCluster.waitNameNodeUp(nnIdx);
     assertTrue("The NameNode did not start as Observer despite "
         + DFS_NAMENODE_OBSERVER_ENABLED_KEY + " being true",
@@ -263,8 +267,11 @@ public class TestObserverNode {
     dfs.mkdir(testPath2, FsPermission.getDefault());
     assertSentTo(0);
 
+    // The first request goes to the active because it has not refreshed yet;
+    // the second will properly go to the observer
     dfsCluster.rollEditLogAndTail(0);
-    dfs.getFileStatus(testPath);
+    dfs.getFileStatus(testPath2);
+    dfs.getFileStatus(testPath2);
     assertSentTo(nnIdx);
   }
 


### PR DESCRIPTION
### Description of PR
NameNode currently uses a "StartupOption" to decide whether to start a node as an Observer NameNode. This causes an issue during a rolling upgrade because "rollingUpgrade" is also a StartupOption and NameNode will only allow 1 startup option, choosing the last startup option in the list. Observer in our environment starts with the following startup options: ["-rollingUpgrade", "started", "-observer"]. This means that the rolling upgrade gets ignored which causes Observer to have an issue when an actual rolling upgrade is ongoing:
```
2023-08-23T14:59:03.486-0700,WARN,[main],org.apache.hadoop.hdfs.server.namenode.FSNamesystem,"Encountered exception loading fsimage
java.io.IOException: 
File system image contains an old layout version -63.
An upgrade to version -66 is required.
Please restart NameNode with the \'-rollingUpgrade started\' option if a rolling upgrade is already started; or restart NameNode with the \'-upgrade\' option to start a new upgrade.
at org.apache.hadoop.hdfs.server.namenode.FSImage.recoverTransitionRead(FSImage.java:271)
at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.loadFSImage(FSNamesystem.java:1116)
at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.loadFromDisk(FSNamesystem.java:724)
at org.apache.hadoop.hdfs.server.namenode.NameNode.loadNamesystem(NameNode.java:681)
at org.apache.hadoop.hdfs.server.namenode.NameNode.initialize(NameNode.java:763)
at org.apache.hadoop.hdfs.server.namenode.NameNode.<init>(NameNode.java:1013)
at org.apache.hadoop.hdfs.server.namenode.NameNode.<init>(NameNode.java:992)
at org.apache.hadoop.hdfs.server.namenode.NameNode.createNameNode(NameNode.java:1743)
at org.apache.hadoop.hdfs.server.namenode.NameNode.main(NameNode.java:1811)
"
```

### How was this patch tested?
This was tested in an environment where the Observer was not able to start with the "-rollingUpgrade started" startup option because it also had the "-observer" startup option. The Observer needs to start with "-rollingUpgrade started" in the environment while a rolling upgrade is happening or it will fail to load the fsimage with a layout version that is not equal to its `NameNodeLayoutVersion.CURRENT_LAYOUT_VERSION`

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

