### PR TITLE
HDFS-17216. Distcp: When handle the small files, the bandwidth parameter will be invalid, fix this bug.

### DIFF
--- a/hadoop-tools/hadoop-distcp/pom.xml
+++ b/hadoop-tools/hadoop-distcp/pom.xml
@@ -114,6 +114,12 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/ThrottledInputStream.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/ThrottledInputStream.java
@@ -120,12 +120,11 @@ public class ThrottledInputStream extends InputStream implements Seekable {
    * @return Read rate, in bytes/sec.
    */
   public long getBytesPerSec() {
-    long elapsed = (System.currentTimeMillis() - startTime) / 1000;
-    if (elapsed == 0) {
-      return bytesRead;
-    } else {
-      return bytesRead / elapsed;
+    if (bytesRead == 0){
+      return 0;
     }
+    float elapsed = (System.currentTimeMillis() - startTime) / 1000.0f;
+    return (long) (bytesRead / elapsed);
   }
 
   /**


### PR DESCRIPTION
jira:  https://issues.apache.org/jira/browse/HDFS-17216

When distcp copies small files (file size slightly smaller than the bandwidth), the throbber only starts to throb after 1 second, and the throttled is specific to a single file. so the throbber becomes invalid, causing distcp to fill the cluster bandwidth and crush production traffic, which is a terrible thing.
![DiscpAnalyze](https://github.com/apache/hadoop/assets/65019264/db2f6347-8ff9-4b51-bb3d-11026c091a43)

Also, it takes time for files to set up the IO pipeline, so you shouldn't test with very small files, which will slow the transfer, especially as bandwidth kicks in, which will amplify the impact of small files on the rate
