### PR TITLE
HDFS-17237. Remove IPCLoggerChannelMetrics when the logger is closed

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/IPCLoggerChannel.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/IPCLoggerChannel.java
@@ -206,6 +206,7 @@ public class IPCLoggerChannel implements AsyncLogger {
       // making any more calls after this point (eg clear the queue)
       RPC.stopProxy(proxy);
     }
+    metrics.unregister();
   }
   
   protected QJournalProtocol getProxy() throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/IPCLoggerChannelMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/IPCLoggerChannelMetrics.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdfs.qjournal.client;
 
 import java.net.InetSocketAddress;
-import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
@@ -28,8 +27,6 @@ import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableQuantiles;
-
-import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 
 /**
  * The metrics for a journal from the writer's perspective.
@@ -43,21 +40,6 @@ class IPCLoggerChannelMetrics {
   private final MutableQuantiles[] writeEndToEndLatencyQuantiles;
   private final MutableQuantiles[] writeRpcLatencyQuantiles;
 
-  
-  /**
-   * In the case of the NN transitioning between states, edit logs are closed
-   * and reopened. Thus, the IPCLoggerChannel instance that writes to a
-   * given JournalNode may change over the lifetime of the process.
-   * However, metrics2 doesn't have a function to unregister a set of metrics
-   * and fails if a new metrics class is registered with the same name
-   * as the existing one. Hence, we have to maintain our own registry
-   * ("multiton") here, so that we have exactly one metrics instance
-   * per JournalNode, and switch out the pointer to the underlying
-   * IPCLoggerChannel instance.
-   */
-  private static final Map<String, IPCLoggerChannelMetrics> REGISTRY =
-      Maps.newHashMap();
-  
   private IPCLoggerChannelMetrics(IPCLoggerChannel ch) {
     this.ch = ch;
     
@@ -81,25 +63,16 @@ class IPCLoggerChannelMetrics {
       writeRpcLatencyQuantiles = null;
     }
   }
-  
-  private void setChannel(IPCLoggerChannel ch) {
-    assert ch.getRemoteAddress().equals(this.ch.getRemoteAddress());
-    this.ch = ch;
+
+  public void unregister() {
+    DefaultMetricsSystem.instance().unregisterSource(getName(ch));
   }
 
   static IPCLoggerChannelMetrics create(IPCLoggerChannel ch) {
     String name = getName(ch);
-    synchronized (REGISTRY) {
-      IPCLoggerChannelMetrics m = REGISTRY.get(name);
-      if (m != null) {
-        m.setChannel(ch);
-      } else {
-        m = new IPCLoggerChannelMetrics(ch);
-        DefaultMetricsSystem.instance().register(name, null, m);
-        REGISTRY.put(name, m);
-      }
-      return m;
-    }
+    IPCLoggerChannelMetrics m = new IPCLoggerChannelMetrics(ch);
+    DefaultMetricsSystem.instance().register(name, null, m);
+    return m;
   }
 
   private static String getName(IPCLoggerChannel ch) {


### PR DESCRIPTION
### Description of PR

When an IPCLoggerChannel is created (which is used to read from and write to the Journal nodes) it also creates a metrics object. When the namenodes failover, the IPC loggers are all closed and reopened in read mode on the new SBNN or the read mode is closed on the SBNN and re-opened in write mode. The closing frees the resources and discards the original IPCLoggerChannel object and causes a new one to be created by the caller.

If a Journal node was down and added back to the cluster with the same hostname, but a different IP, when the failover happens, you end up with 4 metrics objects for the JNs:

1. For for each of the original 3 IPs
2. One for the new IP

The old stale metric will remain forever and will no longer be updated, leading to confusing results in any tools that use the metrics for monitoring.

This change, ensures we un-register the metrics when the logger channel is closed and a new metrics object gets created when the new channel is created.

For info, the logger metrics look like:

```
{
   "name" : "Hadoop:service=NameNode,name=IPCLoggerChannel-192.168.32.8-8485",
    "modelerType" : "IPCLoggerChannel-192.168.32.8-8485",
    "tag.Context" : "dfs",
    "tag.IsOutOfSync" : "false",
    "tag.Hostname" : "957e3e66f10b",
    "QueuedEditsSize" : 0,
    "LagTimeMillis" : 0,
    "CurrentLagTxns" : 0
  }
```

Note the name includes the IP, rather than the hostname.

### How was this patch tested?

I have added a small test to prove this, but also reproduced the original issue on a docker cluster and validated it is resolved with this change in place.
