### PR TITLE
HDFS-17198. RBF: fix bug of getRepresentativeQuorum when records have same dateModified

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/impl/MembershipStoreImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/impl/MembershipStoreImpl.java
@@ -279,21 +279,22 @@ public class MembershipStoreImpl
       Collection<MembershipState> records) {
 
     // Collate objects by field value: field value -> order set of records
-    Map<FederationNamenodeServiceState, Set<MembershipState>> occurenceMap =
+    Map<FederationNamenodeServiceState, TreeSet<MembershipState>> occurenceMap =
         new HashMap<>();
     for (MembershipState record : records) {
       FederationNamenodeServiceState state = record.getState();
-      Set<MembershipState> matchingSet = occurenceMap.get(state);
+      TreeSet<MembershipState> matchingSet = occurenceMap.get(state);
       if (matchingSet == null) {
-        matchingSet = new HashSet<>();
+        // TreeSet orders elements by descending date via comparators
+        matchingSet = new TreeSet<>();
         occurenceMap.put(state, matchingSet);
       }
       matchingSet.add(record);
     }
 
     // Select largest group
-    Set<MembershipState> largestSet = new HashSet<>();
-    for (Set<MembershipState> matchingSet : occurenceMap.values()) {
+    TreeSet<MembershipState> largestSet = new TreeSet<>();
+    for (TreeSet<MembershipState> matchingSet : occurenceMap.values()) {
       if (largestSet.size() < matchingSet.size()) {
         largestSet = matchingSet;
       }
@@ -301,8 +302,7 @@ public class MembershipStoreImpl
 
     // If quorum, use the newest element here
     if (largestSet.size() > records.size() / 2) {
-      TreeSet<MembershipState> sortedList = new TreeSet<>(largestSet);
-      return sortedList.first();
+      return largestSet.first();
       // Otherwise, return most recent by class comparator
     } else if (records.size() > 0) {
       TreeSet<MembershipState> sortedList = new TreeSet<>(records);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/impl/MembershipStoreImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/impl/MembershipStoreImpl.java
@@ -279,22 +279,21 @@ public class MembershipStoreImpl
       Collection<MembershipState> records) {
 
     // Collate objects by field value: field value -> order set of records
-    Map<FederationNamenodeServiceState, TreeSet<MembershipState>> occurenceMap =
+    Map<FederationNamenodeServiceState, Set<MembershipState>> occurenceMap =
         new HashMap<>();
     for (MembershipState record : records) {
       FederationNamenodeServiceState state = record.getState();
-      TreeSet<MembershipState> matchingSet = occurenceMap.get(state);
+      Set<MembershipState> matchingSet = occurenceMap.get(state);
       if (matchingSet == null) {
-        // TreeSet orders elements by descending date via comparators
-        matchingSet = new TreeSet<>();
+        matchingSet = new HashSet<>();
         occurenceMap.put(state, matchingSet);
       }
       matchingSet.add(record);
     }
 
     // Select largest group
-    TreeSet<MembershipState> largestSet = new TreeSet<>();
-    for (TreeSet<MembershipState> matchingSet : occurenceMap.values()) {
+    Set<MembershipState> largestSet = new TreeSet<>();
+    for (Set<MembershipState> matchingSet : occurenceMap.values()) {
       if (largestSet.size() < matchingSet.size()) {
         largestSet = matchingSet;
       }
@@ -302,7 +301,8 @@ public class MembershipStoreImpl
 
     // If quorum, use the newest element here
     if (largestSet.size() > records.size() / 2) {
-      return largestSet.first();
+      TreeSet<MembershipState> sortedList = new TreeSet<>(largestSet);
+      return sortedList.first();
       // Otherwise, return most recent by class comparator
     } else if (records.size() > 0) {
       TreeSet<MembershipState> sortedList = new TreeSet<>(records);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/impl/MembershipStoreImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/impl/MembershipStoreImpl.java
@@ -292,7 +292,7 @@ public class MembershipStoreImpl
     }
 
     // Select largest group
-    Set<MembershipState> largestSet = new TreeSet<>();
+    Set<MembershipState> largestSet = new HashSet<>();
     for (Set<MembershipState> matchingSet : occurenceMap.values()) {
       if (largestSet.size() < matchingSet.size()) {
         largestSet = matchingSet;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/records/MembershipState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/records/MembershipState.java
@@ -358,4 +358,23 @@ public abstract class MembershipState extends BaseRecord
   public static void setDeletionMs(long time) {
     MembershipState.deletionMs = time;
   }
+
+  /**
+   * First use the comparator of the BaseRecord to compare the date modified.
+   * If they are equal, use {@link MembershipState#NAME_COMPARATOR} to continue the comparison
+   * to ensure that MembershipStates with the same date modified but reported by different routers
+   * will not be judged as equal.
+   *
+   * @param record the MembershipState object to be compared.
+   * @return a negative integer, zero, or a positive integer as this object
+   *         is less than, equal to, or greater than the specified object.
+   */
+  @Override
+  public int compareTo(BaseRecord record) {
+    int order = super.compareTo(record);
+    if (order == 0) {
+      return NAME_COMPARATOR.compare(this, (MembershipState) record);
+    }
+    return order;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/records/MembershipState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/records/MembershipState.java
@@ -361,9 +361,8 @@ public abstract class MembershipState extends BaseRecord
 
   /**
    * First use the comparator of the BaseRecord to compare the date modified.
-   * If they are equal, use {@link MembershipState#NAME_COMPARATOR} to continue the comparison
-   * to ensure that MembershipStates with the same date modified but reported by different routers
-   * will not be judged as equal.
+   * If they are equal, compare their primary keys to ensure that MembershipStates
+   * with the same date modified but reported by different routers will not be judged as equal.
    *
    * @param record the MembershipState object to be compared.
    * @return a negative integer, zero, or a positive integer as this object
@@ -373,7 +372,8 @@ public abstract class MembershipState extends BaseRecord
   public int compareTo(BaseRecord record) {
     int order = super.compareTo(record);
     if (order == 0) {
-      return NAME_COMPARATOR.compare(this, (MembershipState) record);
+      MembershipState other = (MembershipState) record;
+      return this.getPrimaryKey().compareTo(other.getPrimaryKey());
     }
     return order;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMembershipState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMembershipState.java
@@ -224,6 +224,54 @@ public class TestStateStoreMembershipState extends TestStateStoreBase {
   }
 
   @Test
+  public void testRegistrationMajorityQuorumEqDateModified()
+          throws InterruptedException, IOException {
+
+    // Populate the state store with a set of non-matching elements
+    // 1) ns0:nn0 - Standby (newest)
+    // 2) ns0:nn0 - Active
+    // 3) ns0:nn0 - Active
+    // 4) ns0:nn0 - Active
+    // (2), (3), (4) have the same date modified time
+    // Verify the selected entry is the newest majority opinion (4)
+    String ns = "ns0";
+    String nn = "nn0";
+
+    long dateModified = Time.now();
+    // Active - oldest
+    MembershipState report = createRegistration(
+            ns, nn, ROUTERS[1], FederationNamenodeServiceState.ACTIVE);
+    report.setDateModified(dateModified);
+    assertTrue(namenodeHeartbeat(report));
+
+    // Active - 2nd oldest
+    report = createRegistration(
+            ns, nn, ROUTERS[2], FederationNamenodeServiceState.ACTIVE);
+    report.setDateModified(dateModified);
+    assertTrue(namenodeHeartbeat(report));
+
+    // Active - 3rd oldest
+    report = createRegistration(
+            ns, nn, ROUTERS[3], FederationNamenodeServiceState.ACTIVE);
+    report.setDateModified(dateModified);
+    assertTrue(namenodeHeartbeat(report));
+
+    // standby - newest overall
+    report = createRegistration(
+            ns, nn, ROUTERS[0], FederationNamenodeServiceState.STANDBY);
+    assertTrue(namenodeHeartbeat(report));
+
+    // Load and calculate quorum
+    assertTrue(getStateStore().loadCache(MembershipStore.class, true));
+
+    // Verify quorum entry
+    MembershipState quorumEntry = getNamenodeRegistration(
+            report.getNameserviceId(), report.getNamenodeId());
+    assertNotNull(quorumEntry);
+    assertEquals(quorumEntry.getState(), FederationNamenodeServiceState.ACTIVE);
+  }
+
+  @Test
   public void testRegistrationQuorumExcludesExpired()
       throws InterruptedException, IOException {
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMembershipState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMembershipState.java
@@ -228,7 +228,7 @@ public class TestStateStoreMembershipState extends TestStateStoreBase {
    */
   @Test
   public void testRegistrationMajorityQuorumEqDateModified()
-          throws InterruptedException, IOException {
+        throws IOException {
 
     // Populate the state store with a set of non-matching elements
     // 1) ns0:nn0 - Standby (newest)

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMembershipState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMembershipState.java
@@ -271,6 +271,7 @@ public class TestStateStoreMembershipState extends TestStateStoreBase {
     MembershipState quorumEntry = getNamenodeRegistration(
         report.getNameserviceId(), report.getNamenodeId());
     assertNotNull(quorumEntry);
+    // The name node status should be active
     assertEquals(FederationNamenodeServiceState.ACTIVE, quorumEntry.getState());
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMembershipState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMembershipState.java
@@ -243,25 +243,25 @@ public class TestStateStoreMembershipState extends TestStateStoreBase {
     long dateModified = Time.now();
     // Active - oldest
     MembershipState report = createRegistration(
-            ns, nn, ROUTERS[1], FederationNamenodeServiceState.ACTIVE);
+        ns, nn, ROUTERS[1], FederationNamenodeServiceState.ACTIVE);
     report.setDateModified(dateModified);
     assertTrue(namenodeHeartbeat(report));
 
     // Active - 2nd oldest
     report = createRegistration(
-            ns, nn, ROUTERS[2], FederationNamenodeServiceState.ACTIVE);
+        ns, nn, ROUTERS[2], FederationNamenodeServiceState.ACTIVE);
     report.setDateModified(dateModified);
     assertTrue(namenodeHeartbeat(report));
 
     // Active - 3rd oldest
     report = createRegistration(
-            ns, nn, ROUTERS[3], FederationNamenodeServiceState.ACTIVE);
+        ns, nn, ROUTERS[3], FederationNamenodeServiceState.ACTIVE);
     report.setDateModified(dateModified);
     assertTrue(namenodeHeartbeat(report));
 
     // standby - newest overall
     report = createRegistration(
-            ns, nn, ROUTERS[0], FederationNamenodeServiceState.STANDBY);
+        ns, nn, ROUTERS[0], FederationNamenodeServiceState.STANDBY);
     assertTrue(namenodeHeartbeat(report));
 
     // Load and calculate quorum
@@ -269,9 +269,9 @@ public class TestStateStoreMembershipState extends TestStateStoreBase {
 
     // Verify quorum entry
     MembershipState quorumEntry = getNamenodeRegistration(
-            report.getNameserviceId(), report.getNamenodeId());
+        report.getNameserviceId(), report.getNamenodeId());
     assertNotNull(quorumEntry);
-    assertEquals(quorumEntry.getState(), FederationNamenodeServiceState.ACTIVE);
+    assertEquals(FederationNamenodeServiceState.ACTIVE, quorumEntry.getState());
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMembershipState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMembershipState.java
@@ -223,6 +223,9 @@ public class TestStateStoreMembershipState extends TestStateStoreBase {
     assertEquals(quorumEntry.getRouterId(), ROUTERS[3]);
   }
 
+  /**
+   * Fix getRepresentativeQuorum when records have same date modified time.
+   */
   @Test
   public void testRegistrationMajorityQuorumEqDateModified()
           throws InterruptedException, IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMembershipState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMembershipState.java
@@ -228,7 +228,7 @@ public class TestStateStoreMembershipState extends TestStateStoreBase {
    */
   @Test
   public void testRegistrationMajorityQuorumEqDateModified()
-        throws IOException {
+      throws IOException {
 
     // Populate the state store with a set of non-matching elements
     // 1) ns0:nn0 - Standby (newest)


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
In the original implementation, when each router reports nn status at different times, the nn status is the status reported by majority routers, for example:
router1 -> nn0:active dateModified:1

router2 -> nn0:active dateModified:2

router3 -> nn0:active dateModified:3

router0 -> nn0:standby dateModified:4

Then, the status of nn0 is active, because majority routers report that nn0 is active.

If majority routers report nn status at the same time, for example:
(record1) router1 -> nn0:active dateModified:1

(record2) router2 -> nn0:active dateModified:1

(record3) router3 -> nn0:active dateModified:1

(record4) router0 -> nn0:standbydateModified:2

Then the state of nn0 is standby, but We expect the status of nn0 is active

This bug is because the above record is put into the Treeset in the method getRepresentativeQuorum. Since record1,2,3 have the same dateModified, there will only be one record in the final treeset of this method, so this method thinks that this nn is standby, because record4 newer

see: https://issues.apache.org/jira/browse/HDFS-17198

### How was this patch tested?
my unit test testRegistrationMajorityQuorumEqDateModified

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

