### PR TITLE
HDFS-17226. Building native libraries fails on Fedora 38.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/include/hdfspp/content_summary.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/include/hdfspp/content_summary.h
@@ -19,6 +19,7 @@
 #define HDFSPP_CONTENT_SUMMARY_H_
 
 #include <string>
+#include <cstdint>
 
 namespace hdfs {
 

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/include/hdfspp/fsinfo.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/include/hdfspp/fsinfo.h
@@ -19,6 +19,7 @@
 #define HDFSPP_FSINFO_H_
 
 #include <string>
+#include <cstdint>
 
 namespace hdfs {
 

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/include/hdfspp/statinfo.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/include/hdfspp/statinfo.h
@@ -19,6 +19,7 @@
 #define HDFSPP_STATINFO_H_
 
 #include <string>
+#include <cstdint>
 
 namespace hdfs {
 

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/include/hdfspp/uri.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/include/hdfspp/uri.h
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <cstdint>
 #include <stdexcept>
 
 namespace hdfs


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Currently, building libhdfs++ on Fedora 38, in which g++ 13.2.1 is installed by default, fails due to the lack of the include statement for cstdint. This PR fixes this problem.

### How was this patch tested?

Ran `mvn clean package -DskipTests -Pnative` on Fedora 38 and ensured it succeeded. I also ran the same command in the Docker environment launched by start-build-env.sh as a regression check.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
