### PR TITLE
HADOOP-18928: S3AFileSystem URL encodes twice where Path has trailing /

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.AccessDeniedException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -1652,7 +1653,12 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         LOG.debug("Stripping trailing '/' from {}", q);
         // deal with an empty "/" at the end by mapping to the parent and
         // creating a new path from it
-        q = new Path(urlString.substring(0, urlString.length() - 1));
+        try {
+          q = new Path(new URI(urlString.substring(0, urlString.length() - 1)));
+        } catch (URISyntaxException e) {
+          LOG.error(String.format("Error removing trailing / from path %s", path.toString()));
+          return q;
+        }
       }
     }
     if (!q.isRoot() && q.getName().isEmpty()) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMiscOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMiscOperations.java
@@ -313,6 +313,15 @@ public class ITestS3AMiscOperations extends AbstractS3ATestBase {
         fs.makeQualified(pathFromTrailingURI));
   }
 
+  @Test
+  public void testQualifyPathWithWhitespace() {
+    final S3AFileSystem fs = getFileSystem();
+    Path pathWithSpace = fs.makeQualified(new Path("path with space"));
+    Path pathWithSpaceTrailingSlash = fs.makeQualified(new Path("path with space/"));
+    // removing trailing / should not recreate the Path object in a URL encoded way
+    assertEquals(pathWithSpace, pathWithSpaceTrailingSlash);
+  }
+
   /**
    * Verify that paths with a trailing "//" are fixed up.
    */


### PR DESCRIPTION
As per the comment at https://github.com/apache/hadoop/pull/1646#issuecomment-1754221384 ...

due to [HADOOP-15430](https://issues.apache.org/jira/browse/HADOOP-15430) a Path

`s3://my.bucket/my folder/`
becomes

`s3://my.bucket/my%20folder`
which upon HTTP request creation becomes

`"GET
...&prefix=my%2520folder
which is a wrong path.`

This PR re-adds the missing step of converting the modified String back to URI before creating a Path out of it.

cc: @steveloughran @bgaborg  @whenamanlies