### PR TITLE
HDFS-17196. Overflow during getDatanodeReadTimeout

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -477,7 +477,10 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
 
   int getDatanodeReadTimeout(int numNodes) {
     final int t = dfsClientConf.getSocketTimeout();
-    return t > 0? HdfsConstants.READ_TIMEOUT_EXTENSION*numNodes + t: 0;
+    int readTimeout = HdfsConstants.READ_TIMEOUT_EXTENSION*numNodes + t;
+    Preconditions.checkArgument(readTimeout >= 0,
+            "Read timeout should be non-negative.");
+    return t > 0? readTimeout: 0;
   }
 
   @VisibleForTesting


### PR DESCRIPTION
### Description of PR

Datanode read timeout equals to READ_TIMEOUT_EXTENSION * numNodes + `dfs.client.socket-timeout`. A large dfs.client.socket-timeout/numNodes/READ_TIMEOUT_EXTENSION will cause overflow.

To reproduce:
1. set `dfs.client.socket-timeout` to 2147483646
2. run `mvn surefire:test -Dtest=org.apache.hadoop.hdfs.server.namenode.ha.TestHASafeMode#testBlocksRemovedWhileInSafeModeEditsArriveFirst`

This PR provides a fix by checking the read timeout calculation is at least 0.

### How was this patch tested?

Unit test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under ASF 2.0?
- [ ] If applicable, have you updated the LICENSE, LICENSE-binary, NOTICE-binary files?

