### PR TITLE
HADOOP-18932. upgrade AWS v1 and v2 SDKs

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -360,7 +360,7 @@ org.objenesis:objenesis:2.6
 org.xerial.snappy:snappy-java:1.1.10.4
 org.yaml:snakeyaml:2.0
 org.wildfly.openssl:wildfly-openssl:1.1.3.Final
-software.amazon.awssdk:bundle:jar:2.20.128
+software.amazon.awssdk:bundle:jar:2.20.160
 
 
 --------------------------------------------------------------------------------

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -180,10 +180,10 @@
     <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <surefire.fork.timeout>900</surefire.fork.timeout>
-    <aws-java-sdk.version>1.12.499</aws-java-sdk.version>
-    <hsqldb.version>2.7.1</hsqldb.version>
-    <aws-java-sdk-v2.version>2.20.128</aws-java-sdk-v2.version>
+    <aws-java-sdk.version>1.12.565</aws-java-sdk.version>
+    <aws-java-sdk-v2.version>2.20.160</aws-java-sdk-v2.version>
     <aws.eventstream.version>1.0.1</aws.eventstream.version>
+    <hsqldb.version>2.7.1</hsqldb.version>
     <frontend-maven-plugin.version>1.11.2</frontend-maven-plugin.version>
     <jasmine-maven-plugin.version>2.1</jasmine-maven-plugin.version>
     <phantomjs-maven-plugin.version>0.7</phantomjs-maven-plugin.version>


### PR DESCRIPTION

v1 => 1.12.565
v1 => 2.20.160



### How was this patch tested?

not yet followed the full qualification process, though tested with third party pr

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

