### PR TITLE
YARN-11560. Fix NPE bug when multi-node enabled with schedule asynchronously

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
@@ -1737,6 +1737,10 @@ public class CapacityScheduler extends
 
   private void allocateFromReservedContainer(FiCaSchedulerNode node,
       boolean withNodeHeartbeat, RMContainer reservedContainer) {
+    if(reservedContainer == null){
+      LOG.warn("reservedContainer is null,that may be unreserved by the proposal judgment thread");
+      return;
+    }
     FiCaSchedulerApp reservedApplication = getCurrentAttemptForContainer(
         reservedContainer.getContainerId());
     if (reservedApplication == null) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
@@ -1738,7 +1738,7 @@ public class CapacityScheduler extends
   private void allocateFromReservedContainer(FiCaSchedulerNode node,
       boolean withNodeHeartbeat, RMContainer reservedContainer) {
     if(reservedContainer == null){
-      LOG.warn("reservedContainer is null,that may be unreserved by the proposal judgment thread");
+      LOG.warn("reservedContainer is null, that may be unreserved by the proposal judgment thread");
       return;
     }
     FiCaSchedulerApp reservedApplication = getCurrentAttemptForContainer(


### PR DESCRIPTION
NPE exception may happend when commit thread calling  allocateFromReservedContainer with param reservedContainer ,while the container may be un reserved by the judgment thread in tryCommit->apply  function 