### PR TITLE
YARN-11599. Incorrect log4j properties file in SLS sample conf

### DIFF
--- a/hadoop-tools/hadoop-sls/src/main/sample-conf/log4j.properties
+++ b/hadoop-tools/hadoop-sls/src/main/sample-conf/log4j.properties
@@ -16,4 +16,4 @@ log4j.appender.test.Target=System.out
 log4j.appender.test.layout=org.apache.log4j.PatternLayout
 log4j.appender.test.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L - %m%n
 
-log4j.logger=NONE, test
+log4j.rootLogger=WARN, test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11599. Incorrect log4j properties file in SLS sample conf.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

