### PR TITLE
HADOOP-18915. Tune/extend S3A http connection and thread pool settings

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1608,14 +1608,15 @@
 
 <property>
   <name>fs.s3a.connection.establish.timeout</name>
-  <value>5000</value>
-  <description>Socket connection setup timeout in milliseconds.</description>
+  <value>5s</value>
+  <description>Socket connection setup timeout in milliseconds; this will be retried
+    more than once.</description>
 </property>
 
 <property>
   <name>fs.s3a.connection.timeout</name>
-  <value>200000</value>
-  <description>Socket connection timeout in milliseconds.</description>
+  <value>200s</value>
+  <description>Socket connection timeout.</description>
 </property>
 
 <property>
@@ -2091,7 +2092,7 @@
 
 <property>
   <name>fs.s3a.connection.request.timeout</name>
-  <value>0</value>
+  <value>0ms</value>
   <description>
     Time out on HTTP requests to the AWS service; 0 means no timeout.
     Measured in seconds; the usual time suffixes are all supported

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1646,14 +1646,14 @@
 
 <property>
   <name>fs.s3a.threads.max</name>
-  <value>64</value>
+  <value>96</value>
   <description>The total number of threads available in the filesystem for data
     uploads *or any other queued filesystem operation*.</description>
 </property>
 
 <property>
   <name>fs.s3a.threads.keepalivetime</name>
-  <value>60</value>
+  <value>60s</value>
   <description>Number of seconds a thread can be idle before being
     terminated.</description>
 </property>
@@ -1733,7 +1733,7 @@
 
 <property>
   <name>fs.s3a.multipart.purge.age</name>
-  <value>86400</value>
+  <value>24h</value>
   <description>Minimum age in seconds of multipart uploads to purge
     on startup if "fs.s3a.multipart.purge" is true
   </description>

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1530,7 +1530,7 @@
 
 <property>
   <name>fs.s3a.connection.maximum</name>
-  <value>96</value>
+  <value>200</value>
   <description>Controls the maximum number of simultaneous connections to S3.
     This must be bigger than the value of fs.s3a.threads.max so as to stop
     threads being blocked waiting for new HTTPS connections.
@@ -1617,6 +1617,12 @@
   <name>fs.s3a.connection.timeout</name>
   <value>200s</value>
   <description>Socket connection timeout.</description>
+</property>
+
+<property>
+  <name>fs.s3a.connection.ttl</name>
+  <value>5m</value>
+  <description>Expiry time for any active connection.</description>
 </property>
 
 <property>

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2098,18 +2098,15 @@
 
 <property>
   <name>fs.s3a.connection.request.timeout</name>
-  <value>0ms</value>
+  <value>0s</value>
   <description>
     Time out on HTTP requests to the AWS service; 0 means no timeout.
-    Measured in seconds; the usual time suffixes are all supported
 
     Important: this is the maximum duration of any AWS service call,
     including upload and copy operations. If non-zero, it must be larger
     than the time to upload multi-megabyte blocks to S3 from the client,
     and to rename many-GB files. Use with care.
 
-    Values that are larger than Integer.MAX_VALUE milliseconds are
-    converged to Integer.MAX_VALUE milliseconds
   </description>
 </property>
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/AWSApiCallTimeoutException.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/AWSApiCallTimeoutException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import org.apache.hadoop.net.ConnectTimeoutException;
+
+/**
+ * IOException equivalent of an {@code ApiCallTimeoutException}.
+ * Declared as a subclass of {@link ConnectTimeoutException} to allow
+ * for existing code to catch it.
+ */
+public class AWSApiCallTimeoutException extends ConnectTimeoutException {
+
+  /**
+   * Constructor.
+   * @param operation operation in progress
+   * @param cause cause.
+   */
+  public AWSApiCallTimeoutException(
+      final String operation,
+      final Exception cause) {
+    super(operation);
+    initCause(cause);
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -161,10 +162,8 @@ public final class Constants {
 
   /**
    * Default value for {@code CONNECTION_TTL}: {@value}.
-   * Even this is a long, this is only to ensure the type doesn't change
-   * with older versions. It is cast to an int before use.
    */
-  public static final long DEFAULT_CONNECTION_TTL = 5 * 60_000;
+  public static final long DEFAULT_CONNECTION_TTL = Duration.ofMinutes(5).toMillis();
 
   // connect to s3 over ssl?
   public static final String SECURE_CONNECTIONS =

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -281,7 +281,7 @@ public final class Constants {
       "fs.s3a.connection.establish.timeout";
 
   /**
-   * Default establish timeout in millis: {@value}.
+   * Default establish timeout in millis: 30 seconds.
    */
   public static final int DEFAULT_ESTABLISH_TIMEOUT = (int)Duration.ofSeconds(30).toMillis();
 
@@ -316,7 +316,7 @@ public final class Constants {
       "fs.s3a.connection.acquisition.timeout";
 
   /**
-   * Default acquisition timeout (unless set in core-default.xml -check!).
+   * Default acquisition timeout: 60 seconds.
    */
   public static final Duration DEFAULT_CONNECTION_ACQUISITION_TIMEOUT =
       Duration.ofSeconds(60);
@@ -348,7 +348,7 @@ public final class Constants {
       "fs.s3a.connection.idle.time";
 
   /**
-   * Default idle time (unless set in core-default.xml -check!).
+   * Default idle time: 60 seconds.
    */
   public static final Duration DEFAULT_CONNECTION_IDLE_TIME =
       Duration.ofSeconds(60);
@@ -365,15 +365,26 @@ public final class Constants {
   public static final String MAX_PAGING_KEYS = "fs.s3a.paging.maximum";
   public static final int DEFAULT_MAX_PAGING_KEYS = 5000;
 
-  // the maximum number of threads to allow in the pool used by TransferManager
+  /**
+   * The maximum number of threads to allow in the pool used by S3A.
+   * Value: {@value}.
+   */
   public static final String MAX_THREADS = "fs.s3a.threads.max";
-  public static final int DEFAULT_MAX_THREADS = 64;
+
+  /**
+   * Default value of {@link #MAX_THREADS}: {@value}.
+   */
+  public static final int DEFAULT_MAX_THREADS = 96;
 
   /**
    * The time an idle thread waits before terminating: {@value}.
-   * This is in SECONDS.
+   * This is in SECONDS unless the optional unit is given.
    */
   public static final String KEEPALIVE_TIME = "fs.s3a.threads.keepalivetime";
+
+  /**
+   * Default value of {@link #KEEPALIVE_TIME}: {@value}.
+   */
   public static final int DEFAULT_KEEPALIVE_TIME = 60;
 
   // size of each of or multipart pieces in bytes
@@ -579,10 +590,17 @@ public final class Constants {
       "fs.s3a.multipart.purge";
   public static final boolean DEFAULT_PURGE_EXISTING_MULTIPART = false;
 
-  // purge any multipart uploads older than this number of seconds
+  /**
+   * purge any multipart uploads older than this number of seconds.
+   */
   public static final String PURGE_EXISTING_MULTIPART_AGE =
       "fs.s3a.multipart.purge.age";
-  public static final long DEFAULT_PURGE_EXISTING_MULTIPART_AGE = 86400;
+
+  /**
+   * Default Age.
+   */
+  public static final long DEFAULT_PURGE_EXISTING_MULTIPART_AGE =
+      Duration.ofDays(1).getSeconds();
 
   /**
    * s3 server-side encryption, see

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -161,6 +161,8 @@ public final class Constants {
 
   /**
    * Default value for {@code CONNECTION_TTL}: {@value}.
+   * Even this is a long, this is only to ensure the type doesn't change
+   * with older versions. It is cast to an int before use.
    */
   public static final long DEFAULT_CONNECTION_TTL = 5 * 60_000;
 
@@ -267,11 +269,11 @@ public final class Constants {
   // milliseconds until we give up trying to establish a connection to s3
   public static final String ESTABLISH_TIMEOUT =
       "fs.s3a.connection.establish.timeout";
-  public static final int DEFAULT_ESTABLISH_TIMEOUT = 5000;
+  public static final int DEFAULT_ESTABLISH_TIMEOUT = 5_000;
 
   // milliseconds until we give up on a connection to s3
   public static final String SOCKET_TIMEOUT = "fs.s3a.connection.timeout";
-  public static final int DEFAULT_SOCKET_TIMEOUT = 200000;
+  public static final int DEFAULT_SOCKET_TIMEOUT = 200_000;
 
   // milliseconds until a request is timed-out
   public static final String REQUEST_TIMEOUT =

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -338,7 +338,7 @@ public final class Constants {
   public static final int DEFAULT_SOCKET_TIMEOUT = (int)DEFAULT_SOCKET_TIMEOUT_DURATION.toMillis();
 
   /**
-   * Milliseconds until a request is timed-out: {@value}.
+   * Time until a request is timed-out: {@value}.
    * If zero, there is no timeout.
    */
   public static final String REQUEST_TIMEOUT =
@@ -347,7 +347,14 @@ public final class Constants {
   /**
    * Default duration of a request before it is timed out: {@value}.
    */
-  public static final int DEFAULT_REQUEST_TIMEOUT = 0;
+  public static final Duration DEFAULT_REQUEST_TIMEOUT_DURATION = Duration.ZERO;
+
+  /**
+   * Default duration of a request before it is timed out: {@value}.
+   */
+  @Deprecated
+  public static final int DEFAULT_REQUEST_TIMEOUT =
+      (int)DEFAULT_REQUEST_TIMEOUT_DURATION.toMillis();
 
   /**
    * Acquisition timeout for connections from the pool:
@@ -360,7 +367,7 @@ public final class Constants {
   /**
    * Default acquisition timeout: 60 seconds.
    */
-  public static final Duration DEFAULT_CONNECTION_ACQUISITION_TIMEOUT =
+  public static final Duration DEFAULT_CONNECTION_ACQUISITION_TIMEOUT_DURATION =
       Duration.ofSeconds(60);
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -34,7 +34,14 @@ import java.util.concurrent.TimeUnit;
  * as deprecated and simply ignored.
  *
  * All S3Guard related constants are marked as Deprecated and either ignored (ddb config)
- * or rejected (setting the metastore to anything other than the null store)
+ * or rejected (setting the metastore to anything other than the null store).
+ * <p>
+ * Timeout default values are declared as integers or long values in milliseconds and
+ * occasionally seconds.
+ * There are now {@code Duration} constants for these default values; the original
+ * fields are retained for compatibility, and derive their value from the Duration equivalent.
+ * <p>
+ * New timeout/duration constants do not get the equivalent integer/long fields.
  */
 @InterfaceAudience.Public
 @InterfaceStability.Evolving
@@ -145,13 +152,28 @@ public final class Constants {
       SimpleAWSCredentialsProvider.NAME;
 
 
-  // the maximum number of tasks cached if all threads are already uploading
+  /**
+   * The maximum number of tasks queued (other than prefetcher tasks) if all threads are
+   * busy: {@value}.
+   */
   public static final String MAX_TOTAL_TASKS = "fs.s3a.max.total.tasks";
 
+  /**
+   * Default value for {@link #MAX_TOTAL_TASKS}: {@value}.
+   */
   public static final int DEFAULT_MAX_TOTAL_TASKS = 32;
 
-  // number of simultaneous connections to s3
+  /**
+   * Number of simultaneous connections to S3: {@value}.
+   */
   public static final String MAXIMUM_CONNECTIONS = "fs.s3a.connection.maximum";
+
+  /**
+   * Default value for {@link #MAXIMUM_CONNECTIONS}: {@value}.
+   * Note this value gets increased over time as more connections are used
+   * in parallel operations.
+   * Keep in sync with the value in {@code core-default.xml}
+   */
   public static final int DEFAULT_MAXIMUM_CONNECTIONS = 200;
 
   /**
@@ -161,10 +183,17 @@ public final class Constants {
   public static final String CONNECTION_TTL = "fs.s3a.connection.ttl";
 
   /**
-   * Default value in millis for {@code CONNECTION_TTL}: {@value}.
+   * Default value in millis for {@link #CONNECTION_TTL}: 5 minutes.
+   */
+  public static final Duration DEFAULT_CONNECTION_TTL_DURATION =
+      Duration.ofMinutes(5);
+
+  /**
+   * Default value in millis for {@link #CONNECTION_TTL}: 5 minutes.
+   * @deprecated use {@link #DEFAULT_CONNECTION_TTL_DURATION}
    */
   public static final long DEFAULT_CONNECTION_TTL =
-      Duration.ofMinutes(5).toMillis();
+      DEFAULT_CONNECTION_TTL_DURATION.toMillis();
 
   // connect to s3 over ssl?
   public static final String SECURE_CONNECTIONS =
@@ -281,9 +310,16 @@ public final class Constants {
       "fs.s3a.connection.establish.timeout";
 
   /**
-   * Default establish timeout in millis: 30 seconds.
+   * Default TCP/(and TLS?) establish timeout: 30 seconds.
    */
-  public static final int DEFAULT_ESTABLISH_TIMEOUT = (int)Duration.ofSeconds(30).toMillis();
+  public static final Duration DEFAULT_ESTABLISH_TIMEOUT_DURATION = Duration.ofSeconds(30);
+
+  /**
+   * Default establish timeout in millis: 30 seconds.
+   * @deprecated use {@link #DEFAULT_ESTABLISH_TIMEOUT_DURATION}
+   */
+  public static final int DEFAULT_ESTABLISH_TIMEOUT =
+      (int)DEFAULT_ESTABLISH_TIMEOUT_DURATION.toMillis();
 
   /**
    * Milliseconds until we give up on a connection to s3: {@value}.
@@ -291,9 +327,15 @@ public final class Constants {
   public static final String SOCKET_TIMEOUT = "fs.s3a.connection.timeout";
 
   /**
-   * Default socket timeout in millis: {@value}.
+   * Default socket timeout: 200 seconds.
    */
-  public static final int DEFAULT_SOCKET_TIMEOUT = 200_000;
+  public static final Duration DEFAULT_SOCKET_TIMEOUT_DURATION = Duration.ofSeconds(200);
+
+  /**
+   * Default socket timeout: {@link #DEFAULT_SOCKET_TIMEOUT_DURATION}.
+   * @deprecated use {@link #DEFAULT_SOCKET_TIMEOUT_DURATION}
+   */
+  public static final int DEFAULT_SOCKET_TIMEOUT = (int)DEFAULT_SOCKET_TIMEOUT_DURATION.toMillis();
 
   /**
    * Milliseconds until a request is timed-out: {@value}.
@@ -335,8 +377,7 @@ public final class Constants {
   public static final boolean DEFAULT_CONNECTION_KEEPALIVE = false;
 
   /**
-   * Maximum idle time for connections in the pool
-   * {@value}.
+   * Maximum idle time for connections in the pool: {@value}.
    * <p>
    * Too low: overhead of creating connections.
    * Too high, risk of stale connections and inability to use the
@@ -350,7 +391,7 @@ public final class Constants {
   /**
    * Default idle time: 60 seconds.
    */
-  public static final Duration DEFAULT_CONNECTION_IDLE_TIME =
+  public static final Duration DEFAULT_CONNECTION_IDLE_TIME_DURATION =
       Duration.ofSeconds(60);
 
   // socket send buffer to be used in Amazon client
@@ -383,9 +424,15 @@ public final class Constants {
   public static final String KEEPALIVE_TIME = "fs.s3a.threads.keepalivetime";
 
   /**
-   * Default value of {@link #KEEPALIVE_TIME}: {@value}.
+   * Default value of {@link #KEEPALIVE_TIME}: 60s.
    */
-  public static final int DEFAULT_KEEPALIVE_TIME = 60;
+  public static final Duration DEFAULT_KEEPALIVE_TIME_DURATION = Duration.ofSeconds(60);
+
+  /**
+   * Default value of {@link #KEEPALIVE_TIME}: 60s.
+   * @deprecated use {@link #DEFAULT_KEEPALIVE_TIME_DURATION}
+   */
+  public static final int DEFAULT_KEEPALIVE_TIME = (int)DEFAULT_KEEPALIVE_TIME_DURATION.getSeconds();
 
   // size of each of or multipart pieces in bytes
   public static final String MULTIPART_SIZE = "fs.s3a.multipart.size";

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -344,14 +344,14 @@ public final class Constants {
       "fs.s3a.connection.request.timeout";
 
   /**
-   * Default duration of a request before it is timed out: {@value}.
+   * Default duration of a request before it is timed out: Zero.
    */
   public static final Duration DEFAULT_REQUEST_TIMEOUT_DURATION = Duration.ZERO;
 
   /**
-   * Default duration of a request before it is timed out: {@value}.
+   * Default duration of a request before it is timed out: Zero.
+   * @deprecated use {@link #DEFAULT_REQUEST_TIMEOUT_DURATION}
    */
-  @Deprecated
   public static final int DEFAULT_REQUEST_TIMEOUT =
       (int)DEFAULT_REQUEST_TIMEOUT_DURATION.toMillis();
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -161,9 +161,10 @@ public final class Constants {
   public static final String CONNECTION_TTL = "fs.s3a.connection.ttl";
 
   /**
-   * Default value for {@code CONNECTION_TTL}: {@value}.
+   * Default value in millis for {@code CONNECTION_TTL}: {@value}.
    */
-  public static final long DEFAULT_CONNECTION_TTL = 5 * 60_000;
+  public static final long DEFAULT_CONNECTION_TTL =
+      Duration.ofMinutes(5).toMillis();
 
   // connect to s3 over ssl?
   public static final String SECURE_CONNECTIONS =
@@ -266,15 +267,23 @@ public final class Constants {
       true;
 
   /**
+   * This is the minimum operation duration unless programmatically set.
+   * It ensures that even if a configuration has mistaken a millisecond
+   * option for seconds, a viable duration will actually be used.
+   * Value: 15s.
+   */
+  public static final Duration MINIMUM_NETWORK_OPERATION_DURATION = Duration.ofSeconds(15);
+
+  /**
    * Milliseconds until a connection is established: {@value}.
    */
   public static final String ESTABLISH_TIMEOUT =
       "fs.s3a.connection.establish.timeout";
 
   /**
-   * Default establish timeout: {@value}.
+   * Default establish timeout in millis: {@value}.
    */
-  public static final int DEFAULT_ESTABLISH_TIMEOUT = 5_000;
+  public static final int DEFAULT_ESTABLISH_TIMEOUT = (int)Duration.ofSeconds(30).toMillis();
 
   /**
    * Milliseconds until we give up on a connection to s3: {@value}.
@@ -282,7 +291,7 @@ public final class Constants {
   public static final String SOCKET_TIMEOUT = "fs.s3a.connection.timeout";
 
   /**
-   * Default socket timeout: {@value}.
+   * Default socket timeout in millis: {@value}.
    */
   public static final int DEFAULT_SOCKET_TIMEOUT = 200_000;
 
@@ -358,7 +367,7 @@ public final class Constants {
 
   // the maximum number of threads to allow in the pool used by TransferManager
   public static final String MAX_THREADS = "fs.s3a.threads.max";
-  public static final int DEFAULT_MAX_THREADS = 10;
+  public static final int DEFAULT_MAX_THREADS = 64;
 
   /**
    * The time an idle thread waits before terminating: {@value}.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -152,7 +152,7 @@ public final class Constants {
 
   // number of simultaneous connections to s3
   public static final String MAXIMUM_CONNECTIONS = "fs.s3a.connection.maximum";
-  public static final int DEFAULT_MAXIMUM_CONNECTIONS = 96;
+  public static final int DEFAULT_MAXIMUM_CONNECTIONS = 200;
 
   /**
    * Configuration option to configure expiration time of
@@ -163,7 +163,7 @@ public final class Constants {
   /**
    * Default value for {@code CONNECTION_TTL}: {@value}.
    */
-  public static final long DEFAULT_CONNECTION_TTL = Duration.ofMinutes(5).toMillis();
+  public static final long DEFAULT_CONNECTION_TTL = 5 * 60_000;
 
   // connect to s3 over ssl?
   public static final String SECURE_CONNECTIONS =
@@ -265,19 +265,84 @@ public final class Constants {
   public static final boolean EXPERIMENTAL_AWS_INTERNAL_THROTTLING_DEFAULT =
       true;
 
-  // milliseconds until we give up trying to establish a connection to s3
+  /**
+   * Milliseconds until a connection is established: {@value}.
+   */
   public static final String ESTABLISH_TIMEOUT =
       "fs.s3a.connection.establish.timeout";
+
+  /**
+   * Default establish timeout: {@value}.
+   */
   public static final int DEFAULT_ESTABLISH_TIMEOUT = 5_000;
 
-  // milliseconds until we give up on a connection to s3
+  /**
+   * Milliseconds until we give up on a connection to s3: {@value}.
+   */
   public static final String SOCKET_TIMEOUT = "fs.s3a.connection.timeout";
+
+  /**
+   * Default socket timeout: {@value}.
+   */
   public static final int DEFAULT_SOCKET_TIMEOUT = 200_000;
 
-  // milliseconds until a request is timed-out
+  /**
+   * Milliseconds until a request is timed-out: {@value}.
+   * If zero, there is no timeout.
+   */
   public static final String REQUEST_TIMEOUT =
       "fs.s3a.connection.request.timeout";
+
+  /**
+   * Default duration of a request before it is timed out: {@value}.
+   */
   public static final int DEFAULT_REQUEST_TIMEOUT = 0;
+
+  /**
+   * Acquisition timeout for connections from the pool:
+   * {@value}.
+   * Default unit is milliseconds for consistency with other options.
+   */
+  public static final String CONNECTION_ACQUISITION_TIMEOUT =
+      "fs.s3a.connection.acquisition.timeout";
+
+  /**
+   * Default acquisition timeout (unless set in core-default.xml -check!).
+   */
+  public static final Duration DEFAULT_CONNECTION_ACQUISITION_TIMEOUT =
+      Duration.ofSeconds(60);
+
+  /**
+   * Should TCP Keepalive be enabled on the socket?
+   * This adds some network IO, but finds failures faster.
+   * {@value}.
+   */
+  public static final String CONNECTION_KEEPALIVE =
+      "fs.s3a.connection.keepalive";
+
+  /**
+   * Default value of {@link #CONNECTION_KEEPALIVE}: {@value}.
+   */
+  public static final boolean DEFAULT_CONNECTION_KEEPALIVE = false;
+
+  /**
+   * Maximum idle time for connections in the pool
+   * {@value}.
+   * <p>
+   * Too low: overhead of creating connections.
+   * Too high, risk of stale connections and inability to use the
+   * adaptive load balancing of the S3 front end.
+   * <p>
+   * Default unit is milliseconds for consistency with other options.
+   */
+  public static final String CONNECTION_IDLE_TIME =
+      "fs.s3a.connection.idle.time";
+
+  /**
+   * Default idle time (unless set in core-default.xml -check!).
+   */
+  public static final Duration DEFAULT_CONNECTION_IDLE_TIME =
+      Duration.ofSeconds(60);
 
   // socket send buffer to be used in Amazon client
   public static final String SOCKET_SEND_BUFFER = "fs.s3a.socket.send.buffer";
@@ -295,7 +360,10 @@ public final class Constants {
   public static final String MAX_THREADS = "fs.s3a.threads.max";
   public static final int DEFAULT_MAX_THREADS = 10;
 
-  // the time an idle thread waits before terminating
+  /**
+   * The time an idle thread waits before terminating: {@value}.
+   * This is in SECONDS.
+   */
   public static final String KEEPALIVE_TIME = "fs.s3a.threads.keepalivetime";
   public static final int DEFAULT_KEEPALIVE_TIME = 60;
 
@@ -1202,8 +1270,7 @@ public final class Constants {
    * Default value for create performance in an S3A FS.
    * Value {@value}.
    */
-  public static final boolean FS_S3A_CREATE_PERFORMANCE_DEFAULT = true;
-
+  public static final boolean FS_S3A_CREATE_PERFORMANCE_DEFAULT = false;
 
   /**
    * Capability to indicate that the FS has been instantiated with

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -170,20 +170,19 @@ public final class Constants {
 
   /**
    * Default value for {@link #MAXIMUM_CONNECTIONS}: {@value}.
-   * Note this value gets increased over time as more connections are used
-   * in parallel operations.
+   * Future releases are likely to increase this value.
    * Keep in sync with the value in {@code core-default.xml}
    */
   public static final int DEFAULT_MAXIMUM_CONNECTIONS = 200;
 
   /**
    * Configuration option to configure expiration time of
-   * s3 http connection from the connection pool in milliseconds: {@value}.
+   * S3 http connection from the connection pool: {@value}.
    */
   public static final String CONNECTION_TTL = "fs.s3a.connection.ttl";
 
   /**
-   * Default value in millis for {@link #CONNECTION_TTL}: 5 minutes.
+   * Default duration for {@link #CONNECTION_TTL}: 5 minutes.
    */
   public static final Duration DEFAULT_CONNECTION_TTL_DURATION =
       Duration.ofMinutes(5);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -432,7 +432,8 @@ public final class Constants {
    * Default value of {@link #KEEPALIVE_TIME}: 60s.
    * @deprecated use {@link #DEFAULT_KEEPALIVE_TIME_DURATION}
    */
-  public static final int DEFAULT_KEEPALIVE_TIME = (int)DEFAULT_KEEPALIVE_TIME_DURATION.getSeconds();
+  public static final int DEFAULT_KEEPALIVE_TIME =
+      (int)DEFAULT_KEEPALIVE_TIME_DURATION.getSeconds();
 
   // size of each of or multipart pieces in bytes
   public static final String MULTIPART_SIZE = "fs.s3a.multipart.size";

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.nio.file.AccessDeniedException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -122,6 +123,7 @@ import org.apache.hadoop.fs.s3a.impl.AWSCannedACL;
 import org.apache.hadoop.fs.s3a.impl.AWSHeaders;
 import org.apache.hadoop.fs.s3a.impl.BulkDeleteRetryHandler;
 import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
+import org.apache.hadoop.fs.s3a.impl.ConfigurationHelper;
 import org.apache.hadoop.fs.s3a.impl.ContextAccessors;
 import org.apache.hadoop.fs.s3a.impl.CopyFromLocalOperation;
 import org.apache.hadoop.fs.s3a.impl.CreateFileBuilder;
@@ -828,8 +830,13 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     }
     int totalTasks = intOption(conf,
         MAX_TOTAL_TASKS, DEFAULT_MAX_TOTAL_TASKS, 1);
-    long keepAliveTime = longOption(conf, KEEPALIVE_TIME,
-        DEFAULT_KEEPALIVE_TIME, 0);
+    // keepalive time takes a time suffix; default unit is seconds
+    long keepAliveTime = ConfigurationHelper.getDuration(conf,
+            KEEPALIVE_TIME,
+            Duration.ofSeconds(DEFAULT_KEEPALIVE_TIME),
+            TimeUnit.SECONDS,
+            Duration.ZERO).getSeconds();
+
     int numPrefetchThreads = this.prefetchEnabled ? this.prefetchBlockCount : 0;
 
     int activeTasksForBoundedThreadPool = maxThreads;
@@ -1226,12 +1233,15 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   private void initMultipartUploads(Configuration conf) throws IOException {
     boolean purgeExistingMultipart = conf.getBoolean(PURGE_EXISTING_MULTIPART,
         DEFAULT_PURGE_EXISTING_MULTIPART);
-    long purgeExistingMultipartAge = longOption(conf,
-        PURGE_EXISTING_MULTIPART_AGE, DEFAULT_PURGE_EXISTING_MULTIPART_AGE, 0);
 
     if (purgeExistingMultipart) {
       try {
-        abortOutstandingMultipartUploads(purgeExistingMultipartAge);
+        Duration purgeDuration = ConfigurationHelper.getDuration(conf,
+            PURGE_EXISTING_MULTIPART_AGE,
+            Duration.ofSeconds(DEFAULT_PURGE_EXISTING_MULTIPART_AGE),
+            TimeUnit.SECONDS,
+            Duration.ZERO);
+        abortOutstandingMultipartUploads(purgeDuration.getSeconds());
       } catch (AccessDeniedException e) {
         instrumentation.errorIgnored();
         LOG.debug("Failed to purge multipart uploads against {}," +

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ARetryPolicy.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ARetryPolicy.java
@@ -201,6 +201,9 @@ public class S3ARetryPolicy implements RetryPolicy {
     // Treated as an immediate failure
     policyMap.put(AWSBadRequestException.class, fail);
 
+    // API call timeout.
+    policyMap.put(AWSApiCallTimeoutException.class, retryAwsClientExceptions);
+
     // use specific retry policy for aws client exceptions
     // nested IOExceptions will already have been extracted and used
     // in this map.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -175,6 +175,11 @@ public final class S3AUtils {
         exception);
 
     // timeout issues
+    // ApiCallAttemptTimeoutException: a single HTTP request attempt failed.
+    // ApiCallTimeoutException: a request with any configured retries failed.
+    // The ApiCallTimeoutException exception should be the only one seen in
+    // the S3A code, but for due diligence both are handled and mapped to
+    // our own AWSApiCallTimeoutException.
     if (exception instanceof ApiCallTimeoutException
         || exception instanceof ApiCallAttemptTimeoutException) {
       // An API call to an AWS service timed out.
@@ -184,7 +189,7 @@ public final class S3AUtils {
       return new AWSApiCallTimeoutException(message, exception);
     }
     if (!(exception instanceof AwsServiceException)) {
-      // exceptions raised client-side: connectivity, auth, network problems...p
+      // exceptions raised client-side: connectivity, auth, network problems...
       Exception innerCause = containsInterruptedException(exception);
       if (innerCause != null) {
         // interrupted IO, or a socket exception underneath that class

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -186,7 +186,7 @@ public final class S3AUtils {
         return (EOFException)new EOFException(message).initCause(exception);
       }
       if (exception instanceof ApiCallTimeoutException
-       || exception instanceof ApiCallAttemptTimeoutException) {
+          || exception instanceof ApiCallAttemptTimeoutException) {
         // An API call to an AWS service timed out.
         // It's not clear why there are two; they are both remapped.
         return new AWSApiCallTimeoutException(message, exception);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
@@ -46,14 +46,14 @@ import static org.apache.hadoop.fs.s3a.Constants.AWS_SERVICE_IDENTIFIER_STS;
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_IDLE_TIME;
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_KEEPALIVE;
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_TTL;
-import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_ACQUISITION_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_ACQUISITION_TIMEOUT_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_IDLE_TIME_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_KEEPALIVE;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_TTL_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_ESTABLISH_TIMEOUT_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_MAXIMUM_CONNECTIONS;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_MAX_ERROR_RETRIES;
-import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_REQUEST_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_REQUEST_TIMEOUT_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_SOCKET_TIMEOUT_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.ESTABLISH_TIMEOUT;
 import static org.apache.hadoop.fs.s3a.Constants.MAXIMUM_CONNECTIONS;
@@ -553,7 +553,7 @@ public final class AWSClientConfig {
   static ConnectionSettings createApiConnectionSettings(Configuration conf) {
 
     Duration apiCallTimeout = getDuration(conf, REQUEST_TIMEOUT,
-        DEFAULT_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS, Duration.ZERO);
+        DEFAULT_REQUEST_TIMEOUT_DURATION, TimeUnit.MILLISECONDS, Duration.ZERO);
 
     // if the API call timeout is set, it must be at least the minimum duration
     if (apiCallTimeout.compareTo(Duration.ZERO) > 0) {
@@ -589,7 +589,7 @@ public final class AWSClientConfig {
 
     // time to acquire a connection from the pool
     Duration acquisitionTimeout = getDuration(conf, CONNECTION_ACQUISITION_TIMEOUT,
-        DEFAULT_CONNECTION_ACQUISITION_TIMEOUT, TimeUnit.MILLISECONDS,
+        DEFAULT_CONNECTION_ACQUISITION_TIMEOUT_DURATION, TimeUnit.MILLISECONDS,
         minimumOperationDuration);
 
     // set the connection TTL irrespective of whether the connection is in use or not.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
@@ -47,14 +47,14 @@ import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_IDLE_TIME;
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_KEEPALIVE;
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_TTL;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_ACQUISITION_TIMEOUT;
-import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_IDLE_TIME;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_IDLE_TIME_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_KEEPALIVE;
-import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_TTL;
-import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_ESTABLISH_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_TTL_DURATION;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_ESTABLISH_TIMEOUT_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_MAXIMUM_CONNECTIONS;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_MAX_ERROR_RETRIES;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_REQUEST_TIMEOUT;
-import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_SOCKET_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_SOCKET_TIMEOUT_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.ESTABLISH_TIMEOUT;
 import static org.apache.hadoop.fs.s3a.Constants.MAXIMUM_CONNECTIONS;
 import static org.apache.hadoop.fs.s3a.Constants.MAX_ERROR_RETRIES;
@@ -596,19 +596,19 @@ public final class AWSClientConfig {
     // this can balance requests over different S3 servers, and avoid failed
     // connections. See HADOOP-18845.
     Duration connectionTTL = getDuration(conf, CONNECTION_TTL,
-        DEFAULT_CONNECTION_TTL, TimeUnit.MILLISECONDS,
+        DEFAULT_CONNECTION_TTL_DURATION, TimeUnit.MILLISECONDS,
         null);
 
     Duration establishTimeout = getDuration(conf, ESTABLISH_TIMEOUT,
-        DEFAULT_ESTABLISH_TIMEOUT, TimeUnit.MILLISECONDS,
+        DEFAULT_ESTABLISH_TIMEOUT_DURATION, TimeUnit.MILLISECONDS,
         minimumOperationDuration);
 
     // limit on the time a connection can be idle in the pool
     Duration maxIdleTime = getDuration(conf, CONNECTION_IDLE_TIME,
-        DEFAULT_CONNECTION_IDLE_TIME, TimeUnit.MILLISECONDS, Duration.ZERO);
+        DEFAULT_CONNECTION_IDLE_TIME_DURATION, TimeUnit.MILLISECONDS, Duration.ZERO);
 
     Duration socketTimeout = getDuration(conf, SOCKET_TIMEOUT,
-        DEFAULT_SOCKET_TIMEOUT, TimeUnit.MILLISECONDS,
+        DEFAULT_SOCKET_TIMEOUT_DURATION, TimeUnit.MILLISECONDS,
         minimumOperationDuration);
 
     return new ConnectionSettings(

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ConfigurationHelper.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ConfigurationHelper.java
@@ -39,7 +39,7 @@ public final class ConfigurationHelper {
   private static final Logger LOG = LoggerFactory.getLogger(ConfigurationHelper.class);
 
   /** Log to warn of range issues on a timeout. */
-  private static final LogExactlyOnce TIMEOUT_WARN_LOG = new LogExactlyOnce(LOG);
+  private static final LogExactlyOnce DURATION_WARN_LOG = new LogExactlyOnce(LOG);
 
   private ConfigurationHelper() {
   }
@@ -91,7 +91,7 @@ public final class ConfigurationHelper {
         defVal, defaultUnit, TimeUnit.MILLISECONDS);
 
     if (timeMillis > Integer.MAX_VALUE) {
-      TIMEOUT_WARN_LOG.warn("Option {} is too high({} ms). Setting to {} ms instead",
+      DURATION_WARN_LOG.warn("Option {} is too high({} ms). Setting to {} ms instead",
           name, timeMillis, Integer.MAX_VALUE);
       LOG.debug("Option {} is too high({} ms). Setting to {} ms instead",
           name, timeMillis, Integer.MAX_VALUE);
@@ -142,10 +142,10 @@ public final class ConfigurationHelper {
       final String name,
       final Duration duration, @Nullable final Duration minimumDuration) {
     if (minimumDuration != null && duration.compareTo(minimumDuration) < 0) {
-      TIMEOUT_WARN_LOG.warn("Option {} is too low({} ms). Setting to {} ms instead",
+      String message = String.format("Option %s is too low (%,d ms). Setting to %,d ms instead",
           name, duration.toMillis(), minimumDuration.toMillis());
-      LOG.debug("Option {} is too low({} ms). Setting to {} ms instead",
-          name, duration.toMillis(), minimumDuration.toMillis());
+      DURATION_WARN_LOG.warn(message);
+      LOG.debug(message);
       return minimumDuration;
     }
     return duration;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ConfigurationHelper.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ConfigurationHelper.java
@@ -54,7 +54,7 @@ public final class ConfigurationHelper {
    * @param conf config
    * @param name option name
    * @param defaultDuration default duration
-   * @param defaultUnit unit of default value
+   * @param defaultUnit default unit on the config option if not declared.
    * @param minimumDuration optional minimum duration;
    * @return duration. may be negative.
    */
@@ -64,31 +64,8 @@ public final class ConfigurationHelper {
       final Duration defaultDuration,
       final TimeUnit defaultUnit,
       @Nullable final Duration minimumDuration) {
-    return getDuration(conf, name, defaultDuration.toMillis(), defaultUnit, minimumDuration);
-  }
-
-  /**
-   * Get duration. This may be negative; callers must check or set a minimum of zero.
-   * If the config option is greater than {@code Integer.MAX_VALUE} milliseconds,
-   * it is set to that max.
-   * If {@code minimumDuration} is set, and the value is less than that, then
-   * the minimum is used.
-   * Logs the value for diagnostics.
-   * @param conf config
-   * @param name option name
-   * @param defVal default duration in the default unit
-   * @param defaultUnit unit of default value
-   * @param minimumDuration optional minimum duration;
-   * @return duration. may be negative.
-   */
-  public static Duration getDuration(
-      final Configuration conf,
-      final String name,
-      final long defVal,
-      final TimeUnit defaultUnit,
-      @Nullable final Duration minimumDuration) {
     long timeMillis = conf.getTimeDuration(name,
-        defVal, defaultUnit, TimeUnit.MILLISECONDS);
+        defaultDuration.toMillis(), defaultUnit, TimeUnit.MILLISECONDS);
 
     if (timeMillis > Integer.MAX_VALUE) {
       DURATION_WARN_LOG.warn("Option {} is too high({} ms). Setting to {} ms instead",
@@ -140,7 +117,9 @@ public final class ConfigurationHelper {
    */
   public static Duration enforceMinimumDuration(
       final String name,
-      final Duration duration, @Nullable final Duration minimumDuration) {
+      final Duration duration,
+      @Nullable final Duration minimumDuration) {
+
     if (minimumDuration != null && duration.compareTo(minimumDuration) < 0) {
       String message = String.format("Option %s is too low (%,d ms). Setting to %,d ms instead",
           name, duration.toMillis(), minimumDuration.toMillis());

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ConfigurationHelper.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ConfigurationHelper.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.store.LogExactlyOnce;
+
+/**
+ * Helper class for configuration; where methods related to extracting
+ * configuration should go instead of {@code S3AUtils}.
+ */
+@InterfaceAudience.Private
+public final class ConfigurationHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ConfigurationHelper.class);
+
+  /** Log to warn of range issues on a timeout. */
+  private static final LogExactlyOnce TIMEOUT_WARN_LOG = new LogExactlyOnce(LOG);
+
+  private ConfigurationHelper() {
+  }
+
+  /**
+   * Get a duration. This may be negative; callers must check or set the minimum to zero.
+   * If the config option is greater than {@code Integer.MAX_VALUE} milliseconds,
+   * it is set to that max.
+   * If {@code minimumDuration} is set, and the value is less than that, then
+   * the minimum is used.
+   * Logs the value for diagnostics.
+   * @param conf config
+   * @param name option name
+   * @param defaultDuration default duration
+   * @param defaultUnit unit of default value
+   * @param minimumDuration optional minimum duration;
+   * @return duration. may be negative.
+   */
+  public static Duration getDuration(
+      final Configuration conf,
+      final String name,
+      final Duration defaultDuration,
+      final TimeUnit defaultUnit,
+      @Nullable final Duration minimumDuration) {
+    return getDuration(conf, name, defaultDuration.toMillis(), defaultUnit, minimumDuration);
+  }
+
+  /**
+   * Get duration. This may be negative; callers must check or set a minimum of zero.
+   * If the config option is greater than {@code Integer.MAX_VALUE} milliseconds,
+   * it is set to that max.
+   * If {@code minimumDuration} is set, and the value is less than that, then
+   * the minimum is used.
+   * Logs the value for diagnostics.
+   * @param conf config
+   * @param name option name
+   * @param defVal default duration in the default unit
+   * @param defaultUnit unit of default value
+   * @param minimumDuration optional minimum duration;
+   * @return duration. may be negative.
+   */
+  public static Duration getDuration(
+      final Configuration conf,
+      final String name,
+      final long defVal,
+      final TimeUnit defaultUnit,
+      @Nullable final Duration minimumDuration) {
+    long timeMillis = conf.getTimeDuration(name,
+        defVal, defaultUnit, TimeUnit.MILLISECONDS);
+
+    if (timeMillis > Integer.MAX_VALUE) {
+      TIMEOUT_WARN_LOG.warn("Option {} is too high({} ms). Setting to {} ms instead",
+          name, timeMillis, Integer.MAX_VALUE);
+      LOG.debug("Option {} is too high({} ms). Setting to {} ms instead",
+          name, timeMillis, Integer.MAX_VALUE);
+      timeMillis = Integer.MAX_VALUE;
+    }
+
+    Duration duration = enforceMinimumDuration(name, Duration.ofMillis(timeMillis),
+        minimumDuration);
+    LOG.debug("Duration of {} = {}", name, duration);
+    return duration;
+  }
+
+  /**
+   * Set a duration as a time in seconds, with the suffix "s" added.
+   * @param conf configuration to update.
+   * @param name option name
+   * @param duration duration
+   */
+  public static void setDurationAsSeconds(
+      final Configuration conf,
+      final String name,
+      final Duration duration) {
+    conf.set(name, duration.getSeconds() + "s");
+  }
+
+  /**
+   * Set a duration as a time in milliseconds, with the suffix "ms" added.
+   * @param conf configuration to update.
+   * @param name option name
+   * @param duration duration
+   */
+  public static void setDurationAsMillis(
+      final Configuration conf,
+      final String name,
+      final Duration duration) {
+    conf.set(name, duration.toMillis()+ "ms");
+  }
+
+  /**
+   * Enforce a minimum duration of a configuration option, if the supplied
+   * value is non-null.
+   * @param name option name
+   * @param duration duration to check
+   * @param minimumDuration minimum duration; may be null
+   * @return a duration which, if the minimum duration is set, is at least that value.
+   */
+  public static Duration enforceMinimumDuration(
+      final String name,
+      final Duration duration, @Nullable final Duration minimumDuration) {
+    if (minimumDuration != null && duration.compareTo(minimumDuration) < 0) {
+      TIMEOUT_WARN_LOG.warn("Option {} is too low({} ms). Setting to {} ms instead",
+          name, duration.toMillis(), minimumDuration.toMillis());
+      LOG.debug("Option {} is too low({} ms). Setting to {} ms instead",
+          name, duration.toMillis(), minimumDuration.toMillis());
+      return minimumDuration;
+    }
+    return duration;
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
@@ -242,11 +242,4 @@ public final class InternalConstants {
       Collections.unmodifiableSet(
           new HashSet<>(Arrays.asList(Constants.FS_S3A_CREATE_PERFORMANCE)));
 
-  /**
-   * This is the minimum operation duration unless programmatically set.
-   * It ensures that even if a configuration has mistaken a millisecond
-   * option for seconds, a viable duration will actually be used.
-   */
-  public static final Duration MINIMUM_OPERATION_DURATION = Duration.ofSeconds(15);
-
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.s3a.impl;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -237,5 +238,20 @@ public final class InternalConstants {
   public static final Set<String> CREATE_FILE_KEYS =
       Collections.unmodifiableSet(
           new HashSet<>(Arrays.asList(Constants.FS_S3A_CREATE_PERFORMANCE)));
+
+  /**
+   * This is the minimum operation duration unless programmatically set.
+   * It ensures that even if a configuration has mistaken a millisecond
+   * option for seconds, a viable duration will actually be used.
+   */
+  public static final Duration MINIMUM_OPERATION_DURATION = Duration.ofSeconds(10);
+
+  /**
+   * Should the idle connection reaper be used?
+   * It is hard to see why it would not be; this constant
+   * is here to make explicit where the option is set in case
+   * anyone ever wishes to experiment with it.
+   */
+  public static final boolean USE_IDLE_HTTP_CONNECTION_REAPER = true;
 
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
@@ -173,6 +173,9 @@ public final class InternalConstants {
   /** 503 status code: Service Unavailable. on AWS S3: throttle response. */
   public static final int SC_503_SERVICE_UNAVAILABLE = 503;
 
+  /** 504 Gateway Timeout. AWS SDK considers retryable. */
+  public static final int SC_504_GATEWAY_TIMEOUT = 504;
+
   /** Name of the log for throttling events. Value: {@value}. */
   public static final String THROTTLE_LOG_NAME =
       "org.apache.hadoop.fs.s3a.throttled";
@@ -244,14 +247,6 @@ public final class InternalConstants {
    * It ensures that even if a configuration has mistaken a millisecond
    * option for seconds, a viable duration will actually be used.
    */
-  public static final Duration MINIMUM_OPERATION_DURATION = Duration.ofSeconds(10);
-
-  /**
-   * Should the idle connection reaper be used?
-   * It is hard to see why it would not be; this constant
-   * is here to make explicit where the option is set in case
-   * anyone ever wishes to experiment with it.
-   */
-  public static final boolean USE_IDLE_HTTP_CONNECTION_REAPER = true;
+  public static final Duration MINIMUM_OPERATION_DURATION = Duration.ofSeconds(15);
 
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.fs.s3a.impl;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -703,8 +703,12 @@ to allow different buckets to override the shared settings. This is commonly
 used to change the endpoint, encryption and authentication mechanisms of buckets.
 and various minor options.
 
-Here are the S3A properties for use in production; some testing-related
-options are covered in [Testing](./testing.md).
+Here are the S3A properties for use in production; 
+
+* See [Performance](./performance.html) for performance related settings including
+  thread and network pool options.
+* some testing-related options are covered in [Testing](./testing.md).
+
 
 ```xml
 
@@ -831,16 +835,6 @@ options are covered in [Testing](./testing.md).
 </property>
 
 <property>
-  <name>fs.s3a.connection.maximum</name>
-  <value>96</value>
-  <description>Controls the maximum number of simultaneous connections to S3.
-    This must be bigger than the value of fs.s3a.threads.max so as to stop
-    threads being blocked waiting for new HTTPS connections.
-    Why not equal? The AWS SDK transfer manager also uses these connections.
-  </description>
-</property>
-
-<property>
   <name>fs.s3a.connection.ssl.enabled</name>
   <value>true</value>
   <description>Enables or disables SSL connections to AWS services.
@@ -909,18 +903,6 @@ options are covered in [Testing](./testing.md).
 </property>
 
 <property>
-  <name>fs.s3a.connection.establish.timeout</name>
-  <value>5000</value>
-  <description>Socket connection setup timeout in milliseconds.</description>
-</property>
-
-<property>
-  <name>fs.s3a.connection.timeout</name>
-  <value>200000</value>
-  <description>Socket connection timeout in milliseconds.</description>
-</property>
-
-<property>
   <name>fs.s3a.socket.send.buffer</name>
   <value>8192</value>
   <description>Socket send buffer hint to amazon connector. Represented in bytes.</description>
@@ -937,43 +919,6 @@ options are covered in [Testing](./testing.md).
   <value>5000</value>
   <description>How many keys to request from S3 when doing
      directory listings at a time.</description>
-</property>
-
-<property>
-  <name>fs.s3a.threads.max</name>
-  <value>64</value>
-  <description>The total number of threads available in the filesystem for data
-    uploads *or any other queued filesystem operation*.</description>
-</property>
-
-<property>
-  <name>fs.s3a.threads.keepalivetime</name>
-  <value>60</value>
-  <description>Number of seconds a thread can be idle before being
-    terminated.</description>
-</property>
-
-<property>
-  <name>fs.s3a.max.total.tasks</name>
-  <value>32</value>
-  <description>The number of operations which can be queued for execution.
-  This is in addition to the number of active threads in fs.s3a.threads.max.
-  </description>
-</property>
-
-<property>
-  <name>fs.s3a.executor.capacity</name>
-  <value>16</value>
-  <description>The maximum number of submitted tasks which is a single
-    operation (e.g. rename(), delete()) may submit simultaneously for
-    execution -excluding the IO-heavy block uploads, whose capacity
-    is set in "fs.s3a.fast.upload.active.blocks"
-
-    All tasks are submitted to the shared thread pool whose size is
-    set in "fs.s3a.threads.max"; the value of capacity should be less than that
-    of the thread pool itself, as the goal is to stop a single operation
-    from overloading that thread pool.
-  </description>
 </property>
 
 <property>
@@ -2232,43 +2177,33 @@ from VMs running on EC2.
   </description>
 </property>
 
-<property>
-  <name>fs.s3a.threads.max</name>
-  <value>10</value>
-  <description>The total number of threads available in the filesystem for data
-    uploads *or any other queued filesystem operation*.</description>
-</property>
-
-<property>
-  <name>fs.s3a.max.total.tasks</name>
-  <value>5</value>
-  <description>The number of operations which can be queued for execution</description>
-</property>
-
-<property>
-  <name>fs.s3a.threads.keepalivetime</name>
-  <value>60</value>
-  <description>Number of seconds a thread can be idle before being
-    terminated.</description>
-</property>
 ```
 
 ### <a name="multipart_purge"></a>Cleaning up after partial Upload Failures
 
-There are two mechanisms for cleaning up after leftover multipart
+There are four mechanisms for cleaning up after leftover multipart
 uploads:
+- AWS Lifecycle rules. This is the simplest and SHOULD be used unless there
+  are are good reasons, such as the store not supporting lifecycle rules.
 - Hadoop s3guard CLI commands for listing and deleting uploads by their
 age. Documented in the [S3Guard](./s3guard.html) section.
+- Setting `fs.s3a.directory.operations.purge.uploads` to `true` for automatic
+  scan and delete during directory rename and delete
 - The configuration parameter `fs.s3a.multipart.purge`, covered below.
 
 If a large stream write operation is interrupted, there may be
 intermediate partitions uploaded to S3 —data which will be billed for.
+If an S3A committer job is halted partway through, again, there may be
+many incomplete multipart uploads in the output directory. 
 
 These charges can be reduced by enabling `fs.s3a.multipart.purge`,
-and setting a purge time in seconds, such as 86400 seconds —24 hours.
+and setting a purge time in seconds, such as 24 hours.
 When an S3A FileSystem instance is instantiated with the purge time greater
 than zero, it will, on startup, delete all outstanding partition requests
-older than this time.
+older than this time. However, this makes filesystem instantiate slow, especially
+against very large buckets, as a full scan is made.
+
+Consider avoiding this in future.
 
 ```xml
 <property>
@@ -2280,7 +2215,7 @@ older than this time.
 
 <property>
   <name>fs.s3a.multipart.purge.age</name>
-  <value>86400</value>
+  <value>24h</value>
   <description>Minimum age in seconds of multipart uploads to purge</description>
 </property>
 ```

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -703,11 +703,11 @@ to allow different buckets to override the shared settings. This is commonly
 used to change the endpoint, encryption and authentication mechanisms of buckets.
 and various minor options.
 
-Here are the S3A properties for use in production; 
+Here are some the S3A properties for use in production.
 
 * See [Performance](./performance.html) for performance related settings including
   thread and network pool options.
-* some testing-related options are covered in [Testing](./testing.md).
+* Testing-related options are covered in [Testing](./testing.md).
 
 
 ```xml
@@ -2194,7 +2194,7 @@ age. Documented in the [S3Guard](./s3guard.html) section.
 If a large stream write operation is interrupted, there may be
 intermediate partitions uploaded to S3 —data which will be billed for.
 If an S3A committer job is halted partway through, again, there may be
-many incomplete multipart uploads in the output directory. 
+many incomplete multipart uploads in the output directory.
 
 These charges can be reduced by enabling `fs.s3a.multipart.purge`,
 and setting a purge time in seconds, such as 24 hours.

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
@@ -199,8 +199,10 @@ Fix: Use one of the dedicated [S3A Committers](committers.md).
 ### <a name="pooling"></a> Thread and connection pool settings.
 
 Each S3A client interacting with a single bucket, as a single user, has its
-own dedicated pool of open HTTP 1.1 connections alongside a pool of threads used
-for upload and copy operations.
+own dedicated pool of open HTTP connections alongside a pool of threads used
+for background/parallel operations in addition to the worker threads of the
+actual application.
+
 The default pool sizes are intended to strike a balance between performance
 and memory/thread use.
 
@@ -209,12 +211,12 @@ for parallel IO (especially uploads, prefetching and vector reads) by setting th
 properties. Note: S3A Connectors have their own thread pools for job commit, but
 everything uses the same HTTP connection pool.
 
-| Property                       | Default | Meaning                                  |
-|--------------------------------|---------|------------------------------------------|
-| `fs.s3a.threads.max`           | `96`    | Threads in the thread pool               |
-| `fs.s3a.threads.keepalivetime` | `60s`   | Threads in the thread pool               |
-| `fs.s3a.executor.capacity`     | `16`    | Maximum threads for any single operation |
-| `fs.s3a.max.total.tasks`       | `16`    | Extra tasks which can be queued          |
+| Property                       | Default | Meaning                                                          |
+|--------------------------------|---------|------------------------------------------------------------------|
+| `fs.s3a.threads.max`           | `96`    | Threads in the thread pool                                       |
+| `fs.s3a.threads.keepalivetime` | `60s`   | Expiry time for idle threads in the thread pool                  |
+| `fs.s3a.executor.capacity`     | `16`    | Maximum threads for any single operation                         |
+| `fs.s3a.max.total.tasks`       | `16`    | Extra tasks which can be queued excluding prefetching operations |
 
 
 Network timeout options can be tuned to make the client fail faster *or* retry more.
@@ -223,10 +225,6 @@ The choice is yours. Generally recovery is better, but sometimes fail-fast is mo
 
 | Property                                | Default | V2  | Meaning                                               |
 |-----------------------------------------|---------|:----|-------------------------------------------------------|
-| `fs.s3a.threads.max`                    | `96`    |     | Threads in the thread pool                            |
-| `fs.s3a.threads.keepalivetime`          | `60s`   |     | Threads in the thread pool                            |
-| `fs.s3a.executor.capacity`              | `16`    |     | Maximum threads for any single operation              |
-| `fs.s3a.max.total.tasks`                | `16`    |     | Maximum threads for any single operation              |
 | `fs.s3a.connection.maximum`             | `200`   |     | Connection pool size                                  |
 | `fs.s3a.connection.keepalive`           | `false` | `*` | Use TCP keepalive on open channels                    |
 | `fs.s3a.connection.acquisition.timeout` | `60s`   | `*` | Timeout for waiting for a connection from the pool.   |

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
@@ -196,7 +196,7 @@ Fix: Use one of the dedicated [S3A Committers](committers.md).
 
 ## <a name="tuning"></a> Options to Tune
 
-### <a name="pooling"></a> Thread and connection pool sizes.
+### <a name="pooling"></a> Thread and connection pool settings.
 
 Each S3A client interacting with a single bucket, as a single user, has its
 own dedicated pool of open HTTP 1.1 connections alongside a pool of threads used
@@ -207,29 +207,65 @@ and memory/thread use.
 You can have a larger pool of (reused) HTTP connections and threads
 for parallel IO (especially uploads) by setting the properties
 
+Network timeout options can be tuned to make the client fail faster *or* retry more.
+The choice is yours. Generally recovery is better, but sometimes fail-fast is more useful.
 
-| property | meaning | default |
-|----------|---------|---------|
-| `fs.s3a.threads.max`| Threads in the AWS transfer manager| 10 |
-| `fs.s3a.connection.maximum`| Maximum number of HTTP connections | 10|
 
-We recommend using larger values for processes which perform
-a lot of IO: `DistCp`, Spark Workers and similar.
 
-```xml
-<property>
-  <name>fs.s3a.threads.max</name>
-  <value>20</value>
-</property>
-<property>
-  <name>fs.s3a.connection.maximum</name>
-  <value>20</value>
-</property>
-```
+| Property                                | Default | V2  | Meaning                                               |
+|-----------------------------------------|---------|:----|-------------------------------------------------------|
+| `fs.s3a.threads.max`                    | `64`    |     | Threads in the thread pool                            |
+| `fs.s3a.connection.maximum`             | `200`   |     | Connection pool size                                  |
+| `fs.s3a.connection.keepalive`           | `false` | `*` | Use TCP keepalive on open channels                    |
+| `fs.s3a.connection.acquisition.timeout` | `60s`   | `*` | Timeout for waiting for a connection from the pool.   |
+| `fs.s3a.connection.establish.timeout`   | `30s`   |     | Time to establish the TCP/TLS connection              |
+| `fs.s3a.connection.idle.time`           | `60s`   | `*` | Maximum time for idle HTTP connections in the pool    |
+| `fs.s3a.connection.request.timeout`     | `0`     |     | If greater than zero, maximum duration of any request |
+| `fs.s3a.connection.timeout`             | `200s`  |     | Timeout for socket problems on a TCP channel          |
+| `fs.s3a.connection.ttl`                 | `5m`    |     | Lifetime of HTTP connections from the pool            |
 
-Be aware, however, that processes which perform many parallel queries
-may consume large amounts of resources if each query is working with
-a different set of s3 buckets, or are acting on behalf of different users.
+
+Units:
+1. The default unit for all these options is milliseconds, unless a time suffix is declared.
+2. Versions of Hadoop built with the AWS V1 SDK *only* support milliseconds rather than suffix values.
+   If configurations are intended to apply across hadoop releases, you MUST use milliseconds without a suffix.
+3. Options flagged as "V2" are new with the AWS V2 SDK; they are ignored on V1 releases.
+
+--- 
+There are some hard tuning decisions related to pool size and expiry.
+As servers add more cores and services add many more worker threads, a larger pool size is more and more important:
+the default values in `core-default.xml` have been slowly increased over time but should be treated as
+"the best", simply what is considered a good starting case.
+With Vectored IO adding multiple GET requests per Spark/Hive worker thread,
+and stream prefetching performing background block prefetch, larger pool and thread sizes are even more important.
+
+In large hive deployments, thread and connection pools of thousands have been known to have been set.
+
+Small pool: small value in `fs.s3a.connection.maximum`. Cost of having many S3A instances in the same process low. But: limit on how many connections can be open at at a time. 
+
+Large Pool. More HTTP connections can be created and kept, but cost of keeping network connections increases.
+
+If exceptions are raised with about timeouts acquiring connections from the pool, this can be a symptom of
+* Heavy load. Increase pool size and acquisition timeout `fs.s3a.connection.acquisition.timeout`
+* Process failing to close open input streams from the S3 store. Fix: Find uses of `open()`/`openFile()` and make sure that the streams are being `close()d`j
+
+*Retirement of HTTP Connections.*
+
+Connections are retired from the pool by `fs.s3a.connection.idle.time`, the maximum time for idle connections, and `fs.s3a.connection.ttl`, the maximum life of any connection in the pool, even if it repeatedly reused.
+
+Limiting idle time saves on network connections, at the cost of requiring new connections on subsequent S3 operations.
+
+Limiting connection TTL is useful to spread across load balancers and recover from some network
+connection problems, including those caused by proxies.
+
+*Request timeout*: `fs.s3a.connection.request.timeout`
+
+If set, this sets an upper limit on any non-streaming API call (i.e. everything but `GET`).
+
+A timeout is good to detect and recover from failures.
+However, it also sets a limit on the duration of a POST/PUT of data 
+-which, if after a timeout, will only be repeated, ultimately to failure.
+
 
 ### For large data uploads, tune the block size: `fs.s3a.block.size`
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -1574,4 +1574,6 @@ public final class S3ATestUtils {
   }
 
 
+
+
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -1574,6 +1574,4 @@ public final class S3ATestUtils {
   }
 
 
-
-
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestConnectionTimeouts.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestConnectionTimeouts.java
@@ -126,16 +126,12 @@ public class ITestConnectionTimeouts extends AbstractS3ATestBase {
           streams.add(in);
           // kick off the read so forcing a GET.
           in.read();
-
         }
       });
     } finally {
-       streams.forEach(s -> {
-         IOUtils.cleanupWithLogger(LOG, s);
-       });
-
+      streams.forEach(s -> {
+        IOUtils.cleanupWithLogger(LOG, s);
+      });
     }
-
-
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestConnectionTimeouts.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestConnectionTimeouts.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.fs.FutureDataInputStreamBuilder;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.s3a.AbstractS3ATestBase;
-import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.net.ConnectTimeoutException;
 
@@ -50,7 +49,6 @@ import static org.apache.hadoop.fs.s3a.Constants.PREFETCH_ENABLED_KEY;
 import static org.apache.hadoop.fs.s3a.Constants.REQUEST_TIMEOUT;
 import static org.apache.hadoop.fs.s3a.Constants.RETRY_LIMIT;
 import static org.apache.hadoop.fs.s3a.Constants.SOCKET_TIMEOUT;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.impl.ConfigurationHelper.setDurationAsMillis;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestConnectionTimeouts.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestConnectionTimeouts.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FutureDataInputStreamBuilder;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.s3a.AbstractS3ATestBase;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.net.ConnectTimeoutException;
+
+import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY;
+import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY_WHOLE_FILE;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_ACQUISITION_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_IDLE_TIME;
+import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_TTL;
+import static org.apache.hadoop.fs.s3a.Constants.ESTABLISH_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.Constants.FS_S3A_CREATE_PERFORMANCE;
+import static org.apache.hadoop.fs.s3a.Constants.MAXIMUM_CONNECTIONS;
+import static org.apache.hadoop.fs.s3a.Constants.MAX_ERROR_RETRIES;
+import static org.apache.hadoop.fs.s3a.Constants.REQUEST_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.Constants.RETRY_LIMIT;
+import static org.apache.hadoop.fs.s3a.Constants.SOCKET_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
+import static org.apache.hadoop.fs.s3a.impl.ConfigurationHelper.setDurationAsMillis;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+
+/**
+ * Test for timeout generation/handling, especially those related to connection
+ * pools.
+ */
+public class ITestConnectionTimeouts extends AbstractS3ATestBase {
+
+
+  /**
+   * How big a file to create?
+   */
+  public static final int FILE_SIZE = 1024;
+
+  @Override
+  protected Configuration createConfiguration() {
+    Configuration conf = super.createConfiguration();
+    removeBaseAndBucketOverrides(conf,
+        CONNECTION_TTL,
+        CONNECTION_ACQUISITION_TIMEOUT,
+        CONNECTION_IDLE_TIME,
+        ESTABLISH_TIMEOUT,
+        MAX_ERROR_RETRIES,
+        MAXIMUM_CONNECTIONS,
+        REQUEST_TIMEOUT,
+        SOCKET_TIMEOUT,
+        FS_S3A_CREATE_PERFORMANCE
+    );
+
+    // only one connection is allowed, and the establish timeout is low
+    conf.setInt(MAXIMUM_CONNECTIONS, 1);
+    conf.setInt(MAX_ERROR_RETRIES, 1);
+    conf.setInt(RETRY_LIMIT, 1);
+    conf.setBoolean(FS_S3A_CREATE_PERFORMANCE, true);
+    final Duration ms10 = Duration.ofMillis(10);
+    setDurationAsMillis(conf, CONNECTION_ACQUISITION_TIMEOUT, ms10);
+    setDurationAsMillis(conf, ESTABLISH_TIMEOUT, ms10);
+
+    return conf;
+  }
+
+  @Override
+  public void setup() throws Exception {
+    AWSClientConfig.setMinimumOperationDuration(Duration.ZERO);
+    super.setup();
+  }
+
+  @Override
+  public void teardown() throws Exception {
+    AWSClientConfig.resetMinimumOperationDuration();
+    super.teardown();
+  }
+
+  /**
+   * Use up the connection pool and expect the failure to be handled.
+   */
+  @Test
+  public void testGeneratePoolTimeouts() throws Throwable {
+    byte[] data = dataset(FILE_SIZE, '0', 10);
+    S3AFileSystem fs = getFileSystem();
+    Path path = methodPath();
+    ContractTestUtils.createFile(fs, path, true, data);
+    final FileStatus st = fs.getFileStatus(path);
+    int streamsToCreate = 20;
+    List<FSDataInputStream> streams = new ArrayList<>(streamsToCreate);
+    try {
+      intercept(ConnectTimeoutException.class, () -> {
+        for (int i = 0; i < streamsToCreate; i++) {
+          FutureDataInputStreamBuilder b = fs.openFile(path);
+          b.withFileStatus(st);
+          b.opt(FS_OPTION_OPENFILE_READ_POLICY, FS_OPTION_OPENFILE_READ_POLICY_WHOLE_FILE);
+
+          final FSDataInputStream in = b.build().get();
+          streams.add(in);
+          // kick off the read so forcing a GET.
+          in.read();
+
+        }
+      });
+    } finally {
+       streams.forEach(s -> {
+         IOUtils.cleanupWithLogger(LOG, s);
+       });
+
+    }
+
+
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
@@ -87,7 +87,7 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
         .describedAs("10s")
         .isEqualTo(s10);
 
-    // and a null checkNo it's kind of like get out the wayI am
+    // and a null check
     Assertions.assertThat(enforceMinimumDuration("key",
            s1, null))
         .describedAs("10s")
@@ -163,17 +163,16 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
   }
 
   /**
-   * Test that {@link AWSClientConfig#createApiConnectionSettings(Configuration)}
-   * loads the subset of options needed for setting up the client config builder.
+   * Test {@link AWSClientConfig#createApiConnectionSettings(Configuration)}.
    */
   @Test
   public void testCreateApiConnectionSettings() {
     final Configuration conf = conf();
     conf.set(REQUEST_TIMEOUT, "1h");
-    final AWSClientConfig.ConnectionSettings conn =
+    final AWSClientConfig.ClientSettings settings =
         createApiConnectionSettings(conf);
-    Assertions.assertThat(conn.getApiCallTimeout())
-        .describedAs("%s in %s", REQUEST_TIMEOUT, conn)
+    Assertions.assertThat(settings.getApiCallTimeout())
+        .describedAs("%s in %s", REQUEST_TIMEOUT, settings)
         .isEqualTo(Duration.ofHours(1));
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
@@ -34,7 +34,7 @@ import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_ACQUISITION_TIMEOUT;
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_IDLE_TIME;
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_KEEPALIVE;
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_TTL;
-import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_ACQUISITION_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_ACQUISITION_TIMEOUT_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_IDLE_TIME_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_KEEPALIVE;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_TTL_DURATION;
@@ -87,7 +87,7 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
         .describedAs("10s")
         .isEqualTo(s10);
 
-    // and a null check
+    // and a null checkNo it's kind of like get out the wayI am
     Assertions.assertThat(enforceMinimumDuration("key",
            s1, null))
         .describedAs("10s")
@@ -101,7 +101,7 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
   @Test
   public void testLoadUnsetValues() {
     final AWSClientConfig.ConnectionSettings conn = createConnectionSettings(conf());
-    assertDuration(CONNECTION_ACQUISITION_TIMEOUT, DEFAULT_CONNECTION_ACQUISITION_TIMEOUT,
+    assertDuration(CONNECTION_ACQUISITION_TIMEOUT, DEFAULT_CONNECTION_ACQUISITION_TIMEOUT_DURATION,
         conn.getAcquisitionTimeout());
     assertDuration(CONNECTION_TTL, DEFAULT_CONNECTION_TTL_DURATION,
         conn.getConnectionTTL());

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.time.Duration;
+import java.util.Arrays;
+
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_ACQUISITION_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_IDLE_TIME;
+import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_KEEPALIVE;
+import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_TTL;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_ACQUISITION_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_IDLE_TIME;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_KEEPALIVE;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_TTL;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_ESTABLISH_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_MAXIMUM_CONNECTIONS;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_SOCKET_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.Constants.ESTABLISH_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.Constants.MAXIMUM_CONNECTIONS;
+import static org.apache.hadoop.fs.s3a.Constants.MINIMUM_NETWORK_OPERATION_DURATION;
+import static org.apache.hadoop.fs.s3a.Constants.REQUEST_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.Constants.SOCKET_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.impl.AWSClientConfig.createApiConnectionSettings;
+import static org.apache.hadoop.fs.s3a.impl.AWSClientConfig.createConnectionSettings;
+import static org.apache.hadoop.fs.s3a.impl.ConfigurationHelper.enforceMinimumDuration;
+
+/**
+ * Unit tests for {@link AWSClientConfig}.
+ * These may play with the config timeout settings, so reset the timeouts
+ * during teardown.
+ * For isolation from any site settings, the tests create configurations
+ * without loading of defaut/site XML files.
+ */
+public class TestAwsClientConfig extends AbstractHadoopTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestAwsClientConfig.class);
+
+  @After
+  public void teardown() throws Exception {
+    AWSClientConfig.resetMinimumOperationDuration();
+  }
+
+  /**
+   * Create a new empty configuration
+   * @return configuration.
+   */
+  private Configuration conf() {
+    return new Configuration(false);
+  }
+
+  /**
+   * Innermost duration enforcement, which is not applied if
+   * the minimum value is null.
+   */
+  @Test
+  public void testEnforceMinDuration() {
+    final Duration s10 = Duration.ofSeconds(10);
+    final Duration s1 = Duration.ofSeconds(1);
+
+    Assertions.assertThat(enforceMinimumDuration("key", s1, s10))
+        .describedAs("10s")
+        .isEqualTo(s10);
+
+    // and a null check
+    Assertions.assertThat(enforceMinimumDuration("key",
+           s1, null))
+        .describedAs("10s")
+        .isEqualTo(s1);
+  }
+
+  @Test
+  public void testLoadUnsetValues() {
+    final AWSClientConfig.ConnectionSettings conn = createConnectionSettings(conf());
+    assertDuration(CONNECTION_ACQUISITION_TIMEOUT, DEFAULT_CONNECTION_ACQUISITION_TIMEOUT,
+        conn.getAcquisitionTimeout());
+    assertDuration(CONNECTION_TTL, DEFAULT_CONNECTION_TTL,
+        conn.getConnectionTTL());
+    assertDuration(CONNECTION_IDLE_TIME, DEFAULT_CONNECTION_IDLE_TIME, conn.getMaxIdleTime());
+    assertDuration(ESTABLISH_TIMEOUT, DEFAULT_ESTABLISH_TIMEOUT, conn.getEstablishTimeout());
+    assertDuration(SOCKET_TIMEOUT, DEFAULT_SOCKET_TIMEOUT, conn.getSocketTimeout());
+    Assertions.assertThat(conn.getMaxConnections())
+        .describedAs(MAXIMUM_CONNECTIONS)
+        .isEqualTo(DEFAULT_MAXIMUM_CONNECTIONS);
+    Assertions.assertThat(conn.isKeepAlive())
+        .describedAs(CONNECTION_KEEPALIVE)
+        .isEqualTo(DEFAULT_CONNECTION_KEEPALIVE);
+  }
+
+  /**
+   * If we set a minimum duration that is bigger than the configured value,
+   * the minimum value wins.
+   * Some options have a minimum value of zero.
+   */
+  @Test
+  public void testMinimumDurationWins() {
+
+    final Configuration conf = conf();
+    setOptionsToValue("1s", conf,
+        CONNECTION_ACQUISITION_TIMEOUT,
+        CONNECTION_TTL,
+        CONNECTION_IDLE_TIME,
+        ESTABLISH_TIMEOUT,
+        SOCKET_TIMEOUT);
+    final AWSClientConfig.ConnectionSettings conn = createConnectionSettings(conf);
+    LOG.info("Connection settings: {}", conn);
+    assertDuration(CONNECTION_ACQUISITION_TIMEOUT, MINIMUM_NETWORK_OPERATION_DURATION,
+        conn.getAcquisitionTimeout());
+
+    assertDuration(ESTABLISH_TIMEOUT, MINIMUM_NETWORK_OPERATION_DURATION,
+        conn.getEstablishTimeout());
+    assertDuration(SOCKET_TIMEOUT, MINIMUM_NETWORK_OPERATION_DURATION, conn.getSocketTimeout());
+
+    // those options with a minimum of zero
+    final Duration s1 = Duration.ofSeconds(1);
+    assertDuration(CONNECTION_TTL, s1, conn.getConnectionTTL());
+    assertDuration(CONNECTION_IDLE_TIME, s1, conn.getMaxIdleTime());
+  }
+
+  private void assertDuration(String name, long expected, Duration duration) {
+    Assertions.assertThat(duration.toMillis())
+        .describedAs(name)
+        .isEqualTo(expected);
+  }
+
+  private void assertDuration(String name, Duration expected, Duration duration) {
+    Assertions.assertThat(duration)
+        .describedAs("option %s with value %d ms", name, duration.toMillis())
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testCreateApiConnectionSettings() throws Throwable {
+    final Configuration conf = conf();
+    conf.set(REQUEST_TIMEOUT, "1h");
+    final AWSClientConfig.ConnectionSettings conn =
+        createApiConnectionSettings(conf);
+    Assertions.assertThat(conn.getApiCallTimeout())
+        .describedAs("%s in %s", REQUEST_TIMEOUT, conn)
+        .isEqualTo(Duration.ofHours(1));
+  }
+
+  /**
+   * Set a list of keys to the same value.
+   * @param value value to set
+   * @param conf configuration to patch
+   * @param keys keys
+   */
+  private void setOptionsToValue(String value, Configuration conf, String... keys) {
+    Arrays.stream(keys).forEach(key -> conf.set(key, value));
+  }
+}


### PR DESCRIPTION
* Default time unit for all values is milliseconds
* Use getDuration() so human units are supported
* add a minimum duration so that even if a config sets seconds "60" it's bumped up to something viable
* add options for the new acquisition, idle timeouts
* handle api timeout exceptions as retryable


### How was this patch tested?

* s3 london
* the minimum operation time can be overridden for testing.
* new test to trigger failures (1 pool entry, open a file, try to do another request...)


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

