### PR TITLE
YARN-11579. Fix 'Physical Mem Used' and 'Physical VCores Used' are not displaying data.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ClusterMetricsInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ClusterMetricsInfo.java
@@ -54,7 +54,9 @@ public class ClusterMetricsInfo {
   private int containersPending;
 
   private long totalMB;
+  private long utilizedMB;
   private long totalVirtualCores;
+  private long utilizedVirtualCores;
   private int utilizedMBPercent;
   private int utilizedVirtualCoresPercent;
   private int rmSchedulerBusyPercent;
@@ -167,6 +169,7 @@ public class ClusterMetricsInfo {
         .getContainerAssignedPerSecond();
     this.rmEventQueueSize = clusterMetrics.getRmEventQueueSize();
     this.schedulerEventQueueSize = clusterMetrics.getSchedulerEventQueueSize();
+    this.utilizedVirtualCores = clusterMetrics.getUtilizedVirtualCores();
   }
 
   public int getAppsSubmitted() {
@@ -431,5 +434,21 @@ public class ClusterMetricsInfo {
 
   public int getSchedulerEventQueueSize() {
     return schedulerEventQueueSize;
+  }
+
+  public long getUtilizedVirtualCores() {
+    return utilizedVirtualCores;
+  }
+
+  public void setUtilizedVirtualCores(long utilizedVirtualCores) {
+    this.utilizedVirtualCores = utilizedVirtualCores;
+  }
+
+  public long getUtilizedMB() {
+    return utilizedMB;
+  }
+
+  public void setUtilizedMB(long utilizedMB) {
+    this.utilizedMB = utilizedMB;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
@@ -481,7 +481,7 @@ public class TestRMWebServices extends JerseyTestBase {
       Exception {
     assertEquals("incorrect number of elements", 1, json.length());
     JSONObject clusterinfo = json.getJSONObject("clusterMetrics");
-    assertEquals("incorrect number of elements", 35, clusterinfo.length());
+    assertEquals("incorrect number of elements", 37, clusterinfo.length());
     verifyClusterMetrics(
         clusterinfo.getInt("appsSubmitted"), clusterinfo.getInt("appsCompleted"),
         clusterinfo.getInt("reservedMB"), clusterinfo.getInt("availableMB"),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/RouterWebServiceUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/RouterWebServiceUtil.java
@@ -506,10 +506,14 @@ public final class RouterWebServiceUtil {
 
     metrics.setTotalMB(metrics.getTotalMB()
         + metricsResponse.getTotalMB());
+    metrics.setUtilizedMB(metrics.getUtilizedMB()
+        + metricsResponse.getUtilizedMB());
     metrics.setTotalVirtualCores(metrics.getTotalVirtualCores()
         + metricsResponse.getTotalVirtualCores());
     metrics.setTotalNodes(metrics.getTotalNodes()
         + metricsResponse.getTotalNodes());
+    metrics.setUtilizedVirtualCores(metrics.getUtilizedVirtualCores()
+        + metricsResponse.getUtilizedVirtualCores());
     metrics.setLostNodes(metrics.getLostNodes()
         + metricsResponse.getLostNodes());
     metrics.setUnhealthyNodes(metrics.getUnhealthyNodes()
@@ -524,6 +528,14 @@ public final class RouterWebServiceUtil {
         + metricsResponse.getActiveNodes());
     metrics.setShutdownNodes(metrics.getShutdownNodes()
         + metricsResponse.getShutdownNodes());
+
+    int utilizedVirtualCoresPercent = metrics.getTotalVirtualCores() <= 0 ? 0 :
+        (int) (metrics.getUtilizedVirtualCores() * 100 / metrics.getTotalVirtualCores());
+    metrics.setUtilizedVirtualCoresPercent(utilizedVirtualCoresPercent);
+
+    int utilizedMBPercent = metrics.getTotalMB() <= 0 ? 0 :
+        (int) (metrics.getUtilizedMB() * 100 / metrics.getTotalMB());
+    metrics.setUtilizedMBPercent(utilizedMBPercent);
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServiceUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServiceUtil.java
@@ -490,9 +490,15 @@ public class TestRouterWebServiceUtil {
         metricsResponse.getTotalMB() + metricsClone.getTotalMB(),
         metrics.getTotalMB());
     Assert.assertEquals(
+        metricsResponse.getUtilizedMB() + metricsClone.getUtilizedMB(),
+        metrics.getUtilizedMB());
+    Assert.assertEquals(
         metricsResponse.getTotalVirtualCores()
             + metricsClone.getTotalVirtualCores(),
         metrics.getTotalVirtualCores());
+    Assert.assertEquals(
+        metricsResponse.getUtilizedVirtualCores() + metricsClone.getUtilizedVirtualCores(),
+        metrics.getUtilizedVirtualCores());
     Assert.assertEquals(
         metricsResponse.getTotalNodes() + metricsClone.getTotalNodes(),
         metrics.getTotalNodes());
@@ -544,7 +550,9 @@ public class TestRouterWebServiceUtil {
     metricsClone.setContainersPending(metrics.getPendingContainers());
 
     metricsClone.setTotalMB(metrics.getTotalMB());
+    metricsClone.setUtilizedMB(metrics.getUtilizedMB());
     metricsClone.setTotalVirtualCores(metrics.getTotalVirtualCores());
+    metricsClone.setUtilizedVirtualCores(metrics.getUtilizedVirtualCores());
     metricsClone.setTotalNodes(metrics.getTotalNodes());
     metricsClone.setLostNodes(metrics.getLostNodes());
     metricsClone.setUnhealthyNodes(metrics.getUnhealthyNodes());
@@ -580,7 +588,9 @@ public class TestRouterWebServiceUtil {
     metrics.setContainersPending(rand.nextInt(1000));
 
     metrics.setTotalMB(rand.nextInt(1000));
+    metrics.setUtilizedMB(metrics.getTotalMB() - rand.nextInt(100));
     metrics.setTotalVirtualCores(rand.nextInt(1000));
+    metrics.setUtilizedVirtualCores(metrics.getUtilizedVirtualCores() - rand.nextInt(100));
     metrics.setTotalNodes(rand.nextInt(1000));
     metrics.setLostNodes(rand.nextInt(1000));
     metrics.setUnhealthyNodes(rand.nextInt(1000));


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11579. Fix 'Physical Mem Used' and 'Physical VCores Used' are not displaying data.

- Before the fix
![image](https://github.com/apache/hadoop/assets/55643692/1ed5b32e-99b5-41e6-8b7e-b6631894bec6)

- After the fix
![image](https://github.com/apache/hadoop/assets/55643692/90a2bb73-fe43-46d5-b43c-b0f2ab84982c)


### How was this patch tested?

Add Junit Test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

