### PR TITLE
HDFS-17193. Optimize dataNodePeerMetrics related parameters to avoid DN heartbeat failure.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodePeerMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodePeerMetrics.java
@@ -86,6 +86,9 @@ public class DataNodePeerMetrics {
     minOutlierDetectionNodes =
         conf.getLong(DFS_DATANODE_MIN_OUTLIER_DETECTION_NODES_KEY,
             DFS_DATANODE_MIN_OUTLIER_DETECTION_NODES_DEFAULT);
+    Preconditions.checkArgument(minOutlierDetectionNodes > 0,
+        DFS_DATANODE_MIN_OUTLIER_DETECTION_NODES_KEY +
+            " should be larger than 0");
     this.slowNodeDetector =
         new OutlierDetector(minOutlierDetectionNodes, lowThresholdMs);
     sendPacketDownstreamRollingAverages = new MutableRollingAverages("Time");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-17193



