### PR TITLE
HADOOP-18942. Upgrade ZooKeeper to 3.7.2.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -103,7 +103,7 @@
     <hadoop-thirdparty-shaded-protobuf-prefix>${hadoop-thirdparty-shaded-prefix}.protobuf</hadoop-thirdparty-shaded-protobuf-prefix>
     <hadoop-thirdparty-shaded-guava-prefix>${hadoop-thirdparty-shaded-prefix}.com.google.common</hadoop-thirdparty-shaded-guava-prefix>
 
-    <zookeeper.version>3.6.4</zookeeper.version>
+    <zookeeper.version>3.7.2</zookeeper.version>
     <curator.version>5.2.0</curator.version>
     <findbugs.version>3.0.5</findbugs.version>
     <dnsjava.version>3.4.0</dnsjava.version>
@@ -1434,6 +1434,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -1461,6 +1465,10 @@
           <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-18942

While [HADOOP-18613](https://issues.apache.org/jira/browse/HADOOP-18613) is proposing to upgrade ZooKeeper to 3.8, it will bring dependency conflicts. Upgrading to ZooKeeper 3.7 could be alternative short-term fix for addressing CVEs.

