### PR TITLE
HADOOP-18949. upgrade maven dependency plugin due to security issue.

### DIFF
--- a/hadoop-maven-plugins/pom.xml
+++ b/hadoop-maven-plugins/pom.xml
@@ -27,13 +27,25 @@
   <name>Apache Hadoop Maven Plugins</name>
   <properties>
     <maven.dependency.version>3.9.5</maven.dependency.version>
-    <maven.plugin-tools.version>3.10.1/maven.plugin-tools.version>
+    <maven.plugin-tools.version>3.10.1</maven.plugin-tools.version>
+    <plexus.classworlds.version>2.7.0</plexus.classworlds.version>
+    <sisu.inject.version>0.3.5</sisu.inject.version>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${maven.dependency.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>org.eclipse.sisu.inject</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-classworlds</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -41,10 +53,28 @@
       <version>${maven.dependency.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>org.eclipse.sisu.inject</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.sonatype.sisu</groupId>
           <artifactId>sisu-inject-plexus</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-classworlds</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-classworlds</artifactId>
+      <version>${plexus.classworlds.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.inject</artifactId>
+      <version>${sisu.inject.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>

--- a/hadoop-maven-plugins/pom.xml
+++ b/hadoop-maven-plugins/pom.xml
@@ -26,8 +26,8 @@
   <packaging>maven-plugin</packaging>
   <name>Apache Hadoop Maven Plugins</name>
   <properties>
-    <maven.dependency.version>3.9.1</maven.dependency.version>
-    <maven.plugin-tools.version>3.6.0</maven.plugin-tools.version>
+    <maven.dependency.version>3.9.5</maven.dependency.version>
+    <maven.plugin-tools.version>3.10.1/maven.plugin-tools.version>
   </properties>
   <dependencies>
     <dependency>

--- a/hadoop-maven-plugins/pom.xml
+++ b/hadoop-maven-plugins/pom.xml
@@ -26,7 +26,7 @@
   <packaging>maven-plugin</packaging>
   <name>Apache Hadoop Maven Plugins</name>
   <properties>
-    <maven.dependency.version>3.0.5</maven.dependency.version>
+    <maven.dependency.version>3.9.1</maven.dependency.version>
     <maven.plugin-tools.version>3.6.0</maven.plugin-tools.version>
   </properties>
   <dependencies>


### PR DESCRIPTION
### Description of PR

https://issues.apache.org/jira/browse/HADOOP-18949

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

