### PR TITLE
HDFS-17106. NameNode can timeout during initialization with dfs.datanode.volumes.replica-add.threadpool.size being 0

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
@@ -284,9 +284,12 @@ public class BlockPoolSlice {
           VOLUMES_REPLICA_ADD_THREADPOOL_SIZE);
       // Default pool sizes is max of (volume * number of bp_service) and
       // number of processor.
-      addReplicaThreadPool = new ForkJoinPool(conf.getInt(
-          DFSConfigKeys.DFS_DATANODE_VOLUMES_REPLICA_ADD_THREADPOOL_SIZE_KEY,
-          poolsize));
+      int addReplicaThreadPoolSize = conf.getInt(
+              DFSConfigKeys.DFS_DATANODE_VOLUMES_REPLICA_ADD_THREADPOOL_SIZE_KEY, poolsize);
+      Preconditions.checkArgument(addReplicaThreadPoolSize > 0,
+              "%s should be a positive integer.",
+              DFSConfigKeys.DFS_DATANODE_VOLUMES_REPLICA_ADD_THREADPOOL_SIZE_KEY);
+      addReplicaThreadPool = new ForkJoinPool(addReplicaThreadPoolSize);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -1472,6 +1472,7 @@
   <description>Specifies the maximum number of threads to use for
   adding block in volume. Default value for this configuration is
   max of (volume * number of bp_service, number of processor).
+  The value should be greater than 0.
   </description>
 </property>
 


### PR DESCRIPTION
### Description of PR

When `dfs.datanode.volumes.replica-add.threadpool.size` is 0, HDFS cluster is never able to start and gets timed out eventually.

To reproduce:
1. set `dfs.datanode.volumes.replica-add.threadpool.size` to 0
2. run `mvn surefire:test -Dtest=org.apache.hadoop.hdfs.server.namenode.metrics.TestNameNodeMetrics#testExcessBlocks`

This PR improves the description of `replica-add.threadpool.size` in `hdfs-default.xml` by sepecifying that it should be positive; the PR also checks whether the value is positive before it is used to initialize `addReplicaThreadPool`.

### How was this patch tested?

Unit test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under ASF 2.0?
- [ ] If applicable, have you updated the LICENSE, LICENSE-binary, NOTICE-binary files?

