### PR TITLE
HDFS-17197. Show file replication when listing corrupt files.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -6141,7 +6141,8 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     
     @Override
     public String toString() {
-      return block.getBlockName() + "\t" + replication + "\t" + path;
+      return block.getBlockName() + "\t" +
+          (replication == -1 ? "EC" : replication) + "\t" + path;
     }
   }
   /**
@@ -6199,7 +6200,11 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
           if (isParentEntry(src, path)) {
             int repl = 0;
             if (inode.isFile()) {
-              repl = inode.asFile().getFileReplication();
+              if (inode.asFile().isStriped()) {
+                repl = -1;
+              } else {
+                repl = inode.asFile().getFileReplication();
+              }
             }
             corruptFiles.add(new CorruptFileBlockInfo(src, blk, repl));
             count++;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -6131,15 +6131,17 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   static class CorruptFileBlockInfo {
     final String path;
     final Block block;
+    final int replication;
     
-    public CorruptFileBlockInfo(String p, Block b) {
+    public CorruptFileBlockInfo(String p, Block b, int r) {
       path = p;
       block = b;
+      replication = r;
     }
     
     @Override
     public String toString() {
-      return block.getBlockName() + "\t" + path;
+      return block.getBlockName() + "\t" + replication + "\t" + path;
     }
   }
   /**
@@ -6195,7 +6197,11 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
         if (inode != null) {
           String src = inode.getFullPathName();
           if (isParentEntry(src, path)) {
-            corruptFiles.add(new CorruptFileBlockInfo(src, blk));
+            int repl = 0;
+            if (inode.isFile()) {
+              repl = inode.asFile().getFileReplication();
+            }
+            corruptFiles.add(new CorruptFileBlockInfo(src, blk, repl));
             count++;
             if (count >= maxCorruptFileBlocksReturn)
               break;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -96,7 +96,6 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SNAPSHOT_DIFF_LI
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SNAPSHOT_DIFF_LISTING_LIMIT_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSUtil.isParentEntry;
 
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.text.CaseUtils;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -6131,9 +6131,9 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   static class CorruptFileBlockInfo {
     final String path;
     final Block block;
-    final int replication;
+    private final int replication;
     
-    public CorruptFileBlockInfo(String p, Block b, int r) {
+    CorruptFileBlockInfo(String p, Block b, int r) {
       path = p;
       block = b;
       replication = r;


### PR DESCRIPTION
### Description of PR
Files with different replication have different reliability guarantees. We need to pay attention to corrupted files with a specified replication greater than or equal to 3. So, when listing corrupt files, it would be useful to display the corresponding replication of the files.