### PR TITLE
YARN-11558. Fix dependency convergence error on hbase2 profile.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1767,6 +1767,24 @@
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-server</artifactId>
         <version>${hbase.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hbase</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/pom.xml
@@ -127,6 +127,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/YARN-11558

Building with `-Dhbase.profile=2.0` fails due to dependency convergence error.

```
$ mvn clean install -DskipTests -DskipShade -Dhbase.profile=2.0
...
[INFO] --- maven-enforcer-plugin:3.0.0:enforce (depcheck) @ hadoop-yarn-server-timelineservice-hbase-client ---
[WARNING] 
Dependency convergence error for org.osgi:org.osgi.core:jar:6.0.0:provided paths to dependency are:
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-common:jar:3.4.0-SNAPSHOT:provided
    +-org.apache.commons:commons-compress:jar:1.21:provided
      +-org.osgi:org.osgi.core:jar:6.0.0:provided
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hbase:hbase-server:jar:2.2.4:provided
    +-org.apache.hbase:hbase-http:jar:2.2.4:provided
      +-org.glassfish.jersey.core:jersey-server:jar:2.25.1:provided
        +-org.glassfish.jersey.core:jersey-common:jar:2.25.1:provided
          +-org.osgi:org.osgi.core:jar:4.2.0:provided
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hbase:hbase-server:jar:2.2.4:provided
    +-org.apache.hbase:hbase-http:jar:2.2.4:provided
      +-org.glassfish.jersey.core:jersey-server:jar:2.25.1:provided
        +-org.glassfish.jersey.core:jersey-common:jar:2.25.1:provided
          +-org.glassfish.hk2:osgi-resource-locator:jar:1.0.1:provided
            +-org.osgi:org.osgi.core:jar:4.2.0:provided
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hbase:hbase-server:jar:2.2.4:provided
    +-org.apache.hbase:hbase-http:jar:2.2.4:provided
      +-org.glassfish.jersey.core:jersey-server:jar:2.25.1:provided
        +-org.osgi:org.osgi.core:jar:4.2.0:provided

[WARNING] 
Dependency convergence error for javax.ws.rs:javax.ws.rs-api:jar:2.1.1:provided paths to dependency are:
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-yarn-common:jar:3.4.0-SNAPSHOT:provided
    +-com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.12.7:provided
      +-com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.12.7:provided
        +-javax.ws.rs:javax.ws.rs-api:jar:2.1.1:provided
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-yarn-common:jar:3.4.0-SNAPSHOT:provided
    +-com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.12.7:provided
      +-javax.ws.rs:javax.ws.rs-api:jar:2.1.1:provided
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hbase:hbase-server:jar:2.2.4:provided
    +-org.apache.hbase:hbase-http:jar:2.2.4:provided
      +-org.glassfish.jersey.core:jersey-server:jar:2.25.1:provided
        +-org.glassfish.jersey.core:jersey-common:jar:2.25.1:provided
          +-javax.ws.rs:javax.ws.rs-api:jar:2.0.1:provided
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hbase:hbase-server:jar:2.2.4:provided
    +-org.apache.hbase:hbase-http:jar:2.2.4:provided
      +-org.glassfish.jersey.core:jersey-server:jar:2.25.1:provided
        +-org.glassfish.jersey.core:jersey-client:jar:2.25.1:provided
          +-javax.ws.rs:javax.ws.rs-api:jar:2.0.1:provided
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hbase:hbase-server:jar:2.2.4:provided
    +-org.apache.hbase:hbase-http:jar:2.2.4:provided
      +-org.glassfish.jersey.core:jersey-server:jar:2.25.1:provided
        +-javax.ws.rs:javax.ws.rs-api:jar:2.0.1:provided
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hbase:hbase-server:jar:2.2.4:provided
    +-org.apache.hbase:hbase-http:jar:2.2.4:provided
      +-org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.25.1:provided
        +-javax.ws.rs:javax.ws.rs-api:jar:2.0.1:provided
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hbase:hbase-server:jar:2.2.4:provided
    +-org.apache.hbase:hbase-http:jar:2.2.4:provided
      +-javax.ws.rs:javax.ws.rs-api:jar:2.0.1:provided

[WARNING] 
Dependency convergence error for org.javassist:javassist:jar:3.18.1-GA:provided paths to dependency are:
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-common:jar:3.4.0-SNAPSHOT:provided
    +-com.sun.jersey:jersey-servlet:jar:1.19.4:compile
      +-org.jboss.weld:weld-osgi-bundle:jar:1.1.32.Final:provided
        +-org.jboss.weld:weld-core:jar:1.1.32.Final:provided
          +-org.javassist:javassist:jar:3.18.1-GA:provided
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-common:jar:3.4.0-SNAPSHOT:provided
    +-com.sun.jersey:jersey-servlet:jar:1.19.4:compile
      +-org.jboss.weld:weld-osgi-bundle:jar:1.1.32.Final:provided
        +-org.javassist:javassist:jar:3.18.1-GA:provided
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hbase:hbase-server:jar:2.2.4:provided
    +-org.apache.hbase:hbase-http:jar:2.2.4:provided
      +-org.glassfish.jersey.core:jersey-server:jar:2.25.1:provided
        +-org.glassfish.hk2:hk2-locator:jar:2.5.0-b32:provided
          +-org.javassist:javassist:jar:3.20.0-GA:provided

[WARNING] 
Dependency convergence error for javax.servlet:servlet-api:jar:2.5:provided paths to dependency are:
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-yarn-common:jar:3.4.0-SNAPSHOT:provided
    +-com.google.inject.extensions:guice-servlet:jar:4.2.3:compile
      +-javax.servlet:servlet-api:jar:2.5:provided
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-yarn-common:jar:3.4.0-SNAPSHOT:provided
    +-com.sun.jersey.contribs:jersey-guice:jar:1.19.4:compile
      +-javax.servlet:servlet-api:jar:2.5:provided
and
+-org.apache.hadoop:hadoop-yarn-server-timelineservice-hbase-client:jar:3.4.0-SNAPSHOT
  +-org.apache.hbase:hbase-server:jar:2.2.4:provided
    +-org.apache.hbase:hbase-http:jar:2.2.4:provided
      +-org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.25.1:provided
        +-javax.servlet:servlet-api:jar:2.4:provided

[WARNING] Rule 0: org.apache.maven.plugins.enforcer.DependencyConvergence failed with message:
Failed while enforcing releasability. See above detailed error message.
```