### PR TITLE
HDFS-17211. RBF: The comments in the RemoteParam class are incorrect.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RemoteParam.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RemoteParam.java
@@ -35,7 +35,7 @@ public class RemoteParam {
 
   /**
    * Constructs a default remote parameter. Always maps the value to the
-   * destination of the provided RemoveLocationContext.
+   * destination of the provided RemoteLocationContext.
    */
   public RemoteParam() {
     this.paramMap = null;


### PR DESCRIPTION
This commmit just modifies the annotation error and does not need to write a test class.
sketch: Remove -> Remote

jira:  https://issues.apache.org/jira/browse/HDFS-17211