### PR TITLE
HADOOP-18814. Direct class cast causes ClassCastException in TestRPC#testReaderExceptions

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -1926,8 +1926,12 @@ public class TestRPC extends TestRpcBase {
           proxy.ping(null, newEmptyRequest());
           fail(reqName + " didn't fail");
         } catch (ServiceException e) {
-          RemoteException re = (RemoteException)e.getCause();
-          assertEquals(reqName, expectedIOE, re.unwrapRemoteException());
+          if (e.getCause() instanceof RemoteException) {
+            RemoteException re = (RemoteException)e.getCause();
+            assertEquals(reqName, expectedIOE, re.unwrapRemoteException());
+          } else {
+            throw e;
+          }
         }
         // check authorizations to ensure new connection when expected,
         // then conclusively determine if connections are disconnected


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HADOOP-18814
This PR adds a check before casting to RemoteException to avoid hiding the actual exception.

### How was this patch tested?
(1) Set hadoop.security.authentication to kerberos
(2) Run test TestRPC#testReaderExceptions
The test throws the actual exception stating that "Client cannot authenticate via:[KERBEROS]".

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

