### PR TITLE
HADOOP-18824. ZKDelegationTokenSecretManager causes ArithmeticException due to improper numRetries value checking

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/ZKDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/ZKDelegationTokenSecretManager.java
@@ -222,7 +222,7 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
                         ZK_DTSM_ZK_CONNECTION_TIMEOUT_DEFAULT)
                 )
                 .retryPolicy(
-                    new RetryNTimes(numRetries, sessionT / numRetries));
+                    new RetryNTimes(numRetries, numRetries == 0 ? 0 : sessionT / numRetries));
       } catch (Exception ex) {
         throw new RuntimeException("Could not Load ZK acls or auth: " + ex, ex);
       }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
@@ -106,10 +106,22 @@ public class TestZKDelegationTokenSecretManager {
   @SuppressWarnings("unchecked")
   @Test
   public void testMultiNodeOperations() throws Exception {
+      testMultiNodeOperationsImpl(false);
+  }
+
+  @Test
+  public void testMultiNodeOperationsWithZeroRetry() throws Exception {
+      testMultiNodeOperationsImpl(true);
+  }
+
+  public void testMultiNodeOperationsImpl(boolean setZeroRetry) throws Exception {
     for (int i = 0; i < TEST_RETRIES; i++) {
       DelegationTokenManager tm1, tm2 = null;
       String connectString = zkServer.getConnectString();
       Configuration conf = getSecretConf(connectString);
+      if (setZeroRetry) {
+          conf.setInt(ZKDelegationTokenSecretManager.ZK_DTSM_ZK_NUM_RETRIES, 0);
+      }
       tm1 = new DelegationTokenManager(conf, new Text("bla"));
       tm1.init();
       tm2 = new DelegationTokenManager(conf, new Text("bla"));


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HADOOP-18824
This PR hardcoded the sleeping time between retry to 0 when the retry time is 0 to avoid division by zero.

### How was this patch tested?
1. set `zk-dt-secret-manager.zkNumRetries=0`
2. run `org.apache.hadoop.security.token.delegation.TestZKDelegationTokenSecretManager.testMultiNodeOperations`
The test passes rather than throwing division by zero.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

