### PR TITLE
HDFS-17133. TestFsDatasetImpl missing null check when cleaning up

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -1173,7 +1173,7 @@ public class TestFsDatasetImpl {
       LOG.info("Exception in testMoveBlockFailure ", ex);
       fail("Exception while testing testMoveBlockFailure ");
     } finally {
-      if (cluster.isClusterUp()) {
+      if (cluster != null && cluster.isClusterUp()) {
         cluster.shutdown();
       }
     }


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17133
This PR adds a check that `cluster` is not `null` before cleaning up and shutting down the cluster.

### How was this patch tested?
1. set dfs.namenode.quota.init-threads=1468568631 
2. run org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.TestFsDatasetImpl#testMoveBlockFailure
The test fails with the `IllegalArgumentException` rather than the `NullPointerException`.
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

