### PR TITLE
YARN-11581. Fix compilation error in hadoop-yarn-applications-catalog-webapp due to unresolved dependency on hamcrest.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
@@ -74,6 +74,11 @@
       </exclusions>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/YARN-11581

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.1:testCompile (default-testCompile) on project hadoop-yarn-applications-catalog-webapp: Compilation failure: Compilation failure:
[ERROR] /home/rocky/srcs/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppDetailsControllerTest.java:[32,27] cannot find symbol
[ERROR]   symbol:   class MatcherAssert
[ERROR]   location: package org.hamcrest
[ERROR] /home/rocky/srcs/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppDetailsControllerTest.java:[32,1] static import only from classes and inter\
faces
[ERROR] /home/rocky/srcs/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppStoreControllerTest.java:[30,27] cannot find symbol
[ERROR]   symbol:   class MatcherAssert
[ERROR]   location: package org.hamcrest
[ERROR] /home/rocky/srcs/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppStoreControllerTest.java:[30,1] static import only from classes and interfa\
ces
[ERROR] /home/rocky/srcs/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppListControllerTest.java:[30,27] cannot find symbol
[ERROR]   symbol:   class MatcherAssert
[ERROR]   location: package org.hamcrest
[ERROR] /home/rocky/srcs/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppListControllerTest.java:[30,1] static import only from classes and interfac\
es
[ERROR] /home/rocky/srcs/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppDetailsControllerTest.java:[129,5] cannot find symbol
[ERROR]   symbol:   method assertThat(java.lang.String,boolean)
[ERROR]   location: class org.apache.hadoop.yarn.appcatalog.controller.AppDetailsControllerTest
[ERROR] /home/rocky/srcs/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppDetailsControllerTest.java:[135,5] cannot find symbol
[ERROR]   symbol:   method assertThat(java.lang.String,java.lang.String,org.hamcrest.Matcher<java.lang.String>)
[ERROR]   location: class org.apache.hadoop.yarn.appcatalog.controller.AppDetailsControllerTest
[ERROR] /home/rocky/srcs/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppStoreControllerTest.java:[89,5] cannot find symbol
[ERROR]   symbol:   method assertThat(java.lang.String,boolean)
[ERROR]   location: class org.apache.hadoop.yarn.appcatalog.controller.AppStoreControllerTest
[ERROR] /home/rocky/srcs/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppStoreControllerTest.java:[95,5] cannot find symbol
[ERROR]   symbol:   method assertThat(java.lang.String,java.lang.String,org.hamcrest.Matcher<java.lang.String>)
[ERROR]   location: class org.apache.hadoop.yarn.appcatalog.controller.AppStoreControllerTest
[ERROR] /home/rocky/srcs/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppListControllerTest.java:[88,5] cannot find symbol
[ERROR]   symbol:   method assertThat(java.lang.String,boolean)
[ERROR]   location: class org.apache.hadoop.yarn.appcatalog.controller.AppListControllerTest
[ERROR] /home/rocky/srcs/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppListControllerTest.java:[93,5] cannot find symbol
[ERROR]   symbol:   method assertThat(java.lang.String,java.lang.String,org.hamcrest.Matcher<java.lang.String>)
[ERROR]   location: class org.apache.hadoop.yarn.appcatalog.controller.AppListControllerTest
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :hadoop-yarn-applications-catalog-webap
```

While I can only reproduce this on aarch64, explicit test-scope dependency should be added since the tests depend on the library.
