### PR TITLE
HADOOP-18487. Protobuf 2.5 removal part 2: stop exporting protobuf-2.5

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -319,21 +319,27 @@ Controlling the redistribution of the protobuf-2.5 dependency
     the Hadoop codebase; alongside the move to Protobuf 3.x a private successor
     class, org.apache.hadoop.ipc.internal.ShadedProtobufHelper is now used.
 
-    The hadoop-common JAR still declares a dependency on protobuf-2.5, but this
-    is likely to change in the future. The maven scope of the dependency can be
-    set with the common.protobuf2.scope option.
-    It can be set to "provided" in a build:
-       -Dcommon.protobuf2.scope=provided
-    If this is done then protobuf-2.5.0.jar will no longer be exported as a dependency,
-    and will then be omitted from the share/hadoop/common/lib/ directory of
-    any Hadoop distribution built. Any application declaring a dependency on hadoop-commmon
-    will no longer get the dependency; if they need it then they must explicitly declare it:
+    The hadoop-common module no longer exports its compile-time dependency on
+    protobuf-2.5. Hadoop distributions no longer include it.
+    Any application declaring a dependency on hadoop-commmon will no longer get
+    the artifact added to their classpath.
+    If is still required, then they must explicitly declare it:
 
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>2.5.0</version>
       </dependency>
+
+    In Hadoop builds the scope of the dependency can be set with the
+    option "common.protobuf2.scope".
+    This can be upgraded from "provided" to "compile" on the maven command line:
+
+           -Dcommon.protobuf2.scope=compile
+
+    If this is done then protobuf-2.5.0.jar will again be exported as a
+    hadoop-common dependency, and included in the share/hadoop/common/lib/
+    directory of any Hadoop distribution built.
 
 ----------------------------------------------------------------------------------
 Building components separately

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -392,7 +392,6 @@ hadoop-tools/hadoop-sls/src/main/html/js/thirdparty/d3.v3.js
 hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/static/d3-3.5.17.min.js
 leveldb v1.13
 
-com.google.protobuf:protobuf-java:2.5.0
 com.google.protobuf:protobuf-java:3.6.1
 com.google.re2j:re2j:1.1
 com.jcraft:jsch:0.1.54

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -88,8 +88,8 @@
     <!-- This is used in hadoop-common for compilation only -->
     <protobuf.version>2.5.0</protobuf.version>
     <!-- Protobuf scope in hadoop common -->
-    <!-- set to "provided" and protobuf2 will no longer be exported as a dependency  -->
-    <common.protobuf2.scope>compile</common.protobuf2.scope>
+    <!-- set to "provided" so protobuf2 is no longer exported as a dependency  -->
+    <common.protobuf2.scope>provided</common.protobuf2.scope>
     <!-- Protobuf scope in other modules which explicitly import the libarary -->
     <transient.protobuf2.scope>${common.protobuf2.scope}</transient.protobuf2.scope>
     <!-- ProtocolBuffer version, actually used in Hadoop -->


### PR DESCRIPTION

Followup to the previous HADOOP-18487 patch: changes the scope of protobuf-2.5 in hadoop-common and elsewhere from "compile" to "provided".

This means that protobuf-2.5 is
* No longer included in hadoop distributions
* No longer exported by hadoop common POM files
* No longer exported transitively by other hadoop modules.



<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

