### PR TITLE
HADOOP-18916. Exclude all module-info classes

### DIFF
--- a/hadoop-client-modules/hadoop-client-minicluster/pom.xml
+++ b/hadoop-client-modules/hadoop-client-minicluster/pom.xml
@@ -748,15 +748,10 @@
                       </excludes>
                     </filter>
                     <filter>
-                      <artifact>com.fasterxml.jackson.*:*</artifact>
-                      <excludes>
-                        <exclude>META-INF/versions/11/module-info.class</exclude>
-                      </excludes>
-                    </filter>
-                    <filter>
-                      <artifact>com.google.code.gson:gson</artifact>
+                      <artifact>*:*</artifact>
                       <excludes>
                         <exclude>META-INF/versions/9/module-info.class</exclude>
+                        <exclude>META-INF/versions/11/module-info.class</exclude>
                       </excludes>
                     </filter>
                     <filter>

--- a/hadoop-client-modules/hadoop-client-minicluster/pom.xml
+++ b/hadoop-client-modules/hadoop-client-minicluster/pom.xml
@@ -754,12 +754,6 @@
                         <exclude>META-INF/versions/11/module-info.class</exclude>
                       </excludes>
                     </filter>
-                    <filter>
-                      <artifact>org.apache.commons:commons-compress</artifact>
-                      <excludes>
-                        <exclude>META-INF/versions/9/module-info.class</exclude>
-                      </excludes>
-                    </filter>
 
                     <!-- Mockito tries to include its own unrelocated copy of hamcrest. :( -->
                     <filter>

--- a/hadoop-client-modules/hadoop-client-runtime/pom.xml
+++ b/hadoop-client-modules/hadoop-client-runtime/pom.xml
@@ -245,12 +245,6 @@
                         <exclude>META-INF/versions/11/module-info.class</exclude>
                       </excludes>
                     </filter>
-                    <filter>
-                      <artifact>org.apache.commons:commons-compress</artifact>
-                      <excludes>
-                        <exclude>META-INF/versions/9/module-info.class</exclude>
-                      </excludes>
-                    </filter>
 
                   </filters>
                   <relocations>

--- a/hadoop-client-modules/hadoop-client-runtime/pom.xml
+++ b/hadoop-client-modules/hadoop-client-runtime/pom.xml
@@ -239,15 +239,10 @@
                       </excludes>
                     </filter>
                     <filter>
-                      <artifact>com.fasterxml.jackson.*:*</artifact>
-                      <excludes>
-                        <exclude>META-INF/versions/11/module-info.class</exclude>
-                      </excludes>
-                    </filter>
-                    <filter>
-                      <artifact>com.google.code.gson:gson</artifact>
+                      <artifact>*:*</artifact>
                       <excludes>
                         <exclude>META-INF/versions/9/module-info.class</exclude>
+                        <exclude>META-INF/versions/11/module-info.class</exclude>
                       </excludes>
                     </filter>
                     <filter>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

