### PR TITLE
HADOOP-18945. S3A: IAMInstanceCredentialsProvider failing.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -80,7 +80,7 @@ import static org.apache.hadoop.fs.s3a.impl.InstantiationIOException.isAbstract;
 import static org.apache.hadoop.fs.s3a.impl.InstantiationIOException.isNotInstanceOf;
 import static org.apache.hadoop.fs.s3a.impl.InstantiationIOException.unsupportedConstructor;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.*;
-import static org.apache.hadoop.fs.s3a.impl.ErrorTranslation.maybeExtractNetworkException;
+import static org.apache.hadoop.fs.s3a.impl.ErrorTranslation.maybeExtractIOException;
 import static org.apache.hadoop.io.IOUtils.cleanupWithLogger;
 import static org.apache.hadoop.util.functional.RemoteIterators.filteringRemoteIterator;
 
@@ -194,7 +194,7 @@ public final class S3AUtils {
         return ioe;
       }
       // network problems covered by an IOE inside the exception chain.
-      ioe = maybeExtractNetworkException(path, exception);
+      ioe = maybeExtractIOException(path, exception);
       if (ioe != null) {
         return ioe;
       }
@@ -583,7 +583,7 @@ public final class S3AUtils {
    * @param uri URI of the FS
    * @param interfaceImplemented interface that this class implements
    * @param methodName name of factory method to be invoked
-   * @param configKey config key under which this class is specified
+   * @param configKey config key under which this class is specified; used for exception text
    * @param <InstanceT> Instance of class
    * @return instance of the specified class
    * @throws IOException on any problem

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -583,7 +583,7 @@ public final class S3AUtils {
    * @param uri URI of the FS
    * @param interfaceImplemented interface that this class implements
    * @param methodName name of factory method to be invoked
-   * @param configKey config key under which this class is specified; used for exception text
+   * @param configKey config key under which this class is specified
    * @param <InstanceT> Instance of class
    * @return instance of the specified class
    * @throws IOException on any problem

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/CredentialProviderListFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/CredentialProviderListFactory.java
@@ -287,12 +287,13 @@ public final class CredentialProviderListFactory {
    * @param conf configuration
    * @param className credential class name
    * @param uri URI of the FS
-   * @param key configuration key to use
+   * @param key configuration key used; used for exception text
    * @return the instantiated class
    * @throws IOException on any instantiation failure.
    * @see S3AUtils#getInstanceFromReflection
    */
-  private static AwsCredentialsProvider createAWSV2CredentialProvider(Configuration conf,
+  @VisibleForTesting
+  public static AwsCredentialsProvider createAWSV2CredentialProvider(Configuration conf,
       String className,
       @Nullable URI uri, final String key) throws IOException {
     LOG.debug("Credential provider class is {}", className);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/CredentialProviderListFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/CredentialProviderListFactory.java
@@ -287,13 +287,12 @@ public final class CredentialProviderListFactory {
    * @param conf configuration
    * @param className credential class name
    * @param uri URI of the FS
-   * @param key configuration key used; used for exception text
+   * @param key configuration key to use
    * @return the instantiated class
    * @throws IOException on any instantiation failure.
    * @see S3AUtils#getInstanceFromReflection
    */
-  @VisibleForTesting
-  public static AwsCredentialsProvider createAWSV2CredentialProvider(Configuration conf,
+  private static AwsCredentialsProvider createAWSV2CredentialProvider(Configuration conf,
       String className,
       @Nullable URI uri, final String key) throws IOException {
     LOG.debug("Credential provider class is {}", className);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ErrorTranslation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ErrorTranslation.java
@@ -79,7 +79,7 @@ public final class ErrorTranslation {
    * @param thrown exception
    * @return a translated exception or null.
    */
-  public static IOException maybeExtractNetworkException(String path, Throwable thrown) {
+  public static IOException maybeExtractIOException(String path, Throwable thrown) {
 
     if (thrown == null) {
       return null;
@@ -100,7 +100,9 @@ public final class ErrorTranslation {
     // as a new instance is created through reflection, the
     // class of the returned instance will be that of the innermost,
     // unless no suitable constructor is available.
-    return wrapWithInnerIOE(path, thrown, (IOException) cause);
+    final IOException ioe = (IOException) cause;
+
+    return wrapWithInnerIOE(path, thrown, ioe);
 
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestIAMInstanceCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestIAMInstanceCredentialsProvider.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.auth;
+
+import java.io.IOException;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+
+/**
+ * Unit tests for IAMInstanceCredentials provider.
+ * This is a bit tricky as don't want to
+ */
+public class TestIAMInstanceCredentialsProvider extends AbstractHadoopTestBase {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestIAMInstanceCredentialsProvider.class);
+
+  /**
+   * Error string from
+   * software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider,
+   * if IAM resolution has been disabled.
+   */
+  public static final String DISABLED =
+      "IMDS credentials have been disabled by environment variable or system property";
+
+  /**
+   * Test an immediate create/close.
+   */
+  @Test
+  public void testIAMInstanceCredentialsProviderClose() throws Throwable {
+    new IAMInstanceCredentialsProvider().close();
+  }
+
+  /**
+   * Test instantiation.
+   * Multiple outcomes depending on host setup.
+   * <ol>
+   *   <li> In EC2: credentials resolved
+   *        Assert comes with a key.</li>
+   *   <li> Not in EC2: network error trying to talk to the service.
+   *        Assert wrapped exception is an IOE.</li>
+   *   <li> IMDS resolution disabled by env var/sysprop.
+   *        Expect the message to contain the "disabled" text.</li>
+   * </ol>
+   */
+  @Test
+  public void testIAMInstanceCredentialsInstantiate() throws Throwable {
+    try (IAMInstanceCredentialsProvider provider = new IAMInstanceCredentialsProvider()) {
+      try {
+        final AwsCredentials credentials = provider.resolveCredentials();
+        // if we get here this test suite is running in a container/EC2
+        LOG.info("Credentials: retrieved from {}: key={}",
+            provider.isContainerCredentialsProvider() ? "container" : "EC2",
+            credentials.accessKeyId());
+        Assertions.assertThat(credentials.accessKeyId())
+            .describedAs("Access key from IMDS")
+            .isNotBlank();
+      } catch (NoAwsCredentialsException expected) {
+        // this is expected if the test is not running in a container/EC2
+        LOG.info("Not running in a container/EC2");
+        LOG.info("Exception raised", expected);
+        // and we expect to have fallen back to the EC2 provider
+        Assertions.assertThat(provider.isContainerCredentialsProvider())
+            .describedAs("%s: shoud be using IAM credentials provider")
+            .isFalse();
+        final Throwable cause = expected.getCause();
+        if (cause == null) {
+          throw expected;
+        }
+        if (!(cause instanceof IOException)
+            && !cause.toString().contains(DISABLED)) {
+          throw new AssertionError("Cause not a IOException", cause);
+        }
+      }
+    }
+  }
+
+
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestIAMInstanceCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestIAMInstanceCredentialsProvider.java
@@ -28,10 +28,10 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 
 import org.apache.hadoop.test.AbstractHadoopTestBase;
 
-
 /**
  * Unit tests for IAMInstanceCredentials provider.
- * This is a bit tricky as don't want to
+ * This is a bit tricky as we don't want to require running in EC2,
+ * but nor do we want a test which doesn't work in EC2.
  */
 public class TestIAMInstanceCredentialsProvider extends AbstractHadoopTestBase {
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestIAMInstanceCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestIAMInstanceCredentialsProvider.java
@@ -78,6 +78,9 @@ public class TestIAMInstanceCredentialsProvider extends AbstractHadoopTestBase {
         Assertions.assertThat(credentials.accessKeyId())
             .describedAs("Access key from IMDS")
             .isNotBlank();
+
+        // and if we get here, so does a second call
+        final AwsCredentials credentials2 = provider.resolveCredentials();
       } catch (NoAwsCredentialsException expected) {
         // this is expected if the test is not running in a container/EC2
         LOG.info("Not running in a container/EC2");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestIAMInstanceCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestIAMInstanceCredentialsProvider.java
@@ -41,7 +41,7 @@ public class TestIAMInstanceCredentialsProvider extends AbstractHadoopTestBase {
   /**
    * Error string from
    * software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider,
-   * if IAM resolution has been disabled.
+   * if IAM resolution has been disabled: {@value}.
    */
   public static final String DISABLED =
       "IMDS credentials have been disabled by environment variable or system property";
@@ -58,12 +58,14 @@ public class TestIAMInstanceCredentialsProvider extends AbstractHadoopTestBase {
    * Test instantiation.
    * Multiple outcomes depending on host setup.
    * <ol>
-   *   <li> In EC2: credentials resolved
-   *        Assert comes with a key.</li>
-   *   <li> Not in EC2: network error trying to talk to the service.
+   *   <li> In EC2: credentials resolved.
+   *        Assert the credentials comes with a key.</li>
+   *   <li> Not in EC2: NoAwsCredentialsException wraps network error trying
+   *        to talk to the service.
    *        Assert wrapped exception is an IOE.</li>
    *   <li> IMDS resolution disabled by env var/sysprop.
-   *        Expect the message to contain the "disabled" text.</li>
+   *        NoAwsCredentialsException raised doesn't contain an IOE.
+   *        Require the message to contain the {@link #DISABLED} text.</li>j
    * </ol>
    */
   @Test
@@ -85,9 +87,9 @@ public class TestIAMInstanceCredentialsProvider extends AbstractHadoopTestBase {
         // this is expected if the test is not running in a container/EC2
         LOG.info("Not running in a container/EC2");
         LOG.info("Exception raised", expected);
-        // and we expect to have fallen back to the EC2 provider
+        // and we expect to have fallen back to InstanceProfileCredentialsProvider
         Assertions.assertThat(provider.isContainerCredentialsProvider())
-            .describedAs("%s: shoud be using IAM credentials provider")
+            .describedAs("%s: shoud be using InstanceProfileCredentialsProvider")
             .isFalse();
         final Throwable cause = expected.getCause();
         if (cause == null) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestIAMInstanceCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestIAMInstanceCredentialsProvider.java
@@ -82,7 +82,7 @@ public class TestIAMInstanceCredentialsProvider extends AbstractHadoopTestBase {
             .isNotBlank();
 
         // and if we get here, so does a second call
-        final AwsCredentials credentials2 = provider.resolveCredentials();
+        provider.resolveCredentials();
       } catch (NoAwsCredentialsException expected) {
         // this is expected if the test is not running in a container/EC2
         LOG.info("Not running in a container/EC2");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestErrorTranslation.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestErrorTranslation.java
@@ -19,8 +19,10 @@
 package org.apache.hadoop.fs.s3a.impl;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.ConnectException;
 import java.net.NoRouteToHostException;
+import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.Collections;
 
@@ -31,9 +33,10 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.retry.RetryPolicyContext;
 
 import org.apache.hadoop.fs.PathIOException;
+import org.apache.hadoop.fs.s3a.auth.NoAwsCredentialsException;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
 
-import static org.apache.hadoop.fs.s3a.impl.ErrorTranslation.maybeExtractNetworkException;
+import static org.apache.hadoop.fs.s3a.impl.ErrorTranslation.maybeExtractIOException;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.junit.Assert.assertTrue;
 
@@ -64,7 +67,7 @@ public class TestErrorTranslation extends AbstractHadoopTestBase {
             new UnknownHostException("bottom")));
     final IOException ioe = intercept(UnknownHostException.class, "top",
         () -> {
-          throw maybeExtractNetworkException("", thrown);
+          throw maybeExtractIOException("", thrown);
         });
 
     // the wrapped exception is the top level one: no stack traces have
@@ -79,7 +82,7 @@ public class TestErrorTranslation extends AbstractHadoopTestBase {
   public void testNoRouteToHostExceptionExtraction() throws Throwable {
     intercept(NoRouteToHostException.class, "top",
         () -> {
-          throw maybeExtractNetworkException("p2",
+          throw maybeExtractIOException("p2",
               sdkException("top",
                   sdkException("middle",
                       new NoRouteToHostException("bottom"))));
@@ -90,17 +93,35 @@ public class TestErrorTranslation extends AbstractHadoopTestBase {
   public void testConnectExceptionExtraction() throws Throwable {
     intercept(ConnectException.class, "top",
         () -> {
-          throw maybeExtractNetworkException("p1",
+          throw maybeExtractIOException("p1",
               sdkException("top",
                   sdkException("middle",
                       new ConnectException("bottom"))));
         });
   }
+
+  /**
+   * When there is an UncheckedIOException, its inner class is
+   * extracted.
+   */
+  @Test
+  public void testUncheckedIOExceptionExtraction() throws Throwable {
+    intercept(SocketTimeoutException.class, "top",
+        () -> {
+          final SdkClientException thrown = sdkException("top",
+              sdkException("middle",
+                  new UncheckedIOException(
+                      new SocketTimeoutException("bottom"))));
+          throw maybeExtractIOException("p1",
+              new NoAwsCredentialsException("IamProvider", thrown.toString(), thrown));
+        });
+  }
+
   @Test
   public void testNoConstructorExtraction() throws Throwable {
     intercept(PathIOException.class, NoConstructorIOE.MESSAGE,
         () -> {
-          throw maybeExtractNetworkException("p1",
+          throw maybeExtractIOException("p1",
               sdkException("top",
                   sdkException("middle",
                       new NoConstructorIOE())));


### PR DESCRIPTION

- Enable async refresh in inner credential provider.
- Store provider instance in a field; use synchronized() call to handle failure and switch from container to EC2 provider.
- Close inner provider in close();
- use ErrorTranslation to extract any IOE at base on stack
- rename maybeExtractNetworkException to maybeExtractIOException (as requested in review of third party support)
- test for error translation going through UncheckedIOException
- TestIAMInstanceCredentialsProvider to test fallback process

TestIAMInstanceCredentialsProvider is tricky as there are different test outcomes

1. In EC2: credentials resolved. Assert comes with a key.
2. Not in EC2: network error trying to talk to the service. Assert wrapped exception is an IOE.
3. IMDS resolution disabled by env var/sysprop. Expect the message to contain the text from the SDK

The test is potentially brittle; there may be followups.


### How was this patch tested?

* Tested with `AWS_EC2_METADATA_DISABLED=true` (my default) and with it unset.
* Not tested in EC2/k8s yet, that will be the success path.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

