### PR TITLE
YARN-11532. Incorrect Check for Permission in Test

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/FSDownload.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/FSDownload.java
@@ -204,7 +204,7 @@ public class FSDownload implements Callable<Path> {
   static boolean ancestorsHaveExecutePermissions(FileSystem fs,
       Path path, LoadingCache<Path,Future<FileStatus>> statCache)
       throws IOException {
-    Path current = path;
+    Path current = path.getParent();
     while (current != null) {
       //the subdirs in the path should have execute permissions for others
       if (!checkPermissionOfOther(fs, current, FsAction.EXECUTE, statCache)) {


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/YARN-11532
This PR changes the code to check ancestor's execute permissions to actually match the functionality of the method.

### How was this patch tested?
Run `org.apache.hadoop.yarn.util.TestFSDownload#testDownloadPublicWithStatCache` and the test passes.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

