### PR TITLE
HADOOP-18941. Modify HBase version in BUILDING.txt

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -163,13 +163,13 @@ Maven build goals:
  YARN Application Timeline Service V2 build options:
 
    YARN Timeline Service v.2 chooses Apache HBase as the primary backing storage. The supported
-   versions of Apache HBase are 1.2.6 (default) and 2.0.0-beta1.
+   versions of Apache HBase are 1.7.1 (default) and 2.2.4.
 
-  * HBase 1.2.6 is used by default to build Hadoop. The official releases are ready to use if you
-    plan on running Timeline Service v2 with HBase 1.2.6.
+  * HBase 1.7.1 is used by default to build Hadoop. The official releases are ready to use if you
+    plan on running Timeline Service v2 with HBase 1.7.1.
 
-  * Use -Dhbase.profile=2.0 to build Hadoop with HBase 2.0.0-beta1. Provide this option if you plan
-    on running Timeline Service v2 with HBase 2.0.
+  * Use -Dhbase.profile=2.2 to build Hadoop with HBase 2.2.4. Provide this option if you plan
+    on running Timeline Service v2 with HBase 2.2.
 
 
  Snappy build options:

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -168,8 +168,8 @@ Maven build goals:
   * HBase 1.7.1 is used by default to build Hadoop. The official releases are ready to use if you
     plan on running Timeline Service v2 with HBase 1.7.1.
 
-  * Use -Dhbase.profile=2.2 to build Hadoop with HBase 2.2.4. Provide this option if you plan
-    on running Timeline Service v2 with HBase 2.2.
+  * Use -Dhbase.profile=2.0 to build Hadoop with HBase 2.2.4. Provide this option if you plan
+    on running Timeline Service v2 with HBase 2.x.
 
 
  Snappy build options:


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Based on [HADOOP-18941](https://issues.apache.org/jira/browse/HADOOP-18941)

While the version of HBase has been updated in the dependencies described file [pom.xml](https://github.com/apache/hadoop/blob/trunk/hadoop-project/pom.xml#L205-L206), the version is still not improved in `BUILDING.txt`.

### How was this patch tested?

It is just a modification of documentation, so it is not involved with source code.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

