### PR TITLE
HDFS-17223. Add journalnode maintenance node list

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1466,6 +1466,10 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
           "dfs.journalnode.edit-cache-size.fraction";
   public static final float DFS_JOURNALNODE_EDIT_CACHE_SIZE_FRACTION_DEFAULT = 0.5f;
 
+  public static final String  DFS_JOURNALNODE_MAINTENANCE_NODES_KEY =
+      "dfs.journalnode.maintenance.nodes";
+  public static final String[]  DFS_JOURNALNODE_MAINTENANCE_NODES_DEFAULT = {};
+
   // Journal-node related configs for the client side.
   public static final String  DFS_QJOURNAL_QUEUE_SIZE_LIMIT_KEY = "dfs.qjournal.queued-edits.limit.mb";
   public static final int     DFS_QJOURNAL_QUEUE_SIZE_LIMIT_DEFAULT = 10;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
@@ -70,6 +70,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.ParentNotDirectoryException;
 import org.apache.hadoop.fs.UnresolvedLinkException;
+import org.apache.hadoop.hdfs.server.blockmanagement.HostSet;
 import org.apache.hadoop.hdfs.server.datanode.metrics.DataNodeMetrics;
 import org.apache.hadoop.hdfs.server.namenode.FSDirectory;
 import org.apache.hadoop.hdfs.server.namenode.INodesInPath;
@@ -1981,5 +1982,33 @@ public class DFSUtil {
     } else {
       LOG.warn("Unexpected value for data transfer bytes={} duration={}", read, duration);
     }
+  }
+
+  /**
+   * Construct a HostSet from an array of "ip:port" strings.
+   * @param nodesHostPort ip port string array.
+   * @return HostSet of InetSocketAddress.
+   */
+  public static HostSet getHostSet(String[] nodesHostPort) {
+    HostSet retSet = new HostSet();
+    for (String hostPort : nodesHostPort) {
+      try {
+        URI uri = new URI("dummy", hostPort, null, null, null);
+        int port = uri.getPort();
+        if (port < 0) {
+          LOG.warn(String.format("The ip:port `%s` is invalid, skip this node.", hostPort));
+          continue;
+        }
+        InetSocketAddress inetSocketAddress = new InetSocketAddress(uri.getHost(), port);
+        if (inetSocketAddress.isUnresolved()) {
+          LOG.warn(String.format("Failed to resolve address `%s`", hostPort));
+          continue;
+        }
+        retSet.add(inetSocketAddress);
+      } catch (URISyntaxException e) {
+        LOG.warn(String.format("Failed to parse `%s`", hostPort));
+      }
+    }
+    return retSet;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/AsyncLoggerSet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/AsyncLoggerSet.java
@@ -53,9 +53,15 @@ class AsyncLoggerSet {
   
   private static final long INVALID_EPOCH = -1;
   private long myEpoch = INVALID_EPOCH;
+  private final int majoritySize;
   
-  public AsyncLoggerSet(List<AsyncLogger> loggers) {
+  AsyncLoggerSet(List<AsyncLogger> loggers) {
+    this(loggers, loggers.size());
+  }
+
+  AsyncLoggerSet(List<AsyncLogger> loggers, int quorumJournalCount) {
     this.loggers = ImmutableList.copyOf(loggers);
+    this.majoritySize = quorumJournalCount / 2 + 1;
   }
   
   void setEpoch(long e) {
@@ -151,7 +157,7 @@ class AsyncLoggerSet {
    * @return the number of nodes which are required to obtain a quorum.
    */
   int getMajoritySize() {
-    return loggers.size() / 2 + 1;
+    return this.majoritySize;
   }
   
   /**
@@ -159,6 +165,11 @@ class AsyncLoggerSet {
    */
   String getMajorityString() {
     return getMajoritySize() + "/" + loggers.size();
+  }
+
+  @VisibleForTesting
+  List<AsyncLogger> getLoggerListForTests() {
+    return loggers;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HostSet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HostSet.java
@@ -45,7 +45,7 @@ public class HostSet implements Iterable<InetSocketAddress> {
    * The function that checks whether there exists an entry foo in the set
    * so that foo &lt;= addr.
    */
-  boolean matchedBy(InetSocketAddress addr) {
+  public boolean matchedBy(InetSocketAddress addr) {
     Collection<Integer> ports = addrs.get(addr.getAddress());
     return addr.getPort() == 0 ? !ports.isEmpty() : ports.contains(addr
         .getPort());
@@ -55,7 +55,7 @@ public class HostSet implements Iterable<InetSocketAddress> {
    * The function that checks whether there exists an entry foo in the set
    * so that addr &lt;= foo.
    */
-  boolean match(InetSocketAddress addr) {
+  public boolean match(InetSocketAddress addr) {
     int port = addr.getPort();
     Collection<Integer> ports = addrs.get(addr.getAddress());
     boolean exactMatch = ports.contains(port);
@@ -63,15 +63,15 @@ public class HostSet implements Iterable<InetSocketAddress> {
     return exactMatch || genericMatch;
   }
 
-  boolean isEmpty() {
+  public boolean isEmpty() {
     return addrs.isEmpty();
   }
 
-  int size() {
+  public int size() {
     return addrs.size();
   }
 
-  void add(InetSocketAddress addr) {
+  public void add(InetSocketAddress addr) {
     Preconditions.checkArgument(!addr.isUnresolved());
     addrs.put(addr.getAddress(), addr.getPort());
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6334,6 +6334,23 @@
   </property>
 
   <property>
+    <name>dfs.journalnode.maintenance.nodes</name>
+    <value></value>
+    <description>
+      In the case that one out of three journal nodes being down, theoretically HDFS can still
+      function. However, in reality, the unavailable journal node may not recover quickly. During
+      this period, when we need to restart an Namenode, the Namenode will try to connect to the
+      unavailable journal node through the lengthy RPC retry mechanism, resulting in a long
+      initialization time for the Namenode. By adding these unavailable journal nodes to the
+      maintenance nodes, we will skip these unavailable journal nodes during Namenode initialization
+      and thus reduce namenode startup time.
+      1-node example values: jn01:8485
+      2-node example values: jn01:8485,jn02:8485
+    </description>
+  </property>
+
+
+  <property>
     <name>dfs.namenode.lease-hard-limit-sec</name>
     <value>1200</value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
@@ -41,6 +41,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -72,6 +73,7 @@ import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
+import org.apache.hadoop.hdfs.server.blockmanagement.HostSet;
 import org.apache.hadoop.hdfs.server.datanode.metrics.DataNodeMetrics;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider;
@@ -1136,5 +1138,25 @@ public class TestDFSUtil {
     DataNodeMetrics mockMetrics = mock(DataNodeMetrics.class);
     DFSUtil.addTransferRateMetric(mockMetrics, 100, 0);
     verify(mockMetrics, times(0)).addReadTransferRate(anyLong());
+  }
+
+  @Test
+  public void testGetHostSet() {
+    String[] testAddrs = new String[] {"unreachable-host1.com:9000", "unreachable-host2.com:9000"};
+    HostSet hostSet = DFSUtil.getHostSet(testAddrs);
+    assertNotNull(hostSet);
+    assertEquals(0, hostSet.size());
+
+    String strAddress = "localhost";
+    testAddrs = new String[] {strAddress};
+    hostSet = DFSUtil.getHostSet(testAddrs);
+    assertEquals(0, hostSet.size());
+
+    strAddress = "localhost:9000";
+    InetSocketAddress inetSocketAddress = new InetSocketAddress("localhost", 9000);
+    testAddrs = new String[] {strAddress};
+    hostSet = DFSUtil.getHostSet(testAddrs);
+    assertNotNull(hostSet);
+    assertTrue(hostSet.match(inetSocketAddress));
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQuorumJournalManagerUnit.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQuorumJournalManagerUnit.java
@@ -95,6 +95,7 @@ public class TestQuorumJournalManagerUnit {
     qjm = new QuorumJournalManager(conf, new URI("qjournal://host/jid"), FAKE_NSINFO) {
       @Override
       protected List<AsyncLogger> createLoggers(AsyncLogger.Factory factory) {
+        setQuorumJournalCount(spyLoggers.size());
         return spyLoggers;
       }
     };


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

* In the case of configuring 3 journal nodes in HDFS, if only 2 journal nodes are available and 1 journal node fails to start due to machine issues, it will result in a long initialization time for the namenode (around 30-40 minutes, depending on the IPC timeout and retry policy configuration). 
* The failed journal node cannot recover immediately, but HDFS can still function in this situation. In our production environment, we encountered this issue and had to reduce the IPC timeout and adjust the retry policy to accelerate the namenode initialization and provide services. 
* I'm wondering if it would be possible to have a journal node maintenance list to speed up the namenode initialization knowing that one journal node cannot provide services in advance?

### How was this patch tested?
unit test.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

