### PR TITLE
HADOOP-18939. NPE in AWS v2 SDK RetryOnErrorCodeCondition.shouldRetry()

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/MultiObjectDeleteException.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/MultiObjectDeleteException.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.util.List;
 
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.s3.model.S3Error;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import org.slf4j.Logger;
@@ -55,10 +57,39 @@ public class MultiObjectDeleteException extends S3Exception {
    */
   public static final String ACCESS_DENIED = "AccessDenied";
 
+  /**
+   * Field value for the superclass builder: {@value}.
+   */
+  private static final int STATUS_CODE = SC_200_OK;
+
+  /**
+   * Field value for the superclass builder: {@value}.
+   */
+  private static final String ERROR_CODE = "MultiObjectDeleteException";
+
+  /**
+   * Field value for the superclass builder: {@value}.
+   */
+  private static final String SERVICE_NAME = "Amazon S3";
+
+  /**
+   * Extracted error list.
+   */
   private final List<S3Error> errors;
 
   public MultiObjectDeleteException(List<S3Error> errors) {
-    super(builder().message(errors.toString()).statusCode(SC_200_OK));
+    super(builder()
+        .message(errors.toString())
+        .awsErrorDetails(
+            AwsErrorDetails.builder()
+                .errorCode(ERROR_CODE)
+                .errorMessage(ERROR_CODE)
+                .serviceName(SERVICE_NAME)
+                .sdkHttpResponse(SdkHttpResponse.builder()
+                    .statusCode(STATUS_CODE)
+                    .build())
+                .build())
+        .statusCode(STATUS_CODE));
     this.errors = errors;
   }
 


### PR DESCRIPTION

### Description of PR


Fixes MultiObjectDeleteException to completely fill in AWS SDK retrier requirements.

testing in progress

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

