### PR TITLE
YARN-10174. Add colored policies to enable manual load balancing across sub clusters.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/FederationPolicyInitializationContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/FederationPolicyInitializationContext.java
@@ -32,6 +32,7 @@ public class FederationPolicyInitializationContext {
   private SubClusterResolver federationSubclusterResolver;
   private FederationStateStoreFacade federationStateStoreFacade;
   private SubClusterId homeSubcluster;
+  private String applicationTag;
 
   public FederationPolicyInitializationContext() {
     federationPolicyConfiguration = null;
@@ -42,10 +43,17 @@ public class FederationPolicyInitializationContext {
   public FederationPolicyInitializationContext(
       SubClusterPolicyConfiguration policy, SubClusterResolver resolver,
       FederationStateStoreFacade storeFacade, SubClusterId home) {
+    this(policy, resolver, storeFacade, home, null);
+  }
+
+  public FederationPolicyInitializationContext(
+      SubClusterPolicyConfiguration policy, SubClusterResolver resolver,
+      FederationStateStoreFacade storeFacade, SubClusterId home, String tag) {
     this.federationPolicyConfiguration = policy;
     this.federationSubclusterResolver = resolver;
     this.federationStateStoreFacade = storeFacade;
     this.homeSubcluster = home;
+    this.applicationTag = tag;
   }
 
   /**
@@ -127,4 +135,7 @@ public class FederationPolicyInitializationContext {
     this.homeSubcluster = homeSubcluster;
   }
 
+  public String getApplicationTag() {
+    return applicationTag;
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/FederationPolicyUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/FederationPolicyUtils.java
@@ -25,6 +25,7 @@ import java.util.Random;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.amrmproxy.FederationAMRMProxyPolicy;
@@ -49,6 +50,9 @@ public final class FederationPolicyUtils {
 
   public static final String NO_ACTIVE_SUBCLUSTER_AVAILABLE =
       "No active SubCluster available to submit the request.";
+
+  public static final String FEDERATION_POLICY_LABEL_TAG_PREFIX = "FEDERATION_POLICY_LABEL_TAG";
+  public static final String DEFAULT_POLICY_KEY = "DEFAULT";
 
   private static Random rand = new Random(System.currentTimeMillis());
 
@@ -154,18 +158,20 @@ public final class FederationPolicyUtils {
   public static FederationAMRMProxyPolicy loadAMRMPolicy(String queue,
       FederationAMRMProxyPolicy oldPolicy, Configuration conf,
       FederationStateStoreFacade federationFacade,
-      SubClusterId homeSubClusterId)
+      SubClusterId homeSubClusterId, ApplicationSubmissionContext submissionContext)
       throws FederationPolicyInitializationException {
 
     // Local policy and its configuration
     SubClusterPolicyConfiguration configuration =
         loadPolicyConfiguration(queue, conf, federationFacade);
 
+    String tag = getApplicationPolicyTag(submissionContext);
+
     // Instantiate the policyManager and get policy
     FederationPolicyInitializationContext context =
         new FederationPolicyInitializationContext(configuration,
             federationFacade.getSubClusterResolver(), federationFacade,
-            homeSubClusterId);
+            homeSubClusterId, tag);
 
     LOG.info("Creating policy manager of type: " + configuration.getType());
     FederationPolicyManager federationPolicyManager =
@@ -174,6 +180,21 @@ public final class FederationPolicyUtils {
     // content of conf), and cache it
     federationPolicyManager.setQueue(configuration.getQueue());
     return federationPolicyManager.getAMRMPolicy(context, oldPolicy);
+  }
+
+  public static String getApplicationPolicyTag(ApplicationSubmissionContext appContext) {
+    if (appContext == null) {
+      return DEFAULT_POLICY_KEY;
+    }
+    String tag = DEFAULT_POLICY_KEY;
+    for (String appTag : appContext.getApplicationTags()) {
+      if (appTag.startsWith(FEDERATION_POLICY_LABEL_TAG_PREFIX + ":") ||
+          appTag.startsWith(FEDERATION_POLICY_LABEL_TAG_PREFIX.toLowerCase() + ":")) {
+        tag = appTag.substring(FEDERATION_POLICY_LABEL_TAG_PREFIX.length() + 1);
+        break;
+      }
+    }
+    return tag;
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/FederationPolicyUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/FederationPolicyUtils.java
@@ -152,6 +152,7 @@ public final class FederationPolicyUtils {
    * @param conf the YARN configuration
    * @param federationFacade state store facade
    * @param homeSubClusterId home sub-cluster id
+   * @param submissionContext application submission context
    * @return FederationAMRMProxyPolicy recreated
    * @throws FederationPolicyInitializationException if fails
    */

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/AbstractAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/AbstractAMRMProxyPolicy.java
@@ -42,10 +42,9 @@ public abstract class AbstractAMRMProxyPolicy extends
       throws FederationPolicyInitializationException {
     super.validate(newPolicyInfo);
     for (PolicyWeights policyWeights : newPolicyInfo.getAmrmPolicyWeightsMap().values()) {
-      Map<SubClusterIdInfo, Float> newWeights = policyWeights.getWeigths();
-      if (newWeights == null || newWeights.size() < 1) {
-        throw new FederationPolicyInitializationException(
-            "Weight vector cannot be null/empty.");
+      if (policyWeights == null || policyWeights.getWeigths() == null ||
+          policyWeights.getWeigths().size() < 1) {
+        throw new FederationPolicyInitializationException("Weight vector cannot be null/empty.");
       }
     }
     if (!newPolicyInfo.getAmrmPolicyWeightsMap()

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/AbstractAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/AbstractAMRMProxyPolicy.java
@@ -23,7 +23,9 @@ import java.util.Map;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.AbstractConfigurableFederationPolicy;
+import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyUtils;
 import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
+import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo.PolicyWeights;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyInitializationException;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
@@ -39,11 +41,16 @@ public abstract class AbstractAMRMProxyPolicy extends
   public void validate(WeightedPolicyInfo newPolicyInfo)
       throws FederationPolicyInitializationException {
     super.validate(newPolicyInfo);
-    Map<SubClusterIdInfo, Float> newWeights =
-        newPolicyInfo.getAMRMPolicyWeights();
-    if (newWeights == null || newWeights.size() < 1) {
-      throw new FederationPolicyInitializationException(
-          "Weight vector cannot be null/empty.");
+    for (PolicyWeights policyWeights : newPolicyInfo.getAmrmPolicyWeightsMap().values()) {
+      Map<SubClusterIdInfo, Float> newWeights = policyWeights.getWeigths();
+      if (newWeights == null || newWeights.size() < 1) {
+        throw new FederationPolicyInitializationException(
+            "Weight vector cannot be null/empty.");
+      }
+    }
+    if (!newPolicyInfo.getAmrmPolicyWeightsMap()
+        .containsKey(FederationPolicyUtils.DEFAULT_POLICY_KEY)) {
+      throw new FederationPolicyInitializationException("DEFAULT policy must be set.");
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/LocalityMulticastAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/LocalityMulticastAMRMProxyPolicy.java
@@ -204,10 +204,9 @@ public class LocalityMulticastAMRMProxyPolicy extends AbstractAMRMProxyPolicy {
     boolean allInactive = true;
     WeightedPolicyInfo policy = getPolicyInfo();
 
-    if (policy.getAMRMPolicyWeights() != null
-        && policy.getAMRMPolicyWeights().size() > 0) {
-      for (Map.Entry<SubClusterIdInfo, Float> e : policy.getAMRMPolicyWeights()
-          .entrySet()) {
+    String tag = policyContext.getApplicationTag();
+    if (policy.getAMRMPolicyWeights(tag) != null && policy.getAMRMPolicyWeights(tag).size() > 0) {
+      for (Map.Entry<SubClusterIdInfo, Float> e : policy.getAMRMPolicyWeights(tag).entrySet()) {
         if (e.getValue() > 0) {
           allInactive = false;
         }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/dao/WeightedPolicyInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/dao/WeightedPolicyInfo.java
@@ -61,7 +61,7 @@ public class WeightedPolicyInfo {
 
   @XmlAccessorType(XmlAccessType.FIELD)
   public static class PolicyWeights {
-    Map<SubClusterIdInfo, Float> weigths;
+    private Map<SubClusterIdInfo, Float> weigths;
 
     public PolicyWeights() {
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/dao/WeightedPolicyInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/dao/WeightedPolicyInfo.java
@@ -35,7 +35,6 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyInitializationException;
-import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/AbstractRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/AbstractRouterPolicy.java
@@ -83,6 +83,7 @@ public abstract class AbstractRouterPolicy extends
    * sub-clusters.
    *
    * @param queue the queue for this application/reservation
+   * @param tag the application tag which is start with "FEDERATION_POLICY_LABEL_TAG:"
    * @param preSelectSubClusters a pre-filter set of sub-clusters
    * @return the chosen sub-cluster
    *

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/HashBasedRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/HashBasedRouterPolicy.java
@@ -49,7 +49,7 @@ public class HashBasedRouterPolicy extends AbstractRouterPolicy {
   }
 
   @Override
-  protected SubClusterId chooseSubCluster(String queue,
+  protected SubClusterId chooseSubCluster(String queue, String tag,
       Map<SubClusterId, SubClusterInfo> preSelectSubclusters) throws YarnException {
     int chosenPosition = Math.abs(queue.hashCode() % preSelectSubclusters.size());
     List<SubClusterId> list = new ArrayList<>(preSelectSubclusters.keySet());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/LocalityRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/LocalityRouterPolicy.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyInitializationContext;
 import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyUtils;
-import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
 import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo.PolicyWeights;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyInitializationException;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/PriorityRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/PriorityRouterPolicy.java
@@ -33,11 +33,11 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;
 public class PriorityRouterPolicy extends AbstractRouterPolicy {
 
   @Override
-  protected SubClusterId chooseSubCluster(
-      String queue, Map<SubClusterId, SubClusterInfo> preSelectSubclusters) throws YarnException {
+  protected SubClusterId chooseSubCluster(String queue, String tag,
+      Map<SubClusterId, SubClusterInfo> preSelectSubclusters) throws YarnException {
     // This finds the sub-cluster with the highest weight among the
     // currently active ones.
-    Map<SubClusterIdInfo, Float> weights = getPolicyInfo().getRouterPolicyWeights();
+    Map<SubClusterIdInfo, Float> weights = getPolicyInfo().getRouterPolicyWeights(tag);
     SubClusterId chosen = null;
     Float currentBest = Float.MIN_VALUE;
     for (SubClusterId id : preSelectSubclusters.keySet()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/RejectRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/RejectRouterPolicy.java
@@ -44,8 +44,8 @@ public class RejectRouterPolicy extends AbstractRouterPolicy {
   }
 
   @Override
-  protected SubClusterId chooseSubCluster(
-      String queue, Map<SubClusterId, SubClusterInfo> preSelectSubclusters) throws YarnException {
+  protected SubClusterId chooseSubCluster(String queue, String tag,
+      Map<SubClusterId, SubClusterInfo> preSelectSubclusters) throws YarnException {
     throw new FederationPolicyException(
         "The policy configured for this queue (" + queue + ") "
         + "reject all routing requests by construction. Application in "

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/UniformRandomRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/UniformRandomRouterPolicy.java
@@ -58,8 +58,8 @@ public class UniformRandomRouterPolicy extends AbstractRouterPolicy {
   }
 
   @Override
-  protected SubClusterId chooseSubCluster(
-      String queue, Map<SubClusterId, SubClusterInfo> preSelectSubclusters) throws YarnException {
+  protected SubClusterId chooseSubCluster(String queue, String tag,
+      Map<SubClusterId, SubClusterInfo> preSelectSubclusters) throws YarnException {
     if (preSelectSubclusters == null || preSelectSubclusters.isEmpty()) {
       throw new FederationPolicyException("No available subcluster to choose from.");
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/WeightedRandomRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/WeightedRandomRouterPolicy.java
@@ -34,14 +34,14 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;
  */
 public class WeightedRandomRouterPolicy extends AbstractRouterPolicy {
   @Override
-  protected SubClusterId chooseSubCluster(
-      String queue, Map<SubClusterId, SubClusterInfo> preSelectSubclusters) throws YarnException {
+  protected SubClusterId chooseSubCluster(String queue, String tag,
+      Map<SubClusterId, SubClusterInfo> preSelectSubclusters) throws YarnException {
 
     // note: we cannot pre-compute the weights, as the set of activeSubCluster
     // changes dynamically (and this would unfairly spread the load to
     // sub-clusters adjacent to an inactive one), hence we need to count/scan
     // the list and based on weight pick the next sub-cluster.
-    Map<SubClusterIdInfo, Float> weights = getPolicyInfo().getRouterPolicyWeights();
+    Map<SubClusterIdInfo, Float> weights = getPolicyInfo().getRouterPolicyWeights(tag);
 
     ArrayList<Float> weightList = new ArrayList<>();
     ArrayList<SubClusterId> scIdList = new ArrayList<>();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/TestFederationPolicyUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/TestFederationPolicyUtils.java
@@ -18,9 +18,17 @@
 package org.apache.hadoop.yarn.server.federation.policies;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 
+import org.apache.hadoop.util.Sets;
+import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.apache.hadoop.yarn.server.federation.policies.FederationPolicyUtils.DEFAULT_POLICY_KEY;
+import static org.apache.hadoop.yarn.server.federation.policies.FederationPolicyUtils.FEDERATION_POLICY_LABEL_TAG_PREFIX;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit test for {@link FederationPolicyUtils}.
@@ -54,5 +62,16 @@ public class TestFederationPolicyUtils {
               + " expected weight: " + expectedWeights[i],
           Math.abs(actualWeight - expectedWeights[i]) < 0.01);
     }
+  }
+
+  @Test
+  public void testGetApplicationPolicyTag() {
+    Assert.assertEquals(DEFAULT_POLICY_KEY, FederationPolicyUtils.getApplicationPolicyTag(null));
+    ApplicationSubmissionContext context = mock(ApplicationSubmissionContext.class);
+    when(context.getApplicationTags()).thenReturn(new HashSet<>());
+    Assert.assertEquals(DEFAULT_POLICY_KEY, FederationPolicyUtils.getApplicationPolicyTag(context));
+    when(context.getApplicationTags()).thenReturn(
+        Sets.newHashSet(FEDERATION_POLICY_LABEL_TAG_PREFIX + ":LABEL1"));
+    Assert.assertEquals("LABEL1", FederationPolicyUtils.getApplicationPolicyTag(context));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/dao/TestWeightedPolicyInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/dao/TestWeightedPolicyInfo.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.yarn.server.federation.policies.dao;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.net.URL;
+import java.nio.ByteBuffer;
+
+public class TestWeightedPolicyInfo {
+
+  @Test
+  public void testParsePoliciesFromJson() throws Exception {
+    URL url =
+        Thread.currentThread().getContextClassLoader().getResource("weighted_policy_info_1.json");
+    if (url == null) {
+      throw new RuntimeException(
+          "Could not find 'federation_weights_1.json' dummy file in classpath");
+    }
+    File file = new File(url.getPath());
+    int size = (int) file.length();
+    byte[] contents = new byte[size];
+    IOUtils.readFully(new FileInputStream(file), contents);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(contents);
+    WeightedPolicyInfo policyInfo = WeightedPolicyInfo.fromByteBuffer(byteBuffer);
+    Assertions.assertEquals(1.0F, policyInfo.getHeadroomAlpha());
+    // Assert DEFAULT weights
+    SubClusterIdInfo cluster1 = new SubClusterIdInfo("SC-1");
+    SubClusterIdInfo cluster2 = new SubClusterIdInfo("SC-2");
+    Assertions.assertEquals(2, policyInfo.getRouterPolicyWeights().size());
+    Assertions.assertEquals(2, policyInfo.getAMRMPolicyWeights().size());
+    Assertions.assertEquals(0.6F, policyInfo.getRouterPolicyWeights().get(cluster1));
+    Assertions.assertEquals(0.4F, policyInfo.getRouterPolicyWeights().get(cluster2));
+    Assertions.assertEquals(0.3F, policyInfo.getAMRMPolicyWeights().get(cluster1));
+    Assertions.assertEquals(0.7F, policyInfo.getAMRMPolicyWeights().get(cluster2));
+
+    // Assert weights of LABEL1 and LABEL2
+    Assertions.assertEquals(3, policyInfo.getRouterPolicyWeightsMap().size());
+    Assertions.assertEquals(3, policyInfo.getAmrmPolicyWeightsMap().size());
+    Assertions.assertEquals(1F, policyInfo.getRouterPolicyWeights("LABEL1").get(cluster1));
+    Assertions.assertEquals(0F, policyInfo.getRouterPolicyWeights("LABEL1").get(cluster2));
+    Assertions.assertEquals(1F, policyInfo.getAMRMPolicyWeights("LABEL1").get(cluster1));
+    Assertions.assertEquals(0F, policyInfo.getAMRMPolicyWeights("LABEL1").get(cluster2));
+    Assertions.assertEquals(0F, policyInfo.getRouterPolicyWeights("LABEL2").get(cluster1));
+    Assertions.assertEquals(1F, policyInfo.getRouterPolicyWeights("LABEL2").get(cluster2));
+    Assertions.assertEquals(0F, policyInfo.getAMRMPolicyWeights("LABEL2").get(cluster1));
+    Assertions.assertEquals(1F, policyInfo.getAMRMPolicyWeights("LABEL2").get(cluster2));
+  }
+
+  @Test
+  public void testParsePoliciesFromJsonWithoutLabledWeights() throws Exception {
+    URL url =
+        Thread.currentThread().getContextClassLoader().getResource("weighted_policy_info_2.json");
+    if (url == null) {
+      throw new RuntimeException(
+          "Could not find 'federation_weights_1.json' dummy file in classpath");
+    }
+    File file = new File(url.getPath());
+    int size = (int) file.length();
+    byte[] contents = new byte[size];
+    IOUtils.readFully(new FileInputStream(file), contents);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(contents);
+    WeightedPolicyInfo policyInfo = WeightedPolicyInfo.fromByteBuffer(byteBuffer);
+    Assertions.assertEquals(1.0F, policyInfo.getHeadroomAlpha());
+    // Assert DEFAULT weights
+    SubClusterIdInfo cluster1 = new SubClusterIdInfo("SC-1");
+    SubClusterIdInfo cluster2 = new SubClusterIdInfo("SC-2");
+    Assertions.assertEquals(2, policyInfo.getRouterPolicyWeights().size());
+    Assertions.assertEquals(2, policyInfo.getAMRMPolicyWeights().size());
+    Assertions.assertEquals(0.1F, policyInfo.getRouterPolicyWeights().get(cluster1));
+    Assertions.assertEquals(0.9F, policyInfo.getRouterPolicyWeights().get(cluster2));
+    Assertions.assertEquals(0.2F, policyInfo.getAMRMPolicyWeights().get(cluster1));
+    Assertions.assertEquals(0.8F, policyInfo.getAMRMPolicyWeights().get(cluster2));
+    Assertions.assertEquals(1, policyInfo.getRouterPolicyWeightsMap().size());
+    Assertions.assertEquals(1, policyInfo.getAmrmPolicyWeightsMap().size());
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestLoadBasedRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestLoadBasedRouterPolicy.java
@@ -208,7 +208,7 @@ public class TestLoadBasedRouterPolicy extends BaseRouterPoliciesTest {
 
   @Test
   public void testChooseSubClusterByTag() throws YarnException {
-    for (int i = 0; i < 20; i ++) {
+    for (int i = 0; i < 20; i++) {
       SubClusterId id = SubClusterId.newInstance("sc" + i);
       if (getActiveSubclusters().containsKey(id)) {
         when(getApplicationSubmissionContext().getApplicationTags()).thenReturn(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestLocalityRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestLocalityRouterPolicy.java
@@ -332,7 +332,7 @@ public class TestLocalityRouterPolicy extends TestWeightedRandomRouterPolicy {
     }
 
     // Case 2: Request is ANY
-    for (int i = 0; i < 4; i ++) {
+    for (int i = 0; i < 4; i++) {
       requests = new ArrayList<ResourceRequest>();
       requests.add(ResourceRequest.newInstance(Priority.UNDEFINED, ResourceRequest.ANY,
           Resource.newInstance(10, 1), 1));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestPriorityRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestPriorityRouterPolicy.java
@@ -119,7 +119,7 @@ public class TestPriorityRouterPolicy extends BaseRouterPoliciesTest {
 
   @Test
   public void testChooseSubClusterByTag() throws YarnException {
-    for (int i = 0; i < 20; i ++) {
+    for (int i = 0; i < 20; i++) {
       SubClusterId id = SubClusterId.newInstance("sc" + i);
       if (getActiveSubclusters().containsKey(id)) {
         when(getApplicationSubmissionContext().getApplicationTags()).thenReturn(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestWeightedRandomRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestWeightedRandomRouterPolicy.java
@@ -88,7 +88,7 @@ public class TestWeightedRandomRouterPolicy extends BaseRouterPoliciesTest {
 
       // Set weights by tag
       Map<SubClusterIdInfo, Float> tagWeights = new HashMap<>();
-      for (int j = 0; j < numSubClusters; j ++) {
+      for (int j = 0; j < numSubClusters; j++) {
         SubClusterIdInfo subClusterIdInfo = new SubClusterIdInfo("subcluster" + j);
         if (i == j) {
           tagWeights.put(subClusterIdInfo, 1F);
@@ -160,7 +160,7 @@ public class TestWeightedRandomRouterPolicy extends BaseRouterPoliciesTest {
 
   @Test
   public void testChooseSubClusterByTag() throws YarnException {
-    for (int i = 0; i < 20; i ++) {
+    for (int i = 0; i < 20; i++) {
       SubClusterId id = SubClusterId.newInstance("subcluster" + i);
       if (getActiveSubclusters().containsKey(id)) {
         when(getApplicationSubmissionContext().getApplicationTags()).thenReturn(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/resources/weighted_policy_info_1.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/resources/weighted_policy_info_1.json
@@ -1,0 +1,127 @@
+{
+  "routerPolicyWeights": {
+    "entry": [
+      {
+        "key": {
+          "id": "SC-2"
+        },
+        "value": "0.4"
+      },
+      {
+        "key": {
+          "id": "SC-1"
+        },
+        "value": "0.6"
+      }
+    ]
+  },
+  "amrmPolicyWeights": {
+    "entry": [
+      {
+        "key": {
+          "id": "SC-2"
+        },
+        "value": "0.7"
+      },
+      {
+        "key": {
+          "id": "SC-1"
+        },
+        "value": "0.3"
+      }
+    ]
+  },
+  "routerPolicyWeightsMap": {
+    "entry": [
+      {
+        "key": "LABEL2",
+        "value": {
+          "weigths": {
+            "entry": [
+              {
+                "key": {
+                  "id": "SC-2"
+                },
+                "value": "1.0"
+              },
+              {
+                "key": {
+                  "id": "SC-1"
+                },
+                "value": "0.0"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "key": "LABEL1",
+        "value": {
+          "weigths": {
+            "entry": [
+              {
+                "key": {
+                  "id": "SC-2"
+                },
+                "value": "0.0"
+              },
+              {
+                "key": {
+                  "id": "SC-1"
+                },
+                "value": "1.0"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "amrmPolicyWeightsMap": {
+    "entry": [
+      {
+        "key": "LABEL2",
+        "value": {
+          "weigths": {
+            "entry": [
+              {
+                "key": {
+                  "id": "SC-2"
+                },
+                "value": "1.0"
+              },
+              {
+                "key": {
+                  "id": "SC-1"
+                },
+                "value": "0.0"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "key": "LABEL1",
+        "value": {
+          "weigths": {
+            "entry": [
+              {
+                "key": {
+                  "id": "SC-2"
+                },
+                "value": "0.0"
+              },
+              {
+                "key": {
+                  "id": "SC-1"
+                },
+                "value": "1.0"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "headroomAlpha": "1.0"
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/resources/weighted_policy_info_1.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/resources/weighted_policy_info_1.json
@@ -1,4 +1,22 @@
 {
+  "___asflicense__": [
+    "",
+    "Licensed to the Apache Software Foundation (ASF) under one",
+    "or more contributor license agreements.  See the NOTICE file",
+    "distributed with this work for additional information",
+    "regarding copyright ownership.  The ASF licenses this file",
+    "to you under the Apache License, Version 2.0 (the",
+    "\"License\"); you may not use this file except in compliance",
+    "with the License.  You may obtain a copy of the License at",
+    "",
+    "     http://www.apache.org/licenses/LICENSE-2.0",
+    "",
+    "Unless required by applicable law or agreed to in writing, software",
+    "distributed under the License is distributed on an \"AS IS\" BASIS,",
+    "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+    "See the License for the specific language governing permissions and",
+    "limitations under the License."
+  ],
   "routerPolicyWeights": {
     "entry": [
       {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/resources/weighted_policy_info_2.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/resources/weighted_policy_info_2.json
@@ -1,0 +1,35 @@
+{
+  "routerPolicyWeights": {
+    "entry": [
+      {
+        "key": {
+          "id": "SC-1"
+        },
+        "value": "0.1"
+      },
+      {
+        "key": {
+          "id": "SC-2"
+        },
+        "value": "0.9"
+      }
+    ]
+  },
+  "amrmPolicyWeights": {
+    "entry": [
+      {
+        "key": {
+          "id": "SC-1"
+        },
+        "value": "0.2"
+      },
+      {
+        "key": {
+          "id": "SC-2"
+        },
+        "value": "0.8"
+      }
+    ]
+  },
+  "headroomAlpha": "1.0"
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/resources/weighted_policy_info_2.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/resources/weighted_policy_info_2.json
@@ -1,4 +1,22 @@
 {
+  "___asflicense__": [
+    "",
+    "Licensed to the Apache Software Foundation (ASF) under one",
+    "or more contributor license agreements.  See the NOTICE file",
+    "distributed with this work for additional information",
+    "regarding copyright ownership.  The ASF licenses this file",
+    "to you under the Apache License, Version 2.0 (the",
+    "\"License\"); you may not use this file except in compliance",
+    "with the License.  You may obtain a copy of the License at",
+    "",
+    "     http://www.apache.org/licenses/LICENSE-2.0",
+    "",
+    "Unless required by applicable law or agreed to in writing, software",
+    "distributed under the License is distributed on an \"AS IS\" BASIS,",
+    "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+    "See the License for the specific language governing permissions and",
+    "limitations under the License."
+  ],
   "routerPolicyWeights": {
     "entry": [
       {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/main/java/org/apache/hadoop/yarn/server/globalpolicygenerator/GPGPolicyFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/main/java/org/apache/hadoop/yarn/server/globalpolicygenerator/GPGPolicyFacade.java
@@ -129,8 +129,8 @@ public class GPGPolicyFacade {
               (WeightedLocalityPolicyManager) policyManager;
           LOG.info("Updating policy for queue {} to configured weights router: "
                   + "{}, amrmproxy: {}", queueName,
-              wpinfo.getRouterPolicyWeights(),
-              wpinfo.getAMRMPolicyWeights());
+              wpinfo.getRouterPolicyWeightsMap(),
+              wpinfo.getAmrmPolicyWeightsMap());
           wlpmanager.setWeightedPolicyInfo(wpinfo);
         } else {
           LOG.warn("Warning: FederationPolicyManager of unsupported type {}, "

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
@@ -440,6 +440,7 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
       String queue = this.amRegistrationResponse.getQueue();
       String homeSCId = this.homeSubClusterId.getId();
       String user = applicationContext.getUser();
+      ApplicationSubmissionContext originalSubmissionContext = null;
 
       for (Map.Entry<String, Token<AMRMTokenIdentifier>> entry : uamMap.entrySet()) {
         String keyScId = entry.getKey();
@@ -452,7 +453,7 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
         FederationProxyProviderUtil.updateConfForFederation(config, keyScId);
 
         try {
-          ApplicationSubmissionContext originalSubmissionContext =
+          originalSubmissionContext =
               federationFacade.getApplicationSubmissionContext(applicationId);
 
           // ReAttachUAM
@@ -534,7 +535,7 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
         // Initialize the AMRMProxyPolicy
         queue = this.amRegistrationResponse.getQueue();
         this.policyInterpreter = FederationPolicyUtils.loadAMRMPolicy(queue, this.policyInterpreter,
-            getConf(), this.federationFacade, this.homeSubClusterId);
+            getConf(), this.federationFacade, this.homeSubClusterId, originalSubmissionContext);
       }
     } catch (IOException | YarnException e) {
       throw new YarnRuntimeException(e);
@@ -692,8 +693,10 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
 
     // Initialize the AMRMProxyPolicy
     try {
+      ApplicationSubmissionContext originalSubmissionContext =
+          federationFacade.getApplicationSubmissionContext(appId);
       this.policyInterpreter = FederationPolicyUtils.loadAMRMPolicy(queue, this.policyInterpreter,
-          getConf(), this.federationFacade, this.homeSubClusterId);
+          getConf(), this.federationFacade, this.homeSubClusterId, originalSubmissionContext);
     } catch (FederationPolicyInitializationException e) {
       throw new YarnRuntimeException(e);
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestSequentialRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestSequentialRouterPolicy.java
@@ -57,7 +57,7 @@ public class TestSequentialRouterPolicy extends AbstractRouterPolicy {
   }
 
   @Override
-  protected SubClusterId chooseSubCluster(String queue,
+  protected SubClusterId chooseSubCluster(String queue, String tag,
       Map<SubClusterId, SubClusterInfo> preSelectSubClusters) throws YarnException {
     /**
       * This strategy is only suitable for testing. We need to obtain subClusters sequentially.


### PR DESCRIPTION
### Description of PR

Add colored policies to enable manual load balancing across sub clusters

### How was this patch tested?

unit test and test in real cluster.

### For code changes:

1. Add tags for selecting subclusters on the client side
2. Add new member variables to WeightedPolicyInfo. This new variable is based on map and is used to store weights of different tags. This method maintains backward compatibility.
