### PR TITLE
HDFS-17209. Correct comments to align with the code

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -2569,7 +2569,7 @@ public class DataNode extends ReconfigurableBase
     if (this.threadGroup != null) {
       int sleepMs = 2;
       while (true) {
-        // When shutting down for restart, wait 2.5 seconds before forcing
+        // When shutting down for restart, wait 1 second before forcing
         // termination of receiver threads.
         if (!this.shutdownForUpgrade ||
             (this.shutdownForUpgrade && (Time.monotonicNow() - timeNotified


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The waiting time in the comments is inconsistent with the code in DataNode.java

public void shutdown() {
...
  while (true) {
    // When shutting down for restart, wait 2.5 seconds before forcing
    // termination of receiver threads.
    if (!this.shutdownForUpgrade ||
        (this.shutdownForUpgrade && (Time.monotonicNow() - timeNotified
            > 1000))) {
      this.threadGroup.interrupt();
      break;
    }
### How was this patch tested?
This patch only modifies comments and does not require adding new test cases

