### PR TITLE
HDFS-17110. Null Pointer Exception when running TestHarFileSystemWithHA#testHarUriWithHaUriWithNoPort

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHarFileSystemWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHarFileSystemWithHA.java
@@ -57,7 +57,9 @@ public class TestHarFileSystemWithHA {
       Path p = new Path("har://hdfs-" + failoverUri.getAuthority() + TEST_HAR_PATH);
       p.getFileSystem(conf);
     } finally {
-      cluster.shutdown();
+      if (cluster != null) {
+        cluster.shutdown();
+      }
     }
   }
   


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17110
This PR adds a check for `cluster` not null to avoid hiding the actual exception with the `NullPointerException`.

### How was this patch tested?
1. Set dfs.namenode.replication.min=12396
2. Run org.apache.hadoop.hdfs.server.namenode.ha.TestHarFileSystemWithHA#testHarUriWithHaUriWithNoPort
The test throws "Unexpected configuration parameters: dfs.namenode.replication.min = 12396 > dfs.replication.max = 512".

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

