### PR TITLE
HADOOP-18904. get local file system fails with a casting error

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -505,7 +505,11 @@ public abstract class FileSystem extends Configured
    */
   public static LocalFileSystem getLocal(Configuration conf)
     throws IOException {
-    return (LocalFileSystem)get(LocalFileSystem.NAME, conf);
+    FileSystem fs = get(LocalFileSystem.NAME, conf);
+    Preconditions.checkArgument(fs instanceof LocalFileSystem,
+        "fs.file.impl should extend " + LocalFileSystem.class.getName() + ", actual: "
+        + fs.getClass().getName());
+    return (LocalFileSystem) fs;
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileSystemInitialization.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileSystemInitialization.java
@@ -77,6 +77,22 @@ public class TestFileSystemInitialization {
         .isEqualTo(1);
   }
 
+  @Test
+  public void testInvalidLocalFileSystem() throws Exception {
+    Configuration conf = new Configuration();
+    conf.set("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem");
+    try {
+      FileSystem.getLocal(conf);
+      fail("get local fs as RawLocalFileSystem should fail since RawLocalFileSystem does not"
+              + "extend LocalFileSystem");
+    } catch (IllegalArgumentException expected) {
+      // the getLocal is expected to throw an IllegalArgumentException indicating the error
+      assertEquals(expected.getMessage(), "fs.file.impl should extend "
+              + "org.apache.hadoop.fs.LocalFileSystem, "
+              + "actual: org.apache.hadoop.fs.RawLocalFileSystem");
+    }
+  }
+
   /**
    * An FS which will fail on both init and close, and update
    * counters of invocations as it does so.


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HADOOP-18904
This PR adds a check for the local system get when the configuration for the local fs implementation is set wrongly. This PR also adds a test for this.

### How was this patch tested?
Run the test `TestFileSystemInitialization#testInvalidLocalFileSystem` and the test passes.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

