### PR TITLE
HDFS-17235. Fix javadoc errors in BlockManager

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -150,8 +150,8 @@ import org.slf4j.LoggerFactory;
  * redundancy.
  *
  * For regular replication, # of min live replicas for maintenance is determined
- * by {@link DFS_NAMENODE_MAINTENANCE_REPLICATION_MIN_KEY}. This number has to &lt;=
- * {@link DFS_NAMENODE_REPLICATION_MIN_KEY}.
+ * by {@link DFSConfigKeys#DFS_NAMENODE_MAINTENANCE_REPLICATION_MIN_KEY}. This number has to &lt;=
+ * {@link DFSConfigKeys#DFS_NAMENODE_REPLICATION_MIN_KEY}.
  * For erasure encoding, # of min live replicas for maintenance is
  * {@link BlockInfoStriped#getRealDataBlockNum}.
  *


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17235

There are 2 errors in BlockManager.java, we need fix it.
https://ci-hadoop.apache.org/job/hadoop-multibranch/job/PR-6194/4/artifact/out/patch-javadoc-hadoop-hdfs-project_hadoop-hdfs-jdkUbuntu-11.0.20.1+1-post-Ubuntu-0ubuntu120.04.txt

```
[ERROR] /home/jenkins/jenkins-agent/workspace/hadoop-multibranch_PR-6194/ubuntu-focal/src/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java:153: error: reference not found
[ERROR]  * by {@link DFS_NAMENODE_MAINTENANCE_REPLICATION_MIN_KEY}. This number has to &lt;=
[ERROR]              ^
[ERROR] /home/jenkins/jenkins-agent/workspace/hadoop-multibranch_PR-6194/ubuntu-focal/src/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java:154: error: reference not found
[ERROR]  * {@link DFS_NAMENODE_REPLICATION_MIN_KEY}.
```
