### PR TITLE
HDFS-17184. Improve BlockReceiver to throws DiskOutOfSpaceException when initialize.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.util.Daemon;
 import org.apache.hadoop.util.DataChecksum;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Time;
+import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 import org.apache.hadoop.tracing.Span;
 import org.apache.hadoop.tracing.Tracer;
 
@@ -274,10 +275,9 @@ class BlockReceiver implements Closeable {
       if (isCreate) {
         BlockMetadataHeader.writeHeader(checksumOut, diskChecksum);
       } 
-    } catch (ReplicaAlreadyExistsException bae) {
-      throw bae;
-    } catch (ReplicaNotFoundException bne) {
-      throw bne;
+    } catch (ReplicaAlreadyExistsException | ReplicaNotFoundException
+        | DiskOutOfSpaceException e) {
+      throw e;
     } catch(IOException ioe) {
       if (replicaInfo != null) {
         replicaInfo.releaseAllBytesReserved();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/RoundRobinVolumeChoosingPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/RoundRobinVolumeChoosingPolicy.java
@@ -117,14 +117,13 @@ public class RoundRobinVolumeChoosingPolicy<V extends FsVolumeSpi>
         maxAvailable = availableVolumeSize;
       }
 
+      LOG.warn("The volume[{}] with the available space (={} B) is "
+              + "less than the block size (={} B).", volume.getBaseURI(),
+          availableVolumeSize, blockSize);
       if (curVolume == startVolume) {
         throw new DiskOutOfSpaceException("Out of space: "
             + "The volume with the most available space (=" + maxAvailable
             + " B) is less than the block size (=" + blockSize + " B).");
-      } else {
-        LOG.warn("The volume[{}] with the available space (={} B) is "
-            + "less than the block size (={} B).", volume.getBaseURI(),
-            availableVolumeSize, blockSize);
       }
     }
   }


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17184

BlockReceiver class will receives a block and writes to its disk,
in the constructor method, createTemporary and createRbw will execute chooseVolume, and DiskOutOfSpaceException may occur in chooseVolume.
current in the processing logic, if the exception occurs will be cacth by BlockReceiver.java line_282 catch(IOException ioe) here, and cleanupBlock() will be executed here.

since the replica of the current block has not been added to ReplicaMap, executing cleanupBlock will throw ReplicaNotFoundException.
the ReplicaNotFoundException exception will overwrite the actual DiskOutOfSpaceException, resulting in inaccurate exception information.

```
BlockReceiver(final ExtendedBlock block, final StorageType storageType,
      final DataInputStream in,
      final String inAddr, final String myAddr,
      final BlockConstructionStage stage, 
      final long newGs, final long minBytesRcvd, final long maxBytesRcvd, 
      final String clientname, final DatanodeInfo srcDataNode,
      final DataNode datanode, DataChecksum requestedChecksum,
      CachingStrategy cachingStrategy,
      final boolean allowLazyPersist,
      final boolean pinning,
      final String storageId) throws IOException {
    try{
      ...
     } catch (ReplicaAlreadyExistsException bae) {
       throw bae;
     } catch (ReplicaNotFoundException bne) {
       throw bne;
     } catch(IOException ioe) {
      if (replicaInfo != null) {
        replicaInfo.releaseAllBytesReserved();
      }
      IOUtils.closeStream(this); 
      cleanupBlock();// if ReplicaMap does not exist  replica  will throw ReplicaNotFoundException
      ...
      throw ioe;
    }
  }```

