### PR TITLE
HADOOP-18954. Filter NaN values from JMX json interface

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -1072,5 +1072,13 @@ public class CommonConfigurationKeysPublic {
   public static final String IPC_SERVER_METRICS_UPDATE_RUNNER_INTERVAL =
       "ipc.server.metrics.update.runner.interval";
   public static final int IPC_SERVER_METRICS_UPDATE_RUNNER_INTERVAL_DEFAULT = 5000;
+
+  /**
+   * @see
+   * <a href="{@docRoot}/../hadoop-project-dist/hadoop-common/core-default.xml">
+   * core-default.xml</a>
+   */
+  public static final String JMX_NAN_FILTER = "hadoop.http.jmx.nan-filter.enabled";
+  public static final boolean JMX_NAN_FILTER_DEFAULT = false;
 }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
@@ -163,9 +163,6 @@ public final class HttpServer2 implements FilterContainer {
   public static final String FILTER_INITIALIZER_PROPERTY
       = "hadoop.http.filter.initializers";
 
-  public static final String JMX_NAN_FILTER = "hadoop.http.jmx.nan-filter.enabled";
-  public static final boolean JMX_NAN_FILTER_DEFAULT = false;
-
   public static final String HTTP_SNI_HOST_CHECK_ENABLED_KEY
       = "hadoop.http.sni.host.check.enabled";
   public static final boolean HTTP_SNI_HOST_CHECK_ENABLED_DEFAULT = false;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
@@ -980,6 +980,7 @@ public final class HttpServer2 implements FilterContainer {
 
   /**
    * Add default servlets.
+   * @param configuration the hadoop configuration
    */
   protected void addDefaultServlets(Configuration configuration) {
     // set up default servlets

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
@@ -163,6 +163,9 @@ public final class HttpServer2 implements FilterContainer {
   public static final String FILTER_INITIALIZER_PROPERTY
       = "hadoop.http.filter.initializers";
 
+  public static final String JMX_NAN_FILTER = "hadoop.http.jmx.nan-filter.enabled";
+  public static final boolean JMX_NAN_FILTER_DEFAULT = false;
+
   public static final String HTTP_SNI_HOST_CHECK_ENABLED_KEY
       = "hadoop.http.sni.host.check.enabled";
   public static final boolean HTTP_SNI_HOST_CHECK_ENABLED_DEFAULT = false;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
@@ -56,6 +56,7 @@ import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.jmx.JMXJsonServletNaNFiltered;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
 import com.sun.jersey.spi.container.servlet.ServletContainer;
@@ -116,6 +117,9 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.JMX_NAN_FILTER;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.JMX_NAN_FILTER_DEFAULT;
 
 /**
  * Create a Jetty embedded server to answer http requests. The primary goal is
@@ -785,7 +789,7 @@ public final class HttpServer2 implements FilterContainer {
       }
     }
 
-    addDefaultServlets();
+    addDefaultServlets(conf);
     addPrometheusServlet(conf);
     addAsyncProfilerServlet(contexts, conf);
   }
@@ -977,11 +981,15 @@ public final class HttpServer2 implements FilterContainer {
   /**
    * Add default servlets.
    */
-  protected void addDefaultServlets() {
+  protected void addDefaultServlets(Configuration configuration) {
     // set up default servlets
     addServlet("stacks", "/stacks", StackServlet.class);
     addServlet("logLevel", "/logLevel", LogLevel.Servlet.class);
-    addServlet("jmx", "/jmx", JMXJsonServlet.class);
+    addServlet("jmx", "/jmx",
+        configuration.getBoolean(JMX_NAN_FILTER, JMX_NAN_FILTER_DEFAULT)
+            ? JMXJsonServletNaNFiltered.class
+            : JMXJsonServlet.class
+    );
     addServlet("conf", "/conf", ConfServlet.class);
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/jmx/JMXJsonServlet.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/jmx/JMXJsonServlet.java
@@ -445,9 +445,6 @@ public class JMXJsonServlet extends HttpServlet {
     return false;
   }
 
-  /**
-   * @see JMXJsonServletNaNFiltered
-   */
   protected void extraWrite(Object value, String attName, JsonGenerator jg) throws IOException {
     throw new NotImplementedException();
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/jmx/JMXJsonServlet.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/jmx/JMXJsonServlet.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.jmx;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.HttpServer2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +49,11 @@ import java.io.PrintWriter;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Array;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.Set;
+
+import static org.apache.hadoop.http.HttpServer2.JMX_NAN_FILTER;
+import static org.apache.hadoop.http.HttpServer2.JMX_NAN_FILTER_DEFAULT;
 
 /*
  * This servlet is based off of the JMXProxyServlet from Tomcat 7.0.14. It has
@@ -136,6 +142,8 @@ public class JMXJsonServlet extends HttpServlet {
    * Json Factory to create Json generators for write objects in json format
    */
   protected transient JsonFactory jsonFactory;
+
+  protected transient boolean nanFilter;
   /**
    * Initialize this servlet.
    */
@@ -143,6 +151,9 @@ public class JMXJsonServlet extends HttpServlet {
   public void init() throws ServletException {
     // Retrieve the MBean server
     mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    Configuration conf = new Configuration();
+    nanFilter = conf.getBoolean(JMX_NAN_FILTER, JMX_NAN_FILTER_DEFAULT);
+    LOG.debug("NaN filter is set to {}", nanFilter);
     jsonFactory = new JsonFactory();
   }
 
@@ -386,10 +397,10 @@ public class JMXJsonServlet extends HttpServlet {
   
   private void writeAttribute(JsonGenerator jg, String attName, Object value) throws IOException {
     jg.writeFieldName(attName);
-    writeObject(jg, value);
+    writeObject(jg, value, attName);
   }
   
-  private void writeObject(JsonGenerator jg, Object value) throws IOException {
+  private void writeObject(JsonGenerator jg, Object value, String attName) throws IOException {
     if(value == null) {
       jg.writeNull();
     } else {
@@ -399,9 +410,17 @@ public class JMXJsonServlet extends HttpServlet {
         int len = Array.getLength(value);
         for (int j = 0; j < len; j++) {
           Object item = Array.get(value, j);
-          writeObject(jg, item);
+          writeObject(jg, item, attName);
         }
         jg.writeEndArray();
+      } else if (nanFilter && Objects.equals("NaN", Objects.toString(value).trim())) {
+        // For example in case of MutableGauge we are using numbers,
+        // but not implementing Number interface,
+        // so we skip class check here because we can not be sure NaN values are wrapped
+        // with classes which implements the Number interface
+        LOG.debug("The {} attribute with value: {} was identified as NaN "
+            + "and will be replaced with 0.0", attName, value);
+        jg.writeNumber(0.0);
       } else if(value instanceof Number) {
         Number n = (Number)value;
         jg.writeNumber(n.toString());
@@ -421,7 +440,7 @@ public class JMXJsonServlet extends HttpServlet {
         TabularData tds = (TabularData)value;
         jg.writeStartArray();
         for(Object entry : tds.values()) {
-          writeObject(jg, entry);
+          writeObject(jg, entry, attName);
         }
         jg.writeEndArray();
       } else {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/jmx/JMXJsonServlet.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/jmx/JMXJsonServlet.java
@@ -52,8 +52,8 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
 
-import static org.apache.hadoop.http.HttpServer2.JMX_NAN_FILTER;
-import static org.apache.hadoop.http.HttpServer2.JMX_NAN_FILTER_DEFAULT;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.JMX_NAN_FILTER;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.JMX_NAN_FILTER_DEFAULT;
 
 /*
  * This servlet is based off of the JMXProxyServlet from Tomcat 7.0.14. It has

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/jmx/JMXJsonServletNaNFiltered.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/jmx/JMXJsonServletNaNFiltered.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/jmx/JMXJsonServletNaNFiltered.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/jmx/JMXJsonServletNaNFiltered.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.jmx;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * For example in case of MutableGauge we are using numbers,
+ * but not implementing Number interface,
+ * so we skip class check here because we can not be sure NaN values are wrapped
+ * with classes which implements the Number interface
+ */
+public class JMXJsonServletNaNFiltered extends JMXJsonServlet {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(JMXJsonServletNaNFiltered.class);
+
+  @Override
+  protected boolean extraCheck(Object value) {
+    return Objects.equals("NaN", Objects.toString(value).trim());
+  }
+
+  @Override
+  protected void extraWrite(Object value, String attName, JsonGenerator jg) throws IOException {
+    LOG.debug("The {} attribute with value: {} was identified as NaN "
+        + "and will be replaced with 0.0", attName, value);
+    jg.writeNumber(0.0);
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -65,6 +65,18 @@
   </description>
 </property>
 
+<property>
+  <name>hadoop.http.jmx.nan-filter.enabled</name>
+  <value>false</value>
+  <description>
+    The REST API of the JMX interface can return with NaN values
+    if the attribute represent a 0.0/0.0 value.
+    Some JSON parser by default can not parse json attributes like foo:NaN.
+    If this filter is enabled the NaN values will be converted to 0.0 values,
+    to make json parse less complicated.
+  </description>
+</property>
+
 <!--- security properties -->
 
 <property>

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/jmx/TestJMXJsonServlet.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/jmx/TestJMXJsonServlet.java
@@ -62,10 +62,15 @@ public class TestJMXJsonServlet extends HttpServerFunctionalTest {
     result = readOutput(new URL(baseUrl, "/jmx?qry=java.lang:type=Memory"));
     assertReFind("\"name\"\\s*:\\s*\"java.lang:type=Memory\"", result);
     assertReFind("\"modelerType\"", result);
-    
+
+    System.setProperty("THE_TEST_OF_THE_NAN_VALUES", String.valueOf(Float.NaN));
     result = readOutput(new URL(baseUrl, "/jmx"));
     assertReFind("\"name\"\\s*:\\s*\"java.lang:type=Memory\"", result);
-    
+    assertReFind(
+        "\"key\"\\s*:\\s*\"THE_TEST_OF_THE_NAN_VALUES\"\\s*,\\s*\"value\"\\s*:\\s*\"NaN\"",
+        result
+    );
+
     // test to get an attribute of a mbean
     result = readOutput(new URL(baseUrl, 
         "/jmx?get=java.lang:type=Memory::HeapMemoryUsage"));

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/jmx/TestJMXJsonServletNaNFiltered.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/jmx/TestJMXJsonServletNaNFiltered.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -42,17 +42,17 @@ public class TestJMXJsonServletNaNFiltered extends HttpServerFunctionalTest {
     server.start();
     baseUrl = getServerURL(server);
   }
-  
+
   @AfterClass public static void cleanup() throws Exception {
     server.stop();
   }
-  
+
   public static void assertReFind(String re, String value) {
     Pattern p = Pattern.compile(re);
     Matcher m = p.matcher(value);
     assertTrue("'"+p+"' does not match "+value, m.find());
   }
-  
+
   @Test public void testQuery() throws Exception {
     System.setProperty("THE_TEST_OF_THE_NAN_VALUES", String.valueOf(Float.NaN));
     String result = readOutput(new URL(baseUrl, "/jmx"));
@@ -62,5 +62,4 @@ public class TestJMXJsonServletNaNFiltered extends HttpServerFunctionalTest {
         result
     );
   }
-
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/jmx/TestJMXJsonServletNaNFiltered.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/jmx/TestJMXJsonServletNaNFiltered.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.jmx;
+
+import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.http.HttpServer2;
+import org.apache.hadoop.http.HttpServerFunctionalTest;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.JMX_NAN_FILTER;
+
+public class TestJMXJsonServletNaNFiltered extends HttpServerFunctionalTest {
+  private static HttpServer2 server;
+  private static URL baseUrl;
+
+  @BeforeClass public static void setup() throws Exception {
+    Configuration configuration = new Configuration();
+    configuration.setBoolean(JMX_NAN_FILTER, true);
+    server = createTestServer(configuration);
+    server.start();
+    baseUrl = getServerURL(server);
+  }
+  
+  @AfterClass public static void cleanup() throws Exception {
+    server.stop();
+  }
+  
+  public static void assertReFind(String re, String value) {
+    Pattern p = Pattern.compile(re);
+    Matcher m = p.matcher(value);
+    assertTrue("'"+p+"' does not match "+value, m.find());
+  }
+  
+  @Test public void testQuery() throws Exception {
+    System.setProperty("THE_TEST_OF_THE_NAN_VALUES", String.valueOf(Float.NaN));
+    String result = readOutput(new URL(baseUrl, "/jmx"));
+    assertReFind("\"name\"\\s*:\\s*\"java.lang:type=Memory\"", result);
+    assertReFind(
+        "\"key\"\\s*:\\s*\"THE_TEST_OF_THE_NAN_VALUES\"\\s*,\\s*\"value\"\\s*:\\s*0.0",
+        result
+    );
+  }
+
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
@@ -634,5 +634,7 @@ public class TestMutableMetrics {
     assertEquals(3.2f, mgf.value(), 0.0);
     mgf.incr();
     assertEquals(4.2f, mgf.value(), 0.0);
+    mgf.set(Float.NaN);
+    assertEquals(Float.NaN, mgf.value(), 0.0);
   }
 }


### PR DESCRIPTION
### Description of PR

- The JMX json represents NaN like invalid JSON token, so some parser can not parse.
- To fix this a new feature introduced to replace NaN with 0.0 values.
- The feature can be turned on with the hadoop.http.jmx.nan-filter.enabled config

### How was this patch tested?

- Manually tested on a cluster where NaN values were present in the RM response.
- When the feature was turned on, the NaN values were replaced

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

