### PR TITLE
HDFS-17214. RBF: The Quota class' andByStorageType method res has an incorrect initial value.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Quota.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Quota.java
@@ -347,7 +347,7 @@ public class Quota {
    * @return true if bitwise AND by all storage type returns true, false otherwise.
    */
   public static boolean andByStorageType(Predicate<StorageType> predicate) {
-    boolean res = false;
+    boolean res = true;
     for (StorageType type : StorageType.values()) {
       res &= predicate.test(type);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterQuota.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterQuota.java
@@ -31,6 +31,8 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
+import java.util.Arrays;
+import java.util.function.Predicate;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CreateFlag;
@@ -1166,6 +1168,32 @@ public class TestRouterQuota {
     assertEquals(ssQuota * 2, quotaUsage.getSpaceQuota());
     assertEquals(0, quotaUsage.getFileAndDirectoryCount());
     assertEquals(0, quotaUsage.getSpaceConsumed());
+  }
+
+  @Test
+  public void testAndByStorageType() {
+    long[] typeQuota = new long[StorageType.values().length];
+    Arrays.fill(typeQuota, HdfsConstants.QUOTA_DONT_SET);
+
+    Predicate<StorageType> predicate = new Predicate<StorageType>() {
+      @Override
+      public boolean test(StorageType storageType) {
+        return typeQuota[storageType.ordinal()] == HdfsConstants.QUOTA_DONT_SET;
+      }
+    };
+
+    assertTrue(Quota.andByStorageType(predicate));
+
+    typeQuota[0] = 2023;
+    assertFalse(Quota.andByStorageType(predicate));
+
+    Arrays.fill(typeQuota, HdfsConstants.QUOTA_DONT_SET);
+    typeQuota[1] = 2023;
+    assertFalse(Quota.andByStorageType(predicate));
+
+    Arrays.fill(typeQuota, HdfsConstants.QUOTA_DONT_SET);
+    typeQuota[typeQuota.length-1] = 2023;
+    assertFalse(Quota.andByStorageType(predicate));
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterQuota.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterQuota.java
@@ -1184,15 +1184,17 @@ public class TestRouterQuota {
 
     assertTrue(Quota.andByStorageType(predicate));
 
-    typeQuota[0] = 2023;
+    // This is a value to test for,
+    // as long as it is not equal to HdfsConstants.QUOTA_DONT_SET
+    typeQuota[0] = HdfsConstants.QUOTA_RESET;
     assertFalse(Quota.andByStorageType(predicate));
 
     Arrays.fill(typeQuota, HdfsConstants.QUOTA_DONT_SET);
-    typeQuota[1] = 2023;
+    typeQuota[1] = HdfsConstants.QUOTA_RESET;
     assertFalse(Quota.andByStorageType(predicate));
 
     Arrays.fill(typeQuota, HdfsConstants.QUOTA_DONT_SET);
-    typeQuota[typeQuota.length-1] = 2023;
+    typeQuota[typeQuota.length-1] = HdfsConstants.QUOTA_RESET;
     assertFalse(Quota.andByStorageType(predicate));
   }
 


### PR DESCRIPTION
jira：https://issues.apache.org/jira/browse/HDFS-17214

The Quata class's andByStorageType method is intended to apply bitwise and to each bit of StorageType.values( ) (the converted value), returning true only if all the values are true.
So the initial value of res should be true and then loop through the array to perform the bitwise and operation. 
However, since res starts with fasle, the bitwise and always evaluates to false, so we should fix res to start with true.