### PR TITLE
YARN-11590. RM process stuck after calling confStore.format() when ZK…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -1903,10 +1903,11 @@ public class ResourceManager extends CompositeService
     }
 
     if (scheduler instanceof MutableConfScheduler && isConfigurationMutable) {
-      YarnConfigurationStore confStore = YarnConfigurationStoreFactory
-          .getStore(conf);
-      confStore.initialize(conf, conf, rmContext);
-      confStore.format();
+      try (YarnConfigurationStore confStore = YarnConfigurationStoreFactory
+          .getStore(conf)) {
+        confStore.initialize(conf, conf, rmContext);
+        confStore.format();
+      }
     } else {
       System.out.println(String.format("Scheduler Configuration format only " +
           "supported by %s.", MutableConfScheduler.class.getSimpleName()));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/YarnConfigurationStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/YarnConfigurationStore.java
@@ -44,7 +44,7 @@ import java.util.Map;
  * {@code getPendingMutations}, and replay/confirm them via
  * {@code confirmMutation} as in the normal case.
  */
-public abstract class YarnConfigurationStore implements AutoCloseable{
+public abstract class YarnConfigurationStore implements AutoCloseable {
 
   public static final Logger LOG =
       LoggerFactory.getLogger(YarnConfigurationStore.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/YarnConfigurationStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/YarnConfigurationStore.java
@@ -44,7 +44,7 @@ import java.util.Map;
  * {@code getPendingMutations}, and replay/confirm them via
  * {@code confirmMutation} as in the normal case.
  */
-public abstract class YarnConfigurationStore {
+public abstract class YarnConfigurationStore implements AutoCloseable{
 
   public static final Logger LOG =
       LoggerFactory.getLogger(YarnConfigurationStore.class);


### PR DESCRIPTION
… SSL/TLS is enabled, as netty thread waits indefinitely

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
YarnConfigurationStore now implements AutoClosable, hence a netty thread is not lingering around when the confStore is deleted by RM.

### How was this patch tested?
Tested on my local cluster. There is no unit test for the secure Curator due to CURATOR-658 "Add Support for TLS-enabled TestingZooKeeperMain" won't be fixed.

### For code changes:

- [ x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

