### PR TITLE
HADOOP-18935. coalesce AWS S3 client proxy settings

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -48,6 +48,8 @@ import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.s3a.statistics.impl.AwsStatisticsCollector;
 import org.apache.hadoop.fs.store.LogExactlyOnce;
 
+import static org.apache.hadoop.fs.s3a.impl.AWSClientConfig.createAsyncHttpClientBuilder;
+import static org.apache.hadoop.fs.s3a.impl.AWSClientConfig.createAsyncProxyConfiguration;
 import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.REQUESTER_PAYS_HEADER;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_SECURE_CONNECTIONS;
 import static org.apache.hadoop.fs.s3a.Constants.SECURE_CONNECTIONS;
@@ -100,9 +102,10 @@ public class DefaultS3ClientFactory extends Configured
     Configuration conf = getConf();
     String bucket = uri.getHost();
 
-    NettyNioAsyncHttpClient.Builder httpClientBuilder = AWSClientConfig
-        .createAsyncHttpClientBuilder(conf)
-        .proxyConfiguration(AWSClientConfig.createAsyncProxyConfiguration(conf, bucket));
+    NettyNioAsyncHttpClient.Builder httpClientBuilder = createAsyncHttpClientBuilder(conf);
+
+    createAsyncProxyConfiguration(conf, bucket)
+        .ifPresent(httpClientBuilder::proxyConfiguration);
 
     MultipartConfiguration multipartConfiguration = MultipartConfiguration.builder()
         .minimumPartSizeInBytes(parameters.getMinimumPartSize())


### PR DESCRIPTION

* coalesce proxy settings between the two clients
* only set async proxy settings if non-empty

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

