### PR TITLE
HDFS-17189. GcTimeMonitor crashes with NegativeArraySizeException during initialization

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSOutputSummer.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSOutputSummer.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.util.DataChecksum;
 import org.apache.hadoop.tracing.TraceScope;
+import org.apache.hadoop.util.Preconditions;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -52,6 +53,9 @@ abstract public class FSOutputSummer extends OutputStream implements
   
   protected FSOutputSummer(DataChecksum sum) {
     this.sum = sum;
+    Preconditions.checkArgument(
+            sum.getBytesPerChecksum() * BUFFER_NUM_CHUNKS > 0,
+            "Buffer size for FSOutputSummer should be a positive integer.");
     this.buf = new byte[sum.getBytesPerChecksum() * BUFFER_NUM_CHUNKS];
     this.checksum = new byte[getChecksumSize() * BUFFER_NUM_CHUNKS];
     this.count = 0;


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17189
This PR provides a fix by checking the computed buffer size is not only within `128 * 1024` but also greater than 0.

### How was this patch tested?

Unit test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under ASF 2.0?
- [ ] If applicable, have you updated the LICENSE, LICENSE-binary, NOTICE-binary files?

