### PR TITLE
HADOOP-18920. RPC Metrics : Optimize logic for log slow RPCs

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -504,6 +504,10 @@ public class CommonConfigurationKeysPublic {
                                                 "ipc.server.log.slow.rpc";
   public static final boolean IPC_SERVER_LOG_SLOW_RPC_DEFAULT = false;
 
+  public static final String IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_KEY =
+      "ipc.server.log.slow.rpc-threshold-ms";
+  public static final long IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_DEFAULT = 10000L;
+
   public static final String IPC_SERVER_PURGE_INTERVAL_MINUTES_KEY =
     "ipc.server.purge.interval";
   public static final int IPC_SERVER_PURGE_INTERVAL_MINUTES_DEFAULT = 15;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -506,7 +506,7 @@ public class CommonConfigurationKeysPublic {
 
   public static final String IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_KEY =
       "ipc.server.log.slow.rpc-threshold-ms";
-  public static final long IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_DEFAULT = 10000L;
+  public static final long IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_DEFAULT = 0;
 
   public static final String IPC_SERVER_PURGE_INTERVAL_MINUTES_KEY =
     "ipc.server.purge.interval";

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -505,7 +505,7 @@ public class CommonConfigurationKeysPublic {
   public static final boolean IPC_SERVER_LOG_SLOW_RPC_DEFAULT = false;
 
   public static final String IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_KEY =
-      "ipc.server.log.slow.rpc-threshold-ms";
+      "ipc.server.log.slow.rpc.threshold.ms";
   public static final long IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_DEFAULT = 0;
 
   public static final String IPC_SERVER_PURGE_INTERVAL_MINUTES_KEY =

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -592,6 +592,7 @@ public abstract class Server {
   void logSlowRpcCalls(String methodName, Call call,
       ProcessingDetails details) {
     final int deviation = 3;
+
     // 1024 for minSampleSize just a guess -- not a number computed based on
     // sample size analysis. It is chosen with the hope that this
     // number is high enough to avoid spurious logging, yet useful

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2512,12 +2512,22 @@ The switch to turn S3A auditing on or off.
 </property>
 
 <property>
-    <name>ipc.server.log.slow.rpc</name>
-    <value>false</value>
-    <description>This setting is useful to troubleshoot performance issues for
-     various services. If this value is set to true then we log requests that
-     fall into 99th percentile as well as increment RpcSlowCalls counter.
-    </description>
+  <name>ipc.server.log.slow.rpc</name>
+  <value>false</value>
+  <description>This setting is useful to troubleshoot performance issues for
+   various services. If this value is set to true then we log requests that
+   fall into 99th percentile as well as increment RpcSlowCalls counter.
+  </description>
+</property>
+
+<property>
+  <name>ipc.server.log.slow.rpc-threshold-ms</name>
+  <value>0</value>
+  <description>The threshold in milliseconds for log slow rpc when ipc.server.log.slow.rpc is enabled.
+    If a request took significant more time than other requests,
+    and its processing time is exceed `logSlowRPCThresholdMs` will consider that as a slow RPC.
+    By default, this parameter is set 0.
+  </description>
 </property>
 
 <property>

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2521,12 +2521,11 @@ The switch to turn S3A auditing on or off.
 </property>
 
 <property>
-  <name>ipc.server.log.slow.rpc-threshold-ms</name>
+  <name>ipc.server.log.slow.rpc.threshold.ms</name>
   <value>0</value>
-  <description>The threshold in milliseconds for log slow rpc when ipc.server.log.slow.rpc is enabled.
-    If a request took significant more time than other requests,
-    and its processing time is exceed `logSlowRPCThresholdMs` will consider that as a slow RPC.
-    By default, this parameter is set 0.
+  <description>The threshold in milliseconds for logging slow rpc when ipc.server.log.slow.rpc is enabled.
+    Besides of being much slower than other RPC requests, an RPC request has to take at least the threshold value
+    defined by this property before it can be considered as slow. By default, this threshold is set to 0 (disabled).
   </description>
 </property>
 

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2512,12 +2512,12 @@ The switch to turn S3A auditing on or off.
 </property>
 
 <property>
-  <name>ipc.server.log.slow.rpc</name>
-  <value>false</value>
-  <description>This setting is useful to troubleshoot performance issues for
-   various services. If this value is set to true then we log requests that
-   fall into 99th percentile as well as increment RpcSlowCalls counter.
-  </description>
+    <name>ipc.server.log.slow.rpc</name>
+    <value>false</value>
+    <description>This setting is useful to troubleshoot performance issues for
+     various services. If this value is set to true then we log requests that
+     fall into 99th percentile as well as increment RpcSlowCalls counter.
+    </description>
 </property>
 
 <property>

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpc.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpc.java
@@ -355,6 +355,7 @@ public class TestProtoBufRpc extends TestRpcBase {
       TimeoutException, InterruptedException {
     //No test with legacy
     assumeFalse(testWithLegacy);
+    server.setLogSlowRPCThresholdMs(SLEEP_DURATION);
     TestRpcService2 client = getClient2();
     // make 10 K fast calls
     for (int x = 0; x < 10000; x++) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpc.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpc.java
@@ -353,11 +353,11 @@ public class TestProtoBufRpc extends TestRpcBase {
   @Test(timeout = 12000)
   public void testLogSlowRPC() throws IOException, ServiceException,
       TimeoutException, InterruptedException {
-    // No test with legacy.
+    //No test with legacy
     assumeFalse(testWithLegacy);
-    server.setLogSlowRPCThresholdMs(SLEEP_DURATION);
+    server.setLogSlowRPCThresholdTime(SLEEP_DURATION);
     TestRpcService2 client = getClient2();
-    // Make 10 K fast calls.
+    // make 10 K fast calls
     for (int x = 0; x < 10000; x++) {
       try {
         client.ping2(null, newEmptyRequest());
@@ -366,12 +366,12 @@ public class TestProtoBufRpc extends TestRpcBase {
       }
     }
 
-    // Ensure RPC metrics are updated.
+    // Ensure RPC metrics are updated
     RpcMetrics rpcMetrics = server.getRpcMetrics();
     assertThat(rpcMetrics.getProcessingSampleCount()).isGreaterThan(999L);
     long before = rpcMetrics.getRpcSlowCalls();
 
-    // Sleep sleeps for 500ms(less than `logSlowRPCThresholdMs`),
+    // Sleep sleeps for 500ms(less than `logSlowRPCThresholdTime`),
     // make sure we never called into Log slow RPC routine.
     client.sleep(null, newSleepRequest(SLEEP_DURATION / 2));
     long after = rpcMetrics.getRpcSlowCalls();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -2537,16 +2537,16 @@ public class NameNode extends ReconfigurableBase implements
         }
         result = Boolean.toString(logSlowRPC);
       } else if (property.equals(IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_KEY)) {
-        long logSlowRPCThresholdMs = (newVal == null ?
+        long logSlowRPCThresholdTime = (newVal == null ?
             IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_DEFAULT : Long.parseLong(newVal));
-        rpcServer.getClientRpcServer().setLogSlowRPCThresholdMs(logSlowRPCThresholdMs);
+        rpcServer.getClientRpcServer().setLogSlowRPCThresholdTime(logSlowRPCThresholdTime);
         if (rpcServer.getServiceRpcServer() != null) {
-          rpcServer.getServiceRpcServer().setLogSlowRPCThresholdMs(logSlowRPCThresholdMs);
+          rpcServer.getServiceRpcServer().setLogSlowRPCThresholdTime(logSlowRPCThresholdTime);
         }
         if (rpcServer.getLifelineRpcServer() != null) {
-          rpcServer.getLifelineRpcServer().setLogSlowRPCThresholdMs(logSlowRPCThresholdMs);
+          rpcServer.getLifelineRpcServer().setLogSlowRPCThresholdTime(logSlowRPCThresholdTime);
         }
-        result = Long.toString(logSlowRPCThresholdMs);
+        result = Long.toString(logSlowRPCThresholdTime);
       }
       LOG.info("RECONFIGURE* changed reconfigureLogSlowRPC {} to {}", property, result);
       return result;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -126,6 +126,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_DEFAULT;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_SERVER_LOG_SLOW_RPC;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_SERVER_LOG_SLOW_RPC_DEFAULT;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_KEY;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_BLOCK_INVALIDATE_LIMIT_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_MAX_NODES_TO_REPORT_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_MAX_NODES_TO_REPORT_KEY;
@@ -365,7 +369,9 @@ public class NameNode extends ReconfigurableBase implements
           DFS_NAMENODE_RECONSTRUCTION_PENDING_TIMEOUT_SEC_KEY,
           DFS_NAMENODE_DECOMMISSION_BACKOFF_MONITOR_PENDING_LIMIT,
           DFS_NAMENODE_DECOMMISSION_BACKOFF_MONITOR_PENDING_BLOCKS_PER_LOCK,
-          DFS_NAMENODE_BLOCKPLACEMENTPOLICY_MIN_BLOCKS_FOR_WRITE_KEY));
+          DFS_NAMENODE_BLOCKPLACEMENTPOLICY_MIN_BLOCKS_FOR_WRITE_KEY,
+          IPC_SERVER_LOG_SLOW_RPC,
+          IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_KEY));
 
   private static final String USAGE = "Usage: hdfs namenode ["
       + StartupOption.BACKUP.getName() + "] | \n\t["
@@ -2367,6 +2373,9 @@ public class NameNode extends ReconfigurableBase implements
           newVal);
     } else if (property.equals(DFS_NAMENODE_BLOCKPLACEMENTPOLICY_MIN_BLOCKS_FOR_WRITE_KEY)) {
       return reconfigureMinBlocksForWrite(property, newVal);
+    } else if (property.equals(IPC_SERVER_LOG_SLOW_RPC) ||
+        (property.equals(IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_KEY))) {
+      return reconfigureLogSlowRPC(property, newVal);
     } else {
       throw new ReconfigurationException(property, newVal, getConf().get(
           property));
@@ -2507,6 +2516,43 @@ public class NameNode extends ReconfigurableBase implements
     rpcServer.getClientRpcServer()
         .setClientBackoffEnabled(clientBackoffEnabled);
     return Boolean.toString(clientBackoffEnabled);
+  }
+
+  String reconfigureLogSlowRPC(String property, String newVal) throws ReconfigurationException {
+    String result = null;
+    try {
+      if (property.equals(IPC_SERVER_LOG_SLOW_RPC)) {
+        if (newVal != null && !newVal.equalsIgnoreCase("true") &&
+            !newVal.equalsIgnoreCase("false")) {
+          throw new IllegalArgumentException(newVal + " is not boolean value");
+        }
+        boolean logSlowRPC = (newVal == null ? IPC_SERVER_LOG_SLOW_RPC_DEFAULT :
+            Boolean.parseBoolean(newVal));
+        rpcServer.getClientRpcServer().setLogSlowRPC(logSlowRPC);
+        if (rpcServer.getServiceRpcServer() != null) {
+          rpcServer.getServiceRpcServer().setLogSlowRPC(logSlowRPC);
+        }
+        if (rpcServer.getLifelineRpcServer() != null) {
+          rpcServer.getLifelineRpcServer().setLogSlowRPC(logSlowRPC);
+        }
+        result = Boolean.toString(logSlowRPC);
+      } else if (property.equals(IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_KEY)) {
+        long logSlowRPCThresholdMs = (newVal == null ?
+            IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_DEFAULT : Long.parseLong(newVal));
+        rpcServer.getClientRpcServer().setLogSlowRPCThresholdMs(logSlowRPCThresholdMs);
+        if (rpcServer.getServiceRpcServer() != null) {
+          rpcServer.getServiceRpcServer().setLogSlowRPCThresholdMs(logSlowRPCThresholdMs);
+        }
+        if (rpcServer.getLifelineRpcServer() != null) {
+          rpcServer.getLifelineRpcServer().setLogSlowRPCThresholdMs(logSlowRPCThresholdMs);
+        }
+        result = Long.toString(logSlowRPCThresholdMs);
+      }
+      LOG.info("RECONFIGURE* changed reconfigureLogSlowRPC {} to {}", property, result);
+      return result;
+    } catch (IllegalArgumentException e) {
+      throw new ReconfigurationException(property, newVal, getConf().get(property), e);
+    }
   }
 
   String reconfigureSPSModeEvent(String newVal, String property)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeReconfigure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeReconfigure.java
@@ -711,7 +711,7 @@ public class TestNameNodeReconfigure {
     // verify default value.
     assertFalse(nnrs.getClientRpcServer().isLogSlowRPC());
     assertEquals(IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_DEFAULT,
-        nnrs.getClientRpcServer().getLogSlowRPCThresholdMs());
+        nnrs.getClientRpcServer().getLogSlowRPCThresholdTime());
 
     // try invalid logSlowRPC.
     try {
@@ -731,20 +731,20 @@ public class TestNameNodeReconfigure {
     nameNode.reconfigurePropertyImpl(IPC_SERVER_LOG_SLOW_RPC, null);
     assertFalse(nnrs.getClientRpcServer().isLogSlowRPC());
 
-    // try invalid logSlowRPCThresholdMs.
+    // try invalid logSlowRPCThresholdTime.
     try {
       nameNode.reconfigureProperty(IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_KEY,
           "non-numeric");
       fail("Should not reach here");
     } catch (ReconfigurationException e) {
       assertEquals("Could not change property " +
-          "ipc.server.log.slow.rpc-threshold-ms' to 'non-numeric'", e.getMessage());
+          "ipc.server.log.slow.rpc-threshold-ms from '0' to 'non-numeric'", e.getMessage());
     }
 
-    // try correct logSlowRPCThresholdMs.
+    // try correct logSlowRPCThresholdTime.
     nameNode.reconfigureProperty(IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_KEY,
         "20000");
-    assertEquals(nnrs.getClientRpcServer().getLogSlowRPCThresholdMs(), 20000);
+    assertEquals(nnrs.getClientRpcServer().getLogSlowRPCThresholdTime(), 20000);
   }
 
   @After

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeReconfigure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeReconfigure.java
@@ -29,6 +29,9 @@ import org.junit.Test;
 import org.junit.Before;
 import org.junit.After;
 
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_SERVER_LOG_SLOW_RPC;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_DEFAULT;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_MAX_NODES_TO_REPORT_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_IMAGE_PARALLEL_LOAD_KEY;
 import static org.junit.Assert.*;
@@ -699,6 +702,49 @@ public class TestNameNodeReconfigure {
     // Ensure none of the values were updated from the new value.
     assertEquals(3, bm.getMinBlocksForWrite(BlockType.CONTIGUOUS));
     assertEquals(3, bm.getMinBlocksForWrite(BlockType.STRIPED));
+  }
+
+  @Test
+  public void testReconfigureLogSlowRPC() throws ReconfigurationException {
+    final NameNode nameNode = cluster.getNameNode();
+    final NameNodeRpcServer nnrs = (NameNodeRpcServer) nameNode.getRpcServer();
+    // verify default value.
+    assertFalse(nnrs.getClientRpcServer().isLogSlowRPC());
+    assertEquals(IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_DEFAULT,
+        nnrs.getClientRpcServer().getLogSlowRPCThresholdMs());
+
+    // try invalid logSlowRPC.
+    try {
+      nameNode.reconfigurePropertyImpl(IPC_SERVER_LOG_SLOW_RPC, "non-boolean");
+      fail("should not reach here");
+    } catch (ReconfigurationException e) {
+      assertEquals(
+          "Could not change property ipc.server.log.slow.rpc from 'false' to 'non-boolean'",
+          e.getMessage());
+    }
+
+    // try correct logSlowRPC.
+    nameNode.reconfigurePropertyImpl(IPC_SERVER_LOG_SLOW_RPC, "True");
+    assertTrue(nnrs.getClientRpcServer().isLogSlowRPC());
+
+    // revert to defaults.
+    nameNode.reconfigurePropertyImpl(IPC_SERVER_LOG_SLOW_RPC, null);
+    assertFalse(nnrs.getClientRpcServer().isLogSlowRPC());
+
+    // try invalid logSlowRPCThresholdMs.
+    try {
+      nameNode.reconfigureProperty(IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_KEY,
+          "non-numeric");
+      fail("Should not reach here");
+    } catch (ReconfigurationException e) {
+      assertEquals("Could not change property " +
+          "ipc.server.log.slow.rpc-threshold-ms' to 'non-numeric'", e.getMessage());
+    }
+
+    // try correct logSlowRPCThresholdMs.
+    nameNode.reconfigureProperty(IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_KEY,
+        "20000");
+    assertEquals(nnrs.getClientRpcServer().getLogSlowRPCThresholdMs(), 20000);
   }
 
   @After

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeReconfigure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeReconfigure.java
@@ -738,7 +738,7 @@ public class TestNameNodeReconfigure {
       fail("Should not reach here");
     } catch (ReconfigurationException e) {
       assertEquals("Could not change property " +
-          "ipc.server.log.slow.rpc-threshold-ms from '0' to 'non-numeric'", e.getMessage());
+          "ipc.server.log.slow.rpc.threshold.ms from '0' to 'non-numeric'", e.getMessage());
     }
 
     // try correct logSlowRPCThresholdTime.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -442,7 +442,7 @@ public class TestDFSAdmin {
     final List<String> outs = Lists.newArrayList();
     final List<String> errs = Lists.newArrayList();
     getReconfigurableProperties("namenode", address, outs, errs);
-    assertEquals(24, outs.size());
+    assertEquals(25, outs.size());
     assertTrue(outs.get(0).contains("Reconfigurable properties:"));
     assertEquals(DFS_BLOCK_INVALIDATE_LIMIT_KEY, outs.get(1));
     assertEquals(DFS_BLOCK_PLACEMENT_EC_CLASSNAME_KEY, outs.get(2));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -442,7 +442,7 @@ public class TestDFSAdmin {
     final List<String> outs = Lists.newArrayList();
     final List<String> errs = Lists.newArrayList();
     getReconfigurableProperties("namenode", address, outs, errs);
-    assertEquals(23, outs.size());
+    assertEquals(24, outs.size());
     assertTrue(outs.get(0).contains("Reconfigurable properties:"));
     assertEquals(DFS_BLOCK_INVALIDATE_LIMIT_KEY, outs.get(1));
     assertEquals(DFS_BLOCK_PLACEMENT_EC_CLASSNAME_KEY, outs.get(2));


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HADOOP-18920

[HADOOP-12325](https://issues.apache.org/jira/browse/HADOOP-12325) implement a capability where "slow" RPCs are logged in NN log.
Current processing logic is the "slow" RPCs are to be those whose processing time is outside 3 standard deviation.
However, in practice it is found that many logs of slow rpc are currently output, and sometimes RPCs with a processing time of 1ms are also declared as slow, this is not in line with actual expectations.

Therefore, consider optimize the logic conditions of slow RPC and add a `logSlowRPCThresholdMs` variable to judge whether the current RPCas slow so that the expected slow RPC log can be logger.
for `logSlowRPCThresholdMs`, we can support dynamic refresh to facilitate adjustments based on the actual operating conditions of the hdfs cluster.
