### PR TITLE
HDFS-17107. Null Pointer Exception after turned on detail metric for namenode lock

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystemLock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystemLock.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.log.LogThrottlingHelper;
 import org.apache.hadoop.metrics2.lib.MutableRatesWithAggregation;
+import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.Timer;
@@ -160,6 +161,10 @@ class FSNamesystemLock {
     FSNamesystem.LOG.info("Detailed lock hold time metrics enabled: " +
         this.metricsEnabled);
     this.detailedHoldTimeMetrics = detailedHoldTimeMetrics;
+    if (metricsEnabled) {
+        Preconditions.checkArgument(detailedHoldTimeMetrics != null, 
+            "Detailed lock hold time metrics enabled, detailed hold time metric should not be null!");
+    }
   }
 
   public void readLock() {


### PR DESCRIPTION
### Description of PR

https://issues.apache.org/jira/browse/HDFS-17107

This PR adds a null check for the `detailedHoldTimeMetrics` if the metric is enabled.

### How was this patch tested?

1. Set `dfs.namenode.lock.detailed-metrics.enabled=true`
2. Run `org.apache.hadoop.hdfs.server.namenode.TestFSNamesystemLock#testFSWriteLockReportSuppressed`
The test throws `IllegalArgumentException` as expected.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

