### PR TITLE
HADOOP-18923 - Switch to SPDX identifier for license name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
 
   <licenses>
     <license>
-      <name>Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>


### PR DESCRIPTION
https://maven.apache.org/pom.html#Licenses
"Using an [SPDX identifier](https://spdx.org/licenses/) as the license name is recommended."

The Apache parent pom is already using this identifier