### PR TITLE
HDFS-17210. Optimize AvailableSpaceBlockPlacementPolicy.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1244,8 +1244,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
           DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY =
           "dfs.namenode.available-space-block-placement-policy.balanced-space-tolerance-limit";
   public static final int
-          DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT =
-          100;
+      DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT =
+      100;
   public static final String
       DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_KEY =
       "dfs.namenode.available-space-rack-fault-tolerant-block-placement-policy"

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1241,8 +1241,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT =
       5;
   public static final String
-          DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY =
-          "dfs.namenode.available-space-block-placement-policy.balanced-space-tolerance-limit";
+      DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY =
+      "dfs.namenode.available-space-block-placement-policy.balanced-space-tolerance-limit";
   public static final int
       DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT =
       100;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1241,6 +1241,12 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT =
       5;
   public static final String
+          DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY =
+          "dfs.namenode.available-space-block-placement-policy.balanced-space-tolerance";
+  public static final int
+          DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT =
+          100;
+  public static final String
       DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_KEY =
       "dfs.namenode.available-space-rack-fault-tolerant-block-placement-policy"
           + ".balanced-space-preference-fraction";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1242,7 +1242,7 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       5;
   public static final String
           DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY =
-          "dfs.namenode.available-space-block-placement-policy.balanced-space-tolerance";
+          "dfs.namenode.available-space-block-placement-policy.balanced-space-tolerance-limit";
   public static final int
           DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT =
           100;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicy.java
@@ -212,10 +212,10 @@ public class AvailableSpaceBlockPlacementPolicy extends
   protected int compareDataNode(final DatanodeDescriptor a,
       final DatanodeDescriptor b, boolean isBalanceLocal) {
 
-    boolean toleranceLimit = Math.min(a.getDfsUsedPercent(), b.getDfsUsedPercent())
-            >= balancedSpaceToleranceLimit;
+    boolean toleranceLimit = Math.max(a.getDfsUsedPercent(), b.getDfsUsedPercent())
+            < balancedSpaceToleranceLimit;
     if (a.equals(b)
-        || (!toleranceLimit && Math.abs(a.getDfsUsedPercent() - b.getDfsUsedPercent())
+        || (toleranceLimit && Math.abs(a.getDfsUsedPercent() - b.getDfsUsedPercent())
             < balancedSpaceTolerance) || ((
         isBalanceLocal && a.getDfsUsedPercent() < 50))) {
       return 0;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicy.java
@@ -64,8 +64,8 @@ public class AvailableSpaceBlockPlacementPolicy extends
     super.initialize(conf, stats, clusterMap, host2datanodeMap);
     float balancedPreferencePercent =
         conf.getFloat(
-          DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_KEY,
-          DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_DEFAULT);
+        DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_KEY,
+        DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_DEFAULT);
 
     LOG.info("Available space block placement policy initialized: "
         + DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_KEY
@@ -99,12 +99,13 @@ public class AvailableSpaceBlockPlacementPolicy extends
 
     if (balancedSpaceToleranceLimit > 100 || balancedSpaceToleranceLimit < 0) {
       LOG.warn("The value of "
-              + DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY
-              + " is invalid, Current value is " + balancedSpaceToleranceLimit + ", Default value " +
-              DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT
-              + " will be used instead.");
+          + DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY
+          + " is invalid, Current value is " + balancedSpaceToleranceLimit + ", Default value "
+          + DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT
+          + " will be used instead.");
+
       balancedSpaceToleranceLimit =
-              DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT;
+          DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT;
     }
 
     if (balancedSpaceTolerance > 20 || balancedSpaceTolerance < 0) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicy.java
@@ -55,7 +55,7 @@ public class AvailableSpaceBlockPlacementPolicy extends
           DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT;
 
   private int balancedSpaceToleranceLimit =
-          DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT;
+      DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT;
   private boolean optimizeLocal;
 
   @Override
@@ -77,9 +77,9 @@ public class AvailableSpaceBlockPlacementPolicy extends
         DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT);
 
     balancedSpaceToleranceLimit =
-            conf.getInt(
-                    DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY,
-                    DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT);
+      conf.getInt(
+      DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY,
+      DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT);
 
     optimizeLocal = conf.getBoolean(
         DFSConfigKeys.DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCE_LOCAL_NODE_KEY,
@@ -213,7 +213,7 @@ public class AvailableSpaceBlockPlacementPolicy extends
       final DatanodeDescriptor b, boolean isBalanceLocal) {
 
     boolean toleranceLimit = Math.min(a.getDfsUsedPercent(), b.getDfsUsedPercent())
-            >= balancedSpaceToleranceLimit ;
+            >= balancedSpaceToleranceLimit;
     if (a.equals(b)
         || (!toleranceLimit && Math.abs(a.getDfsUsedPercent() - b.getDfsUsedPercent())
             < balancedSpaceTolerance) || ((

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicy.java
@@ -52,7 +52,7 @@ public class AvailableSpaceBlockPlacementPolicy extends
   private int balancedPreference =
       (int) (100 * DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_DEFAULT);
   private int balancedSpaceTolerance =
-          DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT;
+      DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT;
 
   private int balancedSpaceToleranceLimit =
       DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT;
@@ -95,6 +95,16 @@ public class AvailableSpaceBlockPlacementPolicy extends
           + DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_KEY
           + " is less than 0.5 so datanodes with more used percent will"
           + " receive  more block allocations.");
+    }
+
+    if (balancedSpaceToleranceLimit > 100 || balancedSpaceToleranceLimit < 0) {
+      LOG.warn("The value of "
+              + DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY
+              + " is invalid, Current value is " + balancedSpaceToleranceLimit + ", Default value " +
+              DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT
+              + " will be used instead.");
+      balancedSpaceToleranceLimit =
+              DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT;
     }
 
     if (balancedSpaceTolerance > 20 || balancedSpaceTolerance < 0) {
@@ -213,7 +223,7 @@ public class AvailableSpaceBlockPlacementPolicy extends
       final DatanodeDescriptor b, boolean isBalanceLocal) {
 
     boolean toleranceLimit = Math.max(a.getDfsUsedPercent(), b.getDfsUsedPercent())
-            < balancedSpaceToleranceLimit;
+        < balancedSpaceToleranceLimit;
     if (a.equals(b)
         || (toleranceLimit && Math.abs(a.getDfsUsedPercent() - b.getDfsUsedPercent())
             < balancedSpaceTolerance) || ((

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -5164,6 +5164,18 @@
     </description>
   </property>
 
+  <property>
+    <name>dfs.namenode.available-space-block-placement-policy.balanced-space-tolerance-limit</name>
+    <value>100</value>
+    <description>
+      Only used when the dfs.block.replicator.classname is set to
+      org.apache.hadoop.hdfs.server.blockmanagement.AvailableSpaceBlockPlacementPolicy.
+      Special value between 0 and 100, inclusive. if the comparable datanodes usage both beyond
+      ${dfs.namenode.available-space-block-placement-policy.balanced-space-tolerance-limit},
+      dfs.namenode.available-space-block-placement-policy.balanced-space-tolerance will be disable.
+    </description>
+  </property>
+
 <property>
   <name>
     dfs.namenode.available-space-block-placement-policy.balance-local-node

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -5170,9 +5170,8 @@
     <description>
       Only used when the dfs.block.replicator.classname is set to
       org.apache.hadoop.hdfs.server.blockmanagement.AvailableSpaceBlockPlacementPolicy.
-      Special value between 0 and 100, inclusive. if the comparable datanodes usage both beyond
-      ${dfs.namenode.available-space-block-placement-policy.balanced-space-tolerance-limit},
-      dfs.namenode.available-space-block-placement-policy.balanced-space-tolerance will be disable.
+      Special value between 0 and 100, inclusive. if the value is set beyond the scope,
+      this value will be set as 100 by default.
     </description>
   </property>
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
@@ -243,37 +243,37 @@ public class TestAvailableSpaceBlockPlacementPolicy {
 
     //96.6%
     updateHeartbeatWithUsage(tolerateDataNodes[0],
-       30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-       29 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-       HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
+        30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+        29 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+        HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
         * blockSize, 0L, 0L, 0L, 0, 0);
 
     //93.3%
     updateHeartbeatWithUsage(tolerateDataNodes[1],
-       30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-       28 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-       HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
+        30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+        28 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+        HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
         * blockSize, 0L, 0L, 0L, 0, 0);
 
     //90.0%
     updateHeartbeatWithUsage(tolerateDataNodes[2],
-       30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-       27 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-       HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
+        30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+        27 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+        HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
         * blockSize, 0L, 0L, 0L, 0, 0);
 
     //86.6%
     updateHeartbeatWithUsage(tolerateDataNodes[3],
-       30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-       26 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-       HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
+        30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+        26 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+        HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
         * blockSize, 0L, 0L, 0L, 0, 0);
 
     //83.3%
     updateHeartbeatWithUsage(tolerateDataNodes[4],
-       30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-       25 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-       HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
+        30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+        25 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+        HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
         * blockSize, 0L, 0L, 0L, 0, 0);
 
     assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[0],

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
@@ -59,10 +59,10 @@ public class TestAvailableSpaceBlockPlacementPolicy {
   public static void setupCluster() throws Exception {
     conf = new HdfsConfiguration();
     conf.setFloat(DFSConfigKeys.
-    DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_KEY,
-      0.6f);
+        DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_KEY,
+            0.6f);
     conf.setInt(DFSConfigKeys.
-    DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY,
+        DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY,
             93);
     String[] racks = new String[numRacks];
     for (int i = 0; i < numRacks; i++) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
@@ -227,7 +227,7 @@ public class TestAvailableSpaceBlockPlacementPolicy {
   public void testCompareDataNode() {
     DatanodeDescriptor[] tolerateDataNodes;
     DatanodeStorageInfo[] tolerateStorages;
-    int capacity  = 4;
+    int capacity  = 5;
     Collection<Node> allTolerateNodes = new ArrayList<>(capacity);
     String[] ownerRackOfTolerateNodes = new String[capacity];
     for (int i = 0; i < capacity; i++) {
@@ -241,25 +241,37 @@ public class TestAvailableSpaceBlockPlacementPolicy {
     AvailableSpaceBlockPlacementPolicy toleratePlacementPolicy =
             (AvailableSpaceBlockPlacementPolicy)bm.getBlockPlacementPolicy();
 
+    //96.6%
     updateHeartbeatWithUsage(tolerateDataNodes[0],
             30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
             29 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
             HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
                     * blockSize, 0L, 0L, 0L, 0, 0);
+
+    //93.3%
     updateHeartbeatWithUsage(tolerateDataNodes[1],
             30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
             28 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
             HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
                     * blockSize, 0L, 0L, 0L, 0, 0);
+
+    //90.0%
     updateHeartbeatWithUsage(tolerateDataNodes[2],
             30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
             27 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
             HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
                     * blockSize, 0L, 0L, 0L, 0, 0);
 
+    //86.6%
     updateHeartbeatWithUsage(tolerateDataNodes[3],
             30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-            20 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+            26 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+            HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
+                    * blockSize, 0L, 0L, 0L, 0, 0);
+    //83.3%
+    updateHeartbeatWithUsage(tolerateDataNodes[4],
+            30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+            25 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
             HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
                     * blockSize, 0L, 0L, 0L, 0, 0);
 
@@ -268,12 +280,16 @@ public class TestAvailableSpaceBlockPlacementPolicy {
     assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[1],
             tolerateDataNodes[0], false) == -1);
     assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[1],
+            tolerateDataNodes[2], false) == 1);
+    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[2],
+            tolerateDataNodes[1], false) == -1);
+    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[2],
+            tolerateDataNodes[3], false) == 0);
+    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[3],
             tolerateDataNodes[2], false) == 0);
     assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[2],
-            tolerateDataNodes[1], false) == 0);
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[2],
-            tolerateDataNodes[3], false) == 1);
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[3],
+            tolerateDataNodes[4], false) == 1);
+    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[4],
             tolerateDataNodes[2], false) == -1);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
@@ -58,10 +58,11 @@ public class TestAvailableSpaceBlockPlacementPolicy {
   @BeforeClass
   public static void setupCluster() throws Exception {
     conf = new HdfsConfiguration();
-    conf.setFloat(
-      DFSConfigKeys.DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_KEY,
+    conf.setFloat(DFSConfigKeys.
+    DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_KEY,
       0.6f);
-    conf.setInt(DFSConfigKeys.DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY,
+    conf.setInt(DFSConfigKeys.
+    DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY,
             93);
     String[] racks = new String[numRacks];
     for (int i = 0; i < numRacks; i++) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
@@ -239,58 +239,59 @@ public class TestAvailableSpaceBlockPlacementPolicy {
     Collections.addAll(allTolerateNodes, tolerateDataNodes);
     final BlockManager bm = namenode.getNamesystem().getBlockManager();
     AvailableSpaceBlockPlacementPolicy toleratePlacementPolicy =
-            (AvailableSpaceBlockPlacementPolicy)bm.getBlockPlacementPolicy();
+        (AvailableSpaceBlockPlacementPolicy)bm.getBlockPlacementPolicy();
 
     //96.6%
     updateHeartbeatWithUsage(tolerateDataNodes[0],
-            30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-            29 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-            HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
-                    * blockSize, 0L, 0L, 0L, 0, 0);
+       30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+       29 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+       HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
+        * blockSize, 0L, 0L, 0L, 0, 0);
 
     //93.3%
     updateHeartbeatWithUsage(tolerateDataNodes[1],
-            30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-            28 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-            HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
-                    * blockSize, 0L, 0L, 0L, 0, 0);
+       30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+       28 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+       HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
+        * blockSize, 0L, 0L, 0L, 0, 0);
 
     //90.0%
     updateHeartbeatWithUsage(tolerateDataNodes[2],
-            30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-            27 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-            HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
-                    * blockSize, 0L, 0L, 0L, 0, 0);
+       30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+       27 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+       HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
+        * blockSize, 0L, 0L, 0L, 0, 0);
 
     //86.6%
     updateHeartbeatWithUsage(tolerateDataNodes[3],
-            30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-            26 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-            HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
-                    * blockSize, 0L, 0L, 0L, 0, 0);
+       30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+       26 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+       HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
+        * blockSize, 0L, 0L, 0L, 0, 0);
+
     //83.3%
     updateHeartbeatWithUsage(tolerateDataNodes[4],
-            30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-            25 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-            HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
-                    * blockSize, 0L, 0L, 0L, 0, 0);
+       30 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+       25 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+       HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
+        * blockSize, 0L, 0L, 0L, 0, 0);
 
     assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[0],
-            tolerateDataNodes[1], false) == 1);
+        tolerateDataNodes[1], false) == 1);
     assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[1],
-            tolerateDataNodes[0], false) == -1);
+        tolerateDataNodes[0], false) == -1);
     assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[1],
-            tolerateDataNodes[2], false) == 1);
+        tolerateDataNodes[2], false) == 1);
     assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[2],
-            tolerateDataNodes[1], false) == -1);
+        tolerateDataNodes[1], false) == -1);
     assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[2],
-            tolerateDataNodes[3], false) == 0);
+        tolerateDataNodes[3], false) == 0);
     assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[3],
-            tolerateDataNodes[2], false) == 0);
+        tolerateDataNodes[2], false) == 0);
     assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[2],
-            tolerateDataNodes[4], false) == 1);
+        tolerateDataNodes[4], false) == 1);
     assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[4],
-            tolerateDataNodes[2], false) == -1);
+        tolerateDataNodes[2], false) == -1);
   }
 
   @AfterClass


### PR DESCRIPTION
### Description of PR
for now ,we may have many nodes usage over 85%, some nodes'usage  have been over 90%, if we choose three nodes as nodeA-97%,nodeB-98%,nodeC-99%, actually i don't want nodeC(99%) be choosen, for nodeC usage is really high , even random chance ,nodeC will reach 100% soon, so we can directly choose the less usage node(nodeA) if all nodes's usage are over 95%(just a example)

### How was this patch tested?
test case added

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

