### PR TITLE
HADOOP-18944. fix default value of Async drain threshold in S3A OpenFile

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/OpenFileSupport.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/OpenFileSupport.java
@@ -285,7 +285,7 @@ public class OpenFileSupport {
         .withSql(sql)
         .withAsyncDrainThreshold(
             builderSupport.getPositiveLong(ASYNC_DRAIN_THRESHOLD,
-                defaultReadAhead))
+                defaultAsyncDrainThreshold))
         .withBufferSize(
             (int)builderSupport.getPositiveLong(
                 FS_OPTION_OPENFILE_BUFFER_SIZE, defaultBufferSize))


### PR DESCRIPTION
### Description of PR
Changing the default value of async drain threshold from read-ahead's default value to actual async drain threshold default value.

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

