### PR TITLE
YARN-11589. Router Policy support user as default queue.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -4127,6 +4127,12 @@ public class YarnConfiguration extends Configuration {
   public static final long DEFAULT_FEDERATION_AMRMPROXY_REGISTER_UAM_RETRY_INTERVAL =
       TimeUnit.MILLISECONDS.toMillis(100);
 
+  /** Whether to use the user name as the queue name (instead of "default") if
+   * the request does not specify a queue. */
+  public static final String USER_AS_DEFAULT_QUEUE =
+          FEDERATION_PREFIX + "user-as-default-queue.enabled";
+  public static final boolean DEFAULT_USER_AS_DEFAULT_QUEUE = false;
+
   public static final String DEFAULT_FEDERATION_POLICY_KEY = "*";
   public static final String FEDERATION_POLICY_MANAGER = FEDERATION_PREFIX
       + "policy-manager";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -3800,6 +3800,12 @@
     <value>1s</value>
   </property>
 
+  <property>
+    <description>Flag to indicate whether to use user as default queue.</description>
+    <name>yarn.federation.user-as-default-queue.enabled</name>
+    <value>false</value>
+  </property>
+
   <!-- Other Configuration -->
 
   <property>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/RouterPolicyFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/RouterPolicyFacade.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
 import org.apache.hadoop.yarn.api.protocolrecords.ReservationSubmissionRequest;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -53,9 +54,15 @@ public class RouterPolicyFacade {
   private final SubClusterResolver subClusterResolver;
   private final FederationStateStoreFacade federationFacade;
   private Map<String, SubClusterPolicyConfiguration> globalConfMap;
+  private boolean userAsDefaultQueue;
 
   @VisibleForTesting
   Map<String, FederationRouterPolicy> globalPolicyMap;
+
+  @VisibleForTesting
+  public void setUserAsDefaultQueue(boolean userAsDefaultQueue) {
+    this.userAsDefaultQueue = userAsDefaultQueue;
+  }
 
   public RouterPolicyFacade(Configuration conf,
       FederationStateStoreFacade facade, SubClusterResolver resolver,
@@ -66,6 +73,9 @@ public class RouterPolicyFacade {
     this.subClusterResolver = resolver;
     this.globalConfMap = new ConcurrentHashMap<>();
     this.globalPolicyMap = new ConcurrentHashMap<>();
+    this.userAsDefaultQueue = conf.getBoolean(
+            YarnConfiguration.USER_AS_DEFAULT_QUEUE,
+            YarnConfiguration.DEFAULT_USER_AS_DEFAULT_QUEUE);
 
     // load default behavior from store if possible
     String defaultKey = YarnConfiguration.DEFAULT_FEDERATION_POLICY_KEY;
@@ -127,7 +137,7 @@ public class RouterPolicyFacade {
    */
   public SubClusterId getHomeSubcluster(
       ApplicationSubmissionContext appSubmissionContext,
-      List<SubClusterId> blackListSubClusters) throws YarnException {
+      List<SubClusterId> blackListSubClusters, String user) throws YarnException {
 
     // the maps are concurrent, but we need to protect from reset()
     // reinitialization mid-execution by creating a new reference local to this
@@ -147,6 +157,14 @@ public class RouterPolicyFacade {
     // default behavior.
     if (queue == null) {
       queue = YarnConfiguration.DEFAULT_QUEUE_NAME;
+    }
+
+    if (userAsDefaultQueue
+            && queue.equals(YarnConfiguration.DEFAULT_QUEUE_NAME)
+            && user != null && !user.isEmpty()) {
+      queue = user.trim();
+      LOG.info("Application {} use user {} as default queue",
+          appSubmissionContext.getApplicationId(), user);
     }
 
     FederationRouterPolicy policy = getFederationRouterPolicy(cachedConfs, policyMap, queue);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/RouterPolicyFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/RouterPolicyFacade.java
@@ -129,6 +129,8 @@ public class RouterPolicyFacade {
    *          {@link SubClusterId} to blackList from the selection of the home
    *          subCluster.
    *
+   * @param user the user who submit the application.
+   *
    * @return the {@link SubClusterId} that will be the "home" for this
    *         application.
    *

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -559,7 +559,7 @@ public class FederationClientInterceptor
     try {
 
       // Step1. Select homeSubCluster for Application according to Policy.
-      subClusterId = policyFacade.getHomeSubcluster(appSubmissionContext, blackList);
+      subClusterId = policyFacade.getHomeSubcluster(appSubmissionContext, blackList, user.getShortUserName());
       LOG.info("submitApplication appId {} try #{} on SubCluster {}.",
           applicationId, retryCount, subClusterId);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
@@ -550,8 +550,9 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
     SubClusterId subClusterId = null;
 
     try {
+      String userName = getUser().getShortUserName();
       // Get subClusterId from policy.
-      subClusterId = policyFacade.getHomeSubcluster(context, blackList);
+      subClusterId = policyFacade.getHomeSubcluster(context, blackList, userName);
 
       // Print the log of submitting the submitApplication.
       LOG.info("submitApplication appId {} try #{} on SubCluster {}.",


### PR DESCRIPTION
### Description of PR
In my cluster, RM is configured to map users to queues, and users do not specify queues when submitting jobs.

When using router, we do not want to change user behavior, so I think we can add config to use user as default queue when getting router policy by queue.

### How was this patch tested?

unit test

