### PR TITLE
YARN-11541. AsyncDispatcher causes ArithmeticException due to improper detailsInterval value checking

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.service.AbstractService;
+import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.util.ShutdownHookManager;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
@@ -185,6 +186,8 @@ public class AsyncDispatcher extends AbstractService implements Dispatcher {
                     YARN_DISPATCHER_PRINT_EVENTS_INFO_THRESHOLD,
             YarnConfiguration.
                     DEFAULT_YARN_DISPATCHER_PRINT_EVENTS_INFO_THRESHOLD);
+    Preconditions.checkArgument(this.detailsInterval > 0, "%s should be a positive integer",
+            YarnConfiguration.YARN_DISPATCHER_PRINT_EVENTS_INFO_THRESHOLD);
 
     ThreadFactory threadFactory = new ThreadFactoryBuilder()
         .setNameFormat("PrintEventDetailsThread #%d")


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/YARN-11541
This PR adds a positivity check for the parameter `yarn.dispatcher.print-events-info.threshold`.

### How was this patch tested?
(1) set yarn.dispatcher.print-events-info.threshold=0
(2) run org.apache.hadoop.yarn.event.TestAsyncDispatcher#testDispatcherMetricsHistogram
The test throws an IllegalArgumentException stating that the configuration value should be positive.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?