### PR TITLE
HDFS-17232. RBF: Fix NoNamenodesAvailableException for a long time, when use observer.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
@@ -79,7 +79,7 @@ public class MembershipNamenodeResolver
    * name and a boolean indicating if observer namenodes should be listed first.
    * If true, observer namenodes are listed first. If false, active namenodes are listed first.
    *  Invalidated on cache refresh. */
-  private Map<Pair<String,Boolean>, List<? extends FederationNamenodeContext>> cacheNS;
+  private Map<Pair<String, Boolean>, List<? extends FederationNamenodeContext>> cacheNS;
   /** Cached lookup of NN for block pool. Invalidated on cache refresh. */
   private Map<String, List<? extends FederationNamenodeContext>> cacheBP;
 
@@ -483,9 +483,9 @@ public class MembershipNamenodeResolver
    * Rotate cache, make the current namenode have the lowest priority,
    * to ensure that the current namenode will not be accessed first next time.
    *
-   * @param nsId name service id
-   * @param namenode namenode contexts
-   * @param listObserversFirst Observer read case, observer NN will be ranked first
+   * @param nsId name service id.
+   * @param namenode namenode contexts.
+   * @param listObserversFirst Observer read case, observer NN will be ranked first.
    */
   @Override
   public void rotateCache(
@@ -503,15 +503,16 @@ public class MembershipNamenodeResolver
         }
       }
 
-      // If the last namenode in the cache at this time is the namenode.
+      // If the last namenode in the cache at this time
+      // is the namenode whose priority needs to be lowered.
       // No need to rotate cache, because other threads have already rotated the cache.
       FederationNamenodeContext lastNamenode = namenodeContexts.get(namenodeContexts.size()-1);
       if (lastNamenode.getRpcAddress().equals(namenode.getRpcAddress())) {
         return namenodeContexts;
       }
 
-      // Move the abnormal namenode to the end of the cache,
-      // to ensure that the current namenode will not be accessed first next time.
+      // Move the inaccessible namenode to the end of the cache,
+      // to ensure that the namenode will not be accessed first next time.
       List<FederationNamenodeContext> rotateNamenodeContexts =
           (List<FederationNamenodeContext>) namenodeContexts;
       rotateNamenodeContexts.remove(namenode);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
@@ -494,29 +494,31 @@ public class MembershipNamenodeResolver
       if (namenodeContexts == null || namenodeContexts.size() <= 1) {
         return namenodeContexts;
       }
-      FederationNamenodeContext firstNamenodeContext = namenodeContexts.get(0);
-      /*
-       * If the first nn in the cache is active, the active nn priority cannot be lowered.
-       * This happens when other threads have already updated the cache.
-       */
-      if (firstNamenodeContext.getState().equals(ACTIVE)) {
+
+      // If there is active nn, rotateCache is not needed
+      // because the router has already loaded the cache.
+      for (FederationNamenodeContext namenodeContext : namenodeContexts) {
+        if (namenodeContext.getState() == ACTIVE) {
+          return namenodeContexts;
+        }
+      }
+
+      // If the last namenode in the cache at this time is the namenode.
+      // No need to rotate cache, because other threads have already rotated the cache.
+      FederationNamenodeContext lastNamenode = namenodeContexts.get(namenodeContexts.size()-1);
+      if (lastNamenode.getRpcAddress().equals(namenode.getRpcAddress())) {
         return namenodeContexts;
       }
-      /*
-       * If the first nn in the cache at this time is not the nn
-       * that needs to be lowered in priority, there is no need to rotate.
-       * This happens when other threads have already rotated the cache.
-       */
-      if (firstNamenodeContext.getRpcAddress().equals(namenode.getRpcAddress())) {
-        List<FederationNamenodeContext> rotatedNnContexts = new ArrayList<>(namenodeContexts);
-        Collections.rotate(rotatedNnContexts, -1);
-        String firstNamenodeId = namenodeContexts.get(0).getNamenodeId();
-        LOG.info("Rotate cache of pair <ns: {}, observer first: {}>, put namenode: {} in the " +
-            "first position of the cache and namenode: {} in the last position of the cache",
-            nsId, listObserversFirst, firstNamenodeId, namenode.getNamenodeId());
-        return rotatedNnContexts;
-      }
-      return namenodeContexts;
+
+      // Move the abnormal namenode to the end of the cache,
+      // to ensure that the current namenode will not be accessed first next time.
+      List<FederationNamenodeContext> rotateNamenodeContexts =
+          (List<FederationNamenodeContext>) namenodeContexts;
+      rotateNamenodeContexts.remove(namenode);
+      rotateNamenodeContexts.add(namenode);
+      LOG.info("Rotate cache of pair<{}, {}> -> {}",
+          nsId, listObserversFirst, rotateNamenodeContexts);
+      return rotateNamenodeContexts;
     });
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -457,9 +457,10 @@ public class RouterRpcClient {
    * @param ioe IOException reported.
    * @param retryCount Number of retries.
    * @param nsId Nameservice ID.
+   * @param namenode namenode context.
+   * @param listObserverFirst Observer read case, observer NN will be ranked first.
    * @return Retry decision.
-   * @throws NoNamenodesAvailableException Exception that the retry policy
-   *         generates for no available namenodes.
+   * @throws IOException An IO Error occurred.
    */
   private RetryDecision shouldRetry(
       final IOException ioe, final int retryCount, final String nsId,
@@ -779,8 +780,8 @@ public class RouterRpcClient {
    * Check if the cluster of given nameservice id is available.
    *
    * @param nsId nameservice ID.
-   * @param namenode
-   * @param listObserverFirst
+   * @param namenode namenode context.
+   * @param listObserverFirst Observer read case, observer NN will be ranked first.
    * @return true if the cluster with given nameservice id is available.
    * @throws IOException if error occurs.
    */
@@ -788,7 +789,7 @@ public class RouterRpcClient {
       String nsId, FederationNamenodeContext namenode,
       boolean listObserverFirst) throws IOException {
     // Use observer and the namenode that causes the exception is an observer,
-    // false is returned so that the oberver can be marked as unavailable,so other observers
+    // false is returned so that the observer can be marked as unavailable,so other observers
     // or active namenode which is standby in the cache of the router can be retried.
     if (listObserverFirst && namenode.getState() == FederationNamenodeServiceState.OBSERVER) {
       return false;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -788,7 +788,8 @@ public class RouterRpcClient {
   private boolean isClusterUnAvailable(
       String nsId, FederationNamenodeContext namenode,
       boolean listObserverFirst) throws IOException {
-    // Use observer and the namenode that causes the exception is an observer,
+    // If the operation is an observer read
+    // and the namenode that caused the exception is an observer,
     // false is returned so that the observer can be marked as unavailable,so other observers
     // or active namenode which is standby in the cache of the router can be retried.
     if (listObserverFirst && namenode.getState() == FederationNamenodeServiceState.OBSERVER) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
@@ -132,9 +132,9 @@ public class MiniRouterDFSCluster {
   /** Mini cluster. */
   private MiniDFSCluster cluster;
 
-  protected static final long DEFAULT_HEARTBEAT_INTERVAL_MS =
+  public static final long DEFAULT_HEARTBEAT_INTERVAL_MS =
       TimeUnit.SECONDS.toMillis(5);
-  protected static final long DEFAULT_CACHE_INTERVAL_MS =
+  public static final long DEFAULT_CACHE_INTERVAL_MS =
       TimeUnit.SECONDS.toMillis(5);
   /** Heartbeat interval in milliseconds. */
   private long heartbeatInterval;
@@ -251,6 +251,19 @@ public class MiniRouterDFSCluster {
       DistributedFileSystem.setDefaultUri(observerReadConf, "hdfs://router-service");
 
       return DistributedFileSystem.get(observerReadConf);
+    }
+
+    public FileSystem getFileSystemWithConfiguredFailoverProxyProvider() throws IOException {
+      conf.set(DFS_NAMESERVICES,
+          conf.get(DFS_NAMESERVICES)+ ",router-service");
+      conf.set(DFS_HA_NAMENODES_KEY_PREFIX + ".router-service", "router1");
+      conf.set(DFS_NAMENODE_RPC_ADDRESS_KEY+ ".router-service.router1",
+          getFileSystemURI().toString());
+      conf.set(HdfsClientConfigKeys.Failover.PROXY_PROVIDER_KEY_PREFIX
+          + "." + "router-service", ConfiguredFailoverProxyProvider.class.getName());
+      DistributedFileSystem.setDefaultUri(conf, "hdfs://router-service");
+
+      return DistributedFileSystem.get(conf);
     }
 
     public DFSClient getClient(UserGroupInformation user)

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
@@ -90,6 +90,7 @@ import org.apache.hadoop.hdfs.server.federation.router.RouterRpcClient;
 import org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer;
 import org.apache.hadoop.hdfs.server.namenode.FSImage;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
+import org.apache.hadoop.hdfs.server.namenode.ha.AbstractNNFailoverProxyProvider;
 import org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider;
 import org.apache.hadoop.hdfs.server.namenode.ha.ObserverReadProxyProvider;
 import org.apache.hadoop.hdfs.server.protocol.NamespaceInfo;
@@ -240,27 +241,23 @@ public class MiniRouterDFSCluster {
     }
 
     public FileSystem getFileSystemWithObserverReadProxyProvider() throws IOException {
-      Configuration observerReadConf = new Configuration(conf);
-      observerReadConf.set(DFS_NAMESERVICES,
-          observerReadConf.get(DFS_NAMESERVICES)+ ",router-service");
-      observerReadConf.set(DFS_HA_NAMENODES_KEY_PREFIX + ".router-service", "router1");
-      observerReadConf.set(DFS_NAMENODE_RPC_ADDRESS_KEY+ ".router-service.router1",
-          getFileSystemURI().toString());
-      observerReadConf.set(HdfsClientConfigKeys.Failover.PROXY_PROVIDER_KEY_PREFIX
-          + "." + "router-service", ObserverReadProxyProvider.class.getName());
-      DistributedFileSystem.setDefaultUri(observerReadConf, "hdfs://router-service");
-
-      return DistributedFileSystem.get(observerReadConf);
+      return getFileSystemWithProxyProvider(ObserverReadProxyProvider.class.getName());
     }
 
     public FileSystem getFileSystemWithConfiguredFailoverProxyProvider() throws IOException {
+      return getFileSystemWithProxyProvider(ConfiguredFailoverProxyProvider.class.getName());
+    }
+
+    private FileSystem getFileSystemWithProxyProvider(
+        String proxyProviderClassName) throws IOException {
       conf.set(DFS_NAMESERVICES,
           conf.get(DFS_NAMESERVICES)+ ",router-service");
       conf.set(DFS_HA_NAMENODES_KEY_PREFIX + ".router-service", "router1");
       conf.set(DFS_NAMENODE_RPC_ADDRESS_KEY+ ".router-service.router1",
           getFileSystemURI().toString());
+
       conf.set(HdfsClientConfigKeys.Failover.PROXY_PROVIDER_KEY_PREFIX
-          + "." + "router-service", ConfiguredFailoverProxyProvider.class.getName());
+          + "." + "router-service", proxyProviderClassName);
       DistributedFileSystem.setDefaultUri(conf, "hdfs://router-service");
 
       return DistributedFileSystem.get(conf);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
@@ -90,7 +90,6 @@ import org.apache.hadoop.hdfs.server.federation.router.RouterRpcClient;
 import org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer;
 import org.apache.hadoop.hdfs.server.namenode.FSImage;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
-import org.apache.hadoop.hdfs.server.namenode.ha.AbstractNNFailoverProxyProvider;
 import org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider;
 import org.apache.hadoop.hdfs.server.namenode.ha.ObserverReadProxyProvider;
 import org.apache.hadoop.hdfs.server.protocol.NamespaceInfo;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestNoNamenodesAvailableLongTime.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestNoNamenodesAvailableLongTime.java
@@ -1,0 +1,415 @@
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import static org.apache.hadoop.fs.permission.AclEntryType.USER;
+import static org.apache.hadoop.fs.permission.FsAction.ALL;
+import static org.apache.hadoop.fs.permission.AclEntryScope.DEFAULT;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.AclEntry;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
+import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.RouterContext;
+import org.apache.hadoop.hdfs.server.federation.RouterConfigBuilder;
+import org.apache.hadoop.hdfs.server.federation.StateStoreDFSCluster;
+import org.apache.hadoop.hdfs.server.federation.metrics.FederationRPCMetrics;
+import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeContext;
+import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeServiceState;
+import org.apache.hadoop.hdfs.server.namenode.NameNode;
+import org.apache.hadoop.ipc.RemoteException;
+import org.apache.hadoop.util.Lists;
+import org.junit.After;
+import org.junit.Test;
+
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.hadoop.ha.HAServiceProtocol.HAServiceState.ACTIVE;
+import static org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.DEFAULT_HEARTBEAT_INTERVAL_MS;
+import static org.apache.hadoop.hdfs.server.namenode.AclTestHelpers.aclEntry;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * When failover occurs, the router may record that the ns has no active namenode
+ * even if there is actually an active namenode.
+ * Only when the router updates the cache next time can the memory status be updated,
+ * causing the router to report NoNamenodesAvailableException for a long time,
+ *
+ * @see org.apache.hadoop.hdfs.server.federation.router.NoNamenodesAvailableException
+ */
+public class TestNoNamenodesAvailableLongTime {
+
+  // router load cache interval 10s
+  private static final long CACHE_FLUSH_INTERVAL_MS = 10000;
+  private StateStoreDFSCluster cluster;
+  private FileSystem fileSystem;
+  private RouterContext routerContext;
+  private FederationRPCMetrics rpcMetrics;
+
+  @After
+  public void cleanup() throws IOException {
+    rpcMetrics = null;
+    routerContext = null;
+    if (fileSystem != null) {
+      fileSystem.close();
+      fileSystem = null;
+    }
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
+    }
+  }
+
+  /**
+   * Set up state store cluster.
+   *
+   * @param numNameservices number of name services
+   * @param numberOfObserver number of observer
+   * @param useObserver whether to use observer
+   */
+  private void setupCluster(int numNameservices, int numberOfObserver, boolean useObserver)
+      throws Exception {
+    if (!useObserver) {
+      numberOfObserver = 0;
+    }
+    int numberOfNamenode = 2 + numberOfObserver;
+    cluster = new StateStoreDFSCluster(true, numNameservices, numberOfNamenode,
+        DEFAULT_HEARTBEAT_INTERVAL_MS, CACHE_FLUSH_INTERVAL_MS);
+    Configuration routerConf = new RouterConfigBuilder()
+        .stateStore()
+        .metrics()
+        .admin()
+        .rpc()
+        .heartbeat()
+        .build();
+
+    // Set router observer related configs
+    if (useObserver) {
+      routerConf.setBoolean(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_DEFAULT_KEY, true);
+      routerConf.setBoolean(DFSConfigKeys.DFS_HA_TAILEDITS_INPROGRESS_KEY, true);
+      routerConf.set(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, "0ms");
+    }
+
+    // Reduce the number of RPC clients threads to overload the Router easy
+    routerConf.setInt(RBFConfigKeys.DFS_ROUTER_CLIENT_THREADS_SIZE, 4);
+
+    // No need for datanodes
+    cluster.setNumDatanodesPerNameservice(0);
+    cluster.addRouterOverrides(routerConf);
+
+    cluster.startCluster();
+
+    // Making one Namenode active per nameservice
+    if (cluster.isHighAvailability()) {
+      for (String ns : cluster.getNameservices()) {
+        List<MiniRouterDFSCluster.NamenodeContext>  nnList = cluster.getNamenodes(ns);
+        cluster.switchToActive(ns, nnList.get(0).getNamenodeId());
+        cluster.switchToStandby(ns, nnList.get(1).getNamenodeId());
+        for (int i = 2; i < numberOfNamenode; i++) {
+          cluster.switchToObserver(ns, nnList.get(i).getNamenodeId());
+        }
+      }
+    }
+
+    cluster.startRouters();
+    cluster.waitClusterUp();
+  }
+
+  /**
+   * Initialize the test environment and start the cluster so that
+   * there is no active namenode record in the router cache,
+   * but the second non-observer namenode in the router cache is actually active.
+   */
+  private void initEnv(int numberOfObserver, boolean useObserver) throws Exception {
+    setupCluster(1, numberOfObserver, useObserver);
+    // Transition all namenodes in the cluster are standby.
+    transitionActiveToStandby();
+    //
+    allRoutersHeartbeat();
+    allRoutersLoadCache();
+
+    List<MiniRouterDFSCluster.NamenodeContext> namenodes = cluster.getNamenodes();
+
+    // Make sure all namenodes are in standby state
+    for (MiniRouterDFSCluster.NamenodeContext namenodeContext : namenodes) {
+      assertNotEquals(ACTIVE.ordinal(), namenodeContext.getNamenode().getNameNodeState());
+    }
+
+    routerContext = cluster.getRandomRouter();
+
+    // Get the second namenode in the router cache and make it active
+    setSecondNonObserverNamenodeInTheRouterCacheActive(numberOfObserver, false);
+    allRoutersHeartbeat();
+
+    // Get router metrics
+    rpcMetrics = routerContext.getRouter().getRpcServer().getRPCMetrics();
+
+    assertTrue(routerCacheNoActiveNamenode(routerContext, "ns0", useObserver));
+
+    // Retries is 2 (see FailoverOnNetworkExceptionRetry#shouldRetry, will fail
+    // when reties > max.attempts), so total access is 3.
+    routerContext.getConf().setInt("dfs.client.retry.max.attempts", 1);
+
+    if (useObserver) {
+      fileSystem = routerContext.getFileSystemWithObserverReadProxyProvider();
+    } else {
+      fileSystem = routerContext.getFileSystemWithConfiguredFailoverProxyProvider();
+    }
+  }
+
+  /**
+   * If NoNamenodesAvailableException occurs due to
+   * {@link RouterRpcClient#isUnavailableException(IOException) unavailable exception},
+   * should rotated Cache.
+   */
+  @Test
+  public void testShouldRotatedCache() throws Exception {
+    // 2 namenodes: 1 active, 1 standby.
+    // But there is no active namenode in router cache.
+    initEnv(0, false);
+    // At this time, the router has recorded 2 standby namenodes in memory.
+    assertTrue(routerCacheNoActiveNamenode(routerContext, "ns0", false));
+
+    Path path = new Path("/test.file");
+    // The first create operation will cause NoNamenodesAvailableException and RotatedCache.
+    // After retrying, create and complete operation will be executed successfully.
+    fileSystem.create(path);
+    assertEquals(1, rpcMetrics.getProxyOpNoNamenodes());
+
+    // At this time, the router has recorded 2 standby namenodes in memory,
+    // the operation can be successful without waiting for the router load cache.
+    assertTrue(routerCacheNoActiveNamenode(routerContext, "ns0", false));
+  }
+
+  /**
+   * If a request still fails even if it is sent to active,
+   * then the change operation itself is illegal,
+   * the cache should not be rotated due to illegal operations.
+   */
+  @Test
+  public void testShouldNotBeRotatedCache() throws Exception {
+    testShouldRotatedCache();
+    long proxyOpNoNamenodes = rpcMetrics.getProxyOpNoNamenodes();
+    Path path = new Path("/test.file");
+    /*
+     * we have put the actually active namenode at the front of the cache by rotating the cache.
+     * Therefore, the setPermission operation does not cause NoNamenodesAvailableException.
+     */
+    fileSystem.setPermission(path, FsPermission.createImmutable((short)0640));
+    assertEquals(proxyOpNoNamenodes, rpcMetrics.getProxyOpNoNamenodes());
+
+    // At this time, the router has recorded 2 standby namenodes in memory
+    assertTrue(routerCacheNoActiveNamenode(routerContext, "ns0", false));
+
+    /*
+     * Even if the router transfers the illegal request to active,
+     * NoNamenodesAvailableException will still be generated.
+     * Therefore, rotated cache is not needed.
+     */
+    List<AclEntry> aclSpec = Lists.newArrayList(aclEntry(DEFAULT, USER, "foo", ALL));
+    try {
+      fileSystem.setAcl(path, aclSpec);
+    }catch (RemoteException e) {
+      assertTrue(e.getMessage().contains(
+          "org.apache.hadoop.hdfs.server.federation.router.NoNamenodesAvailableException: " +
+          "No namenodes available under nameservice ns0"));
+      assertTrue(e.getMessage().contains(
+          "org.apache.hadoop.hdfs.protocol.AclException: Invalid ACL: " +
+          "only directories may have a default ACL. Path: /test.file"));
+    }
+    // Retries is 2 (see FailoverOnNetworkExceptionRetry#shouldRetry, will fail
+    // when reties > max.attempts), so total access is 3.
+    assertEquals(proxyOpNoNamenodes + 3, rpcMetrics.getProxyOpNoNamenodes());
+    proxyOpNoNamenodes = rpcMetrics.getProxyOpNoNamenodes();
+
+    // So legal operations can be accessed normally without reporting NoNamenodesAvailableException.
+    assertTrue(routerCacheNoActiveNamenode(routerContext, "ns0", false));
+    fileSystem.getFileStatus(path);
+    assertEquals(proxyOpNoNamenodes, rpcMetrics.getProxyOpNoNamenodes());
+
+    // At this time, the router has recorded 2 standby namenodes in memory,
+    // the operation can be successful without waiting for the router load cache.
+    assertTrue(routerCacheNoActiveNamenode(routerContext, "ns0", false));
+  }
+
+  /**
+   * In the observer scenario, NoNamenodesAvailableException occurs,
+   * the operation can be successful without waiting for the router load cache.
+   */
+  @Test
+  public void testUseObserver() throws Exception {
+    // 4 namenodes: 2 observers, 1 active, 1 standby.
+    // But there is no active namenode in router cache.
+    initEnv(2, true);
+
+    Path path = new Path("/");
+    // At this time, the router has recorded 2 standby namenodes in memory.
+    assertTrue(routerCacheNoActiveNamenode(routerContext, "ns0", true));
+
+    // The first msync operation will cause NoNamenodesAvailableException and RotatedCache.
+    // After retrying, msync and getFileInfo operation will be executed successfully.
+    fileSystem.getFileStatus(path);
+    assertEquals(1, rpcMetrics.getObserverProxyOps());
+    assertEquals(1, rpcMetrics.getProxyOpNoNamenodes());
+
+    // At this time, the router has recorded 2 standby namenodes in memory,
+    // the operation can be successful without waiting for the router load cache.
+    assertTrue(routerCacheNoActiveNamenode(routerContext, "ns0", true));
+  }
+
+  /**
+   * In a multi-observer environment, if at least one observer is normal,
+   * read requests can still succeed even if NoNamenodesAvailableException occurs.
+   */
+  @Test
+  public void testAtLeastOneObserverNormal() throws Exception {
+    // 4 namenodes: 2 observers, 1 active, 1 standby.
+    // But there is no active namenode in router cache.
+    initEnv(2, true);
+    // Shutdown one observer.
+    stopObserver(1);
+
+    /*
+     * The first msync operation will cause NoNamenodesAvailableException and RotatedCache.
+     * After retrying, msync operation will be executed successfully.
+     * Each read request will shuffle the observer,
+     * if the getFileInfo operation is sent to the downed observer,
+     * it will cause NoNamenodesAvailableException,
+     * at this time, the request can be retried to the normal observer,
+     * no NoNamenodesAvailableException will be generated and the operation will be successful.
+     */
+    fileSystem.getFileStatus(new Path("/"));
+    assertEquals(1, rpcMetrics.getProxyOpNoNamenodes());
+    assertEquals(1, rpcMetrics.getObserverProxyOps());
+
+    // At this time, the router has recorded 2 standby namenodes in memory,
+    // the operation can be successful without waiting for the router load cache.
+    assertTrue(routerCacheNoActiveNamenode(routerContext, "ns0", true));
+  }
+
+  /**
+   * If all obervers are down, read requests can succeed,
+   * even if a NoNamenodesAvailableException occurs.
+   */
+  @Test
+  public void testAllObserverAbnormality() throws Exception {
+    // 4 namenodes: 2 observers, 1 active, 1 standby.
+    // But there is no active namenode in router cache.
+    initEnv(2, true);
+    // Shutdown all observers.
+    stopObserver(2);
+
+    /*
+     * The first msync operation will cause NoNamenodesAvailableException and RotatedCache.
+     * After retrying, msync operation will be executed successfully.
+     * The getFileInfo operation retried 2 namenodes, both causing UnavailableException,
+     * and continued to retry to the standby namenode,
+     * causing NoNamenodesAvailableException and RotatedCache,
+     * and the execution was successful after retrying.
+     */
+    fileSystem.getFileStatus(new Path("/"));
+    assertEquals(2, rpcMetrics.getProxyOpFailureCommunicate());
+    assertEquals(2, rpcMetrics.getProxyOpNoNamenodes());
+
+    // At this time, the router has recorded 2 standby namenodes in memory,
+    // the operation can be successful without waiting for the router load cache.
+    assertTrue(routerCacheNoActiveNamenode(routerContext, "ns0", true));
+  }
+
+  /**
+   * Determine whether cache of the router has an active namenode.
+   *
+   * @return true if no active namenode, otherwise false.
+   */
+  private boolean routerCacheNoActiveNamenode(
+      RouterContext context, String nsId, boolean useObserver) throws IOException {
+    List<? extends FederationNamenodeContext> namenodes
+        = context.getRouter().getNamenodeResolver().getNamenodesForNameserviceId(nsId, useObserver);
+    for (FederationNamenodeContext namenode : namenodes) {
+      if (namenode.getState() == FederationNamenodeServiceState.ACTIVE){
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * All routers in the cluster force loadcache.
+   */
+  private void allRoutersLoadCache() {
+    for (MiniRouterDFSCluster.RouterContext context : cluster.getRouters()) {
+      // Update service cache
+      context.getRouter().getStateStore().refreshCaches(true);
+    }
+  }
+
+  /**
+   * Set the second non-observer state namenode in the router cache to active.
+   */
+  private void setSecondNonObserverNamenodeInTheRouterCacheActive(
+      int numberOfObserver, boolean useObserver) throws IOException {
+    List<? extends FederationNamenodeContext> ns0 = routerContext.getRouter()
+        .getNamenodeResolver()
+        .getNamenodesForNameserviceId("ns0", useObserver);
+
+    String nsId = ns0.get(numberOfObserver+1).getNamenodeId();
+    cluster.switchToActive("ns0", nsId);
+    assertEquals(ACTIVE.ordinal(),
+        cluster.getNamenode("ns0", nsId).getNamenode().getNameNodeState());
+
+  }
+
+  /**
+   * All routers in the cluster force heartbeat.
+   */
+  private void allRoutersHeartbeat() throws IOException {
+    for (RouterContext context : cluster.getRouters()) {
+      // Manually trigger the heartbeat, but the router does not manually load the cache
+      Collection<NamenodeHeartbeatService> heartbeatServices = context
+          .getRouter().getNamenodeHeartbeatServices();
+      for (NamenodeHeartbeatService service : heartbeatServices) {
+        service.periodicInvoke();
+      }
+    }
+  }
+
+  /**
+   * Transition the active namenode in the cluster to standby.
+   */
+  private void transitionActiveToStandby() {
+    if (cluster.isHighAvailability()) {
+      for (String ns : cluster.getNameservices()) {
+        List<MiniRouterDFSCluster.NamenodeContext>  nnList = cluster.getNamenodes(ns);
+        for (MiniRouterDFSCluster.NamenodeContext namenodeContext : nnList) {
+          if (namenodeContext.getNamenode().isActiveState()) {
+            cluster.switchToStandby(ns, namenodeContext.getNamenodeId());
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Shutdown oberver namenode in the cluste.
+   *
+   * @param num The number of shutdown oberver.
+   */
+  private void stopObserver(int num) {
+    int nnIndex;
+    for (nnIndex = 0; nnIndex < cluster.getNamenodes().size(); nnIndex++) {
+      NameNode nameNode = cluster.getCluster().getNameNode(nnIndex);
+      if (nameNode != null && nameNode.isObserverState()) {
+        cluster.getCluster().shutdownNameNode(nnIndex);
+        num--;
+        if (num == 0) {
+          break;
+        }
+      }
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestNoNamenodesAvailableLongTime.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestNoNamenodesAvailableLongTime.java
@@ -412,9 +412,9 @@ public class TestNoNamenodesAvailableLongTime {
   }
 
   /**
-   * Shutdown oberver namenode in the cluste.
+   * Shutdown observer namenode in the cluster.
    *
-   * @param num The number of shutdown oberver.
+   * @param num The number of shutdown observer.
    */
   private void stopObserver(int num) {
     int nnIndex;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestNoNamenodesAvailableLongTime.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestNoNamenodesAvailableLongTime.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hdfs.server.federation.router;
 
 import static org.apache.hadoop.fs.permission.AclEntryType.USER;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestNoNamenodesAvailableLongTime.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestNoNamenodesAvailableLongTime.java
@@ -418,14 +418,12 @@ public class TestNoNamenodesAvailableLongTime {
    */
   private void stopObserver(int num) {
     int nnIndex;
-    for (nnIndex = 0; nnIndex < cluster.getNamenodes().size(); nnIndex++) {
+    int numNns = cluster.getNamenodes().size();
+    for (nnIndex = 0; nnIndex < numNns && num > 0; nnIndex++) {
       NameNode nameNode = cluster.getCluster().getNameNode(nnIndex);
       if (nameNode != null && nameNode.isObserverState()) {
         cluster.getCluster().shutdownNameNode(nnIndex);
         num--;
-        if (num == 0) {
-          break;
-        }
       }
     }
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
see https://issues.apache.org/jira/browse/HDFS-17232

### How was this patch tested?
Added new unit test class TestNoNamenodesAvailableLongTime.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

