### PR TITLE
MAPREDUCE-7455. org.apache.hadoop.mapred.SpillRecord crashes due to overflow in buffer size computation

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/SpillRecord.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/SpillRecord.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.SecureIOUtils;
+import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.util.PureJavaCrc32;
 
 @InterfaceAudience.LimitedPrivate({"MapReduce"})
@@ -48,8 +49,10 @@ public class SpillRecord {
   private final LongBuffer entries;
 
   public SpillRecord(int numPartitions) {
-    buf = ByteBuffer.allocate(
-        numPartitions * MapTask.MAP_OUTPUT_INDEX_RECORD_LENGTH);
+    int bufSize = numPartitions * MapTask.MAP_OUTPUT_INDEX_RECORD_LENGTH;
+    Preconditions.checkArgument(bufSize > 0,
+            "Spill record buffer size should be positive.");
+    buf = ByteBuffer.allocate(bufSize);
     entries = buf.asLongBuffer();
   }
 


### PR DESCRIPTION
### Description of PR

A large `mapreduce.job.reduces` can cause overflow while computing the byte buffer in `org.apache.hadoop.mapred.SpillRecord#SpillRecord(int)`, since the byte buffer size equals to `mapreduce.job.reduces` * MapTask.MAP_OUTPUT_INDEX_RECORD_LENGTH


To reproduce:
1. set `mapreduce.job.reduces` to 509103844
2. run `mvn surefire:test -Dtest=org.apache.hadoop.mapred.TestMapTask#testShufflePermissions`


This PR provides a fix by checking the computed buffer size is positive.

### How was this patch tested?

Unit test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under ASF 2.0?
- [ ] If applicable, have you updated the LICENSE, LICENSE-binary, NOTICE-binary files?

