### PR TITLE
HDFS-17108. Null Pointer Exception when running TestDecommissionWithBackoffMonitor

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommission.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommission.java
@@ -1598,7 +1598,9 @@ public class TestDecommission extends AdminStatesBaseTest {
       assertTrue(usage.get("nodeUsage").get("min").
           equalsIgnoreCase(nodeusageAfterRecommi));
     } finally {
-      cleanupFile(fileSys, file1);
+      if (fileSys != null && fileSys.exists(file1)) {
+        fileSys.delete(file1, true);
+      }
     }
   }
 


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17108
This PR adds a check for `filesys` not `null` and file exists before cleaning up in `finally` clause.

### How was this patch tested?
1. Set `dfs.client.read.shortcircuit=true`
2. Run `org.apache.hadoop.hdfs.TestDecommissionWithBackoffMonitor#testNodeUsageWhileDecommissioning`


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

