### PR TITLE
HADOOP-18889. Third party storage followup.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -1357,7 +1357,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     public String getBucketLocation(String bucketName) throws IOException {
       final String region = trackDurationAndSpan(
           STORE_EXISTS_PROBE, bucketName, null, () ->
-              once("getBucketLocation()", bucketName, () ->
+              invoker.retry("getBucketLocation()", bucketName, true, () ->
                   // If accessPoint then region is known from Arn
                   accessPoint != null
                       ? accessPoint.getRegion()

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/SignerFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/SignerFactory.java
@@ -84,16 +84,6 @@ public final class SignerFactory {
   /**
    * Check if the signer has already been registered.
    * @param signerType signer to get
-   * @throws IllegalArgumentException if the signer type is unknown.
-   */
-  public static void verifySignerRegistered(String signerType) {
-    checkArgument(isSignerRegistered(signerType),
-        "unknown signer type: %s", signerType);
-  }
-
-  /**
-   * Check if the signer has already been registered.
-   * @param signerType signer to get
    * @return true if the signer is registered.
    */
   public static boolean isSignerRegistered(String signerType) {


### PR DESCRIPTION

Followup to HADOOP-18889 third party store support #6141;

Fix some minor review comments which came in after the merge.


### How was this patch tested?

modified tests run in IDE; full testing in progress against s3 london

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

