### PR TITLE
YARN-11588. [Federation] Fix scale bottleneck against cardinality of YARN users

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -232,7 +232,7 @@ public class FederationClientInterceptor
 
     // Adding this line so that unused user threads will exit and be cleaned up if idle for too long
     this.executorService.allowCoreThreadTimeOut(true);
-    
+
     final Configuration conf = this.getConf();
 
     try {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -230,6 +230,9 @@ public class FederationClientInterceptor
     this.executorService = new ThreadPoolExecutor(numMinThreads, numMaxThreads,
         keepAliveTime, TimeUnit.MILLISECONDS, workQueue, threadFactory);
 
+    // Adding this line so that unused user threads will exit and be cleaned up if idle for too long
+    this.executorService.allowCoreThreadTimeOut(true);
+    
     final Configuration conf = this.getConf();
 
     try {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
@@ -1573,6 +1573,13 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
   }
 
   @Test
+  public void testThreadPoolWillTimeout() {
+    // Check if core threads are set to timeout if idle
+    boolean threadPoolTimeout = interceptor.executorService.allowsCoreThreadTimeOut();
+    Assert.assertTrue(threadPoolTimeout);
+  }
+
+  @Test
   public void testGetDelegationToken() throws IOException, YarnException {
 
     // We design such a unit test to check

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
@@ -1573,13 +1573,6 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
   }
 
   @Test
-  public void testThreadPoolWillTimeout() {
-    // Check if core threads are set to timeout if idle
-    boolean threadPoolTimeout = interceptor.executorService.allowsCoreThreadTimeOut();
-    Assert.assertTrue(threadPoolTimeout);
-  }
-
-  @Test
   public void testGetDelegationToken() throws IOException, YarnException {
 
     // We design such a unit test to check


### PR DESCRIPTION
### Description of PR

JIRA: [YARN-11588](https://issues.apache.org/jira/browse/YARN-11588). [Router] Fix uncleaned threads in yarn router thread pool executor

In YARN Federation a new interceptor is generated for each new user that calls YARN Router. This also generates a threadpool which is used to call YARN RM. However, when the call is finished the threadpool threads never exits, causing the interceptor object for the user to never be cleaned up. This causes an issue when the number of users is large in the YARN cluster, as the number of idle, uncleaned thread can reach # of users calling router times number of active core threads in thread pool. This causes performance issues in router due to too many idle threads. 

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

