### PR TITLE
HDFS-17192. Add bock info when constructing remote block reader meets IOException.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/BlockReaderFactory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/BlockReaderFactory.java
@@ -769,7 +769,7 @@ public class BlockReaderFactory implements ShortCircuitReplicaCreator {
           LOG.debug("Closed potentially stale remote peer {}", peer, ioe);
         } else {
           // Handle an I/O error we got when using a newly created peer.
-          LOG.warn("I/O error constructing remote block reader.", ioe);
+          LOG.warn("I/O error constructing remote block reader for block {}", block, ioe);
           throw ioe;
         }
       } finally {


### PR DESCRIPTION
Currently, when constructing remote block reader meets IOException, it will not log block info. We should add it for troubleshooting problems.