### PR TITLE
HDFS-16968. Recover two replicas when 2-replication write pipepine fails

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/ReplaceDatanodeOnFailure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/ReplaceDatanodeOnFailure.java
@@ -42,7 +42,7 @@ public class ReplaceDatanodeOnFailure {
     public boolean satisfy(final short replication,
         final DatanodeInfo[] existings, final int n, final boolean isAppend,
         final boolean isHflushed) {
-      return replication >= 3 &&
+      return replication >= 2 &&
           (n <= (replication / 2) || isAppend || isHflushed);
     }
   };

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/ReplaceDatanodeOnFailure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/ReplaceDatanodeOnFailure.java
@@ -34,7 +34,7 @@ public class ReplaceDatanodeOnFailure {
    * DEFAULT condition:
    *   Let r be the replication number.
    *   Let n be the number of existing datanodes.
-   *   Add a new datanode only if r >= 3 and either
+   *   Add a new datanode only if r >= 2 and either
    *   (1) floor(r/2) >= n or (2) the block is hflushed/appended.
    */
   private static final Condition CONDITION_DEFAULT = new Condition() {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
When user tries to write a 2-replica file and fails in the process, write pipeline will only make sure one DN is written successfully, this will make the data lost. This PR aims to solve this case.

### How was this patch tested?
1. Test in UT
2. This feature has run in our company cluster for more than 6 months and works well

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

