### PR TITLE
HDFS-17109. Null Pointer Exception when running TestBlockManager

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
@@ -1058,8 +1058,10 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy {
     int numXceiver = 0;
     for (StorageType s : storageTypes) {
       StorageTypeStats storageTypeStats = storageStats.get(s);
-      numNodes += storageTypeStats.getNodesInService();
-      numXceiver += storageTypeStats.getNodesInServiceXceiverCount();
+      if (storageTypeStats != null) {
+          numNodes += storageTypeStats.getNodesInService();
+          numXceiver += storageTypeStats.getNodesInServiceXceiverCount();
+      }
     }
     if (numNodes != 0) {
       avgLoad = (double) numXceiver / numNodes;


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17109
This PR adds a check for nullity of `storageTypeStats`. Only updates the InServiceXceiverAverage if the `storageTypeStats` is not `null`.  

### How was this patch tested?
(1) Set `dfs.namenode.redundancy.considerLoadByStorageType=true`
(2) Run `org.apache.hadoop.hdfs.server.blockmanagement.TestBlockManager#testOneOfTwoRacksDecommissioned`
The test passes after the patch.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?