### PR TITLE
YARN-11576. Improve FederationInterceptorREST AuditLog.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/RouterAuditLogger.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/RouterAuditLogger.java
@@ -83,6 +83,10 @@ public final class RouterAuditLogger {
     public static final String GET_ATTRIBUTESTONODES = "Get AttributesToNodes";
     public static final String GET_CLUSTERNODEATTRIBUTES = "Get ClusterNodeAttributes";
     public static final String GET_NODESTOATTRIBUTES = "Get NodesToAttributes";
+    public static final String GET_CLUSTERINFO = "Get ClusterInfo";
+    public static final String GET_CLUSTERUSERINFO = "Get ClusterUserInfo";
+    public static final String GET_SCHEDULERINFO = "Get SchedulerInfo";
+    public static final String DUMP_SCHEDULERLOGS = "Dump SchedulerLogs";
   }
 
   public static void logSuccess(String user, String operation, String target) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/RouterAuditLogger.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/RouterAuditLogger.java
@@ -102,6 +102,13 @@ public final class RouterAuditLogger {
     public static final String UPDATE_APP_QUEUE = "Update AppQueue";
     public static final String POST_DELEGATION_TOKEN = "Post DelegationToken";
     public static final String POST_DELEGATION_TOKEN_EXPIRATION = "Post DelegationTokenExpiration";
+    public static final String GET_APP_TIMEOUT = "Get App Timeout";
+    public static final String GET_APP_TIMEOUTS = "Get App Timeouts";
+    public static final String CHECK_USER_ACCESS_TO_QUEUE = "Check User AccessToQueue";
+    public static final String GET_APP_ATTEMPT = "Get AppAttempt";
+    public static final String GET_CONTAINER = "Get Container";
+    public static final String UPDATE_SCHEDULER_CONFIGURATION = "Update SchedulerConfiguration";
+    public static final String GET_SCHEDULER_CONFIGURATION = "Get SchedulerConfiguration";
   }
 
   public static void logSuccess(String user, String operation, String target) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/RouterAuditLogger.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/RouterAuditLogger.java
@@ -92,6 +92,16 @@ public final class RouterAuditLogger {
     public static final String GET_APPACTIVITIES = "Get AppActivities";
     public static final String GET_APPSTATISTICS = "Get AppStatistics";
     public static final String GET_RMNODELABELS = "Get RMNodeLabels";
+    public static final String REPLACE_LABELSONNODES = "Replace LabelsOnNodes";
+    public static final String REPLACE_LABELSONNODE = "Replace LabelsOnNode";
+    public static final String GET_CLUSTER_NODELABELS = "Get ClusterNodeLabels";
+    public static final String ADD_TO_CLUSTER_NODELABELS = "Add To ClusterNodeLabels";
+    public static final String REMOVE_FROM_CLUSTERNODELABELS = "Remove From ClusterNodeLabels";
+    public static final String GET_LABELS_ON_NODE = "Get LabelsOnNode";
+    public static final String GET_APP_PRIORITY = "Get AppPriority";
+    public static final String UPDATE_APP_QUEUE = "Update AppQueue";
+    public static final String POST_DELEGATION_TOKEN = "Post DelegationToken";
+    public static final String POST_DELEGATION_TOKEN_EXPIRATION = "Post DelegationTokenExpiration";
   }
 
   public static void logSuccess(String user, String operation, String target) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/RouterAuditLogger.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/RouterAuditLogger.java
@@ -87,6 +87,11 @@ public final class RouterAuditLogger {
     public static final String GET_CLUSTERUSERINFO = "Get ClusterUserInfo";
     public static final String GET_SCHEDULERINFO = "Get SchedulerInfo";
     public static final String DUMP_SCHEDULERLOGS = "Dump SchedulerLogs";
+    public static final String GET_ACTIVITIES = "Get Activities";
+    public static final String GET_BULKACTIVITIES = "Get BulkActivities";
+    public static final String GET_APPACTIVITIES = "Get AppActivities";
+    public static final String GET_APPSTATISTICS = "Get AppStatistics";
+    public static final String GET_RMNODELABELS = "Get RMNodeLabels";
   }
 
   public static void logSuccess(String user, String operation, String target) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/RouterAuditLogger.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/RouterAuditLogger.java
@@ -50,6 +50,7 @@ public final class RouterAuditLogger {
     public static final String FORCE_KILL_APP = "Force Kill App";
     public static final String GET_APP_REPORT = "Get Application Report";
     public static final String TARGET_CLIENT_RM_SERVICE = "RouterClientRMService";
+    public static final String TARGET_WEB_SERVICE = "RouterWebServices";
     public static final String UNKNOWN = "UNKNOWN";
     public static final String GET_APPLICATIONS = "Get Applications";
     public static final String GET_CLUSTERMETRICS = "Get ClusterMetrics";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
@@ -408,6 +408,9 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
     try {
       Response response = interceptor.createNewApplication(hsr);
       if (response != null && response.getStatus() == HttpServletResponse.SC_OK) {
+        ApplicationId applicationId = ApplicationId.fromString(response.getEntity().toString());
+        RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_NEW_APP,
+            TARGET_WEB_SERVICE, applicationId, subClusterId);
         return response;
       }
     } catch (Exception e) {
@@ -498,6 +501,8 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       routerMetrics.incrAppsFailedSubmitted();
       String errMsg = "Missing ApplicationSubmissionContextInfo or "
           + "applicationSubmissionContext information.";
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), SUBMIT_NEW_APP, UNKNOWN,
+          TARGET_WEB_SERVICE, errMsg);
       return Response.status(Status.BAD_REQUEST).entity(errMsg).build();
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
@@ -1948,8 +1948,8 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
 
     if (CollectionUtils.isEmpty(oldNodeLabels)) {
       routerMetrics.incrRemoveFromClusterNodeLabelsFailedRetrieved();
-      RouterAuditLogger.logFailure(getUser().getShortUserName(), REMOVE_FROM_CLUSTERNODELABELS, UNKNOWN,
-          TARGET_WEB_SERVICE, "Parameter error, the oldNodeLabels is null or empty.");
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), REMOVE_FROM_CLUSTERNODELABELS,
+          UNKNOWN, TARGET_WEB_SERVICE, "Parameter error, the oldNodeLabels is null or empty.");
       throw new IllegalArgumentException("Parameter error, the oldNodeLabels is null or empty.");
     }
 
@@ -1974,13 +1974,13 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       return Response.status(Status.OK).entity(buffer.toString()).build();
     } catch (NotFoundException e) {
       routerMetrics.incrRemoveFromClusterNodeLabelsFailedRetrieved();
-      RouterAuditLogger.logFailure(getUser().getShortUserName(), REMOVE_FROM_CLUSTERNODELABELS, UNKNOWN,
-          TARGET_WEB_SERVICE, e.getLocalizedMessage());
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), REMOVE_FROM_CLUSTERNODELABELS,
+          UNKNOWN, TARGET_WEB_SERVICE, e.getLocalizedMessage());
       RouterServerUtil.logAndThrowIOException("get all active sub cluster(s) error.", e);
     } catch (YarnException e) {
       routerMetrics.incrRemoveFromClusterNodeLabelsFailedRetrieved();
-      RouterAuditLogger.logFailure(getUser().getShortUserName(), REMOVE_FROM_CLUSTERNODELABELS, UNKNOWN,
-          TARGET_WEB_SERVICE, e.getLocalizedMessage());
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), REMOVE_FROM_CLUSTERNODELABELS,
+          UNKNOWN, TARGET_WEB_SERVICE, e.getLocalizedMessage());
       RouterServerUtil.logAndThrowIOException("removeFromClusterNodeLabels with yarn error.", e);
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
@@ -152,7 +152,14 @@ import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import static org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade.getRandomActiveSubCluster;
-import static org.apache.hadoop.yarn.server.router.RouterAuditLogger.AuditConstants.*;
+import static org.apache.hadoop.yarn.server.router.RouterAuditLogger.AuditConstants.GET_NEW_APP;
+import static org.apache.hadoop.yarn.server.router.RouterAuditLogger.AuditConstants.SUBMIT_NEW_APP;
+import static org.apache.hadoop.yarn.server.router.RouterAuditLogger.AuditConstants.GET_CLUSTERINFO;
+import static org.apache.hadoop.yarn.server.router.RouterAuditLogger.AuditConstants.GET_CLUSTERUSERINFO;
+import static org.apache.hadoop.yarn.server.router.RouterAuditLogger.AuditConstants.GET_SCHEDULERINFO;
+import static org.apache.hadoop.yarn.server.router.RouterAuditLogger.AuditConstants.DUMP_SCHEDULERLOGS;
+import static org.apache.hadoop.yarn.server.router.RouterAuditLogger.AuditConstants.UNKNOWN;
+import static org.apache.hadoop.yarn.server.router.RouterAuditLogger.AuditConstants.TARGET_WEB_SERVICE;
 import static org.apache.hadoop.yarn.server.router.webapp.RouterWebServiceUtil.extractToken;
 import static org.apache.hadoop.yarn.server.router.webapp.RouterWebServiceUtil.getKerberosUserGroupInformation;
 
@@ -597,14 +604,14 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
         LOG.info("Application {} with appId {} submitted on {}.",
             context.getApplicationName(), applicationId, subClusterId);
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), SUBMIT_NEW_APP,
-            TARGET_CLIENT_RM_SERVICE, applicationId, subClusterId);
+            TARGET_WEB_SERVICE, applicationId, subClusterId);
         return response;
       }
       String msg = String.format("application %s failed to be submitted.", applicationId);
       throw new YarnException(msg);
     } catch (Exception e) {
       RouterAuditLogger.logFailure(getUser().getShortUserName(), SUBMIT_NEW_APP, UNKNOWN,
-          TARGET_CLIENT_RM_SERVICE, e.getMessage(), applicationId, subClusterId);
+          TARGET_WEB_SERVICE, e.getMessage(), applicationId, subClusterId);
       LOG.warn("Unable to submit the application {} to SubCluster {}.", applicationId,
           subClusterId, e);
       if (subClusterId != null) {
@@ -1126,16 +1133,24 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
         federationClusterInfo.getList().add(clusterInfo);
       });
       long stopTime = Time.now();
+      RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_CLUSTERINFO,
+          TARGET_WEB_SERVICE);
       routerMetrics.succeededGetClusterInfoRetrieved(stopTime - startTime);
       return federationClusterInfo;
     } catch (NotFoundException e) {
       routerMetrics.incrGetClusterInfoFailedRetrieved();
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), GET_CLUSTERINFO, UNKNOWN,
+          TARGET_WEB_SERVICE, e.getLocalizedMessage());
       RouterServerUtil.logAndThrowRunTimeException("Get all active sub cluster(s) error.", e);
     } catch (YarnException | IOException e) {
       routerMetrics.incrGetClusterInfoFailedRetrieved();
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), GET_CLUSTERINFO, UNKNOWN,
+          TARGET_WEB_SERVICE, e.getLocalizedMessage());
       RouterServerUtil.logAndThrowRunTimeException("getClusterInfo error.", e);
     }
     routerMetrics.incrGetClusterInfoFailedRetrieved();
+    RouterAuditLogger.logFailure(getUser().getShortUserName(), GET_CLUSTERINFO, UNKNOWN,
+        TARGET_WEB_SERVICE, "getClusterInfo error.");
     throw new RuntimeException("getClusterInfo error.");
   }
 
@@ -1167,16 +1182,24 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
         federationClusterUserInfo.getList().add(clusterUserInfo);
       });
       long stopTime = Time.now();
+      RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_CLUSTERUSERINFO,
+          TARGET_WEB_SERVICE);
       routerMetrics.succeededGetClusterUserInfoRetrieved(stopTime - startTime);
       return federationClusterUserInfo;
     } catch (NotFoundException e) {
       routerMetrics.incrGetClusterUserInfoFailedRetrieved();
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), GET_CLUSTERUSERINFO, UNKNOWN,
+          TARGET_WEB_SERVICE, e.getLocalizedMessage());
       RouterServerUtil.logAndThrowRunTimeException("Get all active sub cluster(s) error.", e);
     } catch (YarnException | IOException e) {
       routerMetrics.incrGetClusterUserInfoFailedRetrieved();
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), GET_CLUSTERUSERINFO, UNKNOWN,
+          TARGET_WEB_SERVICE, e.getLocalizedMessage());
       RouterServerUtil.logAndThrowRunTimeException("getClusterUserInfo error.", e);
     }
     routerMetrics.incrGetClusterUserInfoFailedRetrieved();
+    RouterAuditLogger.logFailure(getUser().getShortUserName(), GET_CLUSTERUSERINFO, UNKNOWN,
+        TARGET_WEB_SERVICE, "getClusterUserInfo error.");
     throw new RuntimeException("getClusterUserInfo error.");
   }
 
@@ -1205,16 +1228,24 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
         federationSchedulerTypeInfo.getList().add(schedulerTypeInfo);
       });
       long stopTime = Time.now();
+      RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_SCHEDULERINFO,
+          TARGET_WEB_SERVICE);
       routerMetrics.succeededGetSchedulerInfoRetrieved(stopTime - startTime);
       return federationSchedulerTypeInfo;
     } catch (NotFoundException e) {
       routerMetrics.incrGetSchedulerInfoFailedRetrieved();
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), GET_SCHEDULERINFO, UNKNOWN,
+          TARGET_WEB_SERVICE, e.getLocalizedMessage());
       RouterServerUtil.logAndThrowRunTimeException("Get all active sub cluster(s) error.", e);
     } catch (YarnException | IOException e) {
       routerMetrics.incrGetSchedulerInfoFailedRetrieved();
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), GET_SCHEDULERINFO, UNKNOWN,
+          TARGET_WEB_SERVICE, e.getLocalizedMessage());
       RouterServerUtil.logAndThrowRunTimeException("getSchedulerInfo error.", e);
     }
     routerMetrics.incrGetSchedulerInfoFailedRetrieved();
+    RouterAuditLogger.logFailure(getUser().getShortUserName(), GET_SCHEDULERINFO, UNKNOWN,
+        TARGET_WEB_SERVICE, "getSchedulerInfo error.");
     throw new RuntimeException("getSchedulerInfo error.");
   }
 
@@ -1236,6 +1267,8 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
 
     if (StringUtils.isBlank(time)) {
       routerMetrics.incrDumpSchedulerLogsFailedRetrieved();
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), DUMP_SCHEDULERLOGS, UNKNOWN,
+          TARGET_WEB_SERVICE, "Parameter error, the time is empty or null.");
       throw new IllegalArgumentException("Parameter error, the time is empty or null.");
     }
 
@@ -1246,9 +1279,13 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       }
     } catch (NumberFormatException e) {
       routerMetrics.incrDumpSchedulerLogsFailedRetrieved();
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), DUMP_SCHEDULERLOGS, UNKNOWN,
+          TARGET_WEB_SERVICE, e.getLocalizedMessage());
       throw new IllegalArgumentException("time must be a number.");
     } catch (IllegalArgumentException e) {
       routerMetrics.incrDumpSchedulerLogsFailedRetrieved();
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), DUMP_SCHEDULERLOGS, UNKNOWN,
+          TARGET_WEB_SERVICE, e.getLocalizedMessage());
       throw e;
     }
 
@@ -1269,19 +1306,27 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
             .append(subClusterId).append(" : ").append(msg).append("; ");
       });
       long stopTime = clock.getTime();
+      RouterAuditLogger.logSuccess(getUser().getShortUserName(), DUMP_SCHEDULERLOGS,
+          TARGET_WEB_SERVICE);
       routerMetrics.succeededDumpSchedulerLogsRetrieved(stopTime - startTime);
       return stringBuilder.toString();
     } catch (IllegalArgumentException e) {
       routerMetrics.incrDumpSchedulerLogsFailedRetrieved();
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), DUMP_SCHEDULERLOGS, UNKNOWN,
+          TARGET_WEB_SERVICE, e.getLocalizedMessage());
       RouterServerUtil.logAndThrowRunTimeException(e,
           "Unable to dump SchedulerLogs by time: %s.", time);
     } catch (YarnException e) {
       routerMetrics.incrDumpSchedulerLogsFailedRetrieved();
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), DUMP_SCHEDULERLOGS, UNKNOWN,
+          TARGET_WEB_SERVICE, e.getLocalizedMessage());
       RouterServerUtil.logAndThrowRunTimeException(e,
           "dumpSchedulerLogs by time = %s error .", time);
     }
 
     routerMetrics.incrDumpSchedulerLogsFailedRetrieved();
+    RouterAuditLogger.logFailure(getUser().getShortUserName(), DUMP_SCHEDULERLOGS, UNKNOWN,
+        TARGET_WEB_SERVICE, "dumpSchedulerLogs Failed.");
     throw new RuntimeException("dumpSchedulerLogs Failed.");
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
@@ -120,6 +120,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.SchedulerTypeInf
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.NodeLabelInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ReservationDefinitionInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.NodeToLabelsEntry;
+import org.apache.hadoop.yarn.server.router.RouterAuditLogger;
 import org.apache.hadoop.yarn.server.router.RouterMetrics;
 import org.apache.hadoop.yarn.server.router.RouterServerUtil;
 import org.apache.hadoop.yarn.server.router.clientrm.ClientMethod;
@@ -151,6 +152,7 @@ import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import static org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade.getRandomActiveSubCluster;
+import static org.apache.hadoop.yarn.server.router.RouterAuditLogger.AuditConstants.*;
 import static org.apache.hadoop.yarn.server.router.webapp.RouterWebServiceUtil.extractToken;
 import static org.apache.hadoop.yarn.server.router.webapp.RouterWebServiceUtil.getKerberosUserGroupInformation;
 
@@ -360,9 +362,13 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
     } catch (FederationPolicyException e) {
       // If a FederationPolicyException is thrown, the service is unavailable.
       routerMetrics.incrAppsFailedCreated();
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), GET_NEW_APP, UNKNOWN,
+          TARGET_WEB_SERVICE, e.getLocalizedMessage());
       return Response.status(Status.SERVICE_UNAVAILABLE).entity(e.getLocalizedMessage()).build();
     } catch (Exception e) {
       routerMetrics.incrAppsFailedCreated();
+      RouterAuditLogger.logFailure(getUser().getShortUserName(), GET_NEW_APP, UNKNOWN,
+          TARGET_WEB_SERVICE, e.getLocalizedMessage());
       return Response.status(Status.INTERNAL_SERVER_ERROR).entity(e.getLocalizedMessage()).build();
     }
 
@@ -370,6 +376,8 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
     String errMsg = "Fail to create a new application.";
     LOG.error(errMsg);
     routerMetrics.incrAppsFailedCreated();
+    RouterAuditLogger.logFailure(getUser().getShortUserName(), GET_NEW_APP, UNKNOWN,
+        TARGET_WEB_SERVICE, errMsg);
     return Response.status(Status.INTERNAL_SERVER_ERROR).entity(errMsg).build();
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11576. Improve FederationInterceptorREST AuditLog.

| Method  | Add AuditLog |
| ------------- | ------------- |
| FederationInterceptorREST#get()  | done |
| FederationInterceptorREST#getClusterInfo()  | done | 
| FederationInterceptorREST#getClusterUserInfo()  | done | 
| FederationInterceptorREST#getSchedulerInfo()  | done | 
| FederationInterceptorREST#dumpSchedulerLogs()  | done | 
| FederationInterceptorREST#getActivities()  | done | 
| FederationInterceptorREST#getBulkActivities() | done | 
| FederationInterceptorREST#getAppActivities() | done | 
| FederationInterceptorREST#getAppStatistics() | done | 
| FederationInterceptorREST#getNodeToLabels() | done | 
| FederationInterceptorREST#getRMNodeLabels() | done | 
| FederationInterceptorREST#getLabelsToNodes() | done | 
| FederationInterceptorREST#replaceLabelsOnNodes() | done | 
| FederationInterceptorREST#replaceLabelsOnNode() | done | 
| FederationInterceptorREST#getClusterNodeLabels() | done | 
| FederationInterceptorREST#addToClusterNodeLabels() | done | 
| FederationInterceptorREST#removeFromClusterNodeLabels() | done | 
| FederationInterceptorREST#getLabelsOnNode() | done | 
| FederationInterceptorREST#getAppPriority() | done | 
| FederationInterceptorREST#updateApplicationPriority() | done | 
| FederationInterceptorREST#getAppQueue() | done | 
| FederationInterceptorREST#updateAppQueue() | done | 
| FederationInterceptorREST#postDelegationToken() | done | 
| FederationInterceptorREST#postDelegationTokenExpiration() | done | 
| FederationInterceptorREST#cancelDelegationToken() | done | 
| FederationInterceptorREST#createNewReservation()| done | 
| FederationInterceptorREST#submitReservation()| done | 
| FederationInterceptorREST#updateReservation()| done | 
| FederationInterceptorREST#deleteReservation()| done | 
| FederationInterceptorREST#listReservation()| done | 
| FederationInterceptorREST#getAppTimeout()| done | 
| FederationInterceptorREST#getAppTimeouts()| done | 
| FederationInterceptorREST#updateApplicationTimeout()| done | 
| FederationInterceptorREST#getAppAttempts()| done | 
| FederationInterceptorREST#checkUserAccessToQueue()| done | 
| FederationInterceptorREST#getAppAttempt()| done | 
| FederationInterceptorREST#getContainers()| done | 
| FederationInterceptorREST#updateSchedulerConfiguration()| done | 
| FederationInterceptorREST#getSchedulerConfiguration()| done | 
| FederationInterceptorREST#signalToContainer()| done | 

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

