### PR TITLE
HADOOP-18892 fix Catalog Webapp module compile errors due to low nodejs version

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -213,7 +213,7 @@
     <openssl-wildfly.version>1.1.3.Final</openssl-wildfly.version>
     <woodstox.version>5.4.0</woodstox.version>
     <nimbus-jose-jwt.version>9.8.1</nimbus-jose-jwt.version>
-    <nodejs.version>v12.22.1</nodejs.version>
+    <nodejs.version>v18.17.1</nodejs.version>
     <yarnpkg.version>v1.22.5</yarnpkg.version>
     <apache-ant.version>1.10.13</apache-ant.version>
     <jmh.version>1.20</jmh.version>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
update nodejs to latest stable version to resolve compile failure

### How was this patch tested?
compile in local

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

