### PR TITLE
HADOOP-18946. TestErrorTranslation failure

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestErrorTranslation.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestErrorTranslation.java
@@ -127,8 +127,6 @@ public class TestErrorTranslation extends AbstractHadoopTestBase {
         .exception(ase)
         .build();
     RetryOnErrorCodeCondition retry = RetryOnErrorCodeCondition.create("");
-    assertTrue("retry policy of MultiObjectException",
-        retry.shouldRetry(context));
 
     Assertions.assertThat(retry.shouldRetry(context))
         .describedAs("retry policy of MultiObjectException")


### PR DESCRIPTION

Remove invalid assertion


### How was this patch tested?

Rerun of failing test suite.

Not. bothered with rest of tests

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

