### PR TITLE
YARN-11578. Cache fs supports chmod in LogAggregationFileController.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/LogAggregationFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/LogAggregationFileController.java
@@ -33,7 +33,9 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience.Public;
@@ -110,6 +112,35 @@ public abstract class LogAggregationFileController {
   protected String fileControllerName;
 
   protected boolean fsSupportsChmod = true;
+
+  private static class FsLogPathKey {
+    private Class<? extends FileSystem> fsType;
+    private Path logPath;
+
+    FsLogPathKey(Class<? extends FileSystem> fsType, Path logPath) {
+      this.fsType = fsType;
+      this.logPath = logPath;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      FsLogPathKey that = (FsLogPathKey) o;
+      return Objects.equals(fsType, that.fsType) && Objects.equals(logPath, that.logPath);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(fsType, logPath);
+    }
+  }
+  private static final ConcurrentHashMap<FsLogPathKey, Boolean> FS_CHMOD_CACHE
+      = new ConcurrentHashMap<>();
 
   public LogAggregationFileController() {}
 
@@ -429,26 +460,36 @@ public abstract class LogAggregationFileController {
             + remoteRootLogDir + "]", e);
       }
     } else {
-      //Check if FS has capability to set/modify permissions
-      Path permissionCheckFile = new Path(qualified, String.format("%s.permission_check",
-          RandomStringUtils.randomAlphanumeric(8)));
+      final FsLogPathKey key = new FsLogPathKey(remoteFS.getClass(), qualified);
+      FileSystem finalRemoteFS = remoteFS;
+      FS_CHMOD_CACHE.computeIfAbsent(key, k -> {
+        fsSupportsChmod = checkFsSupportsChmod(finalRemoteFS, remoteRootLogDir, qualified);
+        return fsSupportsChmod;
+      });
+    }
+  }
+
+  private boolean checkFsSupportsChmod(FileSystem remoteFS, Path logDir, Path qualified) {
+    //Check if FS has capability to set/modify permissions
+    Path permissionCheckFile = new Path(qualified, String.format("%s.permission_check",
+        RandomStringUtils.randomAlphanumeric(8)));
+    try {
+      remoteFS.createNewFile(permissionCheckFile);
+      remoteFS.setPermission(permissionCheckFile, new FsPermission(TLDIR_PERMISSIONS));
+      return true;
+    } catch (UnsupportedOperationException use) {
+      LOG.info("Unable to set permissions for configured filesystem since"
+          + " it does not support this {}", remoteFS.getScheme());
+    } catch (IOException e) {
+      LOG.warn("Failed to check if FileSystem supports permissions on "
+          + "remoteLogDir [" + logDir + "]", e);
+    } finally {
       try {
-        remoteFS.createNewFile(permissionCheckFile);
-        remoteFS.setPermission(permissionCheckFile, new FsPermission(TLDIR_PERMISSIONS));
-      } catch (UnsupportedOperationException use) {
-        LOG.info("Unable to set permissions for configured filesystem since"
-            + " it does not support this {}", remoteFS.getScheme());
-        fsSupportsChmod = false;
-      } catch (IOException e) {
-        LOG.warn("Failed to check if FileSystem supports permissions on "
-            + "remoteLogDir [" + remoteRootLogDir + "]", e);
-      } finally {
-        try {
-          remoteFS.delete(permissionCheckFile, false);
-        } catch (IOException ignored) {
-        }
+        remoteFS.delete(permissionCheckFile, false);
+      } catch (IOException ignored) {
       }
     }
+    return false;
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/LogAggregationFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/LogAggregationFileController.java
@@ -480,7 +480,7 @@ public abstract class LogAggregationFileController {
           + " it does not support this {}", remoteFS.getScheme());
     } catch (IOException e) {
       LOG.warn("Failed to check if FileSystem supports permissions on "
-          + "remoteLogDir [" + logDir + "]", e);
+          + "remoteLogDir [{}]", logDir, e);
     } finally {
       try {
         remoteFS.delete(permissionCheckFile, false);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/LogAggregationFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/LogAggregationFileController.java
@@ -462,10 +462,8 @@ public abstract class LogAggregationFileController {
     } else {
       final FsLogPathKey key = new FsLogPathKey(remoteFS.getClass(), qualified);
       FileSystem finalRemoteFS = remoteFS;
-      FS_CHMOD_CACHE.computeIfAbsent(key, k -> {
-        fsSupportsChmod = checkFsSupportsChmod(finalRemoteFS, remoteRootLogDir, qualified);
-        return fsSupportsChmod;
-      });
+      fsSupportsChmod = FS_CHMOD_CACHE.computeIfAbsent(key,
+          k -> checkFsSupportsChmod(finalRemoteFS, remoteRootLogDir, qualified));
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/filecontroller/TestLogAggregationFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/filecontroller/TestLogAggregationFileController.java
@@ -19,7 +19,9 @@
 package org.apache.hadoop.yarn.logaggregation.filecontroller;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
@@ -35,12 +37,14 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 
 import static org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileController.TLDIR_PERMISSIONS;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -116,30 +120,76 @@ public class TestLogAggregationFileController {
 
   @Test
   void testRemoteDirCreationWithCustomUser() throws Exception {
+    LogAggregationFileController controller = mock(
+        LogAggregationFileController.class, Mockito.CALLS_REAL_METHODS);
     FileSystem fs = mock(FileSystem.class);
+    setupCustomUserMocks(controller, fs, "/tmp/logs");
+
+    controller.initialize(new Configuration(), "TFile");
+    controller.fsSupportsChmod = false;
+
+    controller.verifyAndCreateRemoteLogDir();
+    assertPermissionFileWasUsedOneTime(fs);
+    assertTrue(controller.fsSupportsChmod);
+
+    doThrow(UnsupportedOperationException.class).when(fs).setPermission(any(), any());
+    controller.verifyAndCreateRemoteLogDir();
+    assertPermissionFileWasUsedOneTime(fs); // still once -> cached
+    assertTrue(controller.fsSupportsChmod);
+
+    controller.fsSupportsChmod = false;
+    controller.verifyAndCreateRemoteLogDir();
+    assertPermissionFileWasUsedOneTime(fs); // still once -> cached
+    assertTrue(controller.fsSupportsChmod);
+  }
+
+  @Test
+  void testRemoteDirCreationWithCustomUserFsChmodNotSupported() throws Exception {
+    LogAggregationFileController controller = mock(
+        LogAggregationFileController.class, Mockito.CALLS_REAL_METHODS);
+    FileSystem fs = mock(FileSystem.class);
+    setupCustomUserMocks(controller, fs, "/tmp/logs2");
+    doThrow(UnsupportedOperationException.class).when(fs).setPermission(any(), any());
+
+    Configuration conf = new Configuration();
+    conf.set(YarnConfiguration.NM_REMOTE_APP_LOG_DIR, "/tmp/logs2");
+    controller.initialize(conf, "TFile");
+    controller.verifyAndCreateRemoteLogDir();
+    assertPermissionFileWasUsedOneTime(fs);
+    assertFalse(controller.fsSupportsChmod);
+
+    controller.verifyAndCreateRemoteLogDir();
+    assertPermissionFileWasUsedOneTime(fs); // still once -> cached
+    assertFalse(controller.fsSupportsChmod);
+
+    controller.fsSupportsChmod = true;
+    controller.verifyAndCreateRemoteLogDir();
+    assertPermissionFileWasUsedOneTime(fs); // still once -> cached
+    assertFalse(controller.fsSupportsChmod);
+  }
+
+  private static void setupCustomUserMocks(LogAggregationFileController controller,
+                                           FileSystem fs, String path)
+      throws URISyntaxException, IOException {
     doReturn(new URI("")).when(fs).getUri();
     doReturn(new FileStatus(128, false, 0, 64, System.currentTimeMillis(),
         System.currentTimeMillis(), new FsPermission(TLDIR_PERMISSIONS),
-        "not_yarn_user", "yarn_group", new Path("/tmp/logs"))).when(fs)
+        "not_yarn_user", "yarn_group", new Path(path))).when(fs)
         .getFileStatus(any(Path.class));
-
-    Configuration conf = new Configuration();
-    LogAggregationFileController controller = mock(
-        LogAggregationFileController.class, Mockito.CALLS_REAL_METHODS);
-    controller.fsSupportsChmod = true;
     doReturn(fs).when(controller).getFileSystem(any(Configuration.class));
 
     UserGroupInformation ugi = UserGroupInformation.createUserForTesting(
         "yarn_user", new String[]{"yarn_group", "other_group"});
     UserGroupInformation.setLoginUser(ugi);
+  }
 
-    controller.initialize(conf, "TFile");
-    controller.verifyAndCreateRemoteLogDir();
-
-    verify(fs).createNewFile(argThat(new PathContainsString(".permission_check")));
-    verify(fs).setPermission(argThat(new PathContainsString(".permission_check")),
+  private static void assertPermissionFileWasUsedOneTime(FileSystem fs) throws IOException {
+    verify(fs, times(1))
+        .createNewFile(argThat(new PathContainsString(".permission_check")));
+    verify(fs, times(1))
+        .setPermission(argThat(new PathContainsString(".permission_check")),
         eq(new FsPermission(TLDIR_PERMISSIONS)));
-    verify(fs).delete(argThat(new PathContainsString(".permission_check")), eq(false));
-    assertTrue(controller.fsSupportsChmod);
+    verify(fs, times(1))
+        .delete(argThat(new PathContainsString(".permission_check")), eq(false));
   }
 }


### PR DESCRIPTION
The check introduced in YARN-10901 to avoid a warn message in NN logs in certain situations (when /tmp/logs is not owned by the yarn user), but it adds 3 NameNode calls (create, setpermission, delete) during log aggregation collection, for every NM.
Meaning, when a YARN job completes, at the YARN log aggregation phase this check is done for every job, from every NodeManager.

In 30 minutes 4.2 % of all the NameNode calls were due to this in a cluster. "write" calls need a Namesystem writeLock as well, so the impact is bigger.

Change-Id: I65468aa972860d3b62050fcb41b8b06e417ee8bb

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Added a static concurrent cache that maps the `<FS class type + Log Path>` to the check `result`.

**Assumptions:**
 - the permissions won't change while the NMs are running
 - the key <FS class + Log Path> won't grow big
 - <FS class Type + Log Path> is enough for the key. I don't want to keep a FileSystem object in the cache, but if there is a use case where different FileSystem objects are created with the same Class type and would have different permission for the same file path, then this key is not enough.

If these assumptions are not met, we might need to come up with a different idea.

### How was this patch tested?

Updated the unit tests to verify that caching works.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'YARN-11578. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

