### PR TITLE
MAPREDUCE-7447. Unnecessary NPE encountered when starting CryptoOutputStream with encrypted-intermediate-data

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/CryptoOutputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/CryptoOutputStream.java
@@ -100,6 +100,7 @@ public class CryptoOutputStream extends FilterOutputStream implements
       throws IOException {
     super(out);
     CryptoStreamUtils.checkCodec(codec);
+    Preconditions.checkArgument(key != null, "key for CryptoOutputStream cannot be null");
     this.bufferSize = CryptoStreamUtils.checkBufferSize(codec, bufferSize);
     this.codec = codec;
     this.key = key.clone();


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/MAPREDUCE-7447
This PR adds a null check for the key given when initializing a `CryptoOutputStream`.

### How was this patch tested?
(1) set `mapreduce.job.encrypted-intermediate-data` to `true`
(2) run `org.apache.hadoop.mapreduce.task.reduce.TestMergeManager#testLargeMemoryLimits`
The test throws an `IllegalArgumentException` stating that the key given cannot be `null`.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?