### PR TITLE
HDFS-17221. Add NNThroughputBenchmark params to specify subcluster lo…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/Benchmarking.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Benchmarking.md
@@ -30,7 +30,10 @@ The benchmark first generates inputs for each thread so that the input generatio
 
 The general command line syntax is:
 
-`hadoop org.apache.hadoop.hdfs.server.namenode.NNThroughputBenchmark [genericOptions] [commandOptions]`
+`hadoop org.apache.hadoop.hdfs.server.namenode.NNThroughputBenchmark [genericOptions] [commandOptions] .. [genericOptions] [commandOptions]`
+
+Each genericOptions starts with `-op`. You may specify many commands in one run (each starting with `-op`).
+Operations will run in parallel per `-baseDirName`. Separate statistics will be printed per `-baseDirName`.
 
 #### Generic Options
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NNThroughputBenchmark.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NNThroughputBenchmark.java
@@ -26,11 +26,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
-
-import org.apache.hadoop.util.Preconditions;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.CryptoProtocolVersion;
 import org.apache.hadoop.fs.CreateFlag;
@@ -80,12 +83,12 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.GenericOptionsParser;
+import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.hadoop.util.VersionInfo;
-import org.slf4j.event.Level;
 
 /**
  * Main class for a series of name-node benchmarks.
@@ -162,11 +165,12 @@ public class NNThroughputBenchmark implements Tool {
    * specific name-node operation.
    */
   abstract class OperationStatsBase {
-    private String baseDirName = "/nnThroughputBenchmark";
+    protected static final String BASE_DIR_NAME = "/nnThroughputBenchmark";
     protected static final String OP_ALL_NAME = "all";
     protected static final String OP_ALL_USAGE = "-op all <other ops options>";
 
     private String baseDir;
+    private String baseDirName;
     protected short replication;
     protected int blockSize;
     protected int  numThreads = 0;        // number of threads
@@ -228,7 +232,6 @@ public class NNThroughputBenchmark implements Tool {
     abstract void printResults();
 
     OperationStatsBase() {
-      baseDir = baseDirName + "/" + getOpName();
       replication = (short) config.getInt(DFSConfigKeys.DFS_REPLICATION_KEY, 3);
       blockSize = config.getInt(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCK_SIZE);
       numOpsRequired = 10;
@@ -295,12 +298,7 @@ public class NNThroughputBenchmark implements Tool {
         clientProto.saveNamespace(0, 0);
       }
     }
-    public String getBaseDirName() {
-      return baseDirName;
-    }
-    public void setBaseDirName(String baseDirName) {
-      this.baseDirName = baseDirName;
-    }
+
     int getNumOpsExecuted() {
       return numOpsExecuted;
     }
@@ -322,12 +320,14 @@ public class NNThroughputBenchmark implements Tool {
     }
 
     public String getBaseDir() {
-      setBaseDir(baseDirName + "/" + getOpName());
       return baseDir;
     }
 
-    public void setBaseDir(String baseDir) {
-      this.baseDir = baseDir;
+    /**
+     * Path where operation will be executed.
+     */
+    String getBaseDirName() {
+      return baseDirName;
     }
 
     String getClientName(int idx) {
@@ -377,6 +377,22 @@ public class NNThroughputBenchmark implements Tool {
         args.remove(ugrcIndex);
       }
 
+      int baseDirNameIndex = args.indexOf("-baseDirName");
+      if (baseDirNameIndex >= 0) {
+        if (args.size() <= baseDirNameIndex + 1) {
+          printUsage();
+        }
+        this.baseDirName = args.get(baseDirNameIndex + 1);
+        if (!this.baseDirName.startsWith("/")) {
+          this.baseDirName = "/" + this.baseDirName;
+        }
+        args.remove(baseDirNameIndex + 1);
+        args.remove(baseDirNameIndex);
+      } else {
+        this.baseDirName = BASE_DIR_NAME;
+      }
+      baseDir = this.baseDirName + "/" + getOpName();
+
       String type = args.get(1);
       if(OP_ALL_NAME.equals(type)) {
         type = getOpName();
@@ -388,11 +404,11 @@ public class NNThroughputBenchmark implements Tool {
     }
 
     void printStats() {
-      LOG.info("--- " + getOpName() + " stats  ---");
-      LOG.info("# operations: " + getNumOpsExecuted());
-      LOG.info("Elapsed Time: " + getElapsedTime());
-      LOG.info(" Ops per sec: " + getOpsPerSecond());
-      LOG.info("Average Time: " + getAverageTime());
+      LOG.info("--- {} in {} stats  ---", getOpName(), getBaseDir());
+      LOG.info("# operations: {}", getNumOpsExecuted());
+      LOG.info("Elapsed Time: {}", getElapsedTime());
+      LOG.info(" Ops per sec: {}", getOpsPerSecond());
+      LOG.info("Average Time: {}", getAverageTime());
     }
   }
 
@@ -504,7 +520,7 @@ public class NNThroughputBenchmark implements Tool {
       clientProto.setSafeMode(HdfsConstants.SafeModeAction.SAFEMODE_LEAVE,
           false);
       long start = Time.now();
-      clientProto.delete(getBaseDirName(), true);
+      clientProto.delete(this.getBaseDirName(), true);
       long end = Time.now();
       return end-start;
     }
@@ -512,7 +528,7 @@ public class NNThroughputBenchmark implements Tool {
     @Override
     void printResults() {
       LOG.info("--- " + getOpName() + " inputs ---");
-      LOG.info("Remove directory " + getBaseDirName());
+      LOG.info("Remove directory " + this.getBaseDirName());
       printStats();
     }
   }
@@ -537,7 +553,7 @@ public class NNThroughputBenchmark implements Tool {
 
     CreateFileStats(List<String> args) {
       super();
-      parseArguments(args);
+      parseArguments(new ArrayList<>(args));
     }
 
     @Override
@@ -551,7 +567,7 @@ public class NNThroughputBenchmark implements Tool {
       int nrFilesPerDir = 4;
       closeUponCreate = false;
       for (int i = 2; i < args.size(); i++) {       // parse command line
-        if(args.get(i).equals("-files")) {
+        if (args.get(i).equals("-files")) {
           if(i+1 == args.size())  printUsage();
           numOpsRequired = Integer.parseInt(args.get(++i));
         } else if (args.get(i).equals("-blockSize")) {
@@ -563,11 +579,6 @@ public class NNThroughputBenchmark implements Tool {
         } else if(args.get(i).equals("-filesPerDir")) {
           if(i+1 == args.size())  printUsage();
           nrFilesPerDir = Integer.parseInt(args.get(++i));
-        } else if(args.get(i).equals("-baseDirName")) {
-          if (i + 1 == args.size()) {
-            printUsage();
-          }
-          setBaseDirName(args.get(++i));
         } else if(args.get(i).equals("-close")) {
           closeUponCreate = true;
         } else if(!ignoreUnrelatedOptions)
@@ -681,11 +692,6 @@ public class NNThroughputBenchmark implements Tool {
         } else if(args.get(i).equals("-dirsPerDir")) {
           if(i+1 == args.size())  printUsage();
           nrDirsPerDir = Integer.parseInt(args.get(++i));
-        } else if(args.get(i).equals("-baseDirName")) {
-          if (i + 1 == args.size()) {
-            printUsage();
-          }
-          setBaseDirName(args.get(++i));
         } else if(!ignoreUnrelatedOptions)
           printUsage();
       }
@@ -1175,7 +1181,7 @@ public class NNThroughputBenchmark implements Tool {
       this.blocksPerFile = 10;
       // set heartbeat interval to 3 min, so that expiration were 40 min
       config.setLong(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY, 3 * 60);
-      parseArguments(args);
+      parseArguments(new ArrayList<>(args));
       // adjust replication to the number of data-nodes
       this.replication = (short)Math.min(replication, getNumDatanodes());
     }
@@ -1211,11 +1217,6 @@ public class NNThroughputBenchmark implements Tool {
         } else if (args.get(i).equals("-blockSize")) {
           if(i+1 == args.size())  printUsage();
           blockSize = Integer.parseInt(args.get(++i));
-        } else if(args.get(i).equals("-baseDirName")) {
-          if (i + 1 == args.size()) {
-            printUsage();
-          }
-          setBaseDirName(args.get(++i));
         } else if(!ignoreUnrelatedOptions)
           printUsage();
       }
@@ -1441,11 +1442,6 @@ public class NNThroughputBenchmark implements Tool {
         } else if (args.get(i).equals("-blockSize")) {
           if(i+1 == args.size())  printUsage();
           blockSize = Integer.parseInt(args.get(++i));
-        } else if(args.get(i).equals("-baseDirName")) {
-          if (i + 1 == args.size()) {
-            printUsage();
-          }
-          setBaseDirName(args.get(++i));
         } else if(!ignoreUnrelatedOptions)
           printUsage();
       }
@@ -1579,68 +1575,88 @@ public class NNThroughputBenchmark implements Tool {
    */
   @Override // Tool
   public int run(String[] aArgs) throws Exception {
-    List<String> args = new ArrayList<String>(Arrays.asList(aArgs));
-    if(args.size() < 2 || ! args.get(0).startsWith("-op"))
-      printUsage();
+    List<String> plainArgs = new ArrayList<String>(Arrays.asList(aArgs));
+    List<List<String>> operationsArgs = new ArrayList<>();
+    int startIndex = 0;
+    int curIndex = startIndex;
+    for (String arg : plainArgs) {
+      if (arg.startsWith("-op") && curIndex != 0) {
+        operationsArgs.add(plainArgs.subList(startIndex, curIndex));
+        startIndex = curIndex;
+      }
+      curIndex++;
+      if (curIndex == plainArgs.size()) {
+        operationsArgs.add(plainArgs.subList(startIndex, curIndex));
+      }
+    }
 
-    String type = args.get(1);
-    boolean runAll = OperationStatsBase.OP_ALL_NAME.equals(type);
-
-    final URI nnUri = FileSystem.getDefaultUri(config);
-    // Start the NameNode
-    String[] argv = new String[] {};
-
-    List<OperationStatsBase> ops = new ArrayList<OperationStatsBase>();
-    OperationStatsBase opStat = null;
-    try {
-      if(runAll || CreateFileStats.OP_CREATE_NAME.equals(type)) {
-        opStat = new CreateFileStats(args);
-        ops.add(opStat);
-      }
-      if(runAll || MkdirsStats.OP_MKDIRS_NAME.equals(type)) {
-        opStat = new MkdirsStats(args);
-        ops.add(opStat);
-      }
-      if(runAll || OpenFileStats.OP_OPEN_NAME.equals(type)) {
-        opStat = new OpenFileStats(args);
-        ops.add(opStat);
-      }
-      if(runAll || DeleteFileStats.OP_DELETE_NAME.equals(type)) {
-        opStat = new DeleteFileStats(args);
-        ops.add(opStat);
-      }
-      if (runAll || AppendFileStats.OP_APPEND_NAME.equals(type)) {
-        opStat = new AppendFileStats(args);
-        ops.add(opStat);
-      }
-      if(runAll || FileStatusStats.OP_FILE_STATUS_NAME.equals(type)) {
-        opStat = new FileStatusStats(args);
-        ops.add(opStat);
-      }
-      if(runAll || RenameFileStats.OP_RENAME_NAME.equals(type)) {
-        opStat = new RenameFileStats(args);
-        ops.add(opStat);
-      }
-      if(runAll || BlockReportStats.OP_BLOCK_REPORT_NAME.equals(type)) {
-        opStat = new BlockReportStats(args);
-        ops.add(opStat);
-      }
-      if(runAll || ReplicationStats.OP_REPLICATION_NAME.equals(type)) {
-        if (nnUri.getScheme() != null && nnUri.getScheme().equals("hdfs")) {
-          LOG.warn("The replication test is ignored as it does not support " +
-              "standalone namenode in another process or on another host. ");
-        } else {
-          opStat = new ReplicationStats(args);
-          ops.add(opStat);
-        }
-      }
-      if(runAll || CleanAllStats.OP_CLEAN_NAME.equals(type)) {
-        opStat = new CleanAllStats(args);
-        ops.add(opStat);
-      }
-      if (ops.isEmpty()) {
+    for (List<String> args : operationsArgs) {
+      if (args.size() < 2 || !args.get(0).startsWith("-op")) {
         printUsage();
       }
+    }
+
+    List<OperationStatsBase> ops = new ArrayList<OperationStatsBase>();
+    final URI nnUri = FileSystem.getDefaultUri(config);
+
+    try {
+      for (List<String> args : operationsArgs) {
+        String type = args.get(1);
+        boolean runAll = OperationStatsBase.OP_ALL_NAME.equals(type);
+        OperationStatsBase opStat = null;
+
+        if(runAll || CreateFileStats.OP_CREATE_NAME.equals(type)) {
+          opStat = new CreateFileStats(new ArrayList<>(args));
+          ops.add(opStat);
+        }
+        if(runAll || MkdirsStats.OP_MKDIRS_NAME.equals(type)) {
+          opStat = new MkdirsStats(new ArrayList<>(args));
+          ops.add(opStat);
+        }
+        if(runAll || OpenFileStats.OP_OPEN_NAME.equals(type)) {
+          opStat = new OpenFileStats(new ArrayList<>(args));
+          ops.add(opStat);
+        }
+        if(runAll || DeleteFileStats.OP_DELETE_NAME.equals(type)) {
+          opStat = new DeleteFileStats(new ArrayList<>(args));
+          ops.add(opStat);
+        }
+        if (runAll || AppendFileStats.OP_APPEND_NAME.equals(type)) {
+          opStat = new AppendFileStats(new ArrayList<>(args));
+          ops.add(opStat);
+        }
+        if(runAll || FileStatusStats.OP_FILE_STATUS_NAME.equals(type)) {
+          opStat = new FileStatusStats(new ArrayList<>(args));
+          ops.add(opStat);
+        }
+        if(runAll || RenameFileStats.OP_RENAME_NAME.equals(type)) {
+          opStat = new RenameFileStats(new ArrayList<>(args));
+          ops.add(opStat);
+        }
+        if(runAll || BlockReportStats.OP_BLOCK_REPORT_NAME.equals(type)) {
+          opStat = new BlockReportStats(new ArrayList<>(args));
+          ops.add(opStat);
+        }
+        if(runAll || ReplicationStats.OP_REPLICATION_NAME.equals(type)) {
+          if (nnUri.getScheme() != null && nnUri.getScheme().equals("hdfs")) {
+            LOG.warn("The replication test is ignored as it does not support " +
+                    "standalone namenode in another process or on another host. ");
+          } else {
+            opStat = new ReplicationStats(new ArrayList<>(args));
+            ops.add(opStat);
+          }
+        }
+        if(runAll || CleanAllStats.OP_CLEAN_NAME.equals(type)) {
+          opStat = new CleanAllStats(new ArrayList<>(args));
+          ops.add(opStat);
+        }
+        if (ops.isEmpty()) {
+          printUsage();
+        }
+      }
+
+      // Start the NameNode
+      String[] argv = new String[] {};
 
       if (nnUri.getScheme() == null || nnUri.getScheme().equals("file")) {
         LOG.info("Remote NameNode is not specified. Creating one.");
@@ -1666,17 +1682,36 @@ public class NNThroughputBenchmark implements Tool {
             DFSTestUtil.getRefreshUserMappingsProtocolProxy(config, nnAddr);
         getBlockPoolId(dfs);
       }
-      // run each benchmark
-      for(OperationStatsBase op : ops) {
-        LOG.info("Starting benchmark: " + op.getOpName() + ", baseDir: " + op.getBaseDir());
-        op.benchmark();
-        op.cleanUp();
+
+      // group operations by base directories and run in parallel
+      Map<String, List<OperationStatsBase>> operationsByBaseDirs =
+          ops.stream().collect(Collectors.groupingBy(OperationStatsBase::getBaseDirName));
+
+      CountDownLatch latch = new CountDownLatch(operationsByBaseDirs.size());
+      for (Map.Entry<String, List<OperationStatsBase>> opsByDir : operationsByBaseDirs.entrySet()) {
+        new Thread(() -> {
+          try {
+            // run each benchmark
+            for (OperationStatsBase op : opsByDir.getValue()) {
+              LOG.info("Starting benchmark {} in {}", op.getOpName(), opsByDir.getKey());
+              op.benchmark();
+              op.cleanUp();
+            }
+            // print statistics
+            for (OperationStatsBase op : ops) {
+              LOG.info("");
+              op.printResults();
+              LOG.info("");
+            }
+          } catch (Exception e) {
+            LOG.error(StringUtils.stringifyException(e));
+          } finally {
+            latch.countDown();
+          }
+        }).start();
       }
-      // print statistics
-      for(OperationStatsBase op : ops) {
-        LOG.info("");
-        op.printResults();
-      }
+      // wait for all of the parallel running benchmarks to finish
+      latch.await();
     } catch(Exception e) {
       LOG.error(StringUtils.stringifyException(e));
       throw e;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNThroughputBenchmark.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNThroughputBenchmark.java
@@ -191,6 +191,43 @@ public class TestNNThroughputBenchmark {
   }
 
   /**
+   * This test runs all 3 below scenarios in parallel:
+   * 1. create benchmark in /nnThroughputBenchmark1 dir;
+   * 2. mkdirs benchmark in /nnThroughputBenchmark2 dir;
+   * 3. all benchmarks in /nnThroughputBenchmark3 dir.
+   */
+  @Test(timeout = 120000)
+  public void testNNBenchmarkRunningInMultipleDirectoriesInParallel() throws Exception {
+    final Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY, 16);
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf).numDataNodes(0).build();
+      cluster.waitActive();
+      final Configuration benchConf = new HdfsConfiguration();
+      benchConf.setInt(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 16);
+      FileSystem.setDefaultUri(benchConf, cluster.getURI());
+      DistributedFileSystem fs = cluster.getFileSystem();
+
+      NNThroughputBenchmark.runBenchmark(benchConf,
+          new String[] {
+              "-op", "create", "-baseDirName", "nnThroughputBenchmark1", "-files", "3",
+              "-op", "mkdirs", "-keepResults", "-baseDirName", "nnThroughputBenchmark2",
+              "-op", "all", "-keepResults", "-baseDirName", "nnThroughputBenchmark3"});
+
+      Assert.assertTrue(fs.exists(new Path("/nnThroughputBenchmark1")));
+      Assert.assertTrue(fs.exists(new Path("/nnThroughputBenchmark2")));
+      Assert.assertFalse("Remove operation is not executed for -op all!",
+          fs.exists(new Path("/nnThroughputBenchmark3")));
+      Assert.assertFalse(fs.exists(new Path("/nnThroughputBenchmark")));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  /**
    * This test runs {@link NNThroughputBenchmark} against a mini DFS cluster
    * with explicit -baseDirName option.
    */
@@ -214,8 +251,9 @@ public class TestNNThroughputBenchmark {
       Assert.assertFalse(fs.exists(new Path("/nnThroughputBenchmark")));
 
       NNThroughputBenchmark.runBenchmark(benchConf,
-          new String[] {"-op", "all", "-baseDirName", "/nnThroughputBenchmark1"});
-      Assert.assertTrue(fs.exists(new Path("/nnThroughputBenchmark1")));
+          new String[] {"-op", "all", "-keepResults", "-baseDirName", "/nnThroughputBenchmark2"});
+      Assert.assertFalse("Remove operation is not executed for -op all!",
+          fs.exists(new Path("/nnThroughputBenchmark2")));
       Assert.assertFalse(fs.exists(new Path("/nnThroughputBenchmark")));
     } finally {
       if (cluster != null) {


### PR DESCRIPTION
…ad in RBF.

* Added an ability to specify base directory per operation(s) and to run benchmarks in parallel in different directories;
* Added unit test for 3 directories.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
This change adds an ability for NNThroughputBenchmark to run benchmarks in parallel in different directories. This is helpful to create a load on HDFS in Router-Based Federation deployment.
Previous functionality of the NNThroughputBenchmark remains the same if -subClusterPath command line property is not provided.

### How was this patch tested?
A unit test which runs different benchmarks in 3 directories in parallel is provided.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

