### PR TITLE
HADOOP-18891 hadoop distcp needs support to filter by file/directory attribute

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/CopyFilter.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/CopyFilter.java
@@ -47,6 +47,33 @@ public abstract class CopyFilter {
   public abstract boolean shouldCopy(Path path);
 
   /**
+   * Predicate to determine if a fileStatus can be excluded from copy.
+   * The fileStatus object has various attrs, so it is convenient to do
+   * more complex thing.
+   *
+   * The behaviour of calling shouldCopy() is like this：
+   *     if supportFileStatus() is true, then call shouldCopy(fileStatus)
+   *     if supportFileStatus() is false, then call shouldCopy(path)
+   *
+   *
+   * @param fileStatus a FileStatus to be considered for copying
+   * @return boolean, true to copy, false to exclude
+   */
+  public boolean shouldCopy(CopyListingFileStatus fileStatus){
+    return shouldCopy(fileStatus.getPath());
+  }
+
+  /**
+   * Indicate whether to use shouldCopy(fileStatus) or use shouldCopy(path)
+   * The default behaviour is to use shouldCopy(path).
+   *
+   * @return true, if call shouldCopy(fileStatus), or false.
+   */
+  public boolean supportFileStatus(){
+    return false;
+  }
+
+  /**
    * Public factory method which returns the appropriate implementation of
    * CopyFilter.
    *

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DirCopyFilter.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DirCopyFilter.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.tools;
+
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+/**
+ * A CopyFilter which checks if the FileStatus is a file or directory, the directory
+ * will be kept and the file will be filtered out.
+ */
+public class DirCopyFilter extends FileStatusCopyFilter {
+  private static final Logger LOG = LoggerFactory.getLogger(DirCopyFilter.class);
+  private Configuration conf;
+
+  /**
+   * Constructor of DirCopyFilter, it can be instantiated by CopyFilter#getCopyFilter method.
+   * @param conf Configuration.
+   */
+  public DirCopyFilter(Configuration conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public boolean shouldCopy(Path path) {
+    try {
+      FileSystem fs = path.getFileSystem(this.conf);
+      if (fs.getFileStatus(path).isDirectory()) {
+        return true;
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Exception occurred when get FileSystem or get FileStatus", e);
+    }
+
+    LOG.debug("Skipping {} as it is not a directory", path);
+    return false;
+  }
+
+  @Override
+  public boolean shouldCopy(CopyListingFileStatus fileStatus) {
+    return fileStatus.isDirectory();
+  }
+}

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
@@ -92,7 +92,7 @@ public final class DistCpConstants {
   /* Total bytes to be copied. Updated by copylisting. Unfiltered count */
   public static final String CONF_LABEL_TOTAL_BYTES_TO_BE_COPIED = "mapred.total.bytes.expected";
 
-  /* Total number of paths to copy, includes directories. Unfiltered count */
+  /* Total number of paths to be copied, includes directories. */
   public static final String CONF_LABEL_TOTAL_NUMBER_OF_RECORDS = "mapred.number.of.records";
 
   /* If input is based -f <<source listing>>, file containing the src paths */
@@ -185,7 +185,7 @@ public final class DistCpConstants {
   public static final int SPLIT_RATIO_DEFAULT  = 2;
 
   /**
-   * Constants for NONE file deletion
+   * Constants for NONE file deletion.
    */
   public static final String NONE_PATH_NAME = "/NONE";
   public static final Path NONE_PATH = new Path(NONE_PATH_NAME);

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/FileStatusCopyFilter.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/FileStatusCopyFilter.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.tools;
+
+/**
+ * The default implement of FileStatus CopyFilter
+ *
+ * Each CopyFilter class likes to use shouldCopy(fileStatus) should be Subclass
+ * of this class.
+ *
+ */
+public abstract class FileStatusCopyFilter extends CopyFilter{
+
+  /**
+   * Always return true for FileStatusCopyFilter and its subsequent class
+   * to enable shouldCopy(fileStatus).
+   * @return return - for scan file status mode, always return true.
+   */
+  @Override
+  public boolean supportFileStatus() {
+    return true;
+  }
+}

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/UniformRecordInputFormat.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/UniformRecordInputFormat.java
@@ -1,0 +1,174 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.tools.mapred;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.mapreduce.lib.input.SequenceFileRecordReader;
+import org.apache.hadoop.tools.CopyListingFileStatus;
+import org.apache.hadoop.tools.DistCpConstants;
+import org.apache.hadoop.tools.util.DistCpUtils;
+import org.apache.hadoop.util.Preconditions;
+
+/**
+ * UniformRecordInputFormat extends the InputFormat class, to produce
+ * record-splits for DistCp.
+ * It looks at the copy-listing and groups the contents into record-splits such
+ * that the total-records to be copied for each input split is uniform.
+ */
+public class UniformRecordInputFormat extends InputFormat<Text, CopyListingFileStatus> {
+  private static final Logger LOG = LoggerFactory.getLogger(UniformRecordInputFormat.class);
+
+  /**
+   * Implementation of InputFormat::getSplits(). Returns a list of InputSplits,
+   * such that the number of records to be copied for all the splits are
+   * approximately equal.
+   * @param context JobContext for the job.
+   * @return The list of uniformly-distributed input-splits.
+   * @throws IOException Exception Reading split file
+   * @throws InterruptedException Thread interrupted exception
+   */
+  @Override
+  public List<InputSplit> getSplits(JobContext context) throws IOException, InterruptedException {
+    Configuration conf = context.getConfiguration();
+    int numSplits = getNumSplits(conf);
+    if (numSplits == 0){
+      return new ArrayList<InputSplit>();
+    }
+
+    return createSplits(conf, numSplits, getNumberOfRecords(conf));
+  }
+
+  private List<InputSplit> createSplits(Configuration configuration, int numSplits, long numRecords)
+          throws IOException {
+    List<InputSplit> splits = new ArrayList(numSplits);
+    long nRecordsPerSplit = (long) Math.floor(numRecords * 1.0 / numSplits);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Average records per map: " + nRecordsPerSplit +
+              ", Number of maps: " + numSplits + ", total records: " + numRecords);
+    }
+
+    Path listingFilePath = getListingFilePath(configuration);
+    CopyListingFileStatus srcFileStatus = new CopyListingFileStatus();
+    Text srcRelPath = new Text();
+    long lastPosition = 0L;
+    long count = 0L;
+    long remains = numRecords - nRecordsPerSplit * (long) numSplits;
+
+    SequenceFile.Reader reader = null;
+    try {
+      reader = getListingFileReader(configuration);
+      while (reader.next(srcRelPath, srcFileStatus)) {
+        count++;
+
+        // a split's size must be nRecordsPerSplit or (nRecordsPerSplit + 1)
+        // the first N (num of remains) splits have a size of (nRecordsPerSplit + 1),
+        // the others have a size of nRecordsPerSplit
+        if ((remains > 0 && count % (nRecordsPerSplit + 1) == 0) ||
+                (remains == 0 && count % nRecordsPerSplit == 0)) {
+
+          long currentPosition = reader.getPosition();
+          FileSplit split = new FileSplit(listingFilePath, lastPosition,
+                  currentPosition - lastPosition, null);
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Creating split: " + split + ", records in split: " + count);
+          }
+
+          splits.add(split);
+          lastPosition = currentPosition;
+          if (remains > 0) {
+            remains--;
+          }
+          count = 0L;
+        }
+      }
+
+      return splits;
+    } finally {
+      IOUtils.closeStream(reader);
+    }
+  }
+
+  /**
+   * Implementation of InputFormat::createRecordReader().
+   * @param split The split for which the RecordReader is sought.
+   * @param context The context of the current task-attempt.
+   * @return A SequenceFileRecordReader instance, (since the copy-listing is a
+   * simple sequence-file.)
+   * @throws IOException Exception Reading split file
+   * @throws InterruptedException Thread interrupted exception
+   */
+  public RecordReader<Text, CopyListingFileStatus> createRecordReader(
+          InputSplit split, TaskAttemptContext context)
+          throws IOException, InterruptedException {
+    return new SequenceFileRecordReader<Text, CopyListingFileStatus>();
+  }
+
+  private static Path getListingFilePath(Configuration configuration) {
+    String listingFilePathString =
+            configuration.get(DistCpConstants.CONF_LABEL_LISTING_FILE_PATH, "");
+
+    Preconditions.checkState(!listingFilePathString.equals(""),
+            "Listing file doesn't exist at %s", listingFilePathString);
+    return new Path(listingFilePathString);
+  }
+
+  private SequenceFile.Reader getListingFileReader(Configuration conf) {
+    Path listingFilePath = getListingFilePath(conf);
+
+    try {
+      FileSystem fs = listingFilePath.getFileSystem(conf);
+      Preconditions.checkState(fs.exists(listingFilePath),
+              "Listing file doesn't exist at: %s", listingFilePath);
+
+      return new SequenceFile.Reader(conf,
+              SequenceFile.Reader.file(listingFilePath));
+    } catch (IOException | IllegalStateException exception) {
+      LOG.error("Couldn't read listing file at: {}", listingFilePath, exception);
+      throw new IllegalStateException("Couldn't read listing file at: "
+              + listingFilePath, exception);
+    }
+  }
+
+  private static long getNumberOfRecords(Configuration configuration) {
+    return DistCpUtils.getLong(configuration,
+            DistCpConstants.CONF_LABEL_TOTAL_NUMBER_OF_RECORDS);
+  }
+
+  private static int getNumSplits(Configuration configuration) {
+    return DistCpUtils.getInt(configuration, MRJobConfig.NUM_MAPS);
+  }
+}

--- a/hadoop-tools/hadoop-distcp/src/main/resources/distcp-default.xml
+++ b/hadoop-tools/hadoop-distcp/src/main/resources/distcp-default.xml
@@ -20,6 +20,12 @@
 <configuration>
 
     <property>
+        <name>distcp.record.strategy.impl</name>
+        <value>org.apache.hadoop.tools.mapred.UniformRecordInputFormat</value>
+        <description>Implementation of record input format</description>
+    </property>
+
+    <property>
         <name>distcp.dynamic.strategy.impl</name>
         <value>org.apache.hadoop.tools.mapred.lib.DynamicInputFormat</value>
         <description>Implementation of dynamic input format</description>

--- a/hadoop-tools/hadoop-distcp/src/site/markdown/DistCp.md.vm
+++ b/hadoop-tools/hadoop-distcp/src/site/markdown/DistCp.md.vm
@@ -350,7 +350,7 @@ Command Line Options
 | `-filelimit <n>` | Limit the total number of files to be <= n | **Deprecated!** Ignored in the new DistCp. |
 | `-sizelimit <n>` | Limit the total size to be <= n bytes | **Deprecated!** Ignored in the new DistCp. |
 | `-delete` | Delete the files existing in the dst but not in src | The deletion is done by FS Shell. So the trash will be used, if it is enable. Delete is applicable only with update or overwrite options. |
-| `-strategy {dynamic|uniformsize}` | Choose the copy-strategy to be used in DistCp. | By default, uniformsize is used. (i.e. Maps are balanced on the total size of files copied by each map. Similar to legacy.) If "dynamic" is specified, `DynamicInputFormat` is used instead. (This is described in the Architecture section, under InputFormats.) |
+| `-strategy {dynamic\|uniformsize\|uniformrecord}` | Choose the copy-strategy to be used in DistCp. | By default, uniformsize is used. (i.e. Maps are balanced on the total size of files copied by each map. Similar to legacy.) If uniformrecord is used, Maps are balanced on the total number of files copied by each map, this is especially useful when there are lots of empty directories. If "dynamic" is specified, `DynamicInputFormat` is used instead. (This is described in the Architecture section, under InputFormats.) |
 | `-bandwidth` | Specify bandwidth per map, in MB/second. | Each map will be restricted to consume only the specified bandwidth. This is not always exact. The map throttles back its bandwidth consumption during a copy, such that the **net** bandwidth used tends towards the specified value. |
 | `-atomic {-tmp <tmp_dir>}` | Specify atomic commit, with optional tmp directory. | `-atomic` instructs DistCp to copy the source data to a temporary target location, and then move the temporary target to the final-location atomically. Data will either be available at final target in a complete and consistent form, or not at all. Optionally, `-tmp` may be used to specify the location of the tmp-target. If not specified, a default is chosen. **Note:** tmp_dir must be on the final target cluster. |
 | `-async` | Run DistCp asynchronously. Quits as soon as the Hadoop Job is launched. | The Hadoop Job-id is logged, for tracking. |
@@ -456,7 +456,14 @@ $H3 Copy-listing Generator
      `distcp.exclude-file-regex` parameter in "DistCpOptions". Support regular
      expressions specified by java.util.regex.Pattern. This is a more dynamic approach
      as compared to "RegexCopyFilter".
-  3. `distcp.filters.class` to "TrueCopyFilter". This is used as a default
+  3. `distcp.filters.class` to "DirCopyFilter". If you are using this
+       implementation, you will filter out all files and only directories remains.
+       What's more, you can overwrite shouldCopy(CopyListingFileStatus fileStatus) method,
+       which gives you a more fluent way to filter files/dirs by their file statuses.
+       (i.e. A file status contains a lot of useful info such as file path, file length,
+       isDir, modificationTime, owner, etc. You can use them in your own way
+       by extends FileStatusCopyFilter class)
+  4. `distcp.filters.class` to "TrueCopyFilter". This is used as a default
      implementation if none of the above options are specified.
 
   The legacy implementation only lists those paths that must definitely be
@@ -485,6 +492,16 @@ $H3 InputFormats and MapReduce Components
     that the sum of file-sizes in each InputSplit is nearly equal to every
     other map. The splitting isn't always perfect, but its trivial
     implementation keeps the setup-time low.
+
+  * **UniformRecordInputFormat:**
+    This implementation of org.apache.hadoop.mapreduce.InputFormat provides
+    equivalence with Legacy DistCp in balancing load across maps too. The aim of
+    the UniformRecordInputFormat is to make each map copy roughly the same number
+    of file/directories. Apropos, the listing file is split into groups of paths, such
+    that the sum of file/directories number in each InputSplit is nearly equal to every
+    other map. The splitting isn't always perfect, but its trivial
+    implementation keeps the setup-time low. This implementation is especially useful
+    when there are lots of empty directories to be copied.
 
   * **DynamicInputFormat and DynamicRecordReader:**
     The DynamicInputFormat implements `org.apache.hadoop.mapreduce.InputFormat`,

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestCopyFilter.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestCopyFilter.java
@@ -59,6 +59,19 @@ public class TestCopyFilter {
   }
 
   @Test
+  public void testGetDirCopyFilter(){
+    final String filterName =
+            "org.apache.hadoop.tools.DirCopyFilter";
+    Configuration configuration = new Configuration(false);
+    configuration.set(DistCpConstants.CONF_LABEL_FILTERS_CLASS, filterName);
+    CopyFilter copyFilter = CopyFilter.getCopyFilter(configuration);
+    assertTrue("copyFilter should be instance of DirCopyFilter",
+            copyFilter instanceof DirCopyFilter);
+    assertTrue("copyFilter should be instance of FileStatusCopyFilter too",
+            copyFilter instanceof FileStatusCopyFilter);
+  }
+
+  @Test
   public void testGetCopyFilterNonExistingClass() throws Exception {
     final String filterName =
             "org.apache.hadoop.tools.RegexpInConfigurationWrongFilter";

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDirCopyFilter.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDirCopyFilter.java
@@ -1,0 +1,155 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.tools;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.io.IOUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDirCopyFilter {
+
+  private static final String SRCROOT = "/src";
+  private static final long BLOCK_SIZE = 1024;
+  private static MiniDFSCluster cluster;
+  private static Configuration conf;
+  private static FileSystem fs;
+  public static final Path DIR1 = new Path(SRCROOT, "dir1");
+  public static final Path FILE0 = new Path(SRCROOT, "file0");
+  public static final Path DIR1_FILE1 = new Path(DIR1, "file1");
+  public static final Path DIR1_FILE2 = new Path(DIR1, "file2");
+  public static final Path DIR1_DIR3 = new Path(DIR1, "dir3");
+  public static final Path DIR1_DIR3_DIR4 = new Path(DIR1_DIR3, "dir4");
+  public static final Path DIR1_DIR3_DIR4_FILE_3 = new Path(DIR1_DIR3_DIR4, "file1");
+  public static final Path[] FILE_PATHS = new Path[]{FILE0, DIR1_FILE1,
+          DIR1_FILE2, DIR1_DIR3_DIR4_FILE_3};
+  public static final Path[] DIR_PATHS = new Path[]{DIR1, DIR1_DIR3, DIR1_DIR3_DIR4};
+  @BeforeClass
+  public static void setupClass() throws IOException {
+    conf = new Configuration();
+    conf.setLong(DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY, BLOCK_SIZE);
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCK_SIZE);
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(2).build();
+    cluster.waitActive();
+    fs = cluster.getFileSystem();
+
+    for(Path dirPath : DIR_PATHS){
+      createDir(dirPath);
+    }
+
+    for(Path filePath : FILE_PATHS){
+      createFile(filePath);
+    }
+  }
+
+  @AfterClass
+  public static void teardownClass() throws IOException {
+    if (fs != null){
+      fs.close();
+    }
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+
+  @Test
+  public void testSupportFileStatus() {
+    Configuration configuration = new Configuration(false);
+    DirCopyFilter dirCopyFilter = new DirCopyFilter(configuration);
+    assertThat(dirCopyFilter.supportFileStatus()).isTrue();
+  }
+
+
+  @Test
+  public void testShouldCopyTrue() throws IOException {
+    DirCopyFilter copyFilter = new DirCopyFilter(conf);
+    Path[] dirPaths = new Path[]{DIR1, DIR1_DIR3, DIR1_DIR3_DIR4};
+
+    for (Path dirPath : dirPaths) {
+      assertThat(copyFilter.shouldCopy(dirStatus(dirPath)))
+              .describedAs("should copy dir: " + dirPath)
+              .isTrue();
+      assertThat(copyFilter.shouldCopy(dirStatus(dirPath).getPath()))
+              .describedAs("should copy dir: " + dirPath)
+              .isTrue();
+    }
+  }
+
+  @Test
+  public void testShouldCopyFalse() {
+    DirCopyFilter copyFilter = new DirCopyFilter(conf);
+
+
+    for (Path filePath : FILE_PATHS) {
+      assertThat(copyFilter.shouldCopy(fileStatus(filePath)))
+              .describedAs("should copy file: " + filePath)
+              .isFalse();
+      assertThat(copyFilter.shouldCopy(filePath))
+              .describedAs("should copy file: " + filePath)
+              .isFalse();
+    }
+  }
+
+
+  private CopyListingFileStatus newStatus(final Path path,
+                                          final boolean isDir) {
+    return new CopyListingFileStatus(new FileStatus(0, isDir, 0, 0, 0, path));
+  }
+
+  private CopyListingFileStatus dirStatus(final Path path) throws IOException {
+    CopyListingFileStatus dirFileStatus = newStatus(path, true);
+    return dirFileStatus;
+  }
+
+  private CopyListingFileStatus fileStatus(final Path path) {
+    CopyListingFileStatus fileStatus = newStatus(path, false);
+    return fileStatus;
+  }
+
+  private static void createFile(Path filePath) throws IOException {
+    fs.createFile(filePath);
+    Random random = new Random();
+
+    DataOutputStream outputStream = null;
+    try {
+      outputStream = fs.create(filePath, true, 0);
+      outputStream.write(new byte[random.nextInt((int)BLOCK_SIZE * 2)]);
+    } finally {
+      IOUtils.cleanupWithLogger(null, outputStream);
+    }
+  }
+
+  private static void createDir(Path fileStatus) throws IOException {
+    fs.mkdirs(fileStatus);
+  }
+
+}

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpOptions.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpOptions.java
@@ -305,6 +305,8 @@ public class TestDistCpOptions {
         builder.build().getCopyStrategy());
     builder.withCopyStrategy("dynamic");
     Assert.assertEquals("dynamic", builder.build().getCopyStrategy());
+    builder.withCopyStrategy("record");
+    Assert.assertEquals("record", builder.build().getCopyStrategy());
   }
 
   @Test

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestOptionsParser.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestOptionsParser.java
@@ -394,6 +394,14 @@ public class TestOptionsParser {
     assertThat(options.getCopyStrategy()).isEqualTo("dynamic");
 
     options = OptionsParser.parse(new String[] {
+         "-strategy",
+         "record",
+         "-f",
+         "hdfs://localhost:8020/source/first",
+         "hdfs://localhost:8020/target/"});
+    assertThat(options.getCopyStrategy()).isEqualTo("record");
+
+    options = OptionsParser.parse(new String[] {
         "-f",
         "hdfs://localhost:8020/source/first",
         "hdfs://localhost:8020/target/"});

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestUniformRecordInputFormat.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/mapred/TestUniformRecordInputFormat.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,62 +18,69 @@
 
 package org.apache.hadoop.tools.mapred;
 
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.io.IOUtils;
-import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.SequenceFile;
-import org.apache.hadoop.mapreduce.*;
-import org.apache.hadoop.mapreduce.task.JobContextImpl;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.JobID;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.mapreduce.task.JobContextImpl;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
 import org.apache.hadoop.tools.CopyListing;
 import org.apache.hadoop.tools.CopyListingFileStatus;
+import org.apache.hadoop.tools.DistCpConstants;
 import org.apache.hadoop.tools.DistCpContext;
 import org.apache.hadoop.tools.DistCpOptions;
 import org.apache.hadoop.tools.StubContext;
-import org.apache.hadoop.security.Credentials;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.apache.hadoop.tools.util.DistCpUtils;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class TestUniformSizeInputFormat {
+public class TestUniformRecordInputFormat extends AbstractHadoopTestBase {
   private static MiniDFSCluster cluster;
   private static final int N_FILES = 20;
-  private static final int SIZEOF_EACH_FILE=1024;
-  private static final Random RANDOM_VALUE = new Random();
+  private static final int SIZEOF_EACH_FILE = 1024;
+  private static final Random random = new Random();
   private static int totalFileSize = 0;
 
   private static final Credentials CREDENTIALS = new Credentials();
 
 
   @BeforeClass
-  public static void setup() throws Exception {
-    cluster = new MiniDFSCluster.Builder(new Configuration()).numDataNodes(1)
-                                          .format(true).build();
+  public static void setupClass() throws Exception {
+    cluster = new MiniDFSCluster.Builder(new Configuration())
+        .numDataNodes(1)
+        .format(true).build();
     totalFileSize = 0;
 
-    for (int i=0; i<N_FILES; ++i){
+    for (int i = 0; i < N_FILES; ++i)
       totalFileSize += createFile("/tmp/source/" + String.valueOf(i), SIZEOF_EACH_FILE);
-    }
-
   }
 
   private static DistCpOptions getOptions(int nMaps) throws Exception {
     Path sourcePath = new Path(cluster.getFileSystem().getUri().toString()
-                               + "/tmp/source");
+        + "/tmp/source");
     Path targetPath = new Path(cluster.getFileSystem().getUri().toString()
-                               + "/tmp/target");
+        + "/tmp/target");
 
     List<Path> sourceList = new ArrayList<Path>();
     sourceList.add(sourcePath);
@@ -88,69 +95,75 @@ public class TestUniformSizeInputFormat {
     try {
       fileSystem = cluster.getFileSystem();
       outputStream = fileSystem.create(new Path(path), true, 0);
-      int size = (int) Math.ceil(fileSize + (1 - RANDOM_VALUE.nextFloat()) * fileSize);
+      int size = (int) Math.ceil(fileSize + (1 - random.nextFloat()) * fileSize);
       outputStream.write(new byte[size]);
       return size;
-    }
-    finally {
-      IOUtils.cleanupWithLogger(null, fileSystem, outputStream);
+    } finally {
+      IOUtils.cleanupWithLogger(null, outputStream);
     }
   }
 
   @AfterClass
-  public static void tearDown() {
-    cluster.shutdown();
+  public static void tearDownClass() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
   }
 
   public void testGetSplits(int nMaps) throws Exception {
     DistCpContext context = new DistCpContext(getOptions(nMaps));
     Configuration configuration = new Configuration();
-    configuration.set("mapred.map.tasks",
-                      String.valueOf(context.getMaxMaps()));
+    configuration.set(MRJobConfig.NUM_MAPS, String.valueOf(context.getMaxMaps()));
     Path listFile = new Path(cluster.getFileSystem().getUri().toString()
-        + "/tmp/testGetSplits_1/fileList.seq");
+        + "/tmp/testGetSplits_2/fileList.seq");
     CopyListing.getCopyListing(configuration, CREDENTIALS, context)
         .buildListing(listFile, context);
 
     JobContext jobContext = new JobContextImpl(configuration, new JobID());
-    UniformSizeInputFormat uniformSizeInputFormat = new UniformSizeInputFormat();
+    UniformRecordInputFormat uniformRecordInputFormat = new UniformRecordInputFormat();
     List<InputSplit> splits
-            = uniformSizeInputFormat.getSplits(jobContext);
+        = uniformRecordInputFormat.getSplits(jobContext);
 
-    int sizePerMap = totalFileSize/nMaps;
+    long totalRecords = DistCpUtils.getLong(configuration, DistCpConstants.CONF_LABEL_TOTAL_NUMBER_OF_RECORDS);
+    long recordPerMap = totalRecords / nMaps;
+
 
     checkSplits(listFile, splits);
 
     int doubleCheckedTotalSize = 0;
-    int previousSplitSize = -1;
-    for (int i=0; i<splits.size(); ++i) {
+    for (int i = 0; i < splits.size(); ++i) {
       InputSplit split = splits.get(i);
       int currentSplitSize = 0;
       RecordReader<Text, CopyListingFileStatus> recordReader =
-        uniformSizeInputFormat.createRecordReader(split, null);
+          uniformRecordInputFormat.createRecordReader(split, null);
       StubContext stubContext = new StubContext(jobContext.getConfiguration(),
-                                                recordReader, 0);
+          recordReader, 0);
       final TaskAttemptContext taskAttemptContext
-         = stubContext.getContext();
+          = stubContext.getContext();
       recordReader.initialize(split, taskAttemptContext);
+      long recordCnt = 0;
       while (recordReader.nextKeyValue()) {
+        recordCnt++;
         Path sourcePath = recordReader.getCurrentValue().getPath();
         FileSystem fs = sourcePath.getFileSystem(configuration);
-        FileStatus[] fileStatus = fs.listStatus(sourcePath);
+        FileStatus fileStatus[] = fs.listStatus(sourcePath);
+        // If the fileStatus is a file which fileStatus[] must be 1,
+        // then add the size of file, otherwise it is a directory skip.
+        // For all files under the directory will be in the sequence file too.
         if (fileStatus.length > 1) {
           continue;
         }
         currentSplitSize += fileStatus[0].getLen();
       }
-      Assert.assertTrue(
-           previousSplitSize == -1
-               || Math.abs(currentSplitSize - previousSplitSize) < 0.1*sizePerMap
-               || i == splits.size()-1);
 
+      assertThat(recordCnt)
+          .describedAs("record count")
+          .isGreaterThanOrEqualTo(recordPerMap)
+          .isLessThanOrEqualTo(recordPerMap + 1);
       doubleCheckedTotalSize += currentSplitSize;
     }
 
-    Assert.assertEquals(totalFileSize, doubleCheckedTotalSize);
+    assertThat(totalFileSize).isEqualTo(doubleCheckedTotalSize);
   }
 
   private void checkSplits(Path listFile, List<InputSplit> splits) throws IOException {
@@ -161,29 +174,28 @@ public class TestUniformSizeInputFormat {
     for (InputSplit split : splits) {
       FileSplit fileSplit = (FileSplit) split;
       long start = fileSplit.getStart();
-      Assert.assertEquals(lastEnd, start);
+      assertThat(lastEnd)
+          .isEqualTo(start)
+          .withFailMessage("The end of last file is not equals to the begin of current file.");
       lastEnd = start + fileSplit.getLength();
     }
 
     //Verify there is nothing more to read from the input file
-    SequenceFile.Reader reader
-            = new SequenceFile.Reader(cluster.getFileSystem().getConf(),
-                    SequenceFile.Reader.file(listFile));
-
-    try {
+    try (SequenceFile.Reader reader
+             = new SequenceFile.Reader(cluster.getFileSystem().getConf(),
+        SequenceFile.Reader.file(listFile))) {
       reader.seek(lastEnd);
       CopyListingFileStatus srcFileStatus = new CopyListingFileStatus();
       Text srcRelPath = new Text();
-      Assert.assertFalse(reader.next(srcRelPath, srcFileStatus));
-    } finally {
-      IOUtils.closeStream(reader);
+      assertThat(reader.next(srcRelPath, srcFileStatus))
+          .isFalse()
+          .withFailMessage("The reader is expected to reach end of file, but it doesn't.");
     }
   }
 
   @Test
   public void testGetSplits() throws Exception {
-    testGetSplits(9);
-    for (int i=1; i<N_FILES; ++i)
+    for (int i = 1; i < N_FILES; ++i)
       testGetSplits(i);
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
In some circumstances, we need to filter file/directory by file/directroy. For example, we need to filter out them by file modified time, isDir attrs, etc.

So, should we introduce a new method public boolean shouldCopy(CopyListingFileStatus fileStatus) ?
by this approach, we can introduce a more fluent way to do things than public abstract boolean shouldCopy(Path path).

To achieve the goal:
1、Create a method named shouldCopy(CopyListingFileStatus fileStatus) in CopyFilter abstract method, with a supportFileStatus() swtich method which return false by default.
2、For subclasses which impl the abstract class and want to use the new method, should overwrite shouldCopy(CopyListingFileStatus fileStatus) and for the same time, return supportFileStatus() to true.
3、This change is compatible with old use case.

As a impl:
1、I first create a abstract FileStatusCopyFilter extends CopyFilter
2、then create DirCopyFilter class extends FileStatusCopyFilter
3、and , implement UniformRecordInputFormat to support DirCopyFilter

### How was this patch tested?
added unit tests

1、add distcp.filters.class=org.apache.hadoop.tools.DirCopyFilter to distcp-default.xml or set it by -Ddistcp.filters.class=org.apache.hadoop.tools.DirCopyFilter
2、then execute distcp commands

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

