### PR TITLE
HDFS-17102. Timeout encountered when running TestDataNodeOutlierDetectionViaMetrics

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/metrics/TestDataNodeOutlierDetectionViaMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/metrics/TestDataNodeOutlierDetectionViaMetrics.java
@@ -140,7 +140,7 @@ public class TestDataNodeOutlierDetectionViaMetrics {
       final String nodeName = "FastNode-" + nodeIndex;
       LOG.info("Generating stats for node {}", nodeName);
       for (int i = 0;
-           i < 2 * peerMetrics.getMinOutlierDetectionSamples();
+           i < 2 * Math.max(peerMetrics.getMinOutlierDetectionSamples(), 1);
            ++i) {
         peerMetrics.addSendPacketDownstream(
             nodeName, random.nextInt(FAST_NODE_MAX_LATENCY_MS));
@@ -157,7 +157,7 @@ public class TestDataNodeOutlierDetectionViaMetrics {
 
     // And the one slow node.
     for (int i = 0;
-         i < 2 * peerMetrics.getMinOutlierDetectionSamples();
+         i < 2 * Math.max(peerMetrics.getMinOutlierDetectionSamples(), 1);
          ++i) {
       peerMetrics.addSendPacketDownstream(
           slowNodeName, SLOW_NODE_LATENCY_MS);


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17102
This PR adds a lower bound for the number of packets injected in the test to avoid timeout.

### How was this patch tested?
(1) Set `dfs.datanode.peer.metrics.min.outlier.detection.samples` to `0`
(2) Run test: `org.apache.hadoop.hdfs.server.datanode.metrics.TestDataNodeOutlierDetectionViaMetrics#testOutlierIsDetected`
The test no longer times out and passes.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

