### PR TITLE
YARN-11597. Fix NPE when loading static files in SLSWebApp

### DIFF
--- a/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/web/SLSWebApp.java
+++ b/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/web/SLSWebApp.java
@@ -136,6 +136,7 @@ public class SLSWebApp extends HttpServlet {
     String webRootDir = getClass().getClassLoader().getResource("html").
         toExternalForm();
     staticHandler.setResourceBase(webRootDir);
+    staticHandler.start();
 
     Handler handler = new AbstractHandler() {
       @Override


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11597. Fix NPE when loading static files in SLSWebApp

When using the SLS, the web api of http://localhost:10001/simulate is broken, because the static file loading failed of 404 http code.

This is caused by the static handler is not initialized. NPE stacktrace is as follows.

![20231023-171754](https://github.com/apache/hadoop/assets/8609142/a31d199f-5bca-41ed-9d84-57f0020a0818)


### How was this patch tested?

Checked in internal tests.


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

