### PR TITLE
HADOOP-18708. AWS SDK V2 - Implement CSE

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -188,6 +188,7 @@
     <surefire.fork.timeout>900</surefire.fork.timeout>
     <aws-java-sdk.version>1.12.599</aws-java-sdk.version>
     <aws-java-sdk-v2.version>2.24.6</aws-java-sdk-v2.version>
+    <amazon-s3-encryption-client-java.version>3.1.0</amazon-s3-encryption-client-java.version>
     <aws.eventstream.version>1.0.1</aws.eventstream.version>
     <hsqldb.version>2.7.1</hsqldb.version>
     <frontend-maven-plugin.version>1.11.2</frontend-maven-plugin.version>
@@ -1145,6 +1146,17 @@
         <exclusions>
           <exclusion>
             <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.encryption.s3</groupId>
+        <artifactId>amazon-s3-encryption-client-java</artifactId>
+        <version>${amazon-s3-encryption-client-java.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
             <artifactId>*</artifactId>
           </exclusion>
         </exclusions>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -188,7 +188,7 @@
     <surefire.fork.timeout>900</surefire.fork.timeout>
     <aws-java-sdk.version>1.12.599</aws-java-sdk.version>
     <aws-java-sdk-v2.version>2.24.6</aws-java-sdk-v2.version>
-    <amazon-s3-encryption-client-java.version>3.1.0</amazon-s3-encryption-client-java.version>
+    <amazon-s3-encryption-client-java.version>3.1.1</amazon-s3-encryption-client-java.version>
     <aws.eventstream.version>1.0.1</aws.eventstream.version>
     <hsqldb.version>2.7.1</hsqldb.version>
     <frontend-maven-plugin.version>1.11.2</frontend-maven-plugin.version>

--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -464,6 +464,16 @@
                     <bannedImport>org.apache.hadoop.mapred.**</bannedImport>
                   </bannedImports>
                 </restrictImports>
+                <restrictImports>
+                  <includeTestCode>false</includeTestCode>
+                  <reason>Restrict encryption client imports to encryption client factory</reason>
+                  <exclusions>
+                    <exclusion>org.apache.hadoop.fs.s3a.EncryptionS3ClientFactory</exclusion>
+                  </exclusions>
+                  <bannedImports>
+                    <bannedImport>software.amazon.encryption.s3.**</bannedImport>
+                  </bannedImports>
+                </restrictImports>
               </rules>
             </configuration>
           </execution>
@@ -507,6 +517,11 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>bundle</artifactId>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.encryption.s3</groupId>
+      <artifactId>amazon-s3-encryption-client-java</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -146,17 +146,11 @@ public class DefaultS3ClientFactory extends Configured
         .thresholdInBytes(parameters.getMultiPartThreshold())
         .build();
 
-    S3AsyncClientBuilder s3AsyncClientBuilder =
-        configureClientBuilder(S3AsyncClient.builder(), parameters, conf, bucket).httpClientBuilder(
-            httpClientBuilder);
-
-    if (!parameters.isClientSideEncryptionEnabled()) {
-      s3AsyncClientBuilder
-          .multipartConfiguration(multipartConfiguration)
-          .multipartEnabled(parameters.isMultipartCopy());
-    }
-
-    return s3AsyncClientBuilder.build();
+    return configureClientBuilder(S3AsyncClient.builder(), parameters, conf, bucket)
+        .httpClientBuilder(httpClientBuilder)
+        .multipartConfiguration(multipartConfiguration)
+        .multipartEnabled(parameters.isMultipartCopy())
+        .build();
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -38,7 +38,6 @@ import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3BaseClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -38,6 +38,7 @@ import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3BaseClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -145,11 +146,17 @@ public class DefaultS3ClientFactory extends Configured
         .thresholdInBytes(parameters.getMultiPartThreshold())
         .build();
 
-    return configureClientBuilder(S3AsyncClient.builder(), parameters, conf, bucket)
-        .httpClientBuilder(httpClientBuilder)
-        .multipartConfiguration(multipartConfiguration)
-        .multipartEnabled(parameters.isMultipartCopy())
-        .build();
+    S3AsyncClientBuilder s3AsyncClientBuilder =
+        configureClientBuilder(S3AsyncClient.builder(), parameters, conf, bucket).httpClientBuilder(
+            httpClientBuilder);
+
+    if (!parameters.isClientSideEncryptionEnabled()) {
+      s3AsyncClientBuilder
+          .multipartConfiguration(multipartConfiguration)
+          .multipartEnabled(parameters.isMultipartCopy());
+    }
+
+    return s3AsyncClientBuilder.build();
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/EncryptionS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/EncryptionS3ClientFactory.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import java.io.IOException;
+import java.net.URI;
+
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.encryption.s3.S3AsyncEncryptionClient;
+import software.amazon.encryption.s3.S3EncryptionClient;
+
+import org.apache.hadoop.fs.s3a.impl.CSEMaterials;
+
+import static org.apache.hadoop.fs.s3a.impl.InstantiationIOException.unavailable;
+
+public class EncryptionS3ClientFactory extends DefaultS3ClientFactory {
+
+  private static final String ENCRYPTION_CLIENT_CLASSNAME =
+      "software.amazon.encryption.s3.S3EncryptionClient";
+
+  /**
+   * Encryption client availability.
+   */
+  private static final boolean ENCRYPTION_CLIENT_FOUND = checkForEncryptionClient();
+
+  /**
+   * S3Client to be wrapped by encryption client.
+   */
+  private S3Client s3Client;
+
+  /**
+   * S3AsyncClient to be wrapped by encryption client.
+   */
+  private S3AsyncClient s3AsyncClient;
+
+  private static boolean checkForEncryptionClient() {
+    try {
+      ClassLoader cl = EncryptionS3ClientFactory.class.getClassLoader();
+      cl.loadClass(ENCRYPTION_CLIENT_CLASSNAME);
+      LOG.debug("encryption client class {} found", ENCRYPTION_CLIENT_CLASSNAME);
+      return true;
+    } catch (Exception e) {
+      LOG.debug("encryption client class {} not found", ENCRYPTION_CLIENT_CLASSNAME, e);
+      return false;
+    }
+  }
+
+  /**
+   * Is the Encryption client available?
+   * @return true if it was found in the classloader
+   */
+  private static synchronized boolean isEncryptionClientAvailable() {
+    return ENCRYPTION_CLIENT_FOUND;
+  }
+
+
+  @Override
+  public S3Client createS3Client(URI uri, S3ClientCreationParameters parameters) throws IOException {
+
+    if (!isEncryptionClientAvailable()) {
+      throw unavailable(uri, ENCRYPTION_CLIENT_CLASSNAME, null, "No encryption client available");
+    }
+
+    s3Client = super.createS3Client(uri, parameters);
+    s3AsyncClient = super.createS3AsyncClient(uri, parameters);
+
+    return createS3EncryptionClient(parameters.getClientSideEncryptionMaterials());
+  }
+
+  @Override
+  public S3AsyncClient createS3AsyncClient(URI uri, S3ClientCreationParameters parameters) throws IOException {
+
+    if (!isEncryptionClientAvailable()) {
+      throw unavailable(uri, ENCRYPTION_CLIENT_CLASSNAME, null, "No encryption client available");
+    }
+
+    return createS3AsyncEncryptionClient(parameters.getClientSideEncryptionMaterials());
+  }
+
+  private S3Client createS3EncryptionClient(final CSEMaterials cseMaterials) {
+    S3EncryptionClient.Builder s3EncryptionClientBuilder =
+        S3EncryptionClient.builder().wrappedAsyncClient(s3AsyncClient).wrappedClient(s3Client)
+            .enableLegacyUnauthenticatedModes(true);
+
+    if (cseMaterials.getCseKeyType().equals(CSEMaterials.CSEKeyType.KMS)) {
+      s3EncryptionClientBuilder.kmsKeyId(cseMaterials.getKmsKeyId());
+    }
+
+    return s3EncryptionClientBuilder.build();
+  }
+
+
+  private S3AsyncClient createS3AsyncEncryptionClient(final CSEMaterials cseMaterials) {
+
+    S3AsyncEncryptionClient.Builder s3EncryptionAsyncClientBuilder =
+        S3AsyncEncryptionClient.builder().wrappedClient(s3AsyncClient)
+            .enableLegacyUnauthenticatedModes(true);
+
+    if (cseMaterials.getCseKeyType().equals(CSEMaterials.CSEKeyType.KMS)) {
+      s3EncryptionAsyncClientBuilder.kmsKeyId(cseMaterials.getKmsKeyId());
+    }
+
+    return s3EncryptionAsyncClientBuilder.build();
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.SdkPartType;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
@@ -876,11 +877,17 @@ class S3ABlockOutputStream extends OutputStream implements
             ? RequestBody.fromFile(uploadData.getFile())
             : RequestBody.fromInputStream(uploadData.getUploadStream(), size);
 
-        request = writeOperationHelper.newUploadPartRequestBuilder(
+        UploadPartRequest.Builder requestBuilder = writeOperationHelper.newUploadPartRequestBuilder(
             key,
             uploadId,
             currentPartNumber,
-            size).build();
+            size);
+
+        if (isLast) {
+          requestBuilder.sdkPartType(SdkPartType.LAST);
+        }
+
+        request = requestBuilder.build();
       } catch (SdkException aws) {
         // catch and translate
         IOException e = translateException("upload", key, aws);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -120,6 +120,7 @@ import org.apache.hadoop.fs.s3a.auth.delegation.DelegationTokenProvider;
 import org.apache.hadoop.fs.s3a.impl.AWSCannedACL;
 import org.apache.hadoop.fs.s3a.impl.AWSHeaders;
 import org.apache.hadoop.fs.s3a.impl.BulkDeleteRetryHandler;
+import org.apache.hadoop.fs.s3a.impl.CSEMaterials;
 import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
 import org.apache.hadoop.fs.s3a.impl.ConfigurationHelper;
 import org.apache.hadoop.fs.s3a.impl.ContextAccessors;
@@ -1034,6 +1035,21 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         S3_CLIENT_FACTORY_IMPL, DEFAULT_S3_CLIENT_FACTORY_IMPL,
         S3ClientFactory.class);
 
+    S3ClientFactory clientFactory;
+    CSEMaterials cseMaterials = null;
+
+    if (isCSEEnabled) {
+      String kmsKeyId = getS3EncryptionKey(bucket, conf, true);
+
+      cseMaterials  = new CSEMaterials()
+          .withCSEKeyType(CSEMaterials.CSEKeyType.KMS)
+          .withKmsKeyId(kmsKeyId);
+
+      clientFactory = ReflectionUtils.newInstance(EncryptionS3ClientFactory.class, conf);
+    } else {
+      clientFactory = ReflectionUtils.newInstance(s3ClientFactoryClass, conf);
+    }
+
     S3ClientFactory.S3ClientCreationParameters parameters =
         new S3ClientFactory.S3ClientCreationParameters()
         .withCredentialSet(credentials)
@@ -1053,9 +1069,10 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         .withExpressCreateSession(
             conf.getBoolean(S3EXPRESS_CREATE_SESSION, S3EXPRESS_CREATE_SESSION_DEFAULT))
         .withChecksumValidationEnabled(
-            conf.getBoolean(CHECKSUM_VALIDATION, CHECKSUM_VALIDATION_DEFAULT));
+            conf.getBoolean(CHECKSUM_VALIDATION, CHECKSUM_VALIDATION_DEFAULT))
+        .withClientSideEncryptionEnabled(isCSEEnabled)
+        .withClientSideEncryptionMaterials(cseMaterials);
 
-    S3ClientFactory clientFactory = ReflectionUtils.newInstance(s3ClientFactoryClass, conf);
     s3Client = clientFactory.createS3Client(getUri(), parameters);
     createS3AsyncClient(clientFactory, parameters);
     transferManager =  clientFactory.createS3TransferManager(getS3AsyncClient());
@@ -1070,7 +1087,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * @throws IOException on any IO problem
    */
   private void createS3AsyncClient(S3ClientFactory clientFactory,
-      S3ClientFactory.S3ClientCreationParameters parameters) throws IOException {
+      S3ClientFactory.S3ClientCreationParameters parameters)
+      throws IOException {
     s3AsyncClient = clientFactory.createS3AsyncClient(getUri(), parameters);
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -78,6 +78,7 @@ import static org.apache.hadoop.fs.s3a.AWSCredentialProviderList.maybeTranslateC
 import static org.apache.hadoop.fs.s3a.Constants.*;
 import static org.apache.hadoop.fs.s3a.audit.AuditIntegration.maybeTranslateAuditException;
 import static org.apache.hadoop.fs.s3a.impl.ErrorTranslation.isUnknownBucket;
+import static org.apache.hadoop.fs.s3a.impl.ErrorTranslation.maybeExtractSdkException;
 import static org.apache.hadoop.fs.s3a.impl.InstantiationIOException.instantiationException;
 import static org.apache.hadoop.fs.s3a.impl.InstantiationIOException.isAbstract;
 import static org.apache.hadoop.fs.s3a.impl.InstantiationIOException.isNotInstanceOf;
@@ -181,6 +182,8 @@ public final class S3AUtils {
       // exceptions constructed.
       path = "/";
     }
+
+    exception = maybeExtractSdkException(exception);
 
     if (!(exception instanceof AwsServiceException)) {
       // exceptions raised client-side: connectivity, auth, network problems...

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.transfer.s3.S3TransferManager;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.s3a.impl.CSEMaterials;
 import org.apache.hadoop.fs.s3a.statistics.StatisticsFromAwsSdk;
 
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_ENDPOINT;
@@ -185,6 +186,16 @@ public interface S3ClientFactory {
      * Is FIPS enabled?
      */
     private boolean fipsEnabled;
+
+    /**
+     * Is client side encryption enabled.
+     */
+    private Boolean isCSEEnabled;
+
+    /**
+     * Client side encryption materials.
+     */
+    private CSEMaterials cseMaterials;
 
     /**
      * List of execution interceptors to include in the chain
@@ -503,6 +514,44 @@ public interface S3ClientFactory {
     public S3ClientCreationParameters withFipsEnabled(final boolean value) {
       fipsEnabled = value;
       return this;
+    }
+
+    /**
+     * Set the client side encryption flag.
+     *
+     * @param value new value
+     * @return the builder
+     */
+    public S3ClientCreationParameters withClientSideEncryptionEnabled(final boolean value) {
+      this.isCSEEnabled = value;
+      return this;
+    }
+
+    /**
+     * Get the client side encryption flag.
+     * @return client side encryption flag
+     */
+    public boolean isClientSideEncryptionEnabled() {
+      return this.isCSEEnabled;
+    }
+
+    /**
+     * Set the client side encryption materials.
+     *
+     * @param value new value
+     * @return the builder
+     */
+    public S3ClientCreationParameters withClientSideEncryptionMaterials(final CSEMaterials value) {
+      this.cseMaterials = value;
+      return this;
+    }
+
+    /**
+     * Get the client side encryption materials.
+     * @return client side encryption materials
+     */
+    public CSEMaterials getClientSideEncryptionMaterials() {
+      return this.cseMaterials;
     }
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CSEMaterials.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CSEMaterials.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+/**
+ * This class is for storing information about key type and corresponding key
+ * to be used for client side encryption.
+ */
+public class CSEMaterials {
+
+  /**
+   * Enum for CSE key types.
+   */
+  public enum CSEKeyType {
+    KMS,
+    AES,
+    RSA
+  }
+
+  /**
+   * The KMS key Id.
+   */
+  private String kmsKeyId;
+
+  /**
+   * The CSE key type to use.
+   */
+  private CSEKeyType cseKeyType;
+
+  /**
+   * Kms key id to use.
+   * @param value new value
+   * @return the builder
+   */
+  public CSEMaterials withKmsKeyId(
+      final String value) {
+    kmsKeyId = value;
+    return this;
+  }
+
+  /**
+   * Get the Kms key id to use.
+   * @return the kms key id.
+   */
+  public String getKmsKeyId() {
+    return kmsKeyId;
+  }
+
+  /**
+   * CSE key type to use.
+   * @param value new value
+   * @return the builder
+   */
+  public CSEMaterials withCSEKeyType(
+      final CSEKeyType value) {
+    cseKeyType = value;
+    return this;
+  }
+
+  /**
+   * Get the CSE key type.
+   * @return CSE key type
+   */
+  public CSEKeyType getCseKeyType() {
+    return cseKeyType;
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ErrorTranslation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ErrorTranslation.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Constructor;
 
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.encryption.s3.S3EncryptionClientException;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.fs.s3a.HttpChannelEOFException;
@@ -69,9 +70,6 @@ public final class ErrorTranslation {
    */
   private ErrorTranslation() {
   }
-
-  static final String ENCRYPTION_CLIENT_EXCEPTION =
-      "software.amazon.encryption.s3.S3EncryptionClientException";
 
   /**
    * Does this exception indicate that the AWS Bucket was unknown.
@@ -157,13 +155,14 @@ public final class ErrorTranslation {
   }
 
   /**
-   * Extracts the underlying exception from an S3EncryptionClientException.
+   * Extracts the underlying exception from a SdkException.
    * @param exception amazon exception raised
    * @return extractedException
    */
   public static SdkException maybeExtractSdkException(SdkException exception) {
     SdkException extractedException = exception;
-    if (exception.toString().contains(ENCRYPTION_CLIENT_EXCEPTION)) {
+    if (exception instanceof S3EncryptionClientException
+        && exception.getCause() instanceof SdkException) {
       extractedException = (SdkException) exception.getCause();
       if (extractedException != null
           && extractedException.getCause() instanceof AwsServiceException) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ErrorTranslation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ErrorTranslation.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Constructor;
 
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.SdkException;
-import software.amazon.encryption.s3.S3EncryptionClientException;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.fs.s3a.HttpChannelEOFException;
@@ -70,6 +69,9 @@ public final class ErrorTranslation {
    */
   private ErrorTranslation() {
   }
+
+  static final String ENCRYPTION_CLIENT_EXCEPTION =
+      "software.amazon.encryption.s3.S3EncryptionClientException";
 
   /**
    * Does this exception indicate that the AWS Bucket was unknown.
@@ -161,7 +163,7 @@ public final class ErrorTranslation {
    */
   public static SdkException maybeExtractSdkException(SdkException exception) {
     SdkException extractedException = exception;
-    if (exception instanceof S3EncryptionClientException
+    if (exception.toString().contains(ENCRYPTION_CLIENT_EXCEPTION)
         && exception.getCause() instanceof SdkException) {
       extractedException = (SdkException) exception.getCause();
       if (extractedException != null

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ErrorTranslation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ErrorTranslation.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkException;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.fs.s3a.HttpChannelEOFException;
@@ -68,6 +69,9 @@ public final class ErrorTranslation {
    */
   private ErrorTranslation() {
   }
+
+  static final String ENCRYPTION_CLIENT_EXCEPTION =
+      "software.amazon.encryption.s3.S3EncryptionClientException";
 
   /**
    * Does this exception indicate that the AWS Bucket was unknown.
@@ -150,6 +154,24 @@ public final class ErrorTranslation {
     final IOException ioe = (IOException) cause;
 
     return wrapWithInnerIOE(path, message, thrown, ioe);
+  }
+
+  /**
+   * Extracts the underlying exception from an S3EncryptionClientException.
+   * @param exception amazon exception raised
+   * @return extractedException
+   */
+  public static SdkException maybeExtractSdkException(SdkException exception) {
+    SdkException extractedException = exception;
+    if (exception.toString().contains(ENCRYPTION_CLIENT_EXCEPTION)) {
+      extractedException = (SdkException) exception.getCause();
+      if (extractedException != null
+          && extractedException.getCause() instanceof AwsServiceException) {
+        extractedException = (SdkException) extractedException.getCause();
+      }
+    }
+
+    return extractedException;
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AClientSideEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AClientSideEncryption.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.s3a;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -237,8 +238,8 @@ public abstract class ITestS3AClientSideEncryption extends AbstractS3ATestBase {
       assertEquals("Mismatch in content length bytes", SMALL_FILE_SIZE,
           encryptedFSFileStatus.getLen());
 
-      intercept(SecurityException.class, "",
-          "SecurityException should be thrown",
+      intercept(FileNotFoundException.class, "Instruction file not found!",
+          "AWSClientIOException should be thrown",
           () -> {
             in.read(new byte[SMALL_FILE_SIZE]);
             return "Exception should be raised if unencrypted data is read by "

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
@@ -370,6 +370,7 @@ public class ITestS3AConfiguration {
 
     conf = new Configuration();
     skipIfCrossRegionClient(conf);
+    unsetEncryption(conf);
     conf.set(Constants.PATH_STYLE_ACCESS, Boolean.toString(true));
     assertTrue(conf.getBoolean(Constants.PATH_STYLE_ACCESS, false));
 
@@ -409,6 +410,7 @@ public class ITestS3AConfiguration {
   public void testDefaultUserAgent() throws Exception {
     conf = new Configuration();
     skipIfCrossRegionClient(conf);
+    unsetEncryption(conf);
     fs = S3ATestUtils.createTestFileSystem(conf);
     assertNotNull(fs);
     S3Client s3 = getS3Client("User Agent");
@@ -423,6 +425,7 @@ public class ITestS3AConfiguration {
   public void testCustomUserAgent() throws Exception {
     conf = new Configuration();
     skipIfCrossRegionClient(conf);
+    unsetEncryption(conf);
     conf.set(Constants.USER_AGENT_PREFIX, "MyApp");
     fs = S3ATestUtils.createTestFileSystem(conf);
     assertNotNull(fs);
@@ -437,6 +440,7 @@ public class ITestS3AConfiguration {
   @Test
   public void testRequestTimeout() throws Exception {
     conf = new Configuration();
+    unsetEncryption(conf);
     // remove the safety check on minimum durations.
     AWSClientConfig.setMinimumOperationDuration(Duration.ZERO);
     try {
@@ -588,6 +592,12 @@ public class ITestS3AConfiguration {
 
     Assertions.assertThat(CustomSTSSigner.isSTSSignerCalled())
         .describedAs("Custom STS signer not called").isTrue();
+  }
+
+  private void unsetEncryption(Configuration conf) {
+    removeBaseAndBucketOverrides(conf, S3_ENCRYPTION_ALGORITHM);
+    conf.set(Constants.S3_ENCRYPTION_ALGORITHM,
+        S3AEncryptionMethods.NONE.getMethod());
   }
 
   public static final class CustomS3Signer implements Signer {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestErrorTranslation.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestErrorTranslation.java
@@ -30,15 +30,18 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import software.amazon.awssdk.awscore.retry.conditions.RetryOnErrorCodeCondition;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.retry.RetryPolicyContext;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.encryption.s3.S3EncryptionClientException;
 
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.s3a.auth.NoAwsCredentialsException;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
 
 import static org.apache.hadoop.fs.s3a.impl.ErrorTranslation.maybeExtractIOException;
+import static org.apache.hadoop.fs.s3a.impl.ErrorTranslation.maybeExtractSdkException;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests related to the {@link ErrorTranslation} class.
@@ -152,5 +155,21 @@ public class TestErrorTranslation extends AbstractHadoopTestBase {
     Assertions.assertThat(retry.shouldRetry(context))
         .describedAs("retry policy of MultiObjectException")
         .isFalse();
+  }
+
+  @Test
+  public void testEncryptionClientExceptionExtraction() throws Throwable {
+    intercept(NoSuchKeyException.class, () -> {
+      throw maybeExtractSdkException(new S3EncryptionClientException("top",
+          new S3EncryptionClientException("middle", NoSuchKeyException.builder().build())));
+    });
+  }
+
+  @Test
+  public void testNonEncryptionClientExceptionExtraction() throws Throwable {
+    intercept(SdkException.class, () -> {
+      throw maybeExtractSdkException(
+          sdkException("top", sdkException("middle", NoSuchKeyException.builder().build())));
+    });
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestErrorTranslation.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestErrorTranslation.java
@@ -172,4 +172,12 @@ public class TestErrorTranslation extends AbstractHadoopTestBase {
           sdkException("top", sdkException("middle", NoSuchKeyException.builder().build())));
     });
   }
+
+  @Test
+  public void testEncryptionClientExceptionExtractionWithRTE() throws Throwable {
+    intercept(S3EncryptionClientException.class, () -> {
+      throw maybeExtractSdkException(new S3EncryptionClientException("top",
+          new UnsupportedOperationException()));
+    });
+  }
 }


### PR DESCRIPTION
### Description of PR

This adds in CSE back in back in. 

Also adds a new CSEMaterials class which will allow you set different key types (RSA, AES or KMS), which can be extended to allow uses to specify their own keys. That work can be done separately. 

This was previously part of https://github.com/apache/hadoop/pull/5767 which had been reviewed but had some other changes as well and had fallen quite behind. Closed that PR in favour of this.

### How was this patch tested?

Tested in eu-west-1 with `mvn -Dparallel-tests -DtestsThreadCount=16 clean verify` and scale tests enabled.

