### PR TITLE
HDFS-17242. Make congestion backoff time configurable.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -572,21 +572,6 @@ class DataStreamer extends Daemon {
         HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME_DEFAULT);
     if (congestionBackOffMeanTimeInMs <= 0 || congestionBackOffMaxTimeInMs <= 0 ||
         congestionBackOffMaxTimeInMs < congestionBackOffMeanTimeInMs) {
-      if (congestionBackOffMeanTimeInMs <= 0) {
-        LOG.warn("Configuration: {} is not appropriate, using default value: {}",
-            HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME,
-            HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME_DEFAULT);
-      }
-      if (congestionBackOffMaxTimeInMs <= 0) {
-        LOG.warn("Configuration: {} is not appropriate, using default value: {}",
-            HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME,
-            HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME_DEFAULT);
-      }
-      if (congestionBackOffMaxTimeInMs < congestionBackOffMeanTimeInMs) {
-        LOG.warn("Configuration: {} can not less than {}, using their default values.",
-            HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME,
-            HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME);
-      }
       congestionBackOffMeanTimeInMs =
           HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME_DEFAULT;
       congestionBackOffMaxTimeInMs =

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdfs;
 import static org.apache.hadoop.hdfs.protocol.proto.DataTransferProtos.Status.SUCCESS;
 
 import java.io.BufferedOutputStream;
-import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -30,7 +29,6 @@ import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.net.UnknownHostException;
 import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -154,7 +152,7 @@ class DataStreamer extends Daemon {
     }
   }
 
-  private class StreamerStreams implements Closeable {
+  private class StreamerStreams implements java.io.Closeable {
     private Socket sock = null;
     private DataOutputStream out = null;
     private DataInputStream in = null;
@@ -575,17 +573,17 @@ class DataStreamer extends Daemon {
     if (congestionBackOffMeanTimeInMs <= 0 || congestionBackOffMaxTimeInMs <= 0 ||
         congestionBackOffMaxTimeInMs < congestionBackOffMeanTimeInMs) {
       if (congestionBackOffMeanTimeInMs <= 0) {
-        LOG.warn("Configuration: {} is not appropriate, use default value: {}",
+        LOG.warn("Configuration: {} is not appropriate, using default value: {}",
             HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME,
             HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME_DEFAULT);
       }
       if (congestionBackOffMaxTimeInMs <= 0) {
-        LOG.warn("Configuration: {} is not appropriate, use default value: {}",
+        LOG.warn("Configuration: {} is not appropriate, using default value: {}",
             HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME,
             HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME_DEFAULT);
       }
       if (congestionBackOffMaxTimeInMs < congestionBackOffMeanTimeInMs) {
-        LOG.warn("Configuration: {} can not less than {}, use their default values.",
+        LOG.warn("Configuration: {} can not less than {}, using their default values.",
             HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME,
             HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME);
       }
@@ -1143,7 +1141,7 @@ class DataStreamer extends Daemon {
     InetAddress addr = null;
     try {
       addr = InetAddress.getByName(nodes[index].getIpAddr());
-    } catch (UnknownHostException e) {
+    } catch (java.net.UnknownHostException e) {
       // we are passing an ip address. this should not happen.
       assert false;
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -572,7 +572,7 @@ class DataStreamer extends Daemon {
     congestionBackOffMaxTimeInMs = dfsClient.getConfiguration().getInt(
         HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME,
         HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME_DEFAULT);
-    if (congestionBackOffMeanTimeInMs <= 0 || congestionBackOffMaxTimeInMs <= 0 || 
+    if (congestionBackOffMeanTimeInMs <= 0 || congestionBackOffMaxTimeInMs <= 0 ||
         congestionBackOffMaxTimeInMs < congestionBackOffMeanTimeInMs) {
       if (congestionBackOffMeanTimeInMs <= 0) {
         LOG.warn("Configuration: {} is not appropriate, use default value: {}",
@@ -589,8 +589,10 @@ class DataStreamer extends Daemon {
             HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME,
             HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME);
       }
-      congestionBackOffMeanTimeInMs = HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME_DEFAULT;
-      congestionBackOffMaxTimeInMs = HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME_DEFAULT;
+      congestionBackOffMeanTimeInMs =
+          HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME_DEFAULT;
+      congestionBackOffMaxTimeInMs =
+          HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME_DEFAULT;
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -570,6 +570,21 @@ class DataStreamer extends Daemon {
     congestionBackOffMaxTimeInMs = dfsClient.getConfiguration().getInt(
         HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME,
         HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME_DEFAULT);
+    if (congestionBackOffMeanTimeInMs <= 0) {
+      LOG.warn("Configuration: {} is not appropriate, using default value: {}",
+          HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME,
+          HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME_DEFAULT);
+    }
+    if (congestionBackOffMaxTimeInMs <= 0) {
+      LOG.warn("Configuration: {} is not appropriate, using default value: {}",
+          HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME,
+          HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME_DEFAULT);
+    }
+    if (congestionBackOffMaxTimeInMs < congestionBackOffMeanTimeInMs) {
+      LOG.warn("Configuration: {} can not less than {}, using their default values.",
+          HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME,
+          HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME);
+    }
     if (congestionBackOffMeanTimeInMs <= 0 || congestionBackOffMaxTimeInMs <= 0 ||
         congestionBackOffMaxTimeInMs < congestionBackOffMeanTimeInMs) {
       congestionBackOffMeanTimeInMs =
@@ -577,6 +592,7 @@ class DataStreamer extends Daemon {
       congestionBackOffMaxTimeInMs =
           HdfsClientConfigKeys.DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME_DEFAULT;
     }
+
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -287,6 +287,14 @@ public interface HdfsClientConfigKeys {
       "dfs.client.output.stream.uniq.default.key";
   String DFS_OUTPUT_STREAM_UNIQ_DEFAULT_KEY_DEFAULT = "DEFAULT";
 
+  String DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME =
+      "dfs.client.congestion.backoff.mean.time";
+  int DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME_DEFAULT = 5000;
+
+  String DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME = 
+      "dfs.client.congestion.backoff.max.time";
+  int DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME_DEFAULT = 50000;
+
   /**
    * These are deprecated config keys to client code.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -291,7 +291,7 @@ public interface HdfsClientConfigKeys {
       "dfs.client.congestion.backoff.mean.time";
   int DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME_DEFAULT = 5000;
 
-  String DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME = 
+  String DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME =
       "dfs.client.congestion.backoff.max.time";
   int DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME_DEFAULT = 50000;
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -293,7 +293,8 @@ public interface HdfsClientConfigKeys {
 
   String DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME =
       "dfs.client.congestion.backoff.max.time";
-  int DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME_DEFAULT = 50000;
+  int DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME_DEFAULT =
+      DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME_DEFAULT * 10;
 
   /**
    * These are deprecated config keys to client code.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6563,15 +6563,16 @@
     <name>dfs.client.congestion.backoff.mean.time</name>
     <value>5000</value>
     <description>
-      The mean milliseconds which is used to compute client congestion backoff sleep time.
+      The mean time in milliseconds which is used to compute
+      client congestion backoff sleep time.
     </description>
   </property>
   <property>
     <name>dfs.client.congestion.backoff.max.time</name>
     <value>50000</value>
     <description>
-      The max milliseconds which is used to
-      restrict the upper limit backoff sleep time for client.
+      The max time in milliseconds which is used to restrict
+      the upper limit backoff sleep time for client.
     </description>
   </property>
   <property>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6560,6 +6560,21 @@
     </description>
   </property>
   <property>
+    <name>dfs.client.congestion.backoff.mean.time</name>
+    <value>5000</value>
+    <description>
+      The mean milliseconds which is used to compute client congestion backoff sleep time.
+    </description>
+  </property>
+  <property>
+    <name>dfs.client.congestion.backoff.max.time</name>
+    <value>50000</value>
+    <description>
+      The max milliseconds which is used to
+      restrict the upper limit backoff sleep time for client.
+    </description>
+  </property>
+  <property>
     <name>dfs.client.rbf.observer.read.enable</name>
     <value>false</value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSOutputStream.java
@@ -275,6 +275,8 @@ public class TestDFSOutputStream {
   public void testCongestionBackoff() throws IOException {
     DfsClientConf dfsClientConf = mock(DfsClientConf.class);
     DFSClient client = mock(DFSClient.class);
+    Configuration conf = mock(Configuration.class);
+    when(client.getConfiguration()).thenReturn(conf);
     when(client.getConf()).thenReturn(dfsClientConf);
     when(client.getTracer()).thenReturn(FsTracer.get(new Configuration()));
     client.clientRunning = true;
@@ -306,6 +308,8 @@ public class TestDFSOutputStream {
   public void testCongestionAckDelay() {
     DfsClientConf dfsClientConf = mock(DfsClientConf.class);
     DFSClient client = mock(DFSClient.class);
+    Configuration conf = mock(Configuration.class);
+    when(client.getConfiguration()).thenReturn(conf);
     when(client.getConf()).thenReturn(dfsClientConf);
     when(client.getTracer()).thenReturn(FsTracer.get(new Configuration()));
     client.clientRunning = true;
@@ -325,7 +329,7 @@ public class TestDFSOutputStream {
     ArrayList<DatanodeInfo> congestedNodes = (ArrayList<DatanodeInfo>)
             Whitebox.getInternalState(stream, "congestedNodes");
     int backOffMaxTime = (int)
-            Whitebox.getInternalState(stream, "CONGESTION_BACK_OFF_MAX_TIME_IN_MS");
+            Whitebox.getInternalState(stream, "congestionBackOffMaxTimeInMs");
     DFSPacket[] packet = new DFSPacket[100];
     AtomicBoolean isDelay = new AtomicBoolean(true);
 


### PR DESCRIPTION
### Description of PR
Currently，if we enable congestion backoff, we will actually invoke backOffIfNecessary method. and the backoff time is computed using CONGESTION_BACKOFF_MEAN_TIME_IN_MS and CONGESTION_BACK_OFF_MAX_TIME_IN_MS which are hard-code. We should better make them configurable to compute backoff sleep time flexibly.
