### PR TITLE
HDFS-17227. EC: Fix bug in choosing targets when racks is not enough.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyRackFaultTolerant.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyRackFaultTolerant.java
@@ -172,25 +172,20 @@ public class BlockPlacementPolicyRackFaultTolerant extends BlockPlacementPolicyD
     while (results.size() != totalReplicaExpected &&
         bestEffortMaxNodesPerRack < totalReplicaExpected) {
       // Exclude the chosen nodes
-      final Set<Node> newExcludeNodes = new HashSet<>();
       for (DatanodeStorageInfo resultStorage : results) {
-        addToExcludedNodes(resultStorage.getDatanodeDescriptor(),
-            newExcludeNodes);
+        addToExcludedNodes(resultStorage.getDatanodeDescriptor(), excludedNodes);
       }
 
       LOG.trace("Chosen nodes: {}", results);
       LOG.trace("Excluded nodes: {}", excludedNodes);
-      LOG.trace("New Excluded nodes: {}", newExcludeNodes);
       final int numOfReplicas = totalReplicaExpected - results.size();
       numResultsOflastChoose = results.size();
       try {
-        chooseOnce(numOfReplicas, writer, newExcludeNodes, blocksize,
+        chooseOnce(numOfReplicas, writer, excludedNodes, blocksize,
             ++bestEffortMaxNodesPerRack, results, avoidStaleNodes,
             storageTypes);
       } catch (NotEnoughReplicasException nere) {
         lastException = nere;
-      } finally {
-        excludedNodes.addAll(newExcludeNodes);
       }
       // To improve performance, the maximum value of 'bestEffortMaxNodesPerRack'
       // is calculated only when it is not possible to select a node.


### PR DESCRIPTION
### Description of PR
**Bug description**
If,
1. There is a striped block blockinfo1, which has an excess replica on datanodeA.
2. blockinfo1 has an internal block that needs to be reconstruction.
3. The number of racks is less than the number of internal blocks of blockinfo1.

Then, NN may choose datanodeA to reconstruct the internal block, resulting in two internal blocks of blockinfo1 on datanodeA, causing confusion. 

**Root cause and solution**
When we use `BlockPlacementPolicyRackFaultTolerant` for choosing targets and the racks is insufficient, `chooseEvenlyFromRemainingRacks` will be called. Currently, `chooseEvenlyFromRemainingRacks` calls `chooseOnce`, `chooseOnce` use `newExcludeNodes` as parameter instead of `excludedNodes`. When we choose targets for reconstructing internal blocks, `newExcludeNodes` only includes datanodes that contain live replicas, and does not include datanodes that have excess replicas. This may result in datanodes with excess replicas to be chosen. 
https://github.com/apache/hadoop/blob/c8abca30045258668867eeab89fa05fe88fe5be6/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyRackFaultTolerant.java#L181-L189
I think we do not need to use `newExcludeNodes`, just pass `excludedNodes` to `chooseOnce`.