### PR TITLE
HDFS-17103. messy file system cleanup in TestNameEditsConfigs

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameEditsConfigs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameEditsConfigs.java
@@ -447,8 +447,12 @@ public class TestNameEditsConfigs {
           replication, SEED);
       checkFile(fileSys, file1, replication);
     } finally  {
-      fileSys.close();
-      cluster.shutdown();
+      if (fileSys != null) {
+        fileSys.close();
+      }
+      if (cluster != null) {
+        cluster.shutdown();
+      }
     }
 
     // 2


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17103
This PR adds a null check for `fileSys` and `cluster` during test cleanup.

### How was this patch tested?
(1) Set `dfs.namenode.maintenance.replication.min` to `-1155969698`
(2) Run test: `org.apache.hadoop.hdfs.server.namenode.TestNameEditsConfigs#testNameEditsConfigsFailure`
The test now shows the actual exception rather than the `NullPointerException`.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

