### PR TITLE
HADOOP-18711. upgrade nimbus jwt jar due to issues in its embedded shaded json-smart code.

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -242,7 +242,7 @@ com.google.guava:guava:jar:30.1.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.3
 com.microsoft.azure:azure-storage:7.0.1
-com.nimbusds:nimbus-jose-jwt:9.8.1
+com.nimbusds:nimbus-jose-jwt:9.31
 com.yammer.metrics:metrics-core:2.2.0
 com.zaxxer:HikariCP-java7:2.4.12
 commons-beanutils:commons-beanutils:1.9.4

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -217,7 +217,7 @@
     <solr.version>8.8.2</solr.version>
     <openssl-wildfly.version>1.1.3.Final</openssl-wildfly.version>
     <woodstox.version>5.4.0</woodstox.version>
-    <nimbus-jose-jwt.version>9.8.1</nimbus-jose-jwt.version>
+    <nimbus-jose-jwt.version>9.31</nimbus-jose-jwt.version>
     <nodejs.version>v12.22.1</nodejs.version>
     <yarnpkg.version>v1.22.5</yarnpkg.version>
     <apache-ant.version>1.10.13</apache-ant.version>


### PR DESCRIPTION
### Description of PR

backport of #5573

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

