### PR TITLE
YARN-11547. [Federation] Router Supports Remove individual application records from FederationStateStore.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
@@ -1118,19 +1118,4 @@ public final class FederationStateStoreFacade {
   public FederationCache getFederationCache() {
     return federationCache;
   }
-
-  /**
-   * Delete the mapping of home {@code SubClusterId} of a previously submitted
-   * {@code ApplicationId}. Currently response is empty if the operation was
-   * successful, if not an exception reporting reason for a failure.
-   *
-   * @param appId ApplicationId.
-   * @throws YarnException exceptions from yarn servers.
-   */
-  public void deleteApplicationHomeSubCluster(ApplicationId appId)
-      throws YarnException {
-    DeleteApplicationHomeSubClusterRequest request =
-        DeleteApplicationHomeSubClusterRequest.newInstance(appId);
-    stateStore.deleteApplicationHomeSubCluster(request);
-  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
@@ -83,6 +83,7 @@ import org.apache.hadoop.yarn.server.federation.store.records.RouterRMTokenRespo
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterDeregisterRequest;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterDeregisterResponse;
+import org.apache.hadoop.yarn.server.federation.store.records.DeleteApplicationHomeSubClusterRequest;
 import org.apache.hadoop.yarn.security.client.RMDelegationTokenIdentifier;
 import org.apache.hadoop.yarn.webapp.NotFoundException;
 import org.slf4j.Logger;
@@ -1087,5 +1088,22 @@ public final class FederationStateStoreFacade {
   @VisibleForTesting
   public FederationCache getFederationCache() {
     return federationCache;
+  }
+
+  /**
+   * Delete the mapping of home {@code SubClusterId} of a previously submitted
+   * {@code ApplicationId}. Currently response is empty if the operation was
+   * successful, if not an exception reporting reason for a failure.
+   *
+   * @param appId ApplicationId.
+   */
+  public void deleteApplicationHomeSubCluster(ApplicationId appId) {
+    try {
+      DeleteApplicationHomeSubClusterRequest request =
+          DeleteApplicationHomeSubClusterRequest.newInstance(appId);
+      stateStore.deleteApplicationHomeSubCluster(request);
+    } catch (Exception e) {
+      LOG.error("deleteApplicationHomeSubCluster error, applicationId = {}.", appId, e);
+    }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
@@ -1096,14 +1096,12 @@ public final class FederationStateStoreFacade {
    * successful, if not an exception reporting reason for a failure.
    *
    * @param appId ApplicationId.
+   * @throws YarnException exceptions from yarn servers.
    */
-  public void deleteApplicationHomeSubCluster(ApplicationId appId) {
-    try {
-      DeleteApplicationHomeSubClusterRequest request =
-          DeleteApplicationHomeSubClusterRequest.newInstance(appId);
-      stateStore.deleteApplicationHomeSubCluster(request);
-    } catch (Exception e) {
-      LOG.error("deleteApplicationHomeSubCluster error, applicationId = {}.", appId, e);
-    }
+  public void deleteApplicationHomeSubCluster(ApplicationId appId)
+      throws YarnException {
+    DeleteApplicationHomeSubClusterRequest request =
+        DeleteApplicationHomeSubClusterRequest.newInstance(appId);
+    stateStore.deleteApplicationHomeSubCluster(request);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
@@ -389,6 +389,7 @@ public class Router extends CompositeService {
   }
 
   private static void executeRouterCommand(Configuration conf, String[] args) {
+    // Step1. Define Options.
     Options opts = new Options();
     Option formatStateStoreOpt = new Option("format-state-store",  false,
         " Formats the FederationStateStore. " +
@@ -401,11 +402,11 @@ public class Router extends CompositeService {
     opts.addOption(formatStateStoreOpt);
     opts.addOption(removeApplicationFromStateStoreOpt);
 
-    String cmd = args[0];
-
-    CommandLine cliParser = null;
+    // Step2. Parse Options.
     try {
-      cliParser = new DefaultParser().parse(opts, args);
+      String cmd = args[0];
+
+      CommandLine cliParser = new DefaultParser().parse(opts, args);
 
       if (CMD_FORMAT_STATE_STORE.equals(cmd)) {
         handFormatStateStore();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterStoreCommands.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterStoreCommands.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.yarn.server.router;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.LambdaTestUtils;
+import org.apache.hadoop.util.Time;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.server.federation.store.impl.MemoryFederationStateStore;
+import org.apache.hadoop.yarn.server.federation.store.records.AddApplicationHomeSubClusterRequest;
+import org.apache.hadoop.yarn.server.federation.store.records.GetApplicationHomeSubClusterRequest;
+import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
+import org.apache.hadoop.yarn.server.federation.store.records.ApplicationHomeSubCluster;
+import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestRouterStoreCommands {
+
+  ////////////////////////////////
+  // Router Constants
+  ////////////////////////////////
+  private Configuration conf;
+  private MemoryFederationStateStore stateStore;
+  private FederationStateStoreFacade facade;
+
+  @Before
+  public void setup() throws YarnException {
+    conf = new YarnConfiguration();
+    stateStore = new MemoryFederationStateStore();
+    stateStore.init(conf);
+    facade = FederationStateStoreFacade.getInstance(conf);
+    facade.reinitialize(stateStore, conf);
+  }
+
+  @Test
+  public void testRemoveApplicationFromRouterStateStore() throws Exception {
+
+    // We will design such a unit test.
+    // We will write the applicationId and subCluster into the stateStore,
+    // and then remove the application through Router.removeApplication.
+    // At this time, if we continue to query through the stateStore,
+    // We will get a prompt that application not exists.
+
+    ApplicationId appId = ApplicationId.newInstance(Time.now(), 1);
+    SubClusterId homeSubCluster = SubClusterId.newInstance("SC-1");
+    ApplicationHomeSubCluster applicationHomeSubCluster =
+        ApplicationHomeSubCluster.newInstance(appId, homeSubCluster);
+    AddApplicationHomeSubClusterRequest request =
+        AddApplicationHomeSubClusterRequest.newInstance(applicationHomeSubCluster);
+    stateStore.addApplicationHomeSubCluster(request);
+    Router.removeApplication(conf, appId.toString());
+
+    GetApplicationHomeSubClusterRequest request1 =
+        GetApplicationHomeSubClusterRequest.newInstance(appId);
+
+    LambdaTestUtils.intercept(YarnException.class, "Application " + appId + " does not exist.",
+        () -> stateStore.getApplicationHomeSubCluster(request1));
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11547. [Federation] Router Supports Remove individual application records from FederationStateStore.

### How was this patch tested?

Add Junit Test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

