### PR TITLE
HADOOP-18803. ClassCastException in test TestRPC#testWrappedStopProxy

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -764,6 +764,9 @@ public class TestRPC extends TestRpcBase {
 
   @Test
   public void testWrappedStopProxy() throws IOException {
+    RPC.setProtocolEngine(conf,
+        StoppedProtocol.class, StoppedRpcEngine.class);
+
     StoppedProtocol wrappedProxy = RPC.getProxy(StoppedProtocol.class,
         StoppedProtocol.versionID, null, conf);
     StoppedInvocationHandler invocationHandler = (StoppedInvocationHandler)


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HADOOP-18803
This PR adds an extra setting of protocol engine to ensure that when running the test by itself the test would not fail due to wrong conf.

### How was this patch tested?
Run `TestRPC#testWrappedStopProxy` and the test passes by itself.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

