### PR TITLE
 HADOOP-18885. Add rpcCallsRejectedByObserver metric to quantify the number of rejected RPCs by Observer NameNode

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -2945,6 +2945,9 @@ public abstract class Server {
             }
           }
         } catch (IOException ioe) {
+          if (ioe instanceof RetriableException) {
+            rpcMetrics.incrRcRejectedByObserverCalls();
+          }
           throw new RpcServerException("Processing RPC request caught ", ioe);
         }
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -2940,7 +2940,7 @@ public abstract class Server {
             try {
               stateId = alignmentContext.receiveRequestState(header, getMaxIdleTime());
             } catch (RetriableException re) {
-              rpcMetrics.incrRcRejectedByObserverCalls();
+              rpcMetrics.incrRpcCallsRejectedByObserver();
               throw re;
             }
             call.setClientStateId(stateId);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -147,6 +147,8 @@ public class RpcMetrics {
   MutableCounterLong rpcRequeueCalls;
   @Metric("Number of successful RPC calls")
   MutableCounterLong rpcCallSuccesses;
+  @Metric("Number of observer namenode rejected RPC calls")
+  MutableCounterLong rpcRejectedByObserverCalls;
 
   @Metric("Number of open connections") public int numOpenConnections() {
     return server.getNumOpenConnections();
@@ -364,6 +366,13 @@ public class RpcMetrics {
   }
 
   /**
+   * Increments the Observer NameNode rejected RPC Calls Counter.
+   */
+  public void incrRcRejectedByObserverCalls() {
+    rpcRejectedByObserverCalls.incr();
+  }
+
+  /**
    * Returns a MutableRate Counter.
    * @return Mutable Rate
    */
@@ -410,6 +419,15 @@ public class RpcMetrics {
   @VisibleForTesting
   public long getRpcRequeueCalls() {
     return rpcRequeueCalls.value();
+  }
+
+  /**
+   * Returns the number of observer namenode rejected RPC calls.
+   * @return long
+   */
+  @VisibleForTesting
+  public long getRpcRejectedByObserverCalls() {
+    return rpcRejectedByObserverCalls.value();
   }
 
   public MutableRate getDeferredRpcProcessingTime() {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -148,7 +148,7 @@ public class RpcMetrics {
   @Metric("Number of successful RPC calls")
   MutableCounterLong rpcCallSuccesses;
   @Metric("Number of observer namenode rejected RPC calls")
-  MutableCounterLong rpcRejectedByObserverCalls;
+  MutableCounterLong rpcCallsRejectedByObserver;
 
   @Metric("Number of open connections") public int numOpenConnections() {
     return server.getNumOpenConnections();
@@ -368,8 +368,8 @@ public class RpcMetrics {
   /**
    * Increments the Observer NameNode rejected RPC Calls Counter.
    */
-  public void incrRcRejectedByObserverCalls() {
-    rpcRejectedByObserverCalls.incr();
+  public void incrRpcCallsRejectedByObserver() {
+    rpcCallsRejectedByObserver.incr();
   }
 
   /**
@@ -426,8 +426,8 @@ public class RpcMetrics {
    * @return long
    */
   @VisibleForTesting
-  public long getRpcRejectedByObserverCalls() {
-    return rpcRejectedByObserverCalls.value();
+  public long getRpcCallsRejectedByObserver() {
+    return rpcCallsRejectedByObserver.value();
   }
 
   public MutableRate getDeferredRpcProcessingTime() {

--- a/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
@@ -90,7 +90,7 @@ The default timeunit used for RPC metrics is milliseconds (as per the below desc
 | `RpcSlowCalls` | Total number of slow RPC calls |
 | `RpcRequeueCalls` | Total number of requeue RPC calls |
 | `RpcCallsSuccesses` | Total number of RPC calls that are successfully processed |
-| `RpcRejectedByObserverCalls` | Total number of RPC calls that are observer namenode rejected |
+| `RpcCallsRejectedByObserver` | Total number of RPC calls that are observer namenode rejected |
 | `NumOpenConnections` | Current number of open connections |
 | `NumInProcessHandler` | Current number of handlers on working |
 | `CallQueueLength` | Current length of the call queue |

--- a/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
@@ -90,6 +90,7 @@ The default timeunit used for RPC metrics is milliseconds (as per the below desc
 | `RpcSlowCalls` | Total number of slow RPC calls |
 | `RpcRequeueCalls` | Total number of requeue RPC calls |
 | `RpcCallsSuccesses` | Total number of RPC calls that are successfully processed |
+| `RpcRejectedByObserverCalls` | Total number of RPC calls that are observer namenode rejected |
 | `NumOpenConnections` | Current number of open connections |
 | `NumInProcessHandler` | Current number of handlers on working |
 | `CallQueueLength` | Current length of the call queue |

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestMultiObserverNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestMultiObserverNode.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_STATE_CONTEXT_ENABLED_KEY;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -28,6 +29,9 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.qjournal.MiniQJMHACluster;
+import org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer;
+import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.ipc.metrics.RpcMetrics;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -145,13 +149,29 @@ public class TestMultiObserverNode {
   public void testObserverFallBehind() throws Exception {
     dfs.mkdir(testPath, FsPermission.getDefault());
     assertSentTo(0);
+    RPC.Server clientRpcServer2 = ((NameNodeRpcServer)dfsCluster
+        .getNameNodeRpc(2)).getClientRpcServer();
+    RpcMetrics rpcMetrics2 = clientRpcServer2.getRpcMetrics();
+    assertEquals(0, rpcMetrics2.getRpcRejectedByObserverCalls());
+    RPC.Server clientRpcServer3 = ((NameNodeRpcServer)dfsCluster
+        .getNameNodeRpc(3)).getClientRpcServer();
+    RpcMetrics rpcMetrics3 = clientRpcServer3.getRpcMetrics();
+    assertEquals(0, rpcMetrics3.getRpcRejectedByObserverCalls());
 
-    // Set large state Id on the client
+    dfsCluster.rollEditLogAndTail(0);
+    dfs.getFileStatus(testPath);
+    assertSentTo(2, 3);
+
+    // Set large state Id on the client.
     long realStateId = HATestUtil.setACStateId(dfs, 500000);
     dfs.getFileStatus(testPath);
-    // Should end up on ANN
+    // Should end up on ANN.
     assertSentTo(0);
     HATestUtil.setACStateId(dfs, realStateId);
+
+    // Validate rpcRejectedByObserverCalls metric.
+    assertEquals(1, rpcMetrics2.getRpcRejectedByObserverCalls());
+    assertEquals(1, rpcMetrics3.getRpcRejectedByObserverCalls());
   }
 
   private void assertSentTo(int... nnIndices) throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestMultiObserverNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestMultiObserverNode.java
@@ -152,11 +152,11 @@ public class TestMultiObserverNode {
     RPC.Server clientRpcServer2 = ((NameNodeRpcServer)dfsCluster
         .getNameNodeRpc(2)).getClientRpcServer();
     RpcMetrics rpcMetrics2 = clientRpcServer2.getRpcMetrics();
-    assertEquals(0, rpcMetrics2.getRpcRejectedByObserverCalls());
+    assertEquals(0, rpcMetrics2.getRpcCallsRejectedByObserver());
     RPC.Server clientRpcServer3 = ((NameNodeRpcServer)dfsCluster
         .getNameNodeRpc(3)).getClientRpcServer();
     RpcMetrics rpcMetrics3 = clientRpcServer3.getRpcMetrics();
-    assertEquals(0, rpcMetrics3.getRpcRejectedByObserverCalls());
+    assertEquals(0, rpcMetrics3.getRpcCallsRejectedByObserver());
 
     dfsCluster.rollEditLogAndTail(0);
     dfs.getFileStatus(testPath);
@@ -169,9 +169,9 @@ public class TestMultiObserverNode {
     assertSentTo(0);
     HATestUtil.setACStateId(dfs, realStateId);
 
-    // Validate rpcRejectedByObserverCalls metric.
-    assertEquals(1, rpcMetrics2.getRpcRejectedByObserverCalls());
-    assertEquals(1, rpcMetrics3.getRpcRejectedByObserverCalls());
+    // Validate rpcCallsRejectedByObserver metric.
+    assertEquals(1, rpcMetrics2.getRpcCallsRejectedByObserver());
+    assertEquals(1, rpcMetrics3.getRpcCallsRejectedByObserver());
   }
 
   private void assertSentTo(int... nnIndices) throws IOException {


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HADOOP-18885

When observer Node's serverStateId is too far behind clientStateId will rejected client RPC request,
mabe we need add rpcRejectedByObserverCalls metric to RpcMetrics to quantify the number of rejected RPCs by Observer NameNode to help determine how well the server.

