### PR TITLE
HADOOP-18893. Make Trash Policy pluggable for different FileSystems

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/EmptyTrashPolicy.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/EmptyTrashPolicy.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * A No-Op Trash Policy for Filesystems which prefers to have no trash
+ * enabled for them.
+ */
+public class EmptyTrashPolicy extends TrashPolicy {
+  @Override
+  public void initialize(Configuration conf, FileSystem fs, Path home) {
+
+  }
+
+  public void initialize(Configuration conf, FileSystem fs) {
+
+  }
+
+  @Override public boolean isEnabled() {
+    return false;
+  }
+
+  @Override public boolean moveToTrash(Path path) throws IOException {
+    return false;
+  }
+
+  @Override public void createCheckpoint() throws IOException {
+
+  }
+
+  @Override public void deleteCheckpoint() throws IOException {
+
+  }
+
+  @Override public void deleteCheckpointsImmediately() throws IOException {
+
+  }
+
+  @Override public Path getCurrentTrashDir() {
+    return null;
+  }
+
+  @Override public Runnable getEmptier() throws IOException {
+    return null;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -84,6 +84,8 @@ import org.apache.hadoop.tracing.Tracer;
 import org.apache.hadoop.tracing.TraceScope;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.util.functional.ConsumerRaisingIOE;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,6 +93,8 @@ import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_BU
 import static org.apache.hadoop.util.Preconditions.checkArgument;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.*;
 import static org.apache.hadoop.fs.impl.PathCapabilitiesSupport.validatePathCapabilityArgs;
+import static org.apache.hadoop.util.functional.RemoteIterators.foreach;
+import static org.apache.hadoop.util.functional.RemoteIterators.mappingRemoteIterator;
 
 /****************************************************************
  * An abstract base class for a fairly generic filesystem.  It
@@ -3450,23 +3454,29 @@ public abstract class FileSystem extends Configured
   public Collection<FileStatus> getTrashRoots(boolean allUsers) {
     Path userHome = new Path(getHomeDirectory().toUri().getPath());
     List<FileStatus> ret = new ArrayList<>();
+    // an operation to look up a path status and add it to the return list
+    ConsumerRaisingIOE<Path> addIfFound = (userTrash) -> {
+      try {
+        FileStatus status = getFileStatus(userTrash);
+        ret.add(status);
+      } catch (FileNotFoundException noTrashFound) {
+        // user doesn't have a trash directory
+      }
+    };
     try {
       if (!allUsers) {
-        Path userTrash = new Path(userHome, TRASH_PREFIX);
-        if (exists(userTrash)) {
-          ret.add(getFileStatus(userTrash));
-        }
+        // Single user: return the value off the home dir.
+        addIfFound.accept(new Path(userHome, TRASH_PREFIX));
       } else {
-        Path homeParent = userHome.getParent();
-        if (exists(homeParent)) {
-          FileStatus[] candidates = listStatus(homeParent);
-          for (FileStatus candidate : candidates) {
-            Path userTrash = new Path(candidate.getPath(), TRASH_PREFIX);
-            if (exists(userTrash)) {
-              candidate.setPath(userTrash);
-              ret.add(candidate);
-            }
-          }
+        // use the iterator for scale/performance improvements against
+        // HDFS and object stores
+        try {
+          foreach(mappingRemoteIterator(
+              listStatusIterator(userHome.getParent()), (candidate) ->
+                      new Path(candidate.getPath(), TRASH_PREFIX)),
+              addIfFound);
+        } catch (FileNotFoundException noUserHomeParent) {
+          // no /user
         }
       }
     } catch (IOException e) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Trash.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Trash.java
@@ -21,9 +21,9 @@ import java.io.IOException;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
-import org.apache.hadoop.fs.viewfs.ViewFileSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static org.apache.hadoop.fs.viewfs.Constants.*;
@@ -180,7 +180,8 @@ public class Trash extends Configured {
    *
    * @return TrashPolicy.
    */
-  TrashPolicy getTrashPolicy() {
+  @VisibleForTesting
+  public TrashPolicy getTrashPolicy() {
     return trashPolicy;
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/TrashPolicyDefault.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/TrashPolicyDefault.java
@@ -68,7 +68,7 @@ public class TrashPolicyDefault extends TrashPolicy {
   /** Format of checkpoint directories used prior to Hadoop 0.23. */
   private static final DateFormat OLD_CHECKPOINT =
       new SimpleDateFormat("yyMMddHHmm");
-  private static final int MSECS_PER_MINUTE = 60*1000;
+  private static final int MSECS_PER_MINUTE = 60_000;
 
   private long emptierInterval;
 
@@ -159,7 +159,7 @@ public class TrashPolicyDefault extends TrashPolicy {
     for (int i = 0; i < 2; i++) {
       try {
         if (!fs.mkdirs(baseTrashPath, PERMISSION)) {      // create current
-          LOG.warn("Can't create(mkdir) trash directory: " + baseTrashPath);
+          LOG.warn("Can't create(mkdir) trash directory: {}", baseTrashPath);
           return false;
         }
       } catch (FileAlreadyExistsException e) {
@@ -177,7 +177,7 @@ public class TrashPolicyDefault extends TrashPolicy {
         --i;
         continue;
       } catch (IOException e) {
-        LOG.warn("Can't create trash directory: " + baseTrashPath, e);
+        LOG.warn("Can't create trash directory: {}", baseTrashPath, e);
         cause = e;
         break;
       }
@@ -193,7 +193,7 @@ public class TrashPolicyDefault extends TrashPolicy {
         // move to current trash
         fs.rename(path, trashPath,
             Rename.TO_TRASH);
-        LOG.info("Moved: '" + path + "' to trash at: " + trashPath);
+        LOG.info("Moved: '{}' to trash at: {}", path, trashPath);
         return true;
       } catch (IOException e) {
         cause = e;
@@ -232,7 +232,7 @@ public class TrashPolicyDefault extends TrashPolicy {
   private void deleteCheckpoint(boolean deleteImmediately) throws IOException {
     Collection<FileStatus> trashRoots = fs.getTrashRoots(false);
     for (FileStatus trashRoot : trashRoots) {
-      LOG.info("TrashPolicyDefault#deleteCheckpoint for trashRoot: " +
+      LOG.info("TrashPolicyDefault#deleteCheckpoint for trashRoot: {}",
           trashRoot.getPath());
       deleteCheckpoint(trashRoot.getPath(), deleteImmediately);
     }
@@ -253,6 +253,12 @@ public class TrashPolicyDefault extends TrashPolicy {
     return new Emptier(getConf(), emptierInterval);
   }
 
+  /**
+   * The emptier of this trash.
+   * This thread is expected to be run on HDFS namenodes.. After being interrupted, it
+   * will close the filesystem the trash policy was bonded to; see HADOOP-2337.
+   * If used elsewhere, it *must* be given its own instance of the target filesystem.
+   */
   protected class Emptier implements Runnable {
 
     private Configuration conf;
@@ -262,17 +268,16 @@ public class TrashPolicyDefault extends TrashPolicy {
       this.conf = conf;
       this.emptierInterval = emptierInterval;
       if (emptierInterval > deletionInterval || emptierInterval <= 0) {
-        LOG.info("The configured checkpoint interval is " +
-                 (emptierInterval / MSECS_PER_MINUTE) + " minutes." +
-                 " Using an interval of " +
-                 (deletionInterval / MSECS_PER_MINUTE) +
-                 " minutes that is used for deletion instead");
+        LOG.info("The configured checkpoint interval is {} minutes."
+                + " Using an interval of {} minutes that is used for deletion instead",
+            emptierInterval / MSECS_PER_MINUTE,
+            deletionInterval / MSECS_PER_MINUTE);
         this.emptierInterval = deletionInterval;
       }
-      LOG.info("Namenode trash configuration: Deletion interval = "
-          + (deletionInterval / MSECS_PER_MINUTE)
-          + " minutes, Emptier interval = "
-          + (this.emptierInterval / MSECS_PER_MINUTE) + " minutes.");
+      LOG.info("Namenode trash configuration: Deletion interval = {} minutes."
+              + " Emptier interval = {} minutes.",
+          deletionInterval / MSECS_PER_MINUTE,
+          emptierInterval / MSECS_PER_MINUTE);
     }
 
     @Override
@@ -296,16 +301,18 @@ public class TrashPolicyDefault extends TrashPolicy {
             trashRoots = fs.getTrashRoots(true);      // list all trash dirs
 
             for (FileStatus trashRoot : trashRoots) {   // dump each trash
-              if (!trashRoot.isDirectory())
+              if (!trashRoot.isDirectory()) {
+                LOG.debug("Trash root {} is not a directory: {}",
+                    trashRoot.getPath(), trashRoot);
                 continue;
+              }
               try {
                 TrashPolicyDefault trash = new TrashPolicyDefault(fs, conf);
                 trash.deleteCheckpoint(trashRoot.getPath(), false);
                 trash.createCheckpoint(trashRoot.getPath(), new Date(now));
               } catch (IOException e) {
-                LOG.warn("Trash caught: "+e+". Skipping " +
-                    trashRoot.getPath() + ".");
-              } 
+                LOG.warn("Trash caught:{} Skipping {}", e, trashRoot.getPath());
+              }
             }
           }
         } catch (Exception e) {
@@ -332,7 +339,7 @@ public class TrashPolicyDefault extends TrashPolicy {
     }
   }
 
-  private void createCheckpoint(Path trashRoot, Date date) throws IOException {
+  protected void createCheckpoint(Path trashRoot, Date date) throws IOException {
     if (!fs.exists(new Path(trashRoot, CURRENT))) {
       return;
     }
@@ -347,31 +354,42 @@ public class TrashPolicyDefault extends TrashPolicy {
     while (true) {
       try {
         fs.rename(current, checkpoint, Rename.NONE);
-        LOG.info("Created trash checkpoint: " + checkpoint.toUri().getPath());
+        LOG.info("Created trash checkpoint: {}", checkpoint.toUri().getPath());
         break;
       } catch (FileAlreadyExistsException e) {
         if (++attempt > 1000) {
-          throw new IOException("Failed to checkpoint trash: " + checkpoint);
+          throw new IOException("Failed to checkpoint trash: " + checkpoint, e);
         }
         checkpoint = checkpointBase.suffix("-" + attempt);
       }
     }
   }
 
-  private void deleteCheckpoint(Path trashRoot, boolean deleteImmediately)
+  /**
+   * Delete trash directories under a checkpoint older than the interval,
+   * or, if {@code deleteImmediately} is true, all entries.
+   * It is not an error if invoked on a trash root which doesn't exist.
+   * @param trashRoot trash root.
+   * @param deleteImmediately should all entries be deleted
+   * @return the number of entries deleted.
+   * @throws IOException failure in listing or delete() calls
+   */
+  protected int deleteCheckpoint(Path trashRoot, boolean deleteImmediately)
       throws IOException {
-    LOG.info("TrashPolicyDefault#deleteCheckpoint for trashRoot: " + trashRoot);
+    LOG.info("TrashPolicyDefault#deleteCheckpoint for trashRoot: {}", trashRoot);
 
-    FileStatus[] dirs = null;
+    RemoteIterator<FileStatus> dirs;
     try {
-      dirs = fs.listStatus(trashRoot); // scan trash sub-directories
+      dirs = fs.listStatusIterator(trashRoot); // scan trash sub-directories
     } catch (FileNotFoundException fnfe) {
-      return;
+      return 0;
     }
 
     long now = Time.now();
-    for (int i = 0; i < dirs.length; i++) {
-      Path path = dirs[i].getPath();
+    int counter = 0;
+    while (dirs.hasNext()) {
+      counter++;
+      Path path = dirs.next().getPath();
       String dir = path.toUri().getPath();
       String name = path.getName();
       if (name.equals(CURRENT.getName())) {         // skip current
@@ -393,16 +411,34 @@ public class TrashPolicyDefault extends TrashPolicy {
       }
 
       if (((now - deletionInterval) > time) || deleteImmediately) {
-        if (fs.delete(path, true)) {
-          LOG.info("Deleted trash checkpoint: "+dir);
-        } else {
-          LOG.warn("Couldn't delete checkpoint: " + dir + " Ignoring.");
-        }
+        deleteCheckpoint(path);
       }
+    }
+    return counter;
+  }
+
+  /**
+   * Delete a checkpoint
+   * @param path path to delete
+   * @throws IOException IO exception raised in delete call.
+   */
+  protected void deleteCheckpoint(final Path path) throws IOException {
+    String dir = path.toUri().getPath();
+    if (getFileSystem().delete(path, true)) {
+      LOG.info("Deleted trash checkpoint: {}", path);
+    } else {
+      LOG.warn("Couldn't delete checkpoint: {}. Ignoring.", path);
     }
   }
 
-  private long getTimeFromCheckpoint(String name) throws ParseException {
+  /**
+   * parse the name of a checkpoint to extgact its timestamp.
+   * Uses the Hadoop 0.23 checkpoint as well as the older version (!).
+   * @param name filename
+   * @return the timestamp
+   * @throws ParseException the filename is not a timestamp.
+   */
+  protected long getTimeFromCheckpoint(String name) throws ParseException {
     long time;
 
     try {

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2180,6 +2180,17 @@ The switch to turn S3A auditing on or off.
   </description>
 </property>
 
+<!--
+Set the Trash policy for S3A to be Empty.
+-->
+<property>
+  <name>fs.s3a.trash.classname</name>
+  <value>org.apache.hadoop.fs.EmptyTrashPolicy</value>
+  <description>
+    Set the Trash policy for S3A to be Empty. No-op on Trash.
+  </description>
+</property>
+
   <!-- Azure file system properties -->
 <property>
   <name>fs.AbstractFileSystem.wasb.impl</name>
@@ -2225,6 +2236,25 @@ The switch to turn S3A auditing on or off.
   <name>fs.abfss.impl</name>
   <value>org.apache.hadoop.fs.azurebfs.SecureAzureBlobFileSystem</value>
   <description>The implementation class of the Secure Azure Blob Filesystem</description>
+</property>
+
+<!--
+Set the Trash policy for ABFS to be Empty.
+-->
+<property>
+  <name>fs.abfs.trash.classname</name>
+  <value>org.apache.hadoop.fs.EmptyTrashPolicy</value>
+  <description>
+    Set the Trash policy for ABFS to be Empty. No-op on Trash.
+  </description>
+</property>
+
+<property>
+  <name>fs.abfss.trash.classname</name>
+  <value>org.apache.hadoop.fs.EmptyTrashPolicy</value>
+  <description>
+    Set the Trash policy for ABFSS to be Empty. No-op on Trash.
+  </description>
 </property>
 
 <property>

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ATrash.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ATrash.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.EmptyTrashPolicy;
+import org.apache.hadoop.fs.Trash;
+
+/**
+ * Test Trash for S3AFilesystem.
+ */
+public class TestS3ATrash extends AbstractS3ATestBase {
+
+  /**
+   * Test default Trash Policy for S3AFilesystem is Empty.
+   */
+  @Test
+  public void testTrashSetToEmptyTrashPolicy() throws IOException {
+    Configuration conf = new Configuration();
+    Trash trash = new Trash(getFileSystem(), conf);
+    assertEquals("Mismatch in Trash Policy set by the config",
+        trash.getTrashPolicy().getClass(), EmptyTrashPolicy.class);
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsTrash.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsTrash.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.EmptyTrashPolicy;
+import org.apache.hadoop.fs.Trash;
+
+/**
+ * Tests to verify behaviour of Trash with AzureBlobFileSystem.
+ */
+public class TestAbfsTrash extends AbstractAbfsIntegrationTest {
+
+  public TestAbfsTrash() throws Exception {}
+
+  /**
+   * Test default Trash Policy for S3AFilesystem is Empty.
+   */
+  @Test
+  public void testTrashSetToEmptyTrashPolicy() throws IOException {
+    Configuration conf = new Configuration();
+    Trash trash = new Trash(getFileSystem(), conf);
+    assertEquals("Mismatch in Trash Policy set by the config",
+        trash.getTrashPolicy().getClass(), EmptyTrashPolicy.class);
+  }
+}


### PR DESCRIPTION

### Description of PR
Follow up from #4729

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

