### PR TITLE
HDFS-17208. Add the metrics PendingAsyncDiskOperations in datanode

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
@@ -161,7 +161,11 @@ class FsDatasetAsyncDiskService {
       executors.remove(storageId);
     }
   }
-  
+
+  /**
+   * The count of pending and running asynchronous disk operations,
+   * include deletion of block files and requesting sync_file_range() operations.
+   */
   synchronized long countPendingDeletions() {
     long count = 0;
     for (ThreadPoolExecutor exec : executors.values()) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -3822,5 +3822,10 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
   public void setLastDirScannerFinishTime(long time) {
     this.lastDirScannerFinishTime = time;
   }
+
+  @Override
+  public long getPendingAsyncDiskOperations() {
+    return this.asyncDiskService.countPendingDeletions();
+  }
 }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -3824,7 +3824,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
   }
 
   @Override
-  public long getPendingAsyncDiskOperations() {
+  public long getPendingAsyncDeletions() {
     return this.asyncDiskService.countPendingDeletions();
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -3825,7 +3825,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
 
   @Override
   public long getPendingAsyncDeletions() {
-    return this.asyncDiskService.countPendingDeletions();
+    return asyncDiskService.countPendingDeletions();
   }
 }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetricHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetricHelper.java
@@ -73,7 +73,10 @@ public class DataNodeMetricHelper {
           " blocks failed in cache eviction"),
         beanClass.getNumBlocksFailedToUncache())
         .addGauge(Interns.info("LastDirectoryScannerFinishTime",
-        "Finish time of the last directory scan"), beanClass.getLastDirScannerFinishTime());
+        "Finish time of the last directory scan"), beanClass.getLastDirScannerFinishTime())
+        .addGauge(Interns.info("PendingAsyncDiskOperations",
+            "The count of pending and running asynchronous disk operations"),
+            beanClass.getPendingAsyncDiskOperations());
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetricHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetricHelper.java
@@ -74,9 +74,9 @@ public class DataNodeMetricHelper {
         beanClass.getNumBlocksFailedToUncache())
         .addGauge(Interns.info("LastDirectoryScannerFinishTime",
         "Finish time of the last directory scan"), beanClass.getLastDirScannerFinishTime())
-        .addGauge(Interns.info("PendingAsyncDiskOperations",
+        .addGauge(Interns.info("PendingAsyncDeletions",
             "The count of pending and running asynchronous disk operations"),
-            beanClass.getPendingAsyncDiskOperations());
+            beanClass.getPendingAsyncDeletions());
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/FSDatasetMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/FSDatasetMBean.java
@@ -131,5 +131,5 @@ public interface FSDatasetMBean extends MetricsSource {
   /**
    * Returns the count of pending and running asynchronous disk operations.
    */
-  long getPendingAsyncDiskOperations();
+  long getPendingAsyncDeletions();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/FSDatasetMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/FSDatasetMBean.java
@@ -127,4 +127,9 @@ public interface FSDatasetMBean extends MetricsSource {
    * Returns the last time in milliseconds when the directory scanner successfully ran.
    */
   long getLastDirScannerFinishTime();
+
+  /**
+   * Returns the count of pending and running asynchronous disk operations.
+   */
+  long getPendingAsyncDiskOperations();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
@@ -944,6 +944,11 @@ public class SimulatedFSDataset implements FsDatasetSpi<FsVolumeSpi> {
     return 0L;
   }
 
+  @Override
+  public long getPendingAsyncDiskOperations() {
+    return 0;
+  }
+
   /**
    * Get metrics from the metrics source
    *

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
@@ -945,7 +945,7 @@ public class SimulatedFSDataset implements FsDatasetSpi<FsVolumeSpi> {
   }
 
   @Override
-  public long getPendingAsyncDiskOperations() {
+  public long getPendingAsyncDeletions() {
     return 0;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
@@ -483,4 +483,8 @@ public class ExternalDatasetImpl implements FsDatasetSpi<ExternalVolumeImpl> {
     return 0L;
   }
 
+  @Override
+  public long getPendingAsyncDiskOperations() {
+    return 0;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
@@ -484,7 +484,7 @@ public class ExternalDatasetImpl implements FsDatasetSpi<ExternalVolumeImpl> {
   }
 
   @Override
-  public long getPendingAsyncDiskOperations() {
+  public long getPendingAsyncDeletions() {
     return 0;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -1907,15 +1907,15 @@ public class TestFsDatasetImpl {
       assertNotNull(ds.getStoredBlock(bpid, extendedBlock.getBlockId()));
 
       assertEquals(1, ds.asyncDiskService.countPendingDeletions());
-      assertEquals(1, ds.getPendingAsyncDiskOperations());
+      assertEquals(1, ds.getPendingAsyncDeletions());
 
-      // Validate PendingAsyncDiskOperations metrics.
+      // Validate PendingAsyncDeletions metrics.
       MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
       ObjectName mxbeanName = new ObjectName(
           "Hadoop:service=DataNode,name=FSDatasetState-" + dn.getDatanodeUuid());
-      long pendingAsyncDiskOperations = (long) mbs.getAttribute(mxbeanName,
-          "PendingAsyncDiskOperations");
-      assertEquals(1, pendingAsyncDiskOperations);
+      long pendingAsyncDeletions = (long) mbs.getAttribute(mxbeanName,
+          "PendingAsyncDeletions");
+      assertEquals(1, pendingAsyncDeletions);
 
       // Make it resume the removeReplicaFromMem method.
       semaphore.release(1);
@@ -1924,11 +1924,11 @@ public class TestFsDatasetImpl {
       GenericTestUtils.waitFor(() ->
           ds.asyncDiskService.countPendingDeletions() == 0, 100, 1000);
 
-      assertEquals(0, ds.getPendingAsyncDiskOperations());
+      assertEquals(0, ds.getPendingAsyncDeletions());
 
-      pendingAsyncDiskOperations = (long) mbs.getAttribute(mxbeanName,
-          "PendingAsyncDiskOperations");
-      assertEquals(0, pendingAsyncDiskOperations);
+      pendingAsyncDeletions = (long) mbs.getAttribute(mxbeanName,
+          "PendingAsyncDeletions");
+      assertEquals(0, pendingAsyncDeletions);
 
       // Sleep for two heartbeat times.
       Thread.sleep(config.getTimeDuration(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdfs.server.datanode.fsdataset.impl;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Random;
@@ -130,6 +131,14 @@ import static org.mockito.Mockito.when;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
 
 public class TestFsDatasetImpl {
 
@@ -1842,7 +1851,8 @@ public class TestFsDatasetImpl {
    */
   @Test
   public void testAysncDiskServiceDeleteReplica()
-      throws IOException, InterruptedException, TimeoutException {
+      throws IOException, InterruptedException, TimeoutException, MalformedObjectNameException,
+      ReflectionException, AttributeNotFoundException, InstanceNotFoundException, MBeanException {
     HdfsConfiguration config = new HdfsConfiguration();
     // Bump up replication interval.
     config.setInt(DFSConfigKeys.DFS_NAMENODE_REDUNDANCY_INTERVAL_SECONDS_KEY, 10);
@@ -1896,12 +1906,29 @@ public class TestFsDatasetImpl {
       // If this replica is deleted from memory, the client would got an ReplicaNotFoundException.
       assertNotNull(ds.getStoredBlock(bpid, extendedBlock.getBlockId()));
 
+      assertEquals(1, ds.asyncDiskService.countPendingDeletions());
+      assertEquals(1, ds.getPendingAsyncDiskOperations());
+
+      // Validate PendingAsyncDiskOperations metrics.
+      MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+      ObjectName mxbeanName = new ObjectName(
+          "Hadoop:service=DataNode,name=FSDatasetState-" + dn.getDatanodeUuid());
+      long pendingAsyncDiskOperations = (long) mbs.getAttribute(mxbeanName,
+          "PendingAsyncDiskOperations");
+      assertEquals(1, pendingAsyncDiskOperations);
+
       // Make it resume the removeReplicaFromMem method.
       semaphore.release(1);
 
       // Waiting for the async deletion task finish.
       GenericTestUtils.waitFor(() ->
           ds.asyncDiskService.countPendingDeletions() == 0, 100, 1000);
+
+      assertEquals(0, ds.getPendingAsyncDiskOperations());
+
+      pendingAsyncDiskOperations = (long) mbs.getAttribute(mxbeanName,
+          "PendingAsyncDiskOperations");
+      assertEquals(0, pendingAsyncDiskOperations);
 
       // Sleep for two heartbeat times.
       Thread.sleep(config.getTimeDuration(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY,


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17208

Consider should add the metrics `PendingAsyncDiskOperations` to be able to track if we are queueing too many asynchronous disk operations in FsDatasetAsyncDiskService of the datanode.


