### PR TITLE
YARN-11593. [Federation] Improve command line help information.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
@@ -79,75 +79,69 @@ public class RouterCLI extends Configured implements Tool {
 
   private static final Logger LOG = LoggerFactory.getLogger(RouterCLI.class);
 
-  protected final static UsageInfo subClusterId = new UsageInfo("<-sc|--subClusterId>",
+  protected final static UsageInfo SUBCLUSTER_ID = new UsageInfo("<-sc|--subClusterId>",
       "'-sc' option allows you to specify the sub-cluster to operate on, " +
       "while the '--subClusterId' option is the long format of -sc and serves the same purpose.");
-  protected final static String dsExample_1 = "yarn routeradmin -deregisterSubCluster -sc SC-1";
-  protected final static String dsExample_2 = "yarn routeradmin -deregisterSubCluster --subClusterId SC-1";
+  protected final static String DSEXAMPLE_1 = "yarn routeradmin -deregisterSubCluster -sc SC-1";
+  protected final static String DSEXAMPLE_2 = "yarn routeradmin -deregisterSubCluster --subClusterId SC-1";
 
-  protected final static RouterExampleUsageInfos dsExampleUsageInfos_1 = new RouterExampleUsageInfos(
-          Arrays.asList(dsExample_1, dsExample_2),
+  protected final static RouterExampleUsageInfos DSEXAMPLEUSAGEINFOS_1 = new RouterExampleUsageInfos(
+          Arrays.asList(DSEXAMPLE_1, DSEXAMPLE_2),
           Arrays.asList("At this point we can use the following command:"));
-  protected final static RouterUsageInfos deregisterSubCluster =
-      new RouterUsageInfos(Arrays.asList(subClusterId),
-      Arrays.asList("deregister subCluster, If the interval between the heartbeat time of the subCluster" +
+  protected final static RouterUsageInfos DEREGISTER_SUBCLUSTER =
+      new RouterUsageInfos(Arrays.asList(SUBCLUSTER_ID),
+      Arrays.asList("deregister subCluster, " +
+      "If the interval between the heartbeat time of the subCluster" +
       "and the current time exceeds the timeout period, set the state of the subCluster to SC_LOST."),
       ImmutableMap.<String, RouterExampleUsageInfos>builder()
-      .put("<--deregisterSubCluster>", dsExampleUsageInfos_1)
+      .put("<--deregisterSubCluster>", DSEXAMPLEUSAGEINFOS_1)
       .build());
 
-  protected final static UsageInfo policySaveUsage = new UsageInfo(
+  protected final static UsageInfo POLICY_SAVE_USAGE = new UsageInfo(
       "<-s|--save [queue;router weight;amrm weight;headroomalpha]>",
       "We will save the policy information of the queue, including queue and weight information.");
-  protected final static UsageInfo policyBatchSaveUsage = new UsageInfo(
+  protected final static UsageInfo POLICY_BATCH_SAVE_USAGE = new UsageInfo(
       "<-bs|--batch-save [--format xml] [-f|--input-file fileName]]>",
       "We will save queue policies in bulk, where users can provide XML files containing the policies.");
-  protected final static UsageInfo policyListUsage = new UsageInfo("<-l|--list [--pageSize][--currentPage][--queue][--queues]>",
+  protected final static UsageInfo POLICY_LIST_USAGE = new UsageInfo("<-l|--list [--pageSize][--currentPage][--queue][--queues]>",
       "We can display the configured queue policies.");
 
-  protected final static String pExample_1 = "yarn routeradmin -policy -s root.a;SC-1:0.7,SC-2:0.3;SC-1:0.6,SC-2:0.4;1.0";
-  protected final static String pExample_2 = "yarn routeradmin -policy --save root.a;SC-1:0.7,SC-2:0.3;SC-1:0.6,SC-2:0.4;1.0";
-  protected final static RouterExampleUsageInfos pExampleUsageInfos_1 = new RouterExampleUsageInfos(
-      Arrays.asList(pExample_1, pExample_2),
-      Arrays.asList("We have two subClusters, SC-1 and SC-2. For queue root.a, we want the ratio to be set to SC-1:SC-2=0.7:0.3 when routing.",
+  protected final static String PEXAMPLE_1 = "yarn routeradmin -policy -s root.a;SC-1:0.7,SC-2:0.3;SC-1:0.6,SC-2:0.4;1.0";
+  protected final static String PEXAMPLE_2 = "yarn routeradmin -policy --save root.a;SC-1:0.7,SC-2:0.3;SC-1:0.6,SC-2:0.4;1.0";
+  protected final static RouterExampleUsageInfos PEXAMPLEUSAGEINFOS_1 = new RouterExampleUsageInfos(
+      Arrays.asList(PEXAMPLE_1, PEXAMPLE_2),
+      Arrays.asList("We have two subClusters, SC-1 and SC-2. " +
+      "For queue root.a, we want the ratio to be set to SC-1:SC-2=0.7:0.3 when routing.",
       "Additionally, when AM applies containers, we want the allocation ratio to be SC-1:SC-2=0.6:0.4.",
       "Headroomalpha can be set to the default value of 1.0.",
       "At this point we can use the following command:"));
 
-  protected final static String pExample_3 = "yarn routeradmin -policy -bs --format xml -f queue.xml";
-  protected final static String pExample_4 = "yarn routeradmin -policy --batch-save --format xml -f queue.xml";
-  protected final static RouterExampleUsageInfos pExampleUsageInfos_2 = new RouterExampleUsageInfos(
-      Arrays.asList(pExample_3, pExample_4),
+  protected final static String PEXAMPLE_3 = "yarn routeradmin -policy -bs --format xml -f queue.xml";
+  protected final static String PEXAMPLE_4 = "yarn routeradmin -policy --batch-save --format xml -f queue.xml";
+  protected final static RouterExampleUsageInfos PEXAMPLEUSAGEINFOS_2 = new RouterExampleUsageInfos(
+      Arrays.asList(PEXAMPLE_3, PEXAMPLE_4),
       Arrays.asList("We offer the capability to batch input queue policies. ",
       "Currently, this is supported exclusively through XML. " +
       "(We can find federationWeights.xml in the Federation.md on the website.) ",
       "We can use the batch-save command to input proportion information. ",
       "At this point we can use the following command:"));
 
-  protected final static String pExample_5 = "yarn routeradmin -policy -l --pageSize 20 --currentPage 1 --queue root.a";
-  protected final static String pExample_6 = "yarn routeradmin -policy -list --pageSize 20 --currentPage 1 --queues root.a,root.b";
-  protected final static RouterExampleUsageInfos pExampleUsageInfos_3 = new RouterExampleUsageInfos(
-      Arrays.asList(pExample_5, pExample_6),
+  protected final static String PEXAMPLE_5 = "yarn routeradmin -policy -l --pageSize 20 --currentPage 1 --queue root.a";
+  protected final static String PEXAMPLE_6 = "yarn routeradmin -policy -list --pageSize 20 --currentPage 1 --queues root.a,root.b";
+  protected final static RouterExampleUsageInfos PEXAMPLEUSAGEINFOS_3 = new RouterExampleUsageInfos(
+      Arrays.asList(PEXAMPLE_5, PEXAMPLE_6),
       Arrays.asList("We can print the Configured Queue Policies on the command line. ",
       "We can specify a queue through --queue, and we can specify a queue list through --queues.",
       "At this point we can use the following command:"));
 
-  protected final static RouterUsageInfos policy =
-      new RouterUsageInfos(Arrays.asList(policySaveUsage, policyBatchSaveUsage, policyListUsage),
+  protected final static RouterUsageInfos POLICY =
+      new RouterUsageInfos(Arrays.asList(POLICY_SAVE_USAGE, POLICY_BATCH_SAVE_USAGE, POLICY_LIST_USAGE),
       Arrays.asList("We provide a set of commands for Policy Include list policies, save policies, batch save policies."),
       ImmutableMap.<String, RouterExampleUsageInfos>builder()
-          .put("<-s|--save>", pExampleUsageInfos_1)
-          .put("<-bs|--batch-save>", pExampleUsageInfos_2)
-          .put("<-l|--list>", pExampleUsageInfos_3)
+          .put("<-s|--save>", PEXAMPLEUSAGEINFOS_1)
+          .put("<-bs|--batch-save>", PEXAMPLEUSAGEINFOS_2)
+          .put("<-l|--list>", PEXAMPLEUSAGEINFOS_3)
           .build());
-
-  protected final static Map<String, RouterUsageInfos> ADMIN_USAGE =
-      ImmutableMap.<String, RouterUsageInfos>builder()
-      // Command1: deregisterSubCluster
-      .put("-deregisterSubCluster", deregisterSubCluster)
-      // Command2: policy
-      .put("-policy", policy)
-      .build();
 
   // Common Constant
   private static final String SEMICOLON = ";";
@@ -202,6 +196,14 @@ public class RouterCLI extends Configured implements Tool {
   private static final List<String> LIST_POLICIES_HEADER = Arrays.asList(
       "Queue Name", "AMRM Weight", "Router Weight");
 
+  protected final static Map<String, RouterUsageInfos> ADMIN_USAGE =
+       ImmutableMap.<String, RouterUsageInfos>builder()
+       // Command1: deregisterSubCluster
+       .put(CMD_DEREGISTERSUBCLUSTER, DEREGISTER_SUBCLUSTER)
+       // Command2: policy
+       .put(CMD_POLICY, POLICY)
+       .build();
+
   public RouterCLI() {
     super();
   }
@@ -216,19 +218,19 @@ public class RouterCLI extends Configured implements Tool {
     if (routerUsageInfo == null) {
       return;
     }
-    builder.append("[" + cmd + "]\n");
+    builder.append("[").append(cmd).append("]\n");
 
     if (!routerUsageInfo.helpInfos.isEmpty()) {
       builder.append("\t Description: \n");
       for (String helpInfo : routerUsageInfo.helpInfos) {
-        builder.append("\t\t" + helpInfo).append("\n\n");
+        builder.append("\t\t").append(helpInfo).append("\n\n");
       }
     }
 
     if (!routerUsageInfo.usageInfos.isEmpty()) {
       builder.append("\t UsageInfos: \n");
       for (UsageInfo usageInfo : routerUsageInfo.usageInfos) {
-        builder.append("\t\t"+usageInfo.args)
+        builder.append("\t\t").append(usageInfo.args)
             .append(": ")
             .append("\n\t\t")
             .append(usageInfo.help).append("\n\n");
@@ -241,7 +243,7 @@ public class RouterCLI extends Configured implements Tool {
       for (Map.Entry<String, RouterExampleUsageInfos> example :
          routerUsageInfo.examples.entrySet()) {
         String key = example.getKey();
-        builder.append("\t\t").append("Cmd:" + count + ". ").append(key).append(": \n\n");
+        builder.append("\t\t").append("Cmd:").append(count).append(". ").append(key).append(": \n\n");
         RouterExampleUsageInfos values = example.getValue();
         if (values == null) {
           return;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
@@ -98,12 +98,13 @@ public class RouterCLI extends Configured implements Tool {
       .build());
 
   protected final static UsageInfo POLICY_SAVE_USAGE = new UsageInfo(
-      "<-s|--save [queue;router weight;amrm weight;headroomalpha]>",
+      "-s|--save (<queue;router weight;amrm weight;headroomalpha>)",
       "We will save the policy information of the queue, including queue and weight information.");
   protected final static UsageInfo POLICY_BATCH_SAVE_USAGE = new UsageInfo(
-      "<-bs|--batch-save [--format xml] [-f|--input-file fileName]]>",
+      "-bs|--batch-save (--format <xml>) (-f|--input-file <fileName>)",
       "We will save queue policies in bulk, where users can provide XML files containing the policies.");
-  protected final static UsageInfo POLICY_LIST_USAGE = new UsageInfo("<-l|--list [--pageSize][--currentPage][--queue][--queues]>",
+  protected final static UsageInfo POLICY_LIST_USAGE = new UsageInfo(
+      "-l|--list [--pageSize][--currentPage][--queue][--queues]",
       "We can display the configured queue policies.");
 
   protected final static String PEXAMPLE_1 = "yarn routeradmin -policy -s root.a;SC-1:0.7,SC-2:0.3;SC-1:0.6,SC-2:0.4;1.0";
@@ -138,9 +139,9 @@ public class RouterCLI extends Configured implements Tool {
       new RouterUsageInfos(Arrays.asList(POLICY_SAVE_USAGE, POLICY_BATCH_SAVE_USAGE, POLICY_LIST_USAGE),
       Arrays.asList("We provide a set of commands for Policy Include list policies, save policies, batch save policies."),
       ImmutableMap.<String, RouterExampleUsageInfos>builder()
-          .put("<-s|--save>", PEXAMPLEUSAGEINFOS_1)
-          .put("<-bs|--batch-save>", PEXAMPLEUSAGEINFOS_2)
-          .put("<-l|--list>", PEXAMPLEUSAGEINFOS_3)
+          .put("-s|--save (<queue;router weight;amrm weight;headroomalpha>) ", PEXAMPLEUSAGEINFOS_1)
+          .put("-bs|--batch-save (--format <xml>) (-f|--input-file <fileName>)", PEXAMPLEUSAGEINFOS_2)
+          .put("-l|--list [--pageSize][--currentPage][--queue][--queues]", PEXAMPLEUSAGEINFOS_3)
           .build());
 
   // Common Constant

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
@@ -26,6 +26,7 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.ha.HAAdmin.UsageInfo;
@@ -130,12 +131,14 @@ public class RouterCLI extends Configured implements Tool {
   // save policy
   private static final String OPTION_S = "s";
   private static final String OPTION_SAVE = "save";
+  // batch save policy
   private static final String OPTION_BATCH_S = "bs";
   private static final String OPTION_BATCH_SAVE = "batch-save";
   private static final String OPTION_FORMAT = "format";
   private static final String FORMAT_XML = "xml";
   private static final String OPTION_FILE = "f";
   private static final String OPTION_INPUT_FILE = "input-file";
+  // list policy
   private static final String OPTION_L = "l";
   private static final String OPTION_LIST = "list";
   private static final String OPTION_PAGE_SIZE = "pageSize";
@@ -844,7 +847,11 @@ public class RouterCLI extends Configured implements Tool {
     return EXIT_SUCCESS;
   }
 
-  private static class RouterCmdUsageInfos {
+  public static UsageInfo getPolicyBatchSaveUsage() {
+    return POLICY_BATCH_SAVE_USAGE;
+  }
+
+  static class RouterCmdUsageInfos {
     public List<UsageInfo> usageInfos;
     public List<String> helpInfos;
     public Map<String, List<String>> examples;
@@ -885,5 +892,10 @@ public class RouterCLI extends Configured implements Tool {
   public static void main(String[] args) throws Exception {
     int result = ToolRunner.run(new RouterCLI(), args);
     System.exit(result);
+  }
+
+  @VisibleForTesting
+  public Map<String, RouterCmdUsageInfos> getAdminUsage(){
+    return ADMIN_USAGE;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
@@ -199,7 +199,7 @@ public class RouterCLI extends Configured implements Tool {
       "-l|--list [--pageSize][--currentPage][--queue][--queues]",
       "This command is used to display the configured queue weight information.");
 
-  protected final static String POLICY_LIST_USAGE_DESC =
+  protected final static String POLICY_LIST_USAGE_EXAMPLE_DESC =
       "We can display the list of already configured queue weight information. \\" +
       "We can use the --queue option to query the weight information for a specific queue \\" +
       " or use the --queues option to query the weight information for multiple queues. \\";
@@ -223,7 +223,7 @@ public class RouterCLI extends Configured implements Tool {
       .addExample(POLICY_BATCH_SAVE_USAGE.args, POLICY_BATCH_SAVE_USAGE_EXAMPLE_2)
        // Policy List Save
       .addUsageInfo(POLICY_LIST_USAGE)
-      .addExampleDescs(POLICY_LIST_USAGE.args, POLICY_LIST_USAGE_DESC)
+      .addExampleDescs(POLICY_LIST_USAGE.args, POLICY_LIST_USAGE_EXAMPLE_DESC)
       .addExample(POLICY_LIST_USAGE.args, POLICY_LIST_USAGE_EXAMPLE_1)
       .addExample(POLICY_LIST_USAGE.args, POLICY_LIST_USAGE_EXAMPLE_2);
 
@@ -852,12 +852,12 @@ public class RouterCLI extends Configured implements Tool {
   }
 
   static class RouterCmdUsageInfos {
-    public List<UsageInfo> usageInfos;
-    public List<String> helpInfos;
-    public Map<String, List<String>> examples;
-    public Map<String, List<String>> exampleDescs;
+    protected List<UsageInfo> usageInfos;
+    protected List<String> helpInfos;
+    protected Map<String, List<String>> examples;
+    protected Map<String, List<String>> exampleDescs;
 
-    public RouterCmdUsageInfos() {
+    RouterCmdUsageInfos() {
       this.usageInfos = new ArrayList<>();
       this.helpInfos = new ArrayList<>();
       this.examples = new LinkedHashMap<>();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
@@ -852,9 +852,9 @@ public class RouterCLI extends Configured implements Tool {
   }
 
   static class RouterCmdUsageInfos {
-    protected List<UsageInfo> usageInfos;
-    protected List<String> helpInfos;
-    protected Map<String, List<String>> examples;
+    private List<UsageInfo> usageInfos;
+    private List<String> helpInfos;
+    private Map<String, List<String>> examples;
     protected Map<String, List<String>> exampleDescs;
 
     RouterCmdUsageInfos() {
@@ -886,6 +886,10 @@ public class RouterCLI extends Configured implements Tool {
       exampleDescList.add(exampleDesc);
       this.exampleDescs.put(cmd, exampleDescList);
       return this;
+    }
+
+    public Map<String, List<String>> getExamples() {
+      return examples;
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
@@ -65,7 +65,10 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.yarn.server.api.protocolrecords.FederationQueueWeight.checkHeadRoomAlphaValid;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/RouterCLI.java
@@ -117,13 +117,13 @@ public class RouterCLI extends Configured implements Tool {
       "Headroomalpha can be set to the default value of 1.0.",
       "At this point we can use the following command:"));
 
-  protected final static String PEXAMPLE_3 = "yarn routeradmin -policy -bs --format xml -f queue.xml";
-  protected final static String PEXAMPLE_4 = "yarn routeradmin -policy --batch-save --format xml -f queue.xml";
+  protected final static String PEXAMPLE_3 = "yarn routeradmin -policy -bs --format xml -f federation-weights.xml";
+  protected final static String PEXAMPLE_4 = "yarn routeradmin -policy --batch-save --format xml -f federation-weights.xml";
   protected final static RouterExampleUsageInfos PEXAMPLEUSAGEINFOS_2 = new RouterExampleUsageInfos(
       Arrays.asList(PEXAMPLE_3, PEXAMPLE_4),
       Arrays.asList("We offer the capability to batch input queue policies. ",
       "Currently, this is supported exclusively through XML. " +
-      "(We can find federationWeights.xml in the Federation.md on the website.) ",
+      "(We can find federation-weights.xml in the Federation.md on the website.) ",
       "We can use the batch-save command to input proportion information. ",
       "At this point we can use the following command:"));
 
@@ -139,9 +139,9 @@ public class RouterCLI extends Configured implements Tool {
       new RouterUsageInfos(Arrays.asList(POLICY_SAVE_USAGE, POLICY_BATCH_SAVE_USAGE, POLICY_LIST_USAGE),
       Arrays.asList("We provide a set of commands for Policy Include list policies, save policies, batch save policies."),
       ImmutableMap.<String, RouterExampleUsageInfos>builder()
-          .put("-s|--save (<queue;router weight;amrm weight;headroomalpha>) ", PEXAMPLEUSAGEINFOS_1)
+          .put("-s|--save (<queue;router weight;amrm weight;headroomalpha>)", PEXAMPLEUSAGEINFOS_1)
           .put("-bs|--batch-save (--format <xml>) (-f|--input-file <fileName>)", PEXAMPLEUSAGEINFOS_2)
-          .put("-l|--list [--pageSize][--currentPage][--queue][--queues]", PEXAMPLEUSAGEINFOS_3)
+          .put("-l|--list ([--pageSize][--currentPage][--queue][--queues])", PEXAMPLEUSAGEINFOS_3)
           .build());
 
   // Common Constant

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestRouterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestRouterCLI.java
@@ -276,7 +276,7 @@ public class TestRouterCLI {
     RouterCLI.RouterCmdUsageInfos deregisterSubClusterUsageInfos =
         adminUsage.get("-deregisterSubCluster");
     assertNotNull(deregisterSubClusterUsageInfos);
-    Map<String, List<String>> dsExamplesMap = deregisterSubClusterUsageInfos.examples;
+    Map<String, List<String>> dsExamplesMap = deregisterSubClusterUsageInfos.getExamples();
     assertNotNull(dsExamplesMap);
     assertEquals(1, dsExamplesMap.size());
     List<String> dsExamples = dsExamplesMap.get("-deregisterSubCluster");
@@ -285,7 +285,7 @@ public class TestRouterCLI {
 
     RouterCLI.RouterCmdUsageInfos policyUsageInfos = adminUsage.get("-policy");
     assertNotNull(policyUsageInfos);
-    Map<String, List<String>> policyExamplesMap = policyUsageInfos.examples;
+    Map<String, List<String>> policyExamplesMap = policyUsageInfos.getExamples();
     assertNotNull(policyExamplesMap);
     assertEquals(3, policyExamplesMap.size());
     policyExamplesMap.forEach((cmd, cmdExamples) -> {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestRouterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestRouterCLI.java
@@ -40,6 +40,7 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -265,5 +266,30 @@ public class TestRouterCLI {
 
     String[] args = {"-policy", "-l", "--queue", "root.a"};
     assertEquals(0, rmAdminCLI.run(args));
+  }
+
+  @Test
+  public void testBuildHelpMsg() throws Exception {
+    Map<String, RouterCLI.RouterCmdUsageInfos> adminUsage = rmAdminCLI.getAdminUsage();
+    assertEquals(2, adminUsage.size());
+
+    RouterCLI.RouterCmdUsageInfos deregisterSubClusterUsageInfos =
+        adminUsage.get("-deregisterSubCluster");
+    assertNotNull(deregisterSubClusterUsageInfos);
+    Map<String, List<String>> dsExamplesMap = deregisterSubClusterUsageInfos.examples;
+    assertNotNull(dsExamplesMap);
+    assertEquals(1, dsExamplesMap.size());
+    List<String> dsExamples = dsExamplesMap.get("-deregisterSubCluster");
+    assertNotNull(dsExamples);
+    assertEquals(2, dsExamples.size());
+
+    RouterCLI.RouterCmdUsageInfos policyUsageInfos = adminUsage.get("-policy");
+    assertNotNull(policyUsageInfos);
+    Map<String, List<String>> policyExamplesMap = policyUsageInfos.examples;
+    assertNotNull(policyExamplesMap);
+    assertEquals(3, policyExamplesMap.size());
+    policyExamplesMap.forEach((cmd, cmdExamples) -> {
+      assertEquals(2, cmdExamples.size());
+    });
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
@@ -477,9 +477,9 @@ Uasge:
 
 Options:
 
-| Property                            | Example                                                                                                                                                     |
-|:------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| -sc, --subClusterId <subCluster Id> | '-sc' option allows you to specify the sub-cluster to operate on, while the '--subClusterId' option is the long format of -sc and serves the same purpose." |
+| Property                              | Description                                                                                                                                                      |
+|:--------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-sc, --subClusterId [subCluster Id]` | `'-sc' option allows you to specify the sub-cluster to operate on, while the '--subClusterId' option is the long format of -sc and serves the same purpose.`     |
 
 Examples:
 
@@ -489,6 +489,132 @@ If we want to deregisterSubCluster `SC-1`
 - yarn routeradmin -deregisterSubCluster --subClusterId SC-1
 
 - policy
+
+We provide a set of commands for Policy Include list policies, save policies, batch save policies.
+
+Uasge:
+
+`yarn routeradmin -policy -s|--save (queue;router weight;amrm weight;headroomalpha)`
+
+`yarn routeradmin -policy -bs|--batch-save (--format xml) (-f|--input-file fileName)`
+
+`yarn routeradmin -policy -l|--list ([--pageSize][--currentPage][--queue][--queues])`
+
+- -s|--save (<queue;router weight;amrm weight;headroomalpha>)
+
+This command is used to save the policy information of the queue, including queue and weight information.
+
+How to configure `queue;router weight;amrm weight;headroomalpha` 
+
+the sum of weights for all sub-clusters in routerWeight/amrmWeight should be 1.
+
+| Property        | Description                                                                                                                                                                     |
+|:----------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `queue`         | `Scheduled queue`                                                                                                                                                               |
+| `router weight` | `Weight for routing applications to different subclusters.`                                                                                                                     |
+| `amrm weight`   | `Weight for resource request from ApplicationMaster (AM) to different subclusters' Resource Manager (RM).`                                                                      |
+| `headroomalpha` | `Used by policies that balance weight-based and load-based considerations in their decisions. It is recommended to use 1.0 because the load-base function is not yet complete.` |
+
+Example:
+
+We have two subClusters, `SC-1` and `SC-2`. For queue `root.a`, we want the ratio to be set to `SC-1:SC-2=0.7:0.3` when routing.,
+Additionally, when AM applies containers, we want the allocation ratio to be `SC-1:SC-2=0.6:0.4.`, headroomalpha can be set to the default value of `1.0`.
+
+yarn routeradmin -policy --save root.a;SC-1:0.7,SC-2:0.3;SC-1:0.6,SC-2:0.4;1.0
+
+yarn routeradmin -policy -s root.a;SC-1:0.7,SC-2:0.3;SC-1:0.6,SC-2:0.4;1.0
+
+- -bs|--batch-save (--format xml) (-f|--input-file fileName)
+
+This command can batch load weight information for queues based on the provided `federation-weights.xml` file.
+
+| Property                  | Description                                                                                   |
+|:--------------------------|:----------------------------------------------------------------------------------------------|
+| `--format [xml]`          | `Configuration file format, we currently only support xml format`                             |
+| `-f, --input-file [path]` | `The path to the configuration file. Please use the absolute path of the configuration file.` |
+
+How to configure `federation-weights.xml`
+  ```xml
+  <federationWeights>
+    <weight>
+        <queue>
+            <name>root.a</name>
+            <amrmPolicyWeights>
+                <subClusterIdInfo>
+                    <id>SC-1</id>
+                    <weight>0.7</weight>
+                </subClusterIdInfo>
+                <subClusterIdInfo>
+                    <id>SC-2</id>
+                    <weight>0.3</weight>
+                </subClusterIdInfo>
+            </amrmPolicyWeights>
+            <routerPolicyWeights>
+                <subClusterIdInfo>
+                    <id>SC-1</id>
+                    <weight>0.6</weight>
+                </subClusterIdInfo>
+                <subClusterIdInfo>
+                    <id>SC-2</id>
+                    <weight>0.4</weight>
+                </subClusterIdInfo>
+            </routerPolicyWeights>
+            <headroomAlpha>1.0</headroomAlpha>
+        </queue>
+    </weight>
+    <weight>
+        <queue>
+            <name>root.b</name>
+            <amrmPolicyWeights>
+                <subClusterIdInfo>
+                    <id>SC-1</id>
+                    <weight>0.8</weight>
+                </subClusterIdInfo>
+                <subClusterIdInfo>
+                    <id>SC-2</id>
+                    <weight>0.2</weight>
+                </subClusterIdInfo>
+            </amrmPolicyWeights>
+            <routerPolicyWeights>
+                <subClusterIdInfo>
+                    <id>SC-1</id>
+                    <weight>0.6</weight>
+                </subClusterIdInfo>
+                <subClusterIdInfo>
+                    <id>SC-2</id>
+                    <weight>0.4</weight>
+                </subClusterIdInfo>
+            </routerPolicyWeights>
+            <headroomAlpha>1.0</headroomAlpha>
+        </queue>
+    </weight>
+   </federationWeights>
+  ```
+
+Example:
+
+The file name can be any file name, but it is recommended to use `federation-weights.xml`
+
+yarn routeradmin -policy -bs --format xml -f /path/federation-weights.xml
+
+yarn routeradmin -policy --batch-save --format xml -f /path/federation-weights.xml
+
+- -l|--list (--pageSize --currentPage --queue --queues)
+
+This command is used to display the configured queue weight information.
+
+| Property        | Description                                                  |
+|:----------------|:-------------------------------------------------------------|
+| `--pageSize`    | `The number of policies displayed per page.`                 |
+| `--currentPage` | `This parameter represents the page number to be displayed.` |
+| `--queue`       | `the queue we need to filter. example: root.a`               |
+| `--queues`      | `list of queues to filter. example: root.a,root.b,root.c`    |
+
+Example:
+
+yarn routeradmin -policy -l --pageSize 20 --currentPage 1 --queue root.a
+
+yarn routeradmin -policy -list --pageSize 20 --currentPage 1 --queues root.a,root.b
 
 ### ON GPG:
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
@@ -504,7 +504,7 @@ Uasge:
 
 This command is used to save the policy information of the queue, including queue and weight information.
 
-How to configure `queue;router weight;amrm weight;headroomalpha` 
+How to configure `queue;router weight;amrm weight;headroomalpha`
 
 the sum of weights for all sub-clusters in routerWeight/amrmWeight should be 1.
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
@@ -465,9 +465,34 @@ If we want to use JCache, we can configure `yarn.federation.cache.class` to `org
 This is a Cache implemented based on the Guava framework.
 If we want to use it, we can configure `yarn.federation.cache.class` to `org.apache.hadoop.yarn.server.federation.cache.FederationGuavaCache`.
 
+Router command line:
+
+- deregisterSubCluster
+
+This command is used to `deregister subCluster`, If the interval between the heartbeat time of the subCluster, and the current time exceeds the timeout period, set the state of the subCluster to `SC_LOST`.
+
+Uasge:
+
+`yarn routeradmin -deregisterSubCluster [-sc|--subClusterId <subCluster Id>]`
+
+Options:
+
+| Property                            | Example                                                                                                                                                     |
+|:------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -sc, --subClusterId <subCluster Id> | '-sc' option allows you to specify the sub-cluster to operate on, while the '--subClusterId' option is the long format of -sc and serves the same purpose." |
+
+Examples:
+
+If we want to deregisterSubCluster `SC-1`
+
+- yarn routeradmin -deregisterSubCluster -sc SC-1
+- yarn routeradmin -deregisterSubCluster --subClusterId SC-1
+
+- policy
+
 ### ON GPG:
 
-GlobalPolicyGenerator, abbreviated as "GPG," is used for the automatic generation of global policies for subClusters.
+GlobalPolicyGenerator, abbreviated as "GPG", is used for the automatic generation of global policies for subClusters.
 
 These are extra configurations that should appear in the **conf/yarn-site.xml** for GPG. We allow only one GPG.
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
@@ -517,8 +517,8 @@ the sum of weights for all sub-clusters in routerWeight/amrmWeight should be 1.
 
 Example:
 
-We have two subClusters, `SC-1` and `SC-2`. For queue `root.a`, we want the ratio to be set to `SC-1:SC-2=0.7:0.3` when routing.,
-Additionally, when AM applies containers, we want the allocation ratio to be `SC-1:SC-2=0.6:0.4.`, headroomalpha can be set to the default value of `1.0`.
+We have two sub-clusters, `SC-1` and `SC-2`. We want to configure a weight policy for the `root.a` queue. The Router Weight is set to `SC-1` with a weight of `0.7` and `SC-2` with a weight of `0.3`.
+The AMRM Weight is set `SC-1` to `0.6` and `SC-2` to `0.4`. We are using the default value of `0.1` for `headroomalpha`.
 
 yarn routeradmin -policy --save root.a;SC-1:0.7,SC-2:0.3;SC-1:0.6,SC-2:0.4;1.0
 
@@ -593,6 +593,9 @@ How to configure `federation-weights.xml`
 
 Example:
 
+We have two sub-clusters, `SC-1` and `SC-2`. We would like to configure weights for `root.a` and `root.b` queues. We can set the weights for `root.a` and `root.b` in the `federation-weights.xml` file.
+and then use the batch-save command to save the configurations in bulk.
+
 The file name can be any file name, but it is recommended to use `federation-weights.xml`
 
 yarn routeradmin -policy -bs --format xml -f /path/federation-weights.xml
@@ -611,6 +614,8 @@ This command is used to display the configured queue weight information.
 | `--queues`      | `list of queues to filter. example: root.a,root.b,root.c`    |
 
 Example:
+
+We can display the list of already configured queue weight information. We can use the `--queue` option to query the weight information for a specific queue or use the `--queues` option to query the weight information for multiple queues.
 
 yarn routeradmin -policy -l --pageSize 20 --currentPage 1 --queue root.a
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11593. [Federation] Improve command line help information.

We have introduced several command-line features for Yarn Federation, and this PR aims to improve the presentation of help information and supplement the 'YARN Federation.md' file to assist users in better utilizing these command-line features.

> Before modification:

```
routeradmin is the command to execute YARN Federation administrative commands.
The full syntax is: 

routeradmin
   [-deregisterSubCluster [-sc|--subClusterId [subCluster Id]]
   [-policy [-s|--save [queue;router weight;amrm weight;headroomalpha] [-bs|--batch-save [--format xml,json] [-f|--input-file fileName]]] [-l|--list [--pageSize][--currentPage][--queue][--queues]]
   [-help [cmd]]

   -deregisterSubCluster [-sc|--subClusterId [subCluster Id]]: Deregister SubCluster, If the interval between the heartbeat time of the subCluster and the current time exceeds the timeout period, set the state of the subCluster to SC_LOST.
   -policy [-s|--save [queue;router weight;amrm weight;headroomalpha]] [-bs|--batch-save [--format xml] [-f|--input-file fileName]][-l|--list [--pageSize][--currentPage][--queue][--queues]]: We provide a set of commands for Policy: Include list policies, save policies, batch save policies.  (Note: The policy type will be directly read from the yarn.federation.policy-manager in the local yarn-site.xml.) eg. (routeradmin -policy [-s|--save] root.a;SC-1:0.7,SC-2:0.3;SC-1:0.7,SC-2:0.3;1.0)
   -help [cmd]: Displays help for the given command or all commands if none is specified.

Generic options supported are:
-conf <configuration file>        specify an application configuration file
-D <property=value>               define a value for a given property
-fs <file:///|hdfs://namenode:port> specify default filesystem URL to use, overrides 'fs.defaultFS' property from configurations.
-jt <local|resourcemanager:port>  specify a ResourceManager
-files <file1,...>                specify a comma-separated list of files to be copied to the map reduce cluster
-libjars <jar1,...>               specify a comma-separated list of jar files to be included in the classpath
-archives <archive1,...>          specify a comma-separated list of archives to be unarchived on the compute machines

The general command line syntax is:
command [genericOptions] [commandOptions]
```

> After modification:
```
routeradmin is the command to execute YARN Federation administrative commands.
The full syntax is: 

routeradmin

[-deregisterSubCluster]
	 Description: 
		deregister subCluster, If the interval between the heartbeat time of the subClusterand the current time exceeds the timeout period, set the state of the subCluster to SC_LOST.

	 UsageInfos: 
		<-sc|--subClusterId>: 
		'-sc' option allows you to specify the sub-cluster to operate on, while the '--subClusterId' option is the long format of -sc and serves the same purpose.

	 Examples: 
		Cmd:1. <--deregisterSubCluster>: 

		Cmd Requirement Description:
		At this point we can use the following command:

		Cmd Examples:
		yarn routeradmin -deregisterSubCluster -sc SC-1
		yarn routeradmin -deregisterSubCluster --subClusterId SC-1


[-policy]
	 Description: 
		We provide a set of commands for Policy Include list policies, save policies, batch save policies.

	 UsageInfos: 
		-s|--save (<queue;router weight;amrm weight;headroomalpha>): 
		We will save the policy information of the queue, including queue and weight information.

		-bs|--batch-save (--format <xml>) (-f|--input-file <fileName>): 
		We will save queue policies in bulk, where users can provide XML files containing the policies.

		-l|--list [--pageSize][--currentPage][--queue][--queues]: 
		We can display the configured queue policies.

	 Examples: 
		Cmd:1. -s|--save (<queue;router weight;amrm weight;headroomalpha>): 

		Cmd Requirement Description:
		We have two subClusters, SC-1 and SC-2. For queue root.a, we want the ratio to be set to SC-1:SC-2=0.7:0.3 when routing.
		Additionally, when AM applies containers, we want the allocation ratio to be SC-1:SC-2=0.6:0.4.
		Headroomalpha can be set to the default value of 1.0.
		At this point we can use the following command:

		Cmd Examples:
		yarn routeradmin -policy -s root.a;SC-1:0.7,SC-2:0.3;SC-1:0.6,SC-2:0.4;1.0
		yarn routeradmin -policy --save root.a;SC-1:0.7,SC-2:0.3;SC-1:0.6,SC-2:0.4;1.0

		Cmd:2. -bs|--batch-save (--format <xml>) (-f|--input-file <fileName>): 

		Cmd Requirement Description:
		We offer the capability to batch input queue policies. 
		Currently, this is supported exclusively through XML. (We can find federation-weights.xml in the Federation.md on the website.) 
		We can use the batch-save command to input proportion information. 
		At this point we can use the following command:

		Cmd Examples:
		yarn routeradmin -policy -bs --format xml -f federation-weights.xml
		yarn routeradmin -policy --batch-save --format xml -f federation-weights.xml

		Cmd:3. -l|--list ([--pageSize][--currentPage][--queue][--queues]): 

		Cmd Requirement Description:
		We can print the Configured Queue Policies on the command line. 
		We can specify a queue through --queue, and we can specify a queue list through --queues.
		At this point we can use the following command:

		Cmd Examples:
		yarn routeradmin -policy -l --pageSize 20 --currentPage 1 --queue root.a
		yarn routeradmin -policy -list --pageSize 20 --currentPage 1 --queues root.a,root.b


   -help [cmd]: Displays help for the given command or all commands if none is specified.

Generic options supported are:
-conf <configuration file>        specify an application configuration file
-D <property=value>               define a value for a given property
-fs <file:///|hdfs://namenode:port> specify default filesystem URL to use, overrides 'fs.defaultFS' property from configurations.
-jt <local|resourcemanager:port>  specify a ResourceManager
-files <file1,...>                specify a comma-separated list of files to be copied to the map reduce cluster
-libjars <jar1,...>               specify a comma-separated list of jar files to be included in the classpath
-archives <archive1,...>          specify a comma-separated list of archives to be unarchived on the compute machines

The general command line syntax is:
command [genericOptions] [commandOptions]
```

Screenshot of help information:

<img width="1680" alt="image" src="https://github.com/apache/hadoop/assets/55643692/be921abf-b216-4ebd-9bac-583b1490b0eb">


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

