### PR TITLE
MAPREDUCE-7458. Race condition in TaskReportPBImpl#getProto when generating task reports process in concurrency scenarios.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapreduce/v2/api/records/impl/pb/TaskReportPBImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapreduce/v2/api/records/impl/pb/TaskReportPBImpl.java
@@ -60,7 +60,7 @@ public class TaskReportPBImpl extends ProtoBase<TaskReportProto> implements Task
     viaProto = true;
   }
   
-  public TaskReportProto getProto() {
+  public synchronized TaskReportProto getProto() {
       mergeLocalToProto();
     proto = viaProto ? proto : builder.build();
     viaProto = true;


### PR DESCRIPTION
### Description of PR

Please refer to the description in MAPREDUCE-7458 

### How was this patch tested?

No, the exception scenario is hard to reproduce, and the patch is a tiny fix and has the same pattern with others.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

