### PR TITLE
YARN-11574. Make yarn router webservice forward auth type configurable.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/RouterWebServiceUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/RouterWebServiceUtil.java
@@ -95,6 +95,9 @@ public final class RouterWebServiceUtil {
 
   private final static String PARTIAL_REPORT = "Partial Report ";
 
+  private static final String HADOOP_HTTP_AUTHENTICATION_TYPE =
+          "hadoop.http.authentication.type";
+
   /** Disable constructor. */
   private RouterWebServiceUtil() {
   }
@@ -123,7 +126,8 @@ public final class RouterWebServiceUtil {
 
     UserGroupInformation callerUGI = null;
 
-    if (hsr != null) {
+    if (hsr != null && !conf.get(HADOOP_HTTP_AUTHENTICATION_TYPE, "simple")
+            .equalsIgnoreCase("simple")) {
       callerUGI = RMWebAppUtil.getCallerUserGroupInformation(hsr, true);
     } else {
       // user not required

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServiceUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServiceUtil.java
@@ -26,9 +26,12 @@ import java.util.concurrent.TimeUnit;
 
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.config.ClientConfig;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.resourcemanager.MockRM;
+import org.apache.hadoop.yarn.server.resourcemanager.webapp.RMWSConsts;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.AppInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.AppsInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ClusterMetricsInfo;
@@ -43,6 +46,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -761,5 +766,35 @@ public class TestRouterWebServiceUtil {
 
   private long getTimeDuration(YarnConfiguration conf, String varName, long defaultValue) {
     return conf.getTimeDuration(varName, defaultValue, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  public void testGenericForwardAuthentication() {
+    Configuration conf = new Configuration();
+    conf.setBoolean("mockrm.webapp.enabled", true);
+    conf.set(YarnConfiguration.RM_WEBAPP_ADDRESS, "localhost:8088");
+
+    MockRM mockRM = new MockRM(conf);
+    mockRM.start();
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    Client client = RouterWebServiceUtil.createJerseyClient(conf);
+
+    conf.set("hadoop.http.authentication.type", "kerberos");
+    AppsInfo apps = RouterWebServiceUtil.genericForward("http://localhost:8088", request,
+            AppsInfo.class, HTTPMethods.GET,
+            RMWSConsts.RM_WEB_SERVICE_PATH + RMWSConsts.APPS, null,
+            null, conf, client);
+    Assert.assertNull(apps);
+
+    conf.set("hadoop.http.authentication.type", "simple");
+    apps = RouterWebServiceUtil.genericForward("http://localhost:8088", request,
+            AppsInfo.class, HTTPMethods.GET,
+            RMWSConsts.RM_WEB_SERVICE_PATH + RMWSConsts.APPS, null,
+            null, conf, client);
+    Assert.assertNotNull(apps);
+
+    client.destroy();
+    mockRM.stop();
   }
 }


### PR DESCRIPTION
### Description of PR

Now if we request yarn router webservice to get apps without authentication, will return null and print error log "Unable to obtain user name, user not authenticated",  because the RouterWebServiceUtil#genericForward will try to get callerUGI from HttpServletRequest.

I think we can check the config `hadoop.http.authentication.type` to determine whether the user should be authenticated.

### How was this patch tested?

unit test

