### PR TITLE
HDFS-16984. Directory timestamp lost during the upgrade process

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatPBINode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatPBINode.java
@@ -150,7 +150,7 @@ public final class FSImageFormatPBINode {
       final PermissionStatus permissions = loadPermission(d.getPermission(),
           state.getStringTable());
       final INodeDirectory dir = new INodeDirectory(n.getId(), n.getName()
-          .toByteArray(), permissions, d.getModificationTime());
+          .toByteArray(), permissions, d.getModificationTime(), d.getAccessTime());
       final long nsQuota = d.getNsQuota(), dsQuota = d.getDsQuota();
       if (nsQuota >= 0 || dsQuota >= 0) {
         dir.addDirectoryWithQuotaFeature(new DirectoryWithQuotaFeature.Builder().
@@ -707,7 +707,8 @@ public final class FSImageFormatPBINode {
           .newBuilder().setModificationTime(dir.getModificationTime())
           .setNsQuota(quota.getNameSpace())
           .setDsQuota(quota.getStorageSpace())
-          .setPermission(buildPermissionStatus(dir));
+          .setPermission(buildPermissionStatus(dir))
+          .setAccessTime(dir.getAccessTime());
 
       if (quota.getTypeSpaces().anyGreaterOrEqual(0)) {
         b.setTypeQuotas(buildQuotaByStorageTypeEntries(quota));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeDirectory.java
@@ -80,6 +80,12 @@ public class INodeDirectory extends INodeWithAdditionalFields
       long mtime) {
     super(id, name, permissions, mtime, 0L);
   }
+
+  /** constructor */
+  public INodeDirectory(long id, byte[] name, PermissionStatus permissions,
+      long mtime, long atime) {
+    super(id, name, permissions, mtime, atime);
+  }
   
   /**
    * Copy constructor

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/fsimage.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/fsimage.proto
@@ -163,6 +163,7 @@ message INodeSection {
     optional AclFeatureProto acl = 5;
     optional XAttrFeatureProto xAttrs = 6;
     optional QuotaByStorageTypeFeatureProto typeQuotas = 7;
+    optional uint64 accessTime = 8;
   }
 
   message INodeSymlink {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

During the upgrade process, when creating the FSImage the access time of the directory is not serialized to the FSImage. This causes the access timestamp lost.

This PR adds access time field in INodeDirectory just like INodeFile proto definition and persists access time field during the snapshotting process. 

### How was this patch tested?

(1) Tested with system snapshot + restart.
(2) Tested old version system without the patch => upgrade to system with the patch.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

