### PR TITLE
HDFS-17217. Add lifeline RPC start up log when NameNode#startCommonServices

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -1010,13 +1010,13 @@ public class NameNode extends ReconfigurableBase implements
         LOG.warn("ServicePlugin " + p + " could not be started", t);
       }
     }
-    LOG.info("{} RPC up at: {}", getRole(), getNameNodeAddress());
+    LOG.info("{} RPC up at: {}.", getRole(), getNameNodeAddress());
     if (rpcServer.getServiceRpcAddress() != null) {
-      LOG.info("{} service RPC up at: {}", getRole(), rpcServer.getServiceRpcAddress());
+      LOG.info("{} service RPC up at: {}.", getRole(), rpcServer.getServiceRpcAddress());
 
     }
     if (rpcServer.getLifelineRpcAddress() != null) {
-      LOG.info("{} lifeline RPC up at: {}", getRole(), rpcServer.getLifelineRpcAddress());
+      LOG.info("{} lifeline RPC up at: {}.", getRole(), rpcServer.getLifelineRpcAddress());
     }
   }
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -1015,6 +1015,10 @@ public class NameNode extends ReconfigurableBase implements
       LOG.info(getRole() + " service RPC up at: "
           + rpcServer.getServiceRpcAddress());
     }
+    if (rpcServer.getLifelineRpcAddress() != null) {
+      LOG.info(getRole() + " lifeline RPC up at: "
+          + rpcServer.getLifelineRpcAddress());
+    }
   }
   
   private void stopCommonServices() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -1013,7 +1013,6 @@ public class NameNode extends ReconfigurableBase implements
     LOG.info("{} RPC up at: {}.", getRole(), getNameNodeAddress());
     if (rpcServer.getServiceRpcAddress() != null) {
       LOG.info("{} service RPC up at: {}.", getRole(), rpcServer.getServiceRpcAddress());
-
     }
     if (rpcServer.getLifelineRpcAddress() != null) {
       LOG.info("{} lifeline RPC up at: {}.", getRole(), rpcServer.getLifelineRpcAddress());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -1010,14 +1010,13 @@ public class NameNode extends ReconfigurableBase implements
         LOG.warn("ServicePlugin " + p + " could not be started", t);
       }
     }
-    LOG.info(getRole() + " RPC up at: " + getNameNodeAddress());
+    LOG.info("{} RPC up at: {}", getRole(), getNameNodeAddress());
     if (rpcServer.getServiceRpcAddress() != null) {
-      LOG.info(getRole() + " service RPC up at: "
-          + rpcServer.getServiceRpcAddress());
+      LOG.info("{} service RPC up at: {}", getRole(), rpcServer.getServiceRpcAddress());
+
     }
     if (rpcServer.getLifelineRpcAddress() != null) {
-      LOG.info(getRole() + " lifeline RPC up at: "
-          + rpcServer.getLifelineRpcAddress());
+      LOG.info("{} lifeline RPC up at: {}", getRole(), rpcServer.getLifelineRpcAddress());
     }
   }
   


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17217

If start up the lifeline RPC server in NameNode and need add lifeline RPC start up log when NameNode#startCommonServices



