### PR TITLE
YARN-11566. Yarn app kill command can not kill the application in sec…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/uam/UnmanagedAMPoolManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/uam/UnmanagedAMPoolManager.java
@@ -97,17 +97,19 @@ public class UnmanagedAMPoolManager extends AbstractService {
 
   /**
    * Normally we should finish all applications before stop. If there are still
-   * UAMs running, force kill all of them. Do parallel kill because of
-   * performance reasons.
+   * UAMs running, force kill all of them. Do kill in asynchronous thread.
    *
    */
   @Override
   protected void serviceStop() throws Exception {
 
     if (!this.unmanagedAppMasterMap.isEmpty()) {
-      finishApplicationThread = new Thread(createForceFinishApplicationThread());
+      // Save a local copy of the key set so that it won't change with the map
+      finishApplicationThread =
+          new Thread(createForceFinishApplicationThread(new HashMap(this.unmanagedAppMasterMap)));
       finishApplicationThread.setName(dispatcherThreadName);
       finishApplicationThread.start();
+      this.unmanagedAppMasterMap.clear();
     }
 
     super.serviceStop();
@@ -485,45 +487,29 @@ public class UnmanagedAMPoolManager extends AbstractService {
     return responseMap;
   }
 
-  Runnable createForceFinishApplicationThread() {
+  Runnable createForceFinishApplicationThread(
+      Map<String, UnmanagedApplicationManager> unmanagedAppToFinish) {
     return () -> {
+      LOG.warn("Abnormal shutdown of UAMPoolManager, still {} UAMs in map",
+          unmanagedAppToFinish.size());
 
-      ExecutorCompletionService<Pair<String, KillApplicationResponse>> completionService =
-          new ExecutorCompletionService<>(threadpool);
-
-      // Save a local copy of the key set so that it won't change with the map
-      Set<String> addressList = new HashSet<>(unmanagedAppMasterMap.keySet());
-
-      LOG.warn("Abnormal shutdown of UAMPoolManager, still {} UAMs in map", addressList.size());
-
-      for (final String uamId : addressList) {
-        completionService.submit(() -> {
-          try {
-            ApplicationId appId = appIdMap.get(uamId);
-            LOG.info("Force-killing UAM id {} for application {}", uamId, appId);
-            UnmanagedApplicationManager applicationManager = unmanagedAppMasterMap.remove(uamId);
-            KillApplicationResponse response = applicationManager.forceKillApplication();
-            return Pair.of(uamId, response);
-          } catch (Exception e) {
-            LOG.error("Failed to kill unmanaged application master", e);
-            return Pair.of(uamId, null);
-          }
-        });
-      }
-
-      for (int i = 0; i < addressList.size(); ++i) {
+      // We should not use threadpool to execute the operation 'forceKillApplication'.
+      // Because ForceFinishApplication run in asynchronous thread, threadpool may be destroyed.
+      // Since we kill app in asynchronous thread, we could kill app sequentially,
+      // no operations will get stuck.
+      for (Map.Entry<String, UnmanagedApplicationManager> entry : unmanagedAppToFinish.entrySet()) {
+        String uamId = entry.getKey();
+        UnmanagedApplicationManager applicationManager = entry.getValue();
         try {
-          Future<Pair<String, KillApplicationResponse>> future = completionService.take();
-          Pair<String, KillApplicationResponse> pairs = future.get();
-          String uamId = pairs.getLeft();
           ApplicationId appId = appIdMap.get(uamId);
-          KillApplicationResponse response = pairs.getRight();
+          LOG.info("Force-killing UAM id {} for application {}", uamId, appId);
+          KillApplicationResponse response = applicationManager.forceKillApplication();
           if (response == null) {
-            throw new YarnException(
-                "Failed Force-killing UAM id " + uamId + " for application " + appId);
+            LOG.error("Failed Force-killing UAM id {} for application {}", uamId, appId);
+          } else {
+            LOG.info("Force-killing UAM id = {} for application {} KillCompleted {}.", uamId, appId,
+                response.getIsKillCompleted());
           }
-          LOG.info("Force-killing UAM id = {} for application {} KillCompleted {}.",
-              uamId, appId, response.getIsKillCompleted());
         } catch (Exception e) {
           LOG.error("Failed to kill unmanaged application master", e);
         }
@@ -548,7 +534,7 @@ public class UnmanagedAMPoolManager extends AbstractService {
   }
 
   @VisibleForTesting
-  protected Thread getFinishApplicationThread() {
+  public Thread getFinishApplicationThread() {
     return finishApplicationThread;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/uam/UnmanagedAMPoolManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/uam/UnmanagedAMPoolManager.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.hadoop.conf.Configuration;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/MockResourceManagerFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/MockResourceManagerFacade.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
@@ -570,7 +571,16 @@ public class MockResourceManagerFacade implements ApplicationClientProtocol,
 
     validateRunning();
 
-    return GetApplicationsResponse.newInstance(null);
+    List<ApplicationReport> applications = applicationMap.stream().map(applicationId -> {
+      ApplicationReport report = Records.newRecord(ApplicationReport.class);
+      report.setYarnApplicationState(YarnApplicationState.ACCEPTED);
+      report.setApplicationId(applicationId);
+      report.setCurrentApplicationAttemptId(ApplicationAttemptId.newInstance(applicationId, 1));
+      report.setAMRMToken(Token.newInstance(new byte[0], "", new byte[0], ""));
+      return report;
+    }).collect(Collectors.toList());
+
+    return GetApplicationsResponse.newInstance(applications);
   }
 
   @Override


### PR DESCRIPTION
### Description of PR

When AMRMProxy is enable, the application may allocate container among multi sub cluster. The application in secondary sub cluster will be labeled as unmananged application. When we run 'yarn app -kill {appid}', the unmananged application will not be killed in secondary sub cluster.

The unmanaged application will be removed util app attempt is expired after 15 minute.


### How was this patch tested?

unit test and test in real cluster.

### For code changes:

1. When MRMProxyService::stopApplication, before interceptor.shutdown, call UnmanagedAMPoolManager::stop so that we could kill all unmanaged application. It means when application is succeed, killed or failed, we will force kill unmanaged application.
2. When call forceKillApplication, here changed to use proxy user, but not non-security user.
3. Fix createForceFinishApplicationThread. Because of change 1, createForceFinishApplicationThread may be running after 
interceptor.shutdown. So UnmanagedAMPoolManager::unmanagedAppMasterMap may be removed by interceptor.shutdown. And threadpool may be shutdown by interceptor.shutdown. So I use a copy of unmanagedAppMasterMap. And do not use threadpool. Because ForceFinishApplicationThread is a async thread, will not stuck serviceStop, to avoid to allocate new resource, here I just force kill application sequentially.