### PR TITLE
HDFS-17182. DataSetLockManager.lockLeakCheck() is not thread-safe.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataSetLockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataSetLockManager.java
@@ -256,7 +256,7 @@ public class DataSetLockManager implements DataNodeLockManager<AutoCloseDataSetL
     threadCountMap.putIfAbsent(thread, new TrackLog(thread));
   }
 
-  public void lockLeakCheck() {
+  public synchronized void lockLeakCheck() {
     if (!openLockTrace) {
       LOG.warn("not open lock leak check func");
       return;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
threadCountMap is not thread-safe. Other functions add protected by synchronized expect   lockLeakCheck(). Add synchronized on function lockLeakCheck().





