### PR TITLE
MAPREDUCE-7453. Container logs are missing when yarn.app.container.lo…

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/TaskLog.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/TaskLog.java
@@ -466,7 +466,8 @@ public class TaskLog {
   }
 
   public static long getTaskLogLimitBytes(Configuration conf) {
-    return conf.getLong(JobContext.TASK_USERLOG_LIMIT, 0) * 1024;
+    return conf.getLong(JobContext.TASK_USERLOG_LIMIT, JobContext.DEFAULT_TASK_USERLOG_LIMIT) *
+        1024;
   }
 
   

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRJobConfig.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRJobConfig.java
@@ -410,6 +410,8 @@ public interface MRJobConfig {
 
   public static final String TASK_USERLOG_LIMIT = "mapreduce.task.userlog.limit.kb";
 
+  public static final int DEFAULT_TASK_USERLOG_LIMIT = 10240;
+
   public static final String MAP_SORT_SPILL_PERCENT = "mapreduce.map.sort.spill.percent";
 
   public static final String MAP_INPUT_FILE = "mapreduce.map.input.file";
@@ -758,11 +760,11 @@ public interface MRJobConfig {
 
   public static final String MR_AM_LOG_KB =
       MR_AM_PREFIX + "container.log.limit.kb";
-  public static final int DEFAULT_MR_AM_LOG_KB = 0; // don't roll
+  public static final int DEFAULT_MR_AM_LOG_KB = 10240;
 
   public static final String MR_AM_LOG_BACKUPS =
       MR_AM_PREFIX + "container.log.backups";
-  public static final int DEFAULT_MR_AM_LOG_BACKUPS = 0;
+  public static final int DEFAULT_MR_AM_LOG_BACKUPS = 0; // don't roll
 
   /**The number of splits when reporting progress in MR*/
   public static final String MR_AM_NUM_PROGRESS_SPLITS = 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
@@ -823,16 +823,15 @@
 
 <property>
   <name>mapreduce.task.userlog.limit.kb</name>
-  <value>0</value>
-  <description>The maximum size of user-logs of each task in KB. 0 disables the cap.
+  <value>10240</value>
+  <description>The maximum size of user-logs of each task in KB.
   </description>
 </property>
 
 <property>
   <name>yarn.app.mapreduce.am.container.log.limit.kb</name>
-  <value>0</value>
+  <value>10240</value>
   <description>The maximum size of the MRAppMaster attempt container logs in KB.
-    0 disables the cap.
   </description>
 </property>
 


### PR DESCRIPTION
### Description of PR

JIRA: MAPREDUCE-7453. Container logs are missing when yarn.app.container.log.filesize is set to default value 0.

Since [HADOOP-18649](https://issues.apache.org/jira/browse/HADOOP-18649), in container-log4j.properties, log4j.appender.{APPENDER}.MaxFileSize is set to ${yarn.app.container.log.filesize}, but yarn.app.container.log.filesize is 0 in default. So log is missing. This log is always rolling and only show the latest log. 

This is the running log like below:

```
Log Type: syslog
Log Upload Time: Fri Sep 08 11:36:09 +0800 2023
Log Length: 0

Log Type: syslog.1
Log Upload Time: Fri Sep 08 11:36:09 +0800 2023
Log Length: 179
2023-09-08 11:31:34,494 INFO [AsyncDispatcher event handler] org.apache.hadoop.yarn.util.RackResolver: Got an error when resolve hostNames. Falling back to /default-rack for all. 
```

When we read the log from web, syslog is alway nothing, syslog.1 only show the latest log.

> Note: log4j.appender.{APPENDER}.MaxFileSize is not set before, then use default value 10M, so no problem before [HADOOP-18649](https://issues.apache.org/jira/browse/HADOOP-18649)

### How was this patch tested?

test in cluster.

### For code changes:

just fix default value to avoid missing logs.