### PR TITLE
YARN-11587. Fix the possible issue of duplicate registration in the metrics queue.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/QueueMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/QueueMetrics.java
@@ -386,7 +386,7 @@ public class QueueMetrics implements MetricsSource {
    * @param partition
    * @return QueueMetrics
    */
-  private QueueMetrics getPartitionMetrics(String partition) {
+  private synchronized QueueMetrics getPartitionMetrics(String partition) {
 
     String partitionJMXStr = partition;
     if ((partition == null)


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/YARN-11587

### How was this patch tested?
no test

### For code changes:

add synchronized kerword
```
private synchronized QueueMetrics getPartitionMetrics(String partition) {
...
}
```

