### PR TITLE
HADOOP-18957. Use StandardCharsets.UTF_8

### DIFF
--- a/hadoop-common-project/hadoop-auth-examples/src/main/java/org/apache/hadoop/security/authentication/examples/WhoClient.java
+++ b/hadoop-common-project/hadoop-auth-examples/src/main/java/org/apache/hadoop/security/authentication/examples/WhoClient.java
@@ -19,7 +19,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Example that uses <code>AuthenticatedURL</code>.
@@ -42,7 +42,7 @@ public class WhoClient {
       if (conn.getResponseCode() == HttpURLConnection.HTTP_OK) {
         BufferedReader reader = new BufferedReader(
             new InputStreamReader(
-                conn.getInputStream(), Charset.forName("UTF-8")));
+                conn.getInputStream(), StandardCharsets.UTF_8));
         String line = reader.readLine();
         while (line != null) {
           System.out.println(line);

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/PseudoAuthenticationHandler.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/PseudoAuthenticationHandler.java
@@ -23,7 +23,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Properties;
@@ -53,8 +52,6 @@ public class PseudoAuthenticationHandler implements AuthenticationHandler {
    * Constant for the configuration property that indicates if anonymous users are allowed.
    */
   public static final String ANONYMOUS_ALLOWED = TYPE + ".anonymous.allowed";
-
-  private static final Charset UTF8_CHARSET = StandardCharsets.UTF_8;
 
   private static final String PSEUDO_AUTH = "PseudoAuth";
 
@@ -147,7 +144,7 @@ public class PseudoAuthenticationHandler implements AuthenticationHandler {
     if(queryString == null || queryString.length() == 0) {
       return null;
     }
-    List<NameValuePair> list = URLEncodedUtils.parse(queryString, UTF8_CHARSET);
+    List<NameValuePair> list = URLEncodedUtils.parse(queryString, StandardCharsets.UTF_8);
     if (list != null) {
       for (NameValuePair nv : list) {
         if (PseudoAuthenticator.USER_NAME.equals(nv.getName())) {

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/PseudoAuthenticationHandler.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/PseudoAuthenticationHandler.java
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Properties;
 
@@ -53,7 +54,7 @@ public class PseudoAuthenticationHandler implements AuthenticationHandler {
    */
   public static final String ANONYMOUS_ALLOWED = TYPE + ".anonymous.allowed";
 
-  private static final Charset UTF8_CHARSET = Charset.forName("UTF-8");
+  private static final Charset UTF8_CHARSET = StandardCharsets.UTF_8;
 
   private static final String PSEUDO_AUTH = "PseudoAuth";
 

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/StringSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/StringSignerSecretProvider.java
@@ -13,7 +13,7 @@
  */
 package org.apache.hadoop.security.authentication.util;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import javax.servlet.ServletContext;
 
@@ -38,7 +38,7 @@ class StringSignerSecretProvider extends SignerSecretProvider {
           long tokenValidity) throws Exception {
     String signatureSecret = config.getProperty(
             AuthenticationFilter.SIGNATURE_SECRET, null);
-    secret = signatureSecret.getBytes(Charset.forName("UTF-8"));
+    secret = signatureSecret.getBytes(StandardCharsets.UTF_8);
     secrets = new byte[][]{secret};
   }
 

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestZKSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestZKSignerSecretProvider.java
@@ -13,7 +13,7 @@
  */
 package org.apache.hadoop.security.authentication.util;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.Random;
 import javax.servlet.ServletContext;
@@ -140,11 +140,11 @@ public class TestZKSignerSecretProvider {
     long seed = System.currentTimeMillis();
     Random rand = new Random(seed);
     byte[] secret2 = Long.toString(rand.nextLong())
-        .getBytes(Charset.forName("UTF-8"));
+        .getBytes(StandardCharsets.UTF_8);
     byte[] secret1 = Long.toString(rand.nextLong())
-        .getBytes(Charset.forName("UTF-8"));
+        .getBytes(StandardCharsets.UTF_8);
     byte[] secret3 = Long.toString(rand.nextLong())
-        .getBytes(Charset.forName("UTF-8"));
+        .getBytes(StandardCharsets.UTF_8);
     rand = new Random(seed);
     // Secrets 4 and 5 get thrown away by ZK when the new secret provider tries
     // to init
@@ -238,7 +238,7 @@ public class TestZKSignerSecretProvider {
 
     @Override
     protected byte[] generateRandomSecret() {
-      return Long.toString(rand.nextLong()).getBytes(Charset.forName("UTF-8"));
+      return Long.toString(rand.nextLong()).getBytes(StandardCharsets.UTF_8);
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -43,6 +43,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -82,7 +83,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.commons.collections.map.UnmodifiableMap;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -2903,7 +2903,7 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
         LOG.info("found resource " + name + " at " + url);
       }
 
-      return new InputStreamReader(url.openStream(), Charsets.UTF_8);
+      return new InputStreamReader(url.openStream(), StandardCharsets.UTF_8);
     } catch (Exception e) {
       return null;
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
@@ -899,7 +899,7 @@ public class FileUtil {
             try (BufferedReader reader =
                      new BufferedReader(
                          new InputStreamReader(process.getInputStream(),
-                             Charset.forName("UTF-8")))) {
+                             StandardCharsets.UTF_8))) {
               String line;
               while((line = reader.readLine()) != null) {
                 LOG.debug(line);
@@ -922,7 +922,7 @@ public class FileUtil {
             try (BufferedReader reader =
                      new BufferedReader(
                          new InputStreamReader(process.getErrorStream(),
-                             Charset.forName("UTF-8")))) {
+                             StandardCharsets.UTF_8))) {
               String line;
               while((line = reader.readLine()) != null) {
                 LOG.debug(line);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/FileSystemMultipartUploader.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/FileSystemMultipartUploader.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.impl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -30,7 +31,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,7 +104,7 @@ public class FileSystemMultipartUploader extends AbstractMultipartUploader {
       fs.mkdirs(collectorPath, FsPermission.getDirDefault());
 
       ByteBuffer byteBuffer = ByteBuffer.wrap(
-          collectorPath.toString().getBytes(Charsets.UTF_8));
+          collectorPath.toString().getBytes(StandardCharsets.UTF_8));
       return BBUploadHandle.from(byteBuffer);
     });
   }
@@ -130,7 +130,7 @@ public class FileSystemMultipartUploader extends AbstractMultipartUploader {
     byte[] uploadIdByteArray = uploadId.toByteArray();
     checkUploadId(uploadIdByteArray);
     Path collectorPath = new Path(new String(uploadIdByteArray, 0,
-        uploadIdByteArray.length, Charsets.UTF_8));
+        uploadIdByteArray.length, StandardCharsets.UTF_8));
     Path partPath =
         mergePaths(collectorPath, mergePaths(new Path(Path.SEPARATOR),
             new Path(partNumber + ".part")));
@@ -149,7 +149,7 @@ public class FileSystemMultipartUploader extends AbstractMultipartUploader {
       cleanupWithLogger(LOG, inputStream);
     }
     return BBPartHandle.from(ByteBuffer.wrap(
-        partPath.toString().getBytes(Charsets.UTF_8)));
+        partPath.toString().getBytes(StandardCharsets.UTF_8)));
   }
 
   private Path createCollectorPath(Path filePath) {
@@ -210,7 +210,7 @@ public class FileSystemMultipartUploader extends AbstractMultipartUploader {
         .map(pair -> {
           byte[] byteArray = pair.getValue().toByteArray();
           return new Path(new String(byteArray, 0, byteArray.length,
-              Charsets.UTF_8));
+              StandardCharsets.UTF_8));
         })
         .collect(Collectors.toList());
 
@@ -223,7 +223,7 @@ public class FileSystemMultipartUploader extends AbstractMultipartUploader {
         "Duplicate PartHandles");
     byte[] uploadIdByteArray = multipartUploadId.toByteArray();
     Path collectorPath = new Path(new String(uploadIdByteArray, 0,
-        uploadIdByteArray.length, Charsets.UTF_8));
+        uploadIdByteArray.length, StandardCharsets.UTF_8));
 
     boolean emptyFile = totalPartsLen(partHandles) == 0;
     if (emptyFile) {
@@ -250,7 +250,7 @@ public class FileSystemMultipartUploader extends AbstractMultipartUploader {
     byte[] uploadIdByteArray = uploadId.toByteArray();
     checkUploadId(uploadIdByteArray);
     Path collectorPath = new Path(new String(uploadIdByteArray, 0,
-        uploadIdByteArray.length, Charsets.UTF_8));
+        uploadIdByteArray.length, StandardCharsets.UTF_8));
 
     return FutureIO.eval(() -> {
       // force a check for a file existing; raises FNFE if not found

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/CopyCommands.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/CopyCommands.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -114,7 +115,7 @@ class CopyCommands {
 
     private void writeDelimiter(FSDataOutputStream out) throws IOException {
       if (delimiter != null) {
-        out.write(delimiter.getBytes("UTF-8"));
+        out.write(delimiter.getBytes(StandardCharsets.UTF_8));
       }
     }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HtmlQuoting.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HtmlQuoting.java
@@ -120,7 +120,7 @@ public class HtmlQuoting {
       ByteArrayOutputStream buffer = new ByteArrayOutputStream();
       try {
         quoteHtmlChars(buffer, bytes, 0, bytes.length);
-        return buffer.toString("UTF-8");
+        return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
       } catch (IOException ioe) {
         // Won't happen, since it is a bytearrayoutputstream
         return null;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.io;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
 
 import org.apache.commons.codec.binary.Base64;
@@ -75,14 +74,10 @@ public class DefaultStringifier<T> implements Stringifier<T> {
 
   @Override
   public T fromString(String str) throws IOException {
-    try {
-      byte[] bytes = Base64.decodeBase64(str.getBytes("UTF-8"));
-      inBuf.reset(bytes, bytes.length);
-      T restored = deserializer.deserialize(null);
-      return restored;
-    } catch (UnsupportedCharsetException ex) {
-      throw new IOException(ex.toString());
-    }
+    byte[] bytes = Base64.decodeBase64(str.getBytes(StandardCharsets.UTF_8));
+    inBuf.reset(bytes, bytes.length);
+    T restored = deserializer.deserialize(null);
+    return restored;
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/WritableUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/WritableUtils.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.ReflectionUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -86,12 +87,12 @@ public final class WritableUtils  {
   public static String readCompressedString(DataInput in) throws IOException {
     byte[] bytes = readCompressedByteArray(in);
     if (bytes == null) return null;
-    return new String(bytes, "UTF-8");
+    return new String(bytes, StandardCharsets.UTF_8);
   }
 
 
   public static int  writeCompressedString(DataOutput out, String s) throws IOException {
-    return writeCompressedByteArray(out, (s != null) ? s.getBytes("UTF-8") : null);
+    return writeCompressedByteArray(out, (s != null) ? s.getBytes(StandardCharsets.UTF_8) : null);
   }
 
   /*
@@ -103,7 +104,7 @@ public final class WritableUtils  {
    */
   public static void writeString(DataOutput out, String s) throws IOException {
     if (s != null) {
-      byte[] buffer = s.getBytes("UTF-8");
+      byte[] buffer = s.getBytes(StandardCharsets.UTF_8);
       int len = buffer.length;
       out.writeInt(len);
       out.write(buffer, 0, len);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/LogLevel.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/LogLevel.java
@@ -23,6 +23,7 @@ import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -33,7 +34,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.HadoopIllegalArgumentException;
@@ -297,7 +297,7 @@ public class LogLevel {
 
       // read from the servlet
       BufferedReader in = new BufferedReader(
-          new InputStreamReader(connection.getInputStream(), Charsets.UTF_8));
+          new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
       for (String line;;) {
         line = in.readLine();
         if (line == null) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MetricsConfig.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MetricsConfig.java
@@ -23,6 +23,8 @@ import java.io.PrintWriter;
 import java.net.URL;
 import java.net.URLClassLoader;
 import static java.security.AccessController.*;
+
+import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedAction;
 import java.util.Iterator;
 import java.util.Map;
@@ -289,7 +291,7 @@ class MetricsConfig extends SubsetConfiguration {
       PropertiesConfiguration tmp = new PropertiesConfiguration();
       tmp.copy(c);
       tmp.write(pw);
-      return buffer.toString("UTF-8");
+      return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
     } catch (Exception e) {
       throw new MetricsConfigException(e);
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SaslPlainServer.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SaslPlainServer.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.security;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Provider;
 import java.util.Map;
 
@@ -82,7 +83,7 @@ public class SaslPlainServer implements SaslServer {
     try {
       String payload;
       try {
-        payload = new String(response, "UTF-8");
+        payload = new String(response, StandardCharsets.UTF_8);
       } catch (Exception e) {
         throw new IllegalArgumentException("Received corrupt response", e);
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/AbstractJavaKeyStoreProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/AbstractJavaKeyStoreProvider.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.ProviderUtils;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -199,7 +199,7 @@ public abstract class AbstractJavaKeyStoreProvider extends CredentialProvider {
 
   public static char[] bytesToChars(byte[] bytes) throws IOException {
     String pass;
-    pass = new String(bytes, Charsets.UTF_8);
+    pass = new String(bytes, StandardCharsets.UTF_8);
     return pass.toCharArray();
   }
 
@@ -268,7 +268,7 @@ public abstract class AbstractJavaKeyStoreProvider extends CredentialProvider {
     writeLock.lock();
     try {
       keyStore.setKeyEntry(alias,
-          new SecretKeySpec(new String(material).getBytes("UTF-8"),
+          new SecretKeySpec(new String(material).getBytes(StandardCharsets.UTF_8),
               getAlgorithm()), password, null);
     } catch (KeyStoreException e) {
       throw new IOException("Can't store credential " + alias + " in " + this,

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/UserProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/UserProvider.java
@@ -70,7 +70,7 @@ public class UserProvider extends CredentialProvider {
           " already exists in " + this);
     }
     credentials.addSecretKey(new Text(name), 
-        new String(credential).getBytes("UTF-8"));
+        new String(credential).getBytes(StandardCharsets.UTF_8));
     return new CredentialEntry(name, credential);
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/web/DelegationTokenAuthenticationFilter.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/web/DelegationTokenAuthenticationFilter.java
@@ -52,6 +52,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.Enumeration;
 import java.util.List;
@@ -94,7 +95,7 @@ public class DelegationTokenAuthenticationFilter
   public static final String DELEGATION_TOKEN_SECRET_MANAGER_ATTR =
       "hadoop.http.delegation-token-secret-manager";
 
-  private static final Charset UTF8_CHARSET = Charset.forName("UTF-8");
+  private static final Charset UTF8_CHARSET = StandardCharsets.UTF_8;
 
   private static final ThreadLocal<UserGroupInformation> UGI_TL =
       new ThreadLocal<UserGroupInformation>();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/web/DelegationTokenAuthenticationFilter.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/web/DelegationTokenAuthenticationFilter.java
@@ -51,7 +51,6 @@ import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.Enumeration;
@@ -94,8 +93,6 @@ public class DelegationTokenAuthenticationFilter
 
   public static final String DELEGATION_TOKEN_SECRET_MANAGER_ATTR =
       "hadoop.http.delegation-token-secret-manager";
-
-  private static final Charset UTF8_CHARSET = StandardCharsets.UTF_8;
 
   private static final ThreadLocal<UserGroupInformation> UGI_TL =
       new ThreadLocal<UserGroupInformation>();
@@ -227,7 +224,7 @@ public class DelegationTokenAuthenticationFilter
     if (queryString == null) {
       return null;
     }
-    List<NameValuePair> list = URLEncodedUtils.parse(queryString, UTF8_CHARSET);
+    List<NameValuePair> list = URLEncodedUtils.parse(queryString, StandardCharsets.UTF_8);
     if (list != null) {
       for (NameValuePair nv : list) {
         if (DelegationTokenAuthenticatedURL.DO_AS.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/web/ServletUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/web/ServletUtils.java
@@ -23,7 +23,6 @@ import org.apache.http.client.utils.URLEncodedUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -32,7 +31,6 @@ import java.util.List;
  */
 @InterfaceAudience.Private
 class ServletUtils {
-  private static final Charset UTF8_CHARSET = StandardCharsets.UTF_8;
 
   /**
    * Extract a query string parameter without triggering http parameters
@@ -50,7 +48,7 @@ class ServletUtils {
     if (queryString == null) {
       return null;
     }
-    List<NameValuePair> list = URLEncodedUtils.parse(queryString, UTF8_CHARSET);
+    List<NameValuePair> list = URLEncodedUtils.parse(queryString, StandardCharsets.UTF_8);
     if (list != null) {
       for (NameValuePair nv : list) {
         if (name.equals(nv.getName())) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/web/ServletUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/web/ServletUtils.java
@@ -24,6 +24,7 @@ import org.apache.http.client.utils.URLEncodedUtils;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -31,7 +32,7 @@ import java.util.List;
  */
 @InterfaceAudience.Private
 class ServletUtils {
-  private static final Charset UTF8_CHARSET = Charset.forName("UTF-8");
+  private static final Charset UTF8_CHARSET = StandardCharsets.UTF_8;
 
   /**
    * Extract a query string parameter without triggering http parameters

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SysInfoLinux.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SysInfoLinux.java
@@ -22,7 +22,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -247,7 +247,7 @@ public class SysInfoLinux extends SysInfo {
     try {
       fReader = new InputStreamReader(
           Files.newInputStream(Paths.get(procfsMemFile)),
-          Charset.forName("UTF-8"));
+          StandardCharsets.UTF_8);
       in = new BufferedReader(fReader);
     } catch (IOException f) {
       // shouldn't happen....
@@ -319,7 +319,7 @@ public class SysInfoLinux extends SysInfo {
     try {
       fReader =
           new InputStreamReader(Files.newInputStream(Paths.get(procfsCpuFile)),
-              Charset.forName("UTF-8"));
+              StandardCharsets.UTF_8);
       in = new BufferedReader(fReader);
     } catch (IOException f) {
       // shouldn't happen....
@@ -380,7 +380,7 @@ public class SysInfoLinux extends SysInfo {
     try {
       fReader = new InputStreamReader(
           Files.newInputStream(Paths.get(procfsStatFile)),
-          Charset.forName("UTF-8"));
+          StandardCharsets.UTF_8);
       in = new BufferedReader(fReader);
     } catch (IOException f) {
       // shouldn't happen....
@@ -435,7 +435,7 @@ public class SysInfoLinux extends SysInfo {
     try {
       fReader = new InputStreamReader(
           Files.newInputStream(Paths.get(procfsNetFile)),
-          Charset.forName("UTF-8"));
+          StandardCharsets.UTF_8);
       in = new BufferedReader(fReader);
     } catch (IOException f) {
       return;
@@ -490,7 +490,7 @@ public class SysInfoLinux extends SysInfo {
     try {
       in = new BufferedReader(new InputStreamReader(
           Files.newInputStream(Paths.get(procfsDisksFile)),
-          Charset.forName("UTF-8")));
+          StandardCharsets.UTF_8));
     } catch (IOException f) {
       return;
     }
@@ -558,7 +558,7 @@ public class SysInfoLinux extends SysInfo {
     try {
       in = new BufferedReader(new InputStreamReader(
           Files.newInputStream(Paths.get(procfsDiskSectorFile)),
-              Charset.forName("UTF-8")));
+              StandardCharsets.UTF_8));
     } catch (IOException f) {
       return defSector;
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ZKUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ZKUtil.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -27,7 +28,6 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.base.Splitter;
 import org.apache.hadoop.thirdparty.com.google.common.io.Files;
 
@@ -148,7 +148,7 @@ public class ZKUtil {
             "Auth '" + comp + "' not of expected form scheme:auth");
       }
       ret.add(new ZKAuthInfo(parts[0],
-          parts[1].getBytes(Charsets.UTF_8)));
+          parts[1].getBytes(StandardCharsets.UTF_8)));
     }
     return ret;
   }
@@ -172,7 +172,7 @@ public class ZKUtil {
       return valInConf;
     }
     String path = valInConf.substring(1).trim();
-    return Files.asCharSource(new File(path), Charsets.UTF_8).read().trim();
+    return Files.asCharSource(new File(path), StandardCharsets.UTF_8).read().trim();
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.util.curator;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -260,7 +260,7 @@ public final class ZKCuratorManager {
   public String getStringData(final String path) throws Exception {
     byte[] bytes = getData(path);
     if (bytes != null) {
-      return new String(bytes, Charset.forName("UTF-8"));
+      return new String(bytes, StandardCharsets.UTF_8);
     }
     return null;
   }
@@ -275,7 +275,7 @@ public final class ZKCuratorManager {
   public String getStringData(final String path, Stat stat) throws Exception {
     byte[] bytes = getData(path, stat);
     if (bytes != null) {
-      return new String(bytes, Charset.forName("UTF-8"));
+      return new String(bytes, StandardCharsets.UTF_8);
     }
     return null;
   }
@@ -299,7 +299,7 @@ public final class ZKCuratorManager {
    * @throws Exception If it cannot contact Zookeeper.
    */
   public void setData(String path, String data, int version) throws Exception {
-    byte[] bytes = data.getBytes(Charset.forName("UTF-8"));
+    byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
     setData(path, bytes, version);
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestCommonConfigurationFields.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestCommonConfigurationFields.java
@@ -60,7 +60,7 @@ public class TestCommonConfigurationFields extends TestConfigurationFieldsBase {
   @SuppressWarnings("deprecation")
   @Override
   public void initializeMemberVariables() {
-    xmlFilename = new String("core-default.xml");
+    xmlFilename = "core-default.xml";
     configurationClasses = new Class[] {
         CommonConfigurationKeys.class,
         CommonConfigurationKeysPublic.class,

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
@@ -698,7 +698,7 @@ public class TestFileUtil {
     OutputStream os = new FileOutputStream(simpleTar);
     try (TarOutputStream tos = new TarOutputStream(os)) {
       TarEntry te = new TarEntry("/bar/foo");
-      byte[] data = "some-content".getBytes("UTF-8");
+      byte[] data = "some-content".getBytes(StandardCharsets.UTF_8);
       te.setSize(data.length);
       tos.putNextEntry(te);
       tos.write(data);
@@ -782,7 +782,7 @@ public class TestFileUtil {
         ZipArchiveList.add(new ZipArchiveEntry("foo_" + i));
         ZipArchiveEntry archiveEntry = ZipArchiveList.get(i);
         archiveEntry.setUnixMode(count += 0100);
-        byte[] data = "some-content".getBytes("UTF-8");
+        byte[] data = "some-content".getBytes(StandardCharsets.UTF_8);
         archiveEntry.setSize(data.length);
         tos.putArchiveEntry(archiveEntry);
         tos.write(data);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHarFileSystemBasics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHarFileSystemBasics.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -117,7 +118,7 @@ public class TestHarFileSystemBasics {
     final FSDataOutputStream fsdos = localFileSystem.create(masterIndexPath);
     try {
       String versionString = version + "\n";
-      fsdos.write(versionString.getBytes("UTF-8"));
+      fsdos.write(versionString.getBytes(StandardCharsets.UTF_8));
       fsdos.flush();
     } finally {
       fsdos.close();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractMultipartUploaderTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractMultipartUploaderTest.java
@@ -22,13 +22,13 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.assertj.core.api.Assertions;
 import org.junit.Assume;
 import org.junit.Test;
@@ -596,8 +596,8 @@ public abstract class AbstractContractMultipartUploaderTest extends
     abortUpload(uploadHandle, file);
 
     String contents = "ThisIsPart49\n";
-    int len = contents.getBytes(Charsets.UTF_8).length;
-    InputStream is = IOUtils.toInputStream(contents, "UTF-8");
+    int len = contents.getBytes(StandardCharsets.UTF_8).length;
+    InputStream is = IOUtils.toInputStream(contents, StandardCharsets.UTF_8);
 
     intercept(IOException.class,
         () -> awaitFuture(
@@ -624,7 +624,7 @@ public abstract class AbstractContractMultipartUploaderTest extends
   public void testAbortUnknownUpload() throws Exception {
     Path file = methodPath();
     ByteBuffer byteBuffer = ByteBuffer.wrap(
-        "invalid-handle".getBytes(Charsets.UTF_8));
+        "invalid-handle".getBytes(StandardCharsets.UTF_8));
     intercept(FileNotFoundException.class,
         () -> abortUpload(BBUploadHandle.from(byteBuffer), file));
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -806,7 +807,7 @@ public class ContractTestUtils extends Assert {
     try (FSDataInputStream in = fs.open(path)) {
       byte[] buf = new byte[length];
       in.readFully(0, buf);
-      return new String(buf, "UTF-8");
+      return new String(buf, StandardCharsets.UTF_8);
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestHAAdmin.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestHAAdmin.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ha.HAServiceProtocol.HAServiceState;
@@ -30,7 +31,6 @@ import org.apache.hadoop.ha.HAServiceProtocol.HAServiceState;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,8 +97,8 @@ public class TestHAAdmin {
     outBytes.reset();
     LOG.info("Running: HAAdmin " + Joiner.on(" ").join(args));
     int ret = tool.run(args);
-    errOutput = new String(errOutBytes.toByteArray(), Charsets.UTF_8);
-    output = new String(outBytes.toByteArray(), Charsets.UTF_8);
+    errOutput = new String(errOutBytes.toByteArray(), StandardCharsets.UTF_8);
+    output = new String(outBytes.toByteArray(), StandardCharsets.UTF_8);
     LOG.info("Err_output:\n" + errOutput + "\nOutput:\n" + output);
     return ret;
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestIsActiveServlet.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestIsActiveServlet.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -90,6 +91,6 @@ public class TestIsActiveServlet {
 
   private String doGet() throws IOException {
     servlet.doGet(req, resp);
-    return new String(respOut.toByteArray(), "UTF-8");
+    return new String(respOut.toByteArray(), StandardCharsets.UTF_8);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSecureIOUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSecureIOUtils.java
@@ -23,6 +23,7 @@ import static org.junit.Assume.assumeTrue;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -57,7 +58,7 @@ public class TestSecureIOUtils {
     for (File f : new File[] { testFilePathIs, testFilePathRaf,
         testFilePathFadis }) {
       FileOutputStream fos = new FileOutputStream(f);
-      fos.write("hello".getBytes("UTF-8"));
+      fos.write("hello".getBytes(StandardCharsets.UTF_8));
       fos.close();
     }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestText.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestText.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.primitives.Bytes;
 import org.junit.Test;
 
@@ -105,7 +105,7 @@ public class TestText {
       ByteBuffer bb = Text.encode(before);
           
       byte[] utf8Text = bb.array();
-      byte[] utf8Java = before.getBytes("UTF-8");
+      byte[] utf8Java = before.getBytes(StandardCharsets.UTF_8);
       assertEquals(0, WritableComparator.compareBytes(
               utf8Text, 0, bb.limit(),
               utf8Java, 0, utf8Java.length));
@@ -392,7 +392,7 @@ public class TestText {
   @Test
   public void testReadWithKnownLength() throws IOException {
     String line = "hello world";
-    byte[] inputBytes = line.getBytes(Charsets.UTF_8);
+    byte[] inputBytes = line.getBytes(StandardCharsets.UTF_8);
     DataInputBuffer in = new DataInputBuffer();
     Text text = new Text();
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestUTF8.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestUTF8.java
@@ -23,6 +23,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.UTFDataFormatException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
 
 import org.apache.hadoop.test.GenericTestUtils;
@@ -110,7 +111,7 @@ public class TestUTF8 {
     DataOutputBuffer dob = new DataOutputBuffer();
     new UTF8(s).write(dob);
 
-    assertEquals(s, new String(dob.getData(), 2, dob.getLength()-2, "UTF-8"));
+    assertEquals(s, new String(dob.getData(), 2, dob.getLength()-2, StandardCharsets.UTF_8));
   }
 
   /**
@@ -125,7 +126,7 @@ public class TestUTF8 {
     String catFace = "\uD83D\uDC31";
 
     // This encodes to 4 bytes in UTF-8:
-    byte[] encoded = catFace.getBytes("UTF-8");
+    byte[] encoded = catFace.getBytes(StandardCharsets.UTF_8);
     assertEquals(4, encoded.length);
     assertEquals("f09f90b1", StringUtils.byteToHexString(encoded));
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestFileSink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestFileSink.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
 import org.apache.hadoop.io.IOUtils;
@@ -113,7 +114,7 @@ public class TestFileSink {
       is = new FileInputStream(outFile);
       baos = new ByteArrayOutputStream((int)outFile.length());
       IOUtils.copyBytes(is, baos, 1024, true);
-      outFileContent = new String(baos.toByteArray(), "UTF-8");
+      outFileContent = new String(baos.toByteArray(), StandardCharsets.UTF_8);
     } finally {
       IOUtils.cleanupWithLogger(null, baos, is);
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestStatsDMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestStatsDMetrics.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -75,7 +75,7 @@ public class TestStatsDMetrics {
       sock.receive(p);
 
       String result =new String(p.getData(), 0, p.getLength(),
-          Charset.forName("UTF-8"));
+          StandardCharsets.UTF_8);
       assertTrue(
           "Received data did not match data sent",
           result.equals("host.process.jvm.Context.foo1:1.25|c") ||
@@ -109,7 +109,7 @@ public class TestStatsDMetrics {
       sink.putMetrics(record);
       sock.receive(p);
       String result =
-          new String(p.getData(), 0, p.getLength(), Charset.forName("UTF-8"));
+          new String(p.getData(), 0, p.getLength(), StandardCharsets.UTF_8);
 
       assertTrue("Received data did not match data sent",
           result.equals("process.jvm.Context.foo1:1|c") ||

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestTableMapping.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestTableMapping.java
@@ -21,11 +21,11 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.NET_TOPOLOGY_TA
 
 import static org.junit.Assert.assertEquals;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.io.Files;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,7 +41,7 @@ public class TestTableMapping {
   public void testResolve() throws IOException {
     File mapFile = File.createTempFile(getClass().getSimpleName() +
         ".testResolve", ".txt");
-    Files.asCharSink(mapFile, Charsets.UTF_8).write(
+    Files.asCharSink(mapFile, StandardCharsets.UTF_8).write(
         hostName1 + " /rack1\n" + hostName2 + "\t/rack2\n");
     mapFile.deleteOnExit();
     TableMapping mapping = new TableMapping();
@@ -64,7 +64,7 @@ public class TestTableMapping {
   public void testTableCaching() throws IOException {
     File mapFile = File.createTempFile(getClass().getSimpleName() +
         ".testTableCaching", ".txt");
-    Files.asCharSink(mapFile, Charsets.UTF_8).write(
+    Files.asCharSink(mapFile, StandardCharsets.UTF_8).write(
         hostName1 + " /rack1\n" + hostName2 + "\t/rack2\n");
     mapFile.deleteOnExit();
     TableMapping mapping = new TableMapping();
@@ -128,7 +128,7 @@ public class TestTableMapping {
   public void testClearingCachedMappings() throws IOException {
     File mapFile = File.createTempFile(getClass().getSimpleName() +
         ".testClearingCachedMappings", ".txt");
-    Files.asCharSink(mapFile, Charsets.UTF_8).write(
+    Files.asCharSink(mapFile, StandardCharsets.UTF_8).write(
         hostName1 + " /rack1\n" + hostName2 + "\t/rack2\n");
     mapFile.deleteOnExit();
 
@@ -147,7 +147,7 @@ public class TestTableMapping {
     assertEquals("/rack1", result.get(0));
     assertEquals("/rack2", result.get(1));
 
-    Files.asCharSink(mapFile, Charsets.UTF_8).write("");
+    Files.asCharSink(mapFile, StandardCharsets.UTF_8).write("");
 
     mapping.reloadCachedMappings();
 
@@ -166,7 +166,7 @@ public class TestTableMapping {
   public void testBadFile() throws IOException {
     File mapFile = File.createTempFile(getClass().getSimpleName() +
         ".testBadFile", ".txt");
-    Files.asCharSink(mapFile, Charsets.UTF_8).write("bad contents");
+    Files.asCharSink(mapFile, StandardCharsets.UTF_8).write("bad contents");
     mapFile.deleteOnExit();
     TableMapping mapping = new TableMapping();
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.security.token.delegation;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -400,7 +401,7 @@ public class TestZKDelegationTokenSecretManager {
         .connectString(connectString)
         .retryPolicy(retryPolicy)
         .aclProvider(digestAclProvider)
-        .authorization("digest", userPass.getBytes("UTF-8"))
+        .authorization("digest", userPass.getBytes(StandardCharsets.UTF_8))
         .build();
     curatorFramework.start();
     ZKDelegationTokenSecretManager.setCurator(curatorFramework);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestClasspath.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestClasspath.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
@@ -46,7 +47,7 @@ public class TestClasspath {
       .class);
   private static final File TEST_DIR = GenericTestUtils.getTestDir(
       "TestClasspath");
-  private static final Charset UTF8 = Charset.forName("UTF-8");
+  private static final Charset UTF8 = StandardCharsets.UTF_8;
 
   static {
     ExitUtil.disableSystemExit();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestPureJavaCrc32.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestPureJavaCrc32.java
@@ -21,6 +21,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Constructor;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -49,7 +50,7 @@ public class TestPureJavaCrc32 {
 
     checkOnBytes(new byte[] {40, 60, 97, -70}, false);
     
-    checkOnBytes("hello world!".getBytes("UTF-8"), false);
+    checkOnBytes("hello world!".getBytes(StandardCharsets.UTF_8), false);
 
     for (int i = 0; i < 10000; i++) {
       byte randomBytes[] = new byte[new Random().nextInt(2048)];

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestZKUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestZKUtil.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.*;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.hadoop.test.GenericTestUtils;
@@ -31,7 +32,6 @@ import org.apache.zookeeper.ZooDefs.Perms;
 import org.apache.zookeeper.data.ACL;
 import org.junit.Test;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.io.Files;
 
 public class TestZKUtil {
@@ -131,7 +131,7 @@ public class TestZKUtil {
     assertEquals("x", ZKUtil.resolveConfIndirection("x"));
     
     TEST_FILE.getParentFile().mkdirs();
-    Files.asCharSink(TEST_FILE, Charsets.UTF_8).write("hello world");
+    Files.asCharSink(TEST_FILE, StandardCharsets.UTF_8).write("hello world");
     assertEquals("hello world", ZKUtil.resolveConfIndirection(
         "@" + TEST_FILE.getAbsolutePath()));
     

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/curator/TestZKCuratorManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/curator/TestZKCuratorManager.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -117,7 +118,7 @@ public class TestZKCuratorManager {
     curator.create(node1);
     assertNull(curator.getStringData(node1));
 
-    byte[] setData = "setData".getBytes("UTF-8");
+    byte[] setData = "setData".getBytes(StandardCharsets.UTF_8);
     curator.setData(node1, setData, -1);
     assertEquals("setData", curator.getStringData(node1));
 
@@ -136,7 +137,7 @@ public class TestZKCuratorManager {
     String fencingNodePath = "/fencing";
     String node1 = "/node1";
     String node2 = "/node2";
-    byte[] testData = "testData".getBytes("UTF-8");
+    byte[] testData = "testData".getBytes(StandardCharsets.UTF_8);
     assertFalse(curator.exists(fencingNodePath));
     assertFalse(curator.exists(node1));
     assertFalse(curator.exists(node2));
@@ -154,7 +155,7 @@ public class TestZKCuratorManager {
     assertTrue(Arrays.equals(testData, curator.getData(node1)));
     assertTrue(Arrays.equals(testData, curator.getData(node2)));
 
-    byte[] setData = "setData".getBytes("UTF-8");
+    byte[] setData = "setData".getBytes(StandardCharsets.UTF_8);
     txn = curator.createTransaction(zkAcl, fencingNodePath);
     txn.setData(node1, setData, -1);
     txn.delete(node2);

--- a/hadoop-common-project/hadoop-kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMSJSONWriter.java
+++ b/hadoop-common-project/hadoop-kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMSJSONWriter.java
@@ -33,7 +33,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -64,8 +64,7 @@ public class KMSJSONWriter implements MessageBodyWriter<Object> {
       Annotation[] annotations, MediaType mediaType,
       MultivaluedMap<String, Object> stringObjectMultivaluedMap,
       OutputStream outputStream) throws IOException, WebApplicationException {
-    Writer writer = new OutputStreamWriter(outputStream, Charset
-        .forName("UTF-8"));
+    Writer writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
     JsonSerialization.writer().writeValue(writer, obj);
   }
 

--- a/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/client/binding/JsonSerDeser.java
+++ b/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/client/binding/JsonSerDeser.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.util.JsonSerialization;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Support for marshalling objects to and from JSON.
@@ -47,7 +48,6 @@ import java.io.IOException;
 @InterfaceStability.Evolving
 public class JsonSerDeser<T> extends JsonSerialization<T> {
 
-  private static final String UTF_8 = "UTF-8";
   public static final String E_NO_DATA = "No data at path";
   public static final String E_DATA_TOO_SHORT = "Data at path too short";
   public static final String E_MISSING_MARKER_STRING =
@@ -102,7 +102,7 @@ public class JsonSerDeser<T> extends JsonSerialization<T> {
     if (StringUtils.isNotEmpty(marker) && len < marker.length()) {
       throw new NoRecordException(path, E_DATA_TOO_SHORT);
     }
-    String json = new String(bytes, 0, len, UTF_8);
+    String json = new String(bytes, 0, len, StandardCharsets.UTF_8);
     if (StringUtils.isNotEmpty(marker)
         && !json.contains(marker)) {
       throw new NoRecordException(path, E_MISSING_MARKER_STRING + marker);

--- a/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/client/impl/zk/RegistrySecurity.java
+++ b/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/client/impl/zk/RegistrySecurity.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import javax.security.auth.login.AppConfigurationEntry;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -295,7 +296,7 @@ public class RegistrySecurity extends AbstractService {
           digestAuthUser = id;
           digestAuthPassword = pass;
           String authPair = id + ":" + pass;
-          digestAuthData = authPair.getBytes("UTF-8");
+          digestAuthData = authPair.getBytes(StandardCharsets.UTF_8);
           if (LOG.isDebugEnabled()) {
             LOG.debug("Auth is Digest ACL: {}", aclToString(acl));
           }

--- a/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/server/dns/RegistryDNS.java
+++ b/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/server/dns/RegistryDNS.java
@@ -80,6 +80,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -628,7 +629,7 @@ public class RegistryDNS extends AbstractService implements DNSOperations,
       Name zoneName = zone.getOrigin();
       DNSKEYRecord dnskeyRecord = dnsKeyRecs.get(zoneName);
       if (dnskeyRecord == null) {
-        byte[] key = Base64.decodeBase64(publicKey.getBytes("UTF-8"));
+        byte[] key = Base64.decodeBase64(publicKey.getBytes(StandardCharsets.UTF_8));
         dnskeyRecord = new DNSKEYRecord(zoneName,
             DClass.IN, ttl,
             DNSKEYRecord.Flags.ZONE_KEY,

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +60,6 @@ import org.apache.hadoop.security.SaslRpcServer.QualityOfProtection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 import org.apache.hadoop.thirdparty.com.google.common.net.InetAddresses;
@@ -147,7 +147,7 @@ public final class DataTransferSaslUtil {
    * @return key encoded as SASL password
    */
   public static char[] encryptionKeyToPassword(byte[] encryptionKey) {
-    return new String(Base64.encodeBase64(encryptionKey, false), Charsets.UTF_8)
+    return new String(Base64.encodeBase64(encryptionKey, false), StandardCharsets.UTF_8)
         .toCharArray();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferClient.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -65,7 +66,6 @@ import org.apache.hadoop.util.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
  * Negotiates SASL for DataTransferProtocol on behalf of a client.  There are
@@ -347,7 +347,7 @@ public class SaslDataTransferClient {
     return encryptionKey.keyId + NAME_DELIMITER +
         encryptionKey.blockPoolId + NAME_DELIMITER +
         new String(Base64.encodeBase64(encryptionKey.nonce, false),
-            Charsets.UTF_8);
+            StandardCharsets.UTF_8);
   }
 
   /**
@@ -450,7 +450,7 @@ public class SaslDataTransferClient {
   private void updateToken(Token<BlockTokenIdentifier> accessToken,
       SecretKey secretKey, Map<String, String> saslProps)
       throws IOException {
-    byte[] newSecret = saslProps.get(Sasl.QOP).getBytes(Charsets.UTF_8);
+    byte[] newSecret = saslProps.get(Sasl.QOP).getBytes(StandardCharsets.UTF_8);
     BlockTokenIdentifier bkid = accessToken.decodeIdentifier();
     bkid.setHandshakeMsg(newSecret);
     byte[] bkidBytes = bkid.getBytes();
@@ -471,7 +471,7 @@ public class SaslDataTransferClient {
    */
   private static String buildUserName(Token<BlockTokenIdentifier> blockToken) {
     return new String(Base64.encodeBase64(blockToken.getIdentifier(), false),
-        Charsets.UTF_8);
+        StandardCharsets.UTF_8);
   }
 
   /**
@@ -483,7 +483,7 @@ public class SaslDataTransferClient {
    */
   private char[] buildClientPassword(Token<BlockTokenIdentifier> blockToken) {
     return new String(Base64.encodeBase64(blockToken.getPassword(), false),
-        Charsets.UTF_8).toCharArray();
+        StandardCharsets.UTF_8).toCharArray();
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/CombinedHostsFileReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/CombinedHostsFileReader.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -84,7 +85,7 @@ public final class CombinedHostsFileReader {
     if (hostFile.length() > 0) {
       try (Reader input =
           new InputStreamReader(
-              Files.newInputStream(hostFile.toPath()), "UTF-8")) {
+              Files.newInputStream(hostFile.toPath()), StandardCharsets.UTF_8)) {
         allDNs = objectMapper.readValue(input, DatanodeAdminProperties[].class);
       } catch (JsonMappingException jme) {
         // The old format doesn't have json top-level token to enclose
@@ -103,7 +104,7 @@ public final class CombinedHostsFileReader {
       List<DatanodeAdminProperties> all = new ArrayList<>();
       try (Reader input =
           new InputStreamReader(Files.newInputStream(Paths.get(hostsFilePath)),
-                  "UTF-8")) {
+                  StandardCharsets.UTF_8)) {
         Iterator<DatanodeAdminProperties> iterator =
             objectReader.readValues(jsonFactory.createParser(input));
         while (iterator.hasNext()) {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/CombinedHostsFileWriter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/CombinedHostsFileWriter.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdfs.util;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Set;
@@ -62,7 +63,7 @@ public final class CombinedHostsFileWriter {
 
     try (Writer output =
         new OutputStreamWriter(Files.newOutputStream(Paths.get(hostsFile)),
-            "UTF-8")) {
+            StandardCharsets.UTF_8)) {
       objectMapper.writeValue(output, allDNs);
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
@@ -137,7 +137,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.util.Preconditions;
 
 /** A FileSystem for HDFS over the web. */
@@ -1792,7 +1791,7 @@ public class WebHdfsFileSystem extends FileSystem
     }
     DirectoryListing listing = new FsPathResponseRunner<DirectoryListing>(
         GetOpParam.Op.LISTSTATUS_BATCH,
-        f, new StartAfterParam(new String(prevKey, Charsets.UTF_8))) {
+        f, new StartAfterParam(new String(prevKey, StandardCharsets.UTF_8))) {
       @Override
       DirectoryListing decodeResponse(Map<?, ?> json) throws IOException {
         return JsonUtilClient.toDirectoryListing(json);

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/web/TestWebHdfsContentLength.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/web/TestWebHdfsContentLength.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -204,7 +205,7 @@ public class TestWebHdfsContentLength {
             if (n <= 0) {
               break;
             }
-            sb.append(new String(buf, 0, n, "UTF-8"));
+            sb.append(new String(buf, 0, n, StandardCharsets.UTF_8));
           }
           return sb.toString();
         } finally {

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.fs.http.client;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -24,7 +25,6 @@ import java.util.EnumSet;
 import java.util.List;
 
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicyInfo;
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.MapType;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -796,7 +796,7 @@ public class HttpFSFileSystem extends FileSystem
     Map<String, String> params = new HashMap<String, String>();
     params.put(OP_PARAM, Operation.LISTSTATUS_BATCH.toString());
     if (token != null) {
-      params.put(START_AFTER_PARAM, new String(token, Charsets.UTF_8));
+      params.put(START_AFTER_PARAM, new String(token, StandardCharsets.UTF_8));
     }
     HttpURLConnection conn = getConnection(
         Operation.LISTSTATUS_BATCH.getMethod(),
@@ -811,7 +811,7 @@ public class HttpFSFileSystem extends FileSystem
     byte[] newToken = null;
     if (statuses.length > 0) {
       newToken = statuses[statuses.length - 1].getPath().getName().toString()
-          .getBytes(Charsets.UTF_8);
+          .getBytes(StandardCharsets.UTF_8);
     }
     // Parse the remainingEntries boolean into hasMore
     final long remainingEntries = (Long) listing.get(REMAINING_ENTRIES_JSON);

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.fs.http.server;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -91,6 +90,7 @@ import javax.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessControlException;
 import java.security.PrivilegedExceptionAction;
 import java.text.MessageFormat;
@@ -422,7 +422,7 @@ public class HttpFSServer {
           HttpFSParametersProvider.StartAfterParam.class);
       byte[] token = HttpFSUtils.EMPTY_BYTES;
       if (startAfter != null) {
-        token = startAfter.getBytes(Charsets.UTF_8);
+        token = startAfter.getBytes(StandardCharsets.UTF_8);
       }
       FSOperations.FSListStatusBatch command = new FSOperations
           .FSListStatusBatch(path, token);

--- a/hadoop-hdfs-project/hadoop-hdfs-nfs/src/main/java/org/apache/hadoop/hdfs/nfs/nfs3/RpcProgramNfs3.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-nfs/src/main/java/org/apache/hadoop/hdfs/nfs/nfs3/RpcProgramNfs3.java
@@ -25,7 +25,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
 
 import io.netty.buffer.ByteBuf;
@@ -681,15 +681,15 @@ public class RpcProgramNfs3 extends RpcProgram implements Nfs3Interface {
       }
       int rtmax = config.getInt(NfsConfigKeys.DFS_NFS_MAX_READ_TRANSFER_SIZE_KEY,
           NfsConfigKeys.DFS_NFS_MAX_READ_TRANSFER_SIZE_DEFAULT);
-      if (rtmax < target.getBytes(Charset.forName("UTF-8")).length) {
+      if (rtmax < target.getBytes(StandardCharsets.UTF_8).length) {
         LOG.error("Link size: {} is larger than max transfer size: {}",
-            target.getBytes(Charset.forName("UTF-8")).length, rtmax);
+            target.getBytes(StandardCharsets.UTF_8).length, rtmax);
         return new READLINK3Response(Nfs3Status.NFS3ERR_IO, postOpAttr,
             new byte[0]);
       }
 
       return new READLINK3Response(Nfs3Status.NFS3_OK, postOpAttr,
-          target.getBytes(Charset.forName("UTF-8")));
+          target.getBytes(StandardCharsets.UTF_8));
 
     } catch (IOException e) {
       LOG.warn("Readlink error", e);
@@ -1515,7 +1515,7 @@ public class RpcProgramNfs3 extends RpcProgram implements Nfs3Interface {
       }
       // This happens when startAfter was just deleted
       LOG.info("Cookie couldn't be found: {}, do listing from beginning",
-          new String(startAfter, Charset.forName("UTF-8")));
+          new String(startAfter, StandardCharsets.UTF_8));
       dlisting = dfsClient
           .listPaths(dirFileIdPath, HdfsFileStatus.EMPTY_NAME);
     }
@@ -1628,7 +1628,7 @@ public class RpcProgramNfs3 extends RpcProgram implements Nfs3Interface {
         startAfter = HdfsFileStatus.EMPTY_NAME;
       } else {
         String inodeIdPath = Nfs3Utils.getFileIdPath(cookie);
-        startAfter = inodeIdPath.getBytes(Charset.forName("UTF-8"));
+        startAfter = inodeIdPath.getBytes(StandardCharsets.UTF_8);
       }
 
       dlisting = listPaths(dfsClient, dirFileIdPath, startAfter);
@@ -1800,7 +1800,7 @@ public class RpcProgramNfs3 extends RpcProgram implements Nfs3Interface {
         startAfter = HdfsFileStatus.EMPTY_NAME;
       } else {
         String inodeIdPath = Nfs3Utils.getFileIdPath(cookie);
-        startAfter = inodeIdPath.getBytes(Charset.forName("UTF-8"));
+        startAfter = inodeIdPath.getBytes(StandardCharsets.UTF_8);
       }
 
       dlisting = listPaths(dfsClient, dirFileIdPath, startAfter);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
@@ -28,6 +28,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -62,7 +63,6 @@ import org.apache.hadoop.util.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
  * Negotiates SASL for DataTransferProtocol on behalf of a server.  There are
@@ -326,7 +326,7 @@ public class SaslDataTransferServer {
     byte[] tokenPassword = blockPoolTokenSecretManager.retrievePassword(
       identifier);
     return (new String(Base64.encodeBase64(tokenPassword, false),
-      Charsets.UTF_8)).toCharArray();
+      StandardCharsets.UTF_8)).toCharArray();
   }
 
   /**
@@ -381,7 +381,7 @@ public class SaslDataTransferServer {
       if (secret != null || bpid != null) {
         // sanity check, if one is null, the other must also not be null
         assert(secret != null && bpid != null);
-        String qop = new String(secret, Charsets.UTF_8);
+        String qop = new String(secret, StandardCharsets.UTF_8);
         saslProps.put(Sasl.QOP, qop);
       }
       SaslParticipant sasl = SaslParticipant.createServerSaslParticipant(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/Journal.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/Journal.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.security.PrivilegedExceptionAction;
@@ -72,7 +73,6 @@ import org.apache.hadoop.util.StopWatch;
 import org.apache.hadoop.util.Time;
 
 import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.thirdparty.protobuf.TextFormat;
@@ -1105,7 +1105,7 @@ public class Journal implements Closeable {
       // Write human-readable data after the protobuf. This is only
       // to assist in debugging -- it's not parsed at all.
       try(OutputStreamWriter writer =
-          new OutputStreamWriter(fos, Charsets.UTF_8)) {
+          new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
         writer.write(String.valueOf(newData));
         writer.write('\n');
         writer.flush();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/block/BlockTokenSecretManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/block/BlockTokenSecretManager.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.hdfs.security.token.block;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Arrays;
@@ -293,7 +293,7 @@ public class BlockTokenSecretManager extends
     if (shouldWrapQOP) {
       String qop = Server.getAuxiliaryPortEstablishedQOP();
       if (qop != null) {
-        id.setHandshakeMsg(qop.getBytes(Charsets.UTF_8));
+        id.setHandshakeMsg(qop.getBytes(StandardCharsets.UTF_8));
       }
     }
     return new Token<BlockTokenIdentifier>(id, this);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/Storage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/Storage.java
@@ -25,6 +25,7 @@ import java.io.RandomAccessFile;
 import java.lang.management.ManagementFactory;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermission;
@@ -53,7 +54,6 @@ import org.apache.hadoop.io.nativeio.NativeIOException;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.hadoop.util.VersionInfo;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -944,7 +944,7 @@ public abstract class Storage extends StorageInfo {
           LOG.error("Unable to acquire file lock on path {}", lockF);
           throw new OverlappingFileLockException();
         }
-        file.write(jvmName.getBytes(Charsets.UTF_8));
+        file.write(jvmName.getBytes(StandardCharsets.UTF_8));
         LOG.info("Lock on {} acquired by nodename {}", lockF, jvmName);
       } catch(OverlappingFileLockException oe) {
         // Cannot read from the locked file on Windows.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DiskBalancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DiskBalancer.java
@@ -42,7 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -450,7 +450,7 @@ public class DiskBalancer {
 
     if ((planID == null) ||
         (planID.length() != sha1Length) ||
-        !DigestUtils.sha1Hex(plan.getBytes(Charset.forName("UTF-8")))
+        !DigestUtils.sha1Hex(plan.getBytes(StandardCharsets.UTF_8))
             .equalsIgnoreCase(planID)) {
       LOG.error("Disk Balancer - Invalid plan hash.");
       throw new DiskBalancerException("Invalid or mis-matched hash.",

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/PmemVolumeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/PmemVolumeManager.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -333,7 +334,7 @@ public final class PmemVolumeManager {
 
     String uuidStr = UUID.randomUUID().toString();
     String testFilePath = realPmemDir.getPath() + "/.verify.pmem." + uuidStr;
-    byte[] contents = uuidStr.getBytes("UTF-8");
+    byte[] contents = uuidStr.getBytes(StandardCharsets.UTF_8);
     RandomAccessFile testFile = null;
     MappedByteBuffer out = null;
     try {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/webhdfs/ExceptionHandler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/webhdfs/ExceptionHandler.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdfs.server.datanode.web.webhdfs;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import com.sun.jersey.api.ParamException;
 import com.sun.jersey.api.container.ContainerException;
 import io.netty.buffer.Unpooled;
@@ -32,6 +31,7 @@ import org.apache.hadoop.security.token.SecretManager;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
@@ -83,7 +83,7 @@ class ExceptionHandler {
       s = INTERNAL_SERVER_ERROR;
     }
 
-    final byte[] js = JsonUtil.toJsonString(e).getBytes(Charsets.UTF_8);
+    final byte[] js = JsonUtil.toJsonString(e).getBytes(StandardCharsets.UTF_8);
     DefaultFullHttpResponse resp =
       new DefaultFullHttpResponse(HTTP_1_1, s, Unpooled.wrappedBuffer(js));
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -96,6 +96,7 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SNAPSHOT_DIFF_LI
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SNAPSHOT_DIFF_LISTING_LIMIT_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSUtil.isParentEntry;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.text.CaseUtils;
@@ -343,7 +344,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -1979,7 +1979,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
         File file = new File(System.getProperty("hadoop.log.dir"), filename);
         PrintWriter out = new PrintWriter(new BufferedWriter(
                 new OutputStreamWriter(Files.newOutputStream(file.toPath()),
-                        Charsets.UTF_8)));
+                        StandardCharsets.UTF_8)));
         metaSave(out);
         out.flush();
         out.close();
@@ -4214,7 +4214,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   public byte[] getSrcPathsHash(String[] srcs) {
     synchronized (digest) {
       for (String src : srcs) {
-        digest.update(src.getBytes(Charsets.UTF_8));
+        digest.update(src.getBytes(StandardCharsets.UTF_8));
       }
       byte[] result = digest.digest();
       digest.reset();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/web/resources/NamenodeWebHdfsMethods.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/web/resources/NamenodeWebHdfsMethods.java
@@ -26,6 +26,7 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.security.PrivilegedExceptionAction;
 import java.util.Base64;
@@ -124,7 +125,6 @@ import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.StringUtils;
 
 import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import com.sun.jersey.spi.container.ResourceFilters;
 
 /** Web-hdfs NameNode implementation. */
@@ -1339,7 +1339,7 @@ public class NamenodeWebHdfsMethods {
     {
       byte[] start = HdfsFileStatus.EMPTY_NAME;
       if (startAfter != null && startAfter.getValue() != null) {
-        start = startAfter.getValue().getBytes(Charsets.UTF_8);
+        start = startAfter.getValue().getBytes(StandardCharsets.UTF_8);
       }
       final DirectoryListing listing = getDirectoryListing(cp, fullpath, start);
       final String js = JsonUtil.toJsonString(listing);
@@ -1532,7 +1532,7 @@ public class NamenodeWebHdfsMethods {
       @Override
       public void write(final OutputStream outstream) throws IOException {
         final PrintWriter out = new PrintWriter(new OutputStreamWriter(
-            outstream, Charsets.UTF_8));
+            outstream, StandardCharsets.UTF_8));
         out.println("{\"" + FileStatus.class.getSimpleName() + "es\":{\""
             + FileStatus.class.getSimpleName() + "\":[");
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineEditsViewer/OfflineEditsXmlLoader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineEditsViewer/OfflineEditsXmlLoader.java
@@ -22,6 +22,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Stack;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -41,7 +42,6 @@ import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 import org.xml.sax.helpers.XMLReaderFactory;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
  * OfflineEditsXmlLoader walks an EditsVisitor over an OEV XML file
@@ -75,7 +75,7 @@ class OfflineEditsXmlLoader
         File inputFile, OfflineEditsViewer.Flags flags) throws FileNotFoundException {
     this.visitor = visitor;
     this.fileReader =
-        new InputStreamReader(new FileInputStream(inputFile), Charsets.UTF_8);
+        new InputStreamReader(new FileInputStream(inputFile), StandardCharsets.UTF_8);
     this.fixTxIds = flags.getFixTxIds();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineEditsViewer/StatisticsEditsVisitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineEditsViewer/StatisticsEditsVisitor.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.HashMap;
 
@@ -30,7 +31,6 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLogOp;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLogOpCodes;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
  * StatisticsEditsVisitor implements text version of EditsVisitor
@@ -53,7 +53,7 @@ public class StatisticsEditsVisitor implements OfflineEditsVisitor {
    * @param out Name of file to write output to
    */
   public StatisticsEditsVisitor(OutputStream out) throws IOException {
-    this.out = new PrintWriter(new OutputStreamWriter(out, Charsets.UTF_8));
+    this.out = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
   }
 
   /** Start the visitor */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/FSImageHandler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/FSImageHandler.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdfs.tools.offlineImageViewer;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
@@ -37,6 +36,7 @@ import org.apache.hadoop.util.StringUtils;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -124,7 +124,7 @@ class FSImageHandler extends SimpleChannelInboundHandler<HttpRequest> {
 
     DefaultFullHttpResponse resp = new DefaultFullHttpResponse(HTTP_1_1,
         HttpResponseStatus.OK, Unpooled.wrappedBuffer(content
-            .getBytes(Charsets.UTF_8)));
+            .getBytes(StandardCharsets.UTF_8)));
     resp.headers().set(CONTENT_TYPE, APPLICATION_JSON_UTF8);
     resp.headers().set(CONTENT_LENGTH, resp.content().readableBytes());
     resp.headers().set(CONNECTION, CLOSE);
@@ -142,7 +142,7 @@ class FSImageHandler extends SimpleChannelInboundHandler<HttpRequest> {
     Exception e = cause instanceof Exception ? (Exception) cause : new
         Exception(cause);
     final String output = JsonUtil.toJsonString(e);
-    ByteBuf content = Unpooled.wrappedBuffer(output.getBytes(Charsets.UTF_8));
+    ByteBuf content = Unpooled.wrappedBuffer(output.getBytes(StandardCharsets.UTF_8));
     final DefaultFullHttpResponse resp = new DefaultFullHttpResponse(
             HTTP_1_1, INTERNAL_SERVER_ERROR, content);
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/ImageLoaderCurrent.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/ImageLoaderCurrent.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdfs.tools.offlineImageViewer;
 
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -320,7 +321,7 @@ class ImageLoaderCurrent implements ImageLoader {
     for(int i = 0; i < numINUC; i++) {
       v.visitEnclosingElement(ImageElement.INODE_UNDER_CONSTRUCTION);
       byte [] name = FSImageSerialization.readBytes(in);
-      String n = new String(name, "UTF8");
+      String n = new String(name, StandardCharsets.UTF_8);
       v.visit(ImageElement.INODE_PATH, n);
       
       if (NameNodeLayoutVersion.supports(Feature.ADD_INODE_ID, imageVersion)) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageReconstructor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageReconstructor.java
@@ -36,7 +36,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.DigestOutputStream;
@@ -1840,7 +1840,7 @@ class OfflineImageReconstructor {
       Files.deleteIfExists(Paths.get(outputPath));
       fout = Files.newOutputStream(Paths.get(outputPath));
       fis = Files.newInputStream(Paths.get(inputPath));
-      reader = new InputStreamReader(fis, Charset.forName("UTF-8"));
+      reader = new InputStreamReader(fis, StandardCharsets.UTF_8);
       out = new CountingOutputStream(
           new DigestOutputStream(
               new BufferedOutputStream(fout), digester));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/PBImageTextWriter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/PBImageTextWriter.java
@@ -26,11 +26,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.RandomAccessFile;
-import java.io.UnsupportedEncodingException;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -419,9 +419,8 @@ abstract class PBImageTextWriter implements Closeable {
       return ByteBuffer.allocate(8).putLong(value).array();
     }
 
-    private static byte[] toBytes(String value)
-        throws UnsupportedEncodingException {
-      return value.getBytes("UTF-8");
+    private static byte[] toBytes(String value) {
+      return value.getBytes(StandardCharsets.UTF_8);
     }
 
     private static long toLong(byte[] bytes) {
@@ -430,11 +429,7 @@ abstract class PBImageTextWriter implements Closeable {
     }
 
     private static String toString(byte[] bytes) throws IOException {
-      try {
-        return new String(bytes, "UTF-8");
-      } catch (UnsupportedEncodingException e) {
-        throw new IOException(e);
-      }
+      return new String(bytes, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TextWriterImageVisitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TextWriterImageVisitor.java
@@ -19,10 +19,10 @@ package org.apache.hadoop.hdfs.tools.offlineImageViewer;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
  * TextWriterImageProcessor mixes in the ability for ImageVisitor
@@ -61,7 +61,7 @@ abstract class TextWriterImageVisitor extends ImageVisitor {
     super();
     this.printToScreen = printToScreen;
     fw = new OutputStreamWriter(Files.newOutputStream(Paths.get(filename)),
-        Charsets.UTF_8);
+        StandardCharsets.UTF_8);
     okToWrite = true;
   }
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/MD5FileUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/MD5FileUtils.java
@@ -23,6 +23,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
@@ -35,7 +36,6 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.MD5Hash;
 import org.apache.hadoop.util.StringUtils;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
  * Static functions for dealing with files of the same format
@@ -75,7 +75,7 @@ public abstract class MD5FileUtils {
   private static Matcher readStoredMd5(File md5File) throws IOException {
     BufferedReader reader =
         new BufferedReader(new InputStreamReader(
-            Files.newInputStream(md5File.toPath()), Charsets.UTF_8));
+            Files.newInputStream(md5File.toPath()), StandardCharsets.UTF_8));
     String md5Line;
     try {
       md5Line = reader.readLine();
@@ -155,7 +155,7 @@ public abstract class MD5FileUtils {
     String md5Line = digestString + " *" + dataFile.getName() + "\n";
 
     AtomicFileOutputStream afos = new AtomicFileOutputStream(md5File);
-    afos.write(md5Line.getBytes(Charsets.UTF_8));
+    afos.write(md5Line.getBytes(StandardCharsets.UTF_8));
     afos.close();
 
     if (LOG.isDebugEnabled()) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/PersistentLongFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/PersistentLongFile.java
@@ -22,13 +22,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.io.IOUtils;
-
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
  * Class that represents a file on disk which persistently stores
@@ -77,7 +76,7 @@ public class PersistentLongFile {
   public static void writeFile(File file, long val) throws IOException {
     AtomicFileOutputStream fos = new AtomicFileOutputStream(file);
     try {
-      fos.write(String.valueOf(val).getBytes(Charsets.UTF_8));
+      fos.write(String.valueOf(val).getBytes(StandardCharsets.UTF_8));
       fos.write('\n');
       fos.close();
       fos = null;
@@ -93,7 +92,7 @@ public class PersistentLongFile {
     if (file.exists()) {
       BufferedReader br = 
           new BufferedReader(new InputStreamReader(new FileInputStream(
-              file), Charsets.UTF_8));
+              file), StandardCharsets.UTF_8));
       try {
         val = Long.parseLong(br.readLine());
         br.close();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/DFSTestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/DFSTestUtil.java
@@ -1438,7 +1438,7 @@ public class DFSTestUtil {
     Short permission = 0777;
     filesystem.setPermission(pathFileCreate, new FsPermission(permission));
     // OP_SET_OWNER 8
-    filesystem.setOwner(pathFileCreate, new String("newOwner"), null);
+    filesystem.setOwner(pathFileCreate, "newOwner", null);
     // OP_CLOSE 9 see above
     // OP_SET_GENSTAMP 10 see above
     // OP_SET_NS_QUOTA 11 obsolete

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/DFSTestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/DFSTestUtil.java
@@ -53,6 +53,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
@@ -70,7 +71,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
@@ -985,7 +985,7 @@ public class DFSTestUtil {
    * @return url content as string (UTF-8 encoding assumed)
    */
   public static String urlGet(URL url) throws IOException {
-    return new String(urlGetBytes(url), Charsets.UTF_8);
+    return new String(urlGetBytes(url), StandardCharsets.UTF_8);
   }
   
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestBalancerBandwidth.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestBalancerBandwidth.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.concurrent.TimeoutException;
 
@@ -46,7 +47,7 @@ public class TestBalancerBandwidth {
   final static private int DEFAULT_BANDWIDTH = 1024*1024;
   public static final Logger LOG =
       LoggerFactory.getLogger(TestBalancerBandwidth.class);
-  private static final Charset UTF8 = Charset.forName("UTF-8");
+  private static final Charset UTF8 = StandardCharsets.UTF_8;
   private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
   private final PrintStream outStream = new PrintStream(outContent);
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSRollback.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSRollback.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
@@ -41,7 +42,6 @@ import org.apache.hadoop.util.StringUtils;
 import org.junit.After;
 import org.junit.Test;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
 * This test ensures the appropriate response (successful or failure) from
@@ -312,8 +312,8 @@ public class TestDFSRollback {
       for (File f : baseDirs) { 
         UpgradeUtilities.corruptFile(
             new File(f,"VERSION"),
-            "layoutVersion".getBytes(Charsets.UTF_8),
-            "xxxxxxxxxxxxx".getBytes(Charsets.UTF_8));
+            "layoutVersion".getBytes(StandardCharsets.UTF_8),
+            "xxxxxxxxxxxxx".getBytes(StandardCharsets.UTF_8));
       }
       startNameNodeShouldFail("file VERSION has layoutVersion missing");
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUpgrade.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUpgrade.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
@@ -49,7 +50,6 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 
 /**
@@ -335,8 +335,8 @@ public class TestDFSUpgrade {
       for (File f : baseDirs) { 
         UpgradeUtilities.corruptFile(
             new File(f,"VERSION"),
-            "layoutVersion".getBytes(Charsets.UTF_8),
-            "xxxxxxxxxxxxx".getBytes(Charsets.UTF_8));
+            "layoutVersion".getBytes(StandardCharsets.UTF_8),
+            "xxxxxxxxxxxxx".getBytes(StandardCharsets.UTF_8));
       }
       startNameNodeShouldFail(StartupOption.UPGRADE);
       UpgradeUtilities.createEmptyDirs(nameNodeDirs);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeReport.java
@@ -160,7 +160,7 @@ public class TestDatanodeReport {
       cluster.waitActive();
       DistributedFileSystem fs = cluster.getFileSystem();
       Path p = new Path("/testDatanodeReportMissingBlock");
-      DFSTestUtil.writeFile(fs, p, new String("testdata"));
+      DFSTestUtil.writeFile(fs, p, "testdata");
       LocatedBlock lb = fs.getClient().getLocatedBlocks(p.toString(), 0).get(0);
       assertEquals(3, lb.getLocations().length);
       ExtendedBlock b = lb.getBlock();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestMultipleNNPortQOP.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestMultipleNNPortQOP.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
@@ -287,7 +288,7 @@ public class TestMultipleNNPortQOP extends SaslDataTransferTestCase {
   private void doTest(FileSystem fs, Path path) throws Exception {
     FileSystemTestHelper.createFile(fs, path, NUM_BLOCKS, BLOCK_SIZE);
     assertArrayEquals(FileSystemTestHelper.getFileData(NUM_BLOCKS, BLOCK_SIZE),
-        DFSTestUtil.readFile(fs, path).getBytes("UTF-8"));
+        DFSTestUtil.readFile(fs, path).getBytes(StandardCharsets.UTF_8));
     BlockLocation[] blockLocations = fs.getFileBlockLocations(path, 0,
         Long.MAX_VALUE);
     assertNotNull(blockLocations);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestQuota.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestQuota.java
@@ -32,6 +32,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
 import java.util.List;
 import java.util.Scanner;
@@ -66,7 +67,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
@@ -1216,7 +1216,7 @@ public class TestQuota {
       String[] args =
           { "-setSpaceQuota", "100", "-storageType", "COLD", "/testDir" };
       admin.run(args);
-      String errOutput = new String(err.toByteArray(), Charsets.UTF_8);
+      String errOutput = new String(err.toByteArray(), StandardCharsets.UTF_8);
       assertTrue(
           errOutput.contains(StorageType.getTypesSupportingQuota().toString()));
     } finally {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestSaslDataTransfer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestSaslDataTransfer.java
@@ -32,6 +32,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.LoggerFactory;
@@ -200,7 +201,7 @@ public class TestSaslDataTransfer extends SaslDataTransferTestCase {
     fs = FileSystem.get(cluster.getURI(), conf);
     FileSystemTestHelper.createFile(fs, PATH, NUM_BLOCKS, BLOCK_SIZE);
     assertArrayEquals(FileSystemTestHelper.getFileData(NUM_BLOCKS, BLOCK_SIZE),
-      DFSTestUtil.readFile(fs, PATH).getBytes("UTF-8"));
+      DFSTestUtil.readFile(fs, PATH).getBytes(StandardCharsets.UTF_8));
     BlockLocation[] blockLocations = fs.getFileBlockLocations(PATH, 0,
       Long.MAX_VALUE);
     assertNotNull(blockLocations);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdfs.qjournal.server;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.primitives.Bytes;
 import org.apache.hadoop.thirdparty.com.google.common.primitives.Ints;
 import org.apache.hadoop.conf.Configuration;
@@ -54,6 +53,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -278,7 +278,7 @@ public class TestJournalNode {
     ch.newEpoch(1).get();
     ch.setEpoch(1);
     ch.startLogSegment(1, NameNodeLayoutVersion.CURRENT_LAYOUT_VERSION).get();
-    ch.sendEdits(1L, 1, 1, "hello".getBytes(Charsets.UTF_8)).get();
+    ch.sendEdits(1L, 1, 1, "hello".getBytes(StandardCharsets.UTF_8)).get();
     
     metrics = MetricsAsserts.getMetrics(
         journal.getMetrics().getName());
@@ -291,7 +291,7 @@ public class TestJournalNode {
     beginTimestamp = lastJournalTimestamp;
 
     ch.setCommittedTxId(100L);
-    ch.sendEdits(1L, 2, 1, "goodbye".getBytes(Charsets.UTF_8)).get();
+    ch.sendEdits(1L, 2, 1, "goodbye".getBytes(StandardCharsets.UTF_8)).get();
 
     metrics = MetricsAsserts.getMetrics(
         journal.getMetrics().getName());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
@@ -553,7 +553,7 @@ public class TestDataNodeMetrics {
       cluster.waitActive();
       DistributedFileSystem fs = cluster.getFileSystem();
       Path p = new Path("/testShouldThrowTMP");
-      DFSTestUtil.writeFile(fs, p, new String("testdata"));
+      DFSTestUtil.writeFile(fs, p, "testdata");
       //Before DN throws too many open files
       verifyBlockLocations(fs, p, 1);
       Mockito.doThrow(new FileNotFoundException("Too many open files")).

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFavoredNodesEndToEnd.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFavoredNodesEndToEnd.java
@@ -60,7 +60,7 @@ public class TestFavoredNodesEndToEnd {
   private static Configuration conf;
   private final static int NUM_DATA_NODES = 10;
   private final static int NUM_FILES = 10;
-  private final static byte[] SOME_BYTES = new String("foo").getBytes();
+  private final static byte[] SOME_BYTES = "foo".getBytes();
   private static DistributedFileSystem dfs;
   private static ArrayList<DataNode> datanodes;
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFsck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFsck.java
@@ -919,7 +919,7 @@ public class TestFsck {
     dfs = cluster.getFileSystem();
 
     // create files
-    final String testFile = new String("/testfile");
+    final String testFile = "/testfile";
     final Path path = new Path(testFile);
     DFSTestUtil.createFile(dfs, path, fileSize, replFactor, 1000L);
     DFSTestUtil.waitReplication(dfs, path, replFactor);
@@ -1202,7 +1202,7 @@ public class TestFsck {
     assertNotNull("Failed to get FileSystem", dfs);
 
     // Create a file that will be intentionally under-replicated
-    final String pathString = new String("/testfile");
+    final String pathString = "/testfile";
     final Path path = new Path(pathString);
     long fileLen = blockSize * numBlocks;
     DFSTestUtil.createFile(dfs, path, fileLen, replFactor, 1);
@@ -1263,7 +1263,7 @@ public class TestFsck {
     assertNotNull("Failed to get FileSystem", dfs);
 
     // Create a file that will be intentionally under-replicated
-    final String pathString = new String("/testfile");
+    final String pathString = "/testfile";
     final Path path = new Path(pathString);
     long fileLen = blockSize * numBlocks;
     DFSTestUtil.createFile(dfs, path, fileLen, replFactor, 1);
@@ -1436,7 +1436,7 @@ public class TestFsck {
     DFSTestUtil util = new DFSTestUtil.Builder().
         setName(getClass().getSimpleName()).setNumFiles(1).build();
     //create files
-    final String pathString = new String("/testfile");
+    final String pathString = "/testfile";
     final Path path = new Path(pathString);
     util.createFile(dfs, path, 1024, replFactor, 1000L);
     util.waitReplication(dfs, path, replFactor);
@@ -1490,7 +1490,7 @@ public class TestFsck {
     DFSTestUtil util = new DFSTestUtil.Builder().
         setName(getClass().getSimpleName()).setNumFiles(1).build();
     //create files
-    final String pathString = new String("/testfile");
+    final String pathString = "/testfile";
     final Path path = new Path(pathString);
     util.createFile(dfs, path, 1024, replFactor, 1000L);
     util.waitReplication(dfs, path, replFactor);
@@ -1577,7 +1577,7 @@ public class TestFsck {
     DFSTestUtil util = new DFSTestUtil.Builder().
         setName(getClass().getSimpleName()).setNumFiles(1).build();
     //create files
-    final String pathString = new String("/testfile");
+    final String pathString = "/testfile";
     final Path path = new Path(pathString);
     util.createFile(dfs, path, 1024, replFactor, 1000L);
     util.waitReplication(dfs, path, replFactor);
@@ -1694,7 +1694,7 @@ public class TestFsck {
           setName(getClass().getSimpleName()).setNumFiles(1).build();
 
       // Create one file.
-      final String pathString = new String("/testfile");
+      final String pathString = "/testfile";
       final Path path = new Path(pathString);
       util.createFile(fs, path, 1024L, replFactor, 1024L);
       util.waitReplication(fs, path, replFactor);
@@ -1780,7 +1780,7 @@ public class TestFsck {
     DFSTestUtil util = new DFSTestUtil.Builder().
         setName(getClass().getSimpleName()).setNumFiles(1).build();
     //create files
-    final String pathString = new String("/testfile");
+    final String pathString = "/testfile";
     final Path path = new Path(pathString);
     util.createFile(dfs, path, 1024, repFactor, 1000L);
     util.waitReplication(dfs, path, repFactor);
@@ -1937,7 +1937,7 @@ public class TestFsck {
         setName(getClass().getSimpleName()).setNumFiles(1).build();
 
     //create files
-    final String testFile = new String("/testfile");
+    final String testFile = "/testfile";
     final Path path = new Path(testFile);
     util.createFile(dfs, path, fileSize, replFactor, 1000L);
     util.waitReplication(dfs, path, replFactor);
@@ -2020,7 +2020,7 @@ public class TestFsck {
     DFSTestUtil util = new DFSTestUtil.Builder().
         setName(getClass().getSimpleName()).setNumFiles(1).build();
     //create files
-    final String testFile = new String("/testfile");
+    final String testFile = "/testfile";
     final Path path = new Path(testFile);
     util.createFile(dfs, path, 1024, replFactor, 1000L);
     util.waitReplication(dfs, path, replFactor);
@@ -2394,7 +2394,7 @@ public class TestFsck {
     }
 
     // create files
-    final String testFile = new String("/testfile");
+    final String testFile = "/testfile";
     final Path path = new Path(testFile);
     DFSTestUtil.createFile(dfs, path, fileSize, replFactor, 1000L);
     DFSTestUtil.waitReplication(dfs, path, replFactor);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestINodeFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestINodeFile.java
@@ -1163,7 +1163,7 @@ public class TestINodeFile {
           HdfsFileStatus.EMPTY_NAME, false);
       assertTrue(dl.getPartialListing().length == 3);
 
-      String f2 = new String("f2");
+      String f2 = "f2";
       dl = cluster.getNameNodeRpc().getListing("/tmp", f2.getBytes(), false);
       assertTrue(dl.getPartialListing().length == 1);
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestStartupProgressServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestStartupProgressServlet.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.*;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -245,7 +246,7 @@ public class TestStartupProgressServlet {
    */
   private String doGetAndReturnResponseBody() throws IOException {
     servlet.doGet(req, resp);
-    return new String(respOut.toByteArray(), "UTF-8");
+    return new String(respOut.toByteArray(), StandardCharsets.UTF_8);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdminWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdminWithHA.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.hdfs.tools;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
@@ -56,8 +56,8 @@ public class TestDFSAdminWithHA {
   private static String newLine = System.getProperty("line.separator");
 
   private void assertOutputMatches(String string) {
-    String errOutput = new String(err.toByteArray(), Charsets.UTF_8);
-    String output = new String(out.toByteArray(), Charsets.UTF_8);
+    String errOutput = new String(err.toByteArray(), StandardCharsets.UTF_8);
+    String output = new String(out.toByteArray(), StandardCharsets.UTF_8);
 
     if (!errOutput.matches(string) && !output.matches(string)) {
       fail("Expected output to match '" + string +
@@ -70,8 +70,8 @@ public class TestDFSAdminWithHA {
   }
 
   private void assertOutputMatches(String outMessage, String errMessage) {
-    String errOutput = new String(err.toByteArray(), Charsets.UTF_8);
-    String output = new String(out.toByteArray(), Charsets.UTF_8);
+    String errOutput = new String(err.toByteArray(), StandardCharsets.UTF_8);
+    String output = new String(out.toByteArray(), StandardCharsets.UTF_8);
 
     if (!errOutput.matches(errMessage) || !output.matches(outMessage)) {
       fail("Expected output to match '" + outMessage + " and " + errMessage +

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSHAAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSHAAdmin.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +49,6 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 
 public class TestDFSHAAdmin {
@@ -435,8 +435,8 @@ public class TestDFSHAAdmin {
     outBytes.reset();
     LOG.info("Running: DFSHAAdmin " + Joiner.on(" ").join(args));
     int ret = tool.run(args);
-    errOutput = new String(errOutBytes.toByteArray(), Charsets.UTF_8);
-    output = new String(outBytes.toByteArray(), Charsets.UTF_8);
+    errOutput = new String(errOutBytes.toByteArray(), StandardCharsets.UTF_8);
+    output = new String(outBytes.toByteArray(), StandardCharsets.UTF_8);
     LOG.info("Err_output:\n" + errOutput + "\nOutput:\n" + output);
     return ret;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSHAAdminMiniCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSHAAdminMiniCluster.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +46,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 import org.apache.hadoop.thirdparty.com.google.common.io.Files;
 
@@ -232,7 +232,7 @@ public class TestDFSHAAdminMiniCluster {
     assertEquals(0, runTool("-ns", "minidfs-ns", "-failover", "nn2", "nn1"));
 
     // Fencer has not run yet, since none of the above required fencing 
-    assertEquals("", Files.asCharSource(tmpFile, Charsets.UTF_8).read());
+    assertEquals("", Files.asCharSource(tmpFile, StandardCharsets.UTF_8).read());
 
     // Test failover with fencer and forcefence option
     assertEquals(0, runTool("-failover", "nn1", "nn2", "--forcefence"));
@@ -240,7 +240,7 @@ public class TestDFSHAAdminMiniCluster {
     // The fence script should run with the configuration from the target
     // node, rather than the configuration from the fencing node. Strip
     // out any trailing spaces and CR/LFs which may be present on Windows.
-    String fenceCommandOutput = Files.asCharSource(tmpFile, Charsets.UTF_8)
+    String fenceCommandOutput = Files.asCharSource(tmpFile, StandardCharsets.UTF_8)
         .read().replaceAll(" *[\r\n]+", "");
     assertEquals("minidfs-ns.nn1 " + nn1Port + " nn1", fenceCommandOutput);
     tmpFile.delete();
@@ -325,7 +325,7 @@ public class TestDFSHAAdminMiniCluster {
     errOutBytes.reset();
     LOG.info("Running: DFSHAAdmin " + Joiner.on(" ").join(args));
     int ret = tool.run(args);
-    errOutput = new String(errOutBytes.toByteArray(), Charsets.UTF_8);
+    errOutput = new String(errOutBytes.toByteArray(), StandardCharsets.UTF_8);
     LOG.info("Output:\n" + errOutput);
     return ret;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHdfsFileSystemContract.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHdfsFileSystemContract.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Map;
@@ -341,7 +342,7 @@ public class TestWebHdfsFileSystemContract extends FileSystemContractBaseTest {
       byte[] respBody = new byte[content.length()];
       is = conn.getInputStream();
       IOUtils.readFully(is, respBody, 0, content.length());
-      assertEquals(content, new String(respBody, "US-ASCII"));
+      assertEquals(content, new String(respBody, StandardCharsets.US_ASCII));
     } finally {
       IOUtils.closeStream(is);
       if (conn != null) {
@@ -392,7 +393,7 @@ public class TestWebHdfsFileSystemContract extends FileSystemContractBaseTest {
       byte[] respBody = new byte[content.length() - 1];
       is = conn.getInputStream();
       IOUtils.readFully(is, respBody, 0, content.length() - 1);
-      assertEquals(content.substring(1), new String(respBody, "US-ASCII"));
+      assertEquals(content.substring(1), new String(respBody, StandardCharsets.US_ASCII));
     } finally {
       IOUtils.closeStream(is);
       if (conn != null) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHdfsTimeouts.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHdfsTimeouts.java
@@ -31,6 +31,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -332,7 +333,7 @@ public class TestWebHdfsTimeouts {
 
           // Write response.
           out = clientSocket.getOutputStream();
-          out.write(temporaryRedirect().getBytes("UTF-8"));
+          out.write(temporaryRedirect().getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
           // Fail the test on any I/O error in the server thread.
           LOG.error("unexpected IOException in server thread", e);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/tools/TestHdfsConfigFields.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/tools/TestHdfsConfigFields.java
@@ -39,7 +39,7 @@ public class TestHdfsConfigFields extends TestConfigurationFieldsBase {
 
   @Override
   public void initializeMemberVariables() {
-    xmlFilename = new String("hdfs-default.xml");
+    xmlFilename = "hdfs-default.xml";
     configurationClasses = new Class[] { HdfsClientConfigKeys.class,
         HdfsClientConfigKeys.Failover.class,
         HdfsClientConfigKeys.StripedRead.class, DFSConfigKeys.class,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRecovery.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRecovery.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 import java.io.File;
 import java.io.FileInputStream;
@@ -2097,7 +2098,7 @@ public class TestRecovery {
     String contents = null;
     try {
       in.read(buf, 0, len);
-      contents = new String(buf, "UTF-8");
+      contents = new String(buf, StandardCharsets.UTF_8);
     } finally {
       in.close();
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/JobQueueClient.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/JobQueueClient.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,7 +32,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
  * <code>JobQueueClient</code> is interface provided to the user in order to get
@@ -148,7 +148,7 @@ class JobQueueClient extends Configured implements Tool {
     JobQueueInfo[] rootQueues = jc.getRootQueues();
     for (JobQueueInfo queue : rootQueues) {
       printJobQueueInfo(queue, new PrintWriter(new OutputStreamWriter(
-          System.out, Charsets.UTF_8)));
+          System.out, StandardCharsets.UTF_8)));
     }
   }
   
@@ -187,7 +187,7 @@ class JobQueueClient extends Configured implements Tool {
       return;
     }
     printJobQueueInfo(jobQueueInfo, new PrintWriter(new OutputStreamWriter(
-        System.out, Charsets.UTF_8)));
+        System.out, StandardCharsets.UTF_8)));
     if (showJobs && (jobQueueInfo.getChildren() == null ||
         jobQueueInfo.getChildren().size() == 0)) {
       JobStatus[] jobs = jobQueueInfo.getJobStatuses();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/TaskLog.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/TaskLog.java
@@ -27,6 +27,7 @@ import java.io.Flushable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -56,7 +57,6 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
  * A simple logger to handle the task-specific user logs.
@@ -114,7 +114,7 @@ public class TaskLog {
     File indexFile = getIndexFile(taskid, isCleanup);
     BufferedReader fis = new BufferedReader(new InputStreamReader(
       SecureIOUtils.openForRead(indexFile, obtainLogDirOwner(taskid), null),
-      Charsets.UTF_8));
+      StandardCharsets.UTF_8));
     //the format of the index file is
     //LOG_DIR: <the dir where the task logs are really stored>
     //stdout:<start-offset in the stdout file> <length>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/TextInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/TextInputFormat.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.mapred;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -27,7 +28,6 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.compress.*;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /** 
  * An {@link InputFormat} for plain text files.  Files are broken into lines.
@@ -62,7 +62,7 @@ public class TextInputFormat extends FileInputFormat<LongWritable, Text>
     String delimiter = job.get("textinputformat.record.delimiter");
     byte[] recordDelimiterBytes = null;
     if (null != delimiter) {
-      recordDelimiterBytes = delimiter.getBytes(Charsets.UTF_8);
+      recordDelimiterBytes = delimiter.getBytes(StandardCharsets.UTF_8);
     }
     return new LineRecordReader(job, (FileSplit) genericSplit,
         recordDelimiterBytes);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobSubmitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobSubmitter.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -63,7 +64,6 @@ import org.apache.hadoop.util.JsonSerialization;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.yarn.api.records.ReservationId;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
@@ -409,7 +409,7 @@ class JobSubmitter {
 
         for(Map.Entry<String, String> ent: nm.entrySet()) {
           credentials.addSecretKey(new Text(ent.getKey()), ent.getValue()
-              .getBytes(Charsets.UTF_8));
+              .getBytes(StandardCharsets.UTF_8));
         }
       } catch (JsonMappingException | JsonParseException e) {
         LOG.warn("couldn't parse Token Cache JSON file with user secret keys");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/JSONHistoryViewerPrinter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/JSONHistoryViewerPrinter.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -72,7 +73,7 @@ class JSONHistoryViewerPrinter implements HistoryViewerPrinter {
       printTaskSummary();
       printTasks();
 
-      writer = new OutputStreamWriter(ps, "UTF-8");
+      writer = new OutputStreamWriter(ps, StandardCharsets.UTF_8);
       json.write(writer);
       writer.flush();
     } catch (JSONException je) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/TextInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/TextInputFormat.java
@@ -32,7 +32,8 @@ import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
+import java.nio.charset.StandardCharsets;
+
 
 /** An {@link InputFormat} for plain text files.  Files are broken into lines.
  * Either linefeed or carriage-return are used to signal end of line.  Keys are
@@ -49,7 +50,7 @@ public class TextInputFormat extends FileInputFormat<LongWritable, Text> {
         "textinputformat.record.delimiter");
     byte[] recordDelimiterBytes = null;
     if (null != delimiter)
-      recordDelimiterBytes = delimiter.getBytes(Charsets.UTF_8);
+      recordDelimiterBytes = delimiter.getBytes(StandardCharsets.UTF_8);
     return new LineRecordReader(recordDelimiterBytes);
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/partition/KeyFieldBasedPartitioner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/partition/KeyFieldBasedPartitioner.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.mapreduce.lib.partition;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -90,12 +90,7 @@ public class KeyFieldBasedPartitioner<K2, V2> extends Partitioner<K2, V2>
       return getPartition(key.toString().hashCode(), numReduceTasks);
     }
 
-    try {
-      keyBytes = key.toString().getBytes("UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException("The current system does not " +
-          "support UTF-8 encoding!", e);
-    }
+    keyBytes = key.toString().getBytes(StandardCharsets.UTF_8);
     // return 0 if the key is empty
     if (keyBytes.length == 0) {
       return 0;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/partition/KeyFieldHelper.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/partition/KeyFieldHelper.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.mapreduce.lib.partition;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.StringTokenizer;
@@ -61,13 +61,8 @@ class KeyFieldHelper {
   private boolean keySpecSeen = false;
   
   public void setKeyFieldSeparator(String keyFieldSeparator) {
-    try {
-      this.keyFieldSeparator =
-        keyFieldSeparator.getBytes("UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException("The current system does not " +
-          "support UTF-8 encoding!", e);
-    }    
+    this.keyFieldSeparator =
+      keyFieldSeparator.getBytes(StandardCharsets.UTF_8);
   }
   
   /** Required for backcompatibility with num.key.fields.for.partition in

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/security/SecureShuffleUtils.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/security/SecureShuffleUtils.java
@@ -86,7 +86,7 @@ public class SecureShuffleUtils {
    */
   public static String hashFromString(String enc_str, SecretKey key) 
   throws IOException {
-    return generateHash(enc_str.getBytes(StandardCharsets.UTF_8), key); 
+    return generateHash(enc_str.getBytes(StandardCharsets.UTF_8), key);
   }
   
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/security/SecureShuffleUtils.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/security/SecureShuffleUtils.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import javax.crypto.SecretKey;
 import javax.servlet.http.HttpServletRequest;
 
@@ -34,7 +35,6 @@ import org.apache.hadoop.mapreduce.security.token.JobTokenSecretManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
  * 
@@ -56,7 +56,7 @@ public class SecureShuffleUtils {
    */
   public static String generateHash(byte[] msg, SecretKey key) {
     return new String(Base64.encodeBase64(generateByteHash(msg, key)), 
-        Charsets.UTF_8);
+        StandardCharsets.UTF_8);
   }
   
   /**
@@ -70,7 +70,6 @@ public class SecureShuffleUtils {
   
   /**
    * verify that hash equals to HMacHash(msg)
-   * @param newHash
    * @return true if is the same
    */
   private static boolean verifyHash(byte[] hash, byte[] msg, SecretKey key) {
@@ -87,7 +86,7 @@ public class SecureShuffleUtils {
    */
   public static String hashFromString(String enc_str, SecretKey key) 
   throws IOException {
-    return generateHash(enc_str.getBytes(Charsets.UTF_8), key); 
+    return generateHash(enc_str.getBytes(StandardCharsets.UTF_8), key); 
   }
   
   /**
@@ -98,9 +97,9 @@ public class SecureShuffleUtils {
    */
   public static void verifyReply(String base64Hash, String msg, SecretKey key)
   throws IOException {
-    byte[] hash = Base64.decodeBase64(base64Hash.getBytes(Charsets.UTF_8));
+    byte[] hash = Base64.decodeBase64(base64Hash.getBytes(StandardCharsets.UTF_8));
     
-    boolean res = verifyHash(hash, msg.getBytes(Charsets.UTF_8), key);
+    boolean res = verifyHash(hash, msg.getBytes(StandardCharsets.UTF_8), key);
     
     if(res != true) {
       throw new IOException("Verification of the hashReply failed");
@@ -148,7 +147,7 @@ public class SecureShuffleUtils {
       for (byte b : ba) {
         ps.printf("%x", b);
       }
-      strHex = baos.toString("UTF-8");
+      strHex = new String(baos.toByteArray(), StandardCharsets.UTF_8);
     } catch (UnsupportedEncodingException e) {
     }
     return strHex;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/split/JobSplit.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/split/JobSplit.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.mapreduce.split;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
@@ -47,15 +47,8 @@ import org.apache.hadoop.classification.InterfaceStability;
 @InterfaceStability.Unstable
 public class JobSplit {
   static final int META_SPLIT_VERSION = 1;
-  static final byte[] META_SPLIT_FILE_HEADER;
-  static {
-    try {
-      META_SPLIT_FILE_HEADER = "META-SPL".getBytes("UTF-8");
-    } catch (UnsupportedEncodingException u) {
-      throw new RuntimeException(u);
-    }
-  } 
-  public static final TaskSplitMetaInfo EMPTY_TASK_SPLIT = 
+  static final byte[] META_SPLIT_FILE_HEADER = "META-SPL".getBytes(StandardCharsets.UTF_8);
+  public static final TaskSplitMetaInfo EMPTY_TASK_SPLIT =
     new TaskSplitMetaInfo();
   
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/split/JobSplitWriter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/split/JobSplitWriter.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.mapreduce.split;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -54,16 +54,8 @@ public class JobSplitWriter {
   private static final Logger LOG =
       LoggerFactory.getLogger(JobSplitWriter.class);
   private static final int splitVersion = JobSplit.META_SPLIT_VERSION;
-  private static final byte[] SPLIT_FILE_HEADER;
+  private static final byte[] SPLIT_FILE_HEADER = "SPL".getBytes(StandardCharsets.UTF_8);
 
-  static {
-    try {
-      SPLIT_FILE_HEADER = "SPL".getBytes("UTF-8");
-    } catch (UnsupportedEncodingException u) {
-      throw new RuntimeException(u);
-    }
-  }
-  
   @SuppressWarnings("unchecked")
   public static <T extends InputSplit> void createSplitFiles(Path jobSubmitDir, 
       Configuration conf, FileSystem fs, List<InputSplit> splits) 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/tools/CLI.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/tools/CLI.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -64,7 +65,6 @@ import org.apache.hadoop.yarn.logaggregation.LogCLIHelpers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
  * Interprets the map reduce cli options 
@@ -767,7 +767,7 @@ public class CLI extends Configured implements Tool {
   public void displayJobList(JobStatus[] jobs) 
       throws IOException, InterruptedException {
     displayJobList(jobs, new PrintWriter(new OutputStreamWriter(System.out,
-        Charsets.UTF_8)));
+        StandardCharsets.UTF_8)));
   }
 
   @Private

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestFileOutputCommitter.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -571,7 +572,7 @@ public class TestFileOutputCommitter {
     String contents = null;
     try {
       in.read(buf, 0, len);
-      contents = new String(buf, "UTF-8");
+      contents = new String(buf, StandardCharsets.UTF_8);
     } finally {
       in.close();
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestLineRecordReader.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestLineRecordReader.java
@@ -238,7 +238,7 @@ public class TestLineRecordReader {
     }
     fis.close();
     assertTrue("Test file data too big for buffer", count < data.length);
-    return new String(data, 0, count, "UTF-8").split("\n");
+    return new String(data, 0, count, StandardCharsets.UTF_8).split("\n");
   }
 
   public void checkRecordSpanningMultipleSplits(String testFile,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestLineRecordReader.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestLineRecordReader.java
@@ -183,7 +183,7 @@ public class TestLineRecordReader {
     }
     fis.close();
     assertTrue("Test file data too big for buffer", count < data.length);
-    return new String(data, 0, count, "UTF-8").split("\n");
+    return new String(data, 0, count, StandardCharsets.UTF_8).split("\n");
   }
 
   public void checkRecordSpanningMultipleSplits(String testFile,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -843,7 +844,7 @@ public class TestFileOutputCommitter {
     String contents = null;
     try {
       in.read(buf, 0, len);
-      contents = new String(buf, "UTF-8");
+      contents = new String(buf, StandardCharsets.UTF_8);
     } finally {
       in.close();
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestConcatenatedCompressedInput.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestConcatenatedCompressedInput.java
@@ -38,6 +38,7 @@ import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.Inflater;
@@ -295,7 +296,7 @@ public class TestConcatenatedCompressedInput {
     try {
       int numBytesUncompressed = inflater.inflate(uncompressedBuf);
       String outString =
-        new String(uncompressedBuf, 0, numBytesUncompressed, "UTF-8");
+        new String(uncompressedBuf, 0, numBytesUncompressed, StandardCharsets.UTF_8);
       System.out.println("uncompressed data of first gzip member = [" +
                          outString + "]");
     } catch (java.util.zip.DataFormatException ex) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestFixedLengthInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestFixedLengthInputFormat.java
@@ -97,7 +97,7 @@ public class TestFixedLengthInputFormat {
   @Test (timeout=5000)
   public void testNoRecordLength() throws IOException {
     localFs.delete(workDir, true);
-    Path file = new Path(workDir, new String("testFormat.txt"));
+    Path file = new Path(workDir, "testFormat.txt");
     createFile(file, null, 10, 10);
     // Set the fixed length record length config property 
     JobConf job = new JobConf(defaultConf);
@@ -124,7 +124,7 @@ public class TestFixedLengthInputFormat {
   @Test (timeout=5000)
   public void testZeroRecordLength() throws IOException {
     localFs.delete(workDir, true);
-    Path file = new Path(workDir, new String("testFormat.txt"));
+    Path file = new Path(workDir, "testFormat.txt");
     createFile(file, null, 10, 10);
     // Set the fixed length record length config property 
     JobConf job = new JobConf(defaultConf);
@@ -152,7 +152,7 @@ public class TestFixedLengthInputFormat {
   @Test (timeout=5000)
   public void testNegativeRecordLength() throws IOException {
     localFs.delete(workDir, true);
-    Path file = new Path(workDir, new String("testFormat.txt"));
+    Path file = new Path(workDir, "testFormat.txt");
     createFile(file, null, 10, 10);
     // Set the fixed length record length config property 
     JobConf job = new JobConf(defaultConf);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/UtilsForTests.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/UtilsForTests.java
@@ -24,6 +24,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -180,7 +181,7 @@ public class UtilsForTests {
     String contents = null;
     try {
       in.read(buf, 0, len);
-      contents = new String(buf, "UTF-8");
+      contents = new String(buf, StandardCharsets.UTF_8);
     } finally {
       in.close();
     }
@@ -194,7 +195,7 @@ public class UtilsForTests {
     String contents = null;
     try {
       in.read(buf, 0, len);
-      contents = new String(buf, "UTF-8");
+      contents = new String(buf, StandardCharsets.UTF_8);
     } finally {
       in.close();
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/jobcontrol/JobControlTestUtils.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/jobcontrol/JobControlTestUtils.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.mapred.jobcontrol;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import java.util.Iterator;
 import java.util.List;
@@ -100,7 +101,7 @@ public class JobControlTestUtils {
     FSDataOutputStream out = fs.create(new Path(dirPath, "data.txt"));
     for (int i = 0; i < 10000; i++) {
       String line = generateRandomLine();
-      out.write(line.getBytes("UTF-8"));
+      out.write(line.getBytes(StandardCharsets.UTF_8));
     }
     out.close();
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/MapReduceTestUtil.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/MapReduceTestUtil.java
@@ -25,6 +25,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -116,7 +117,7 @@ public class MapReduceTestUtil {
     FSDataOutputStream out = fs.create(new Path(dirPath, "data.txt"));
     for (int i = 0; i < 10000; i++) {
       String line = generateRandomLine();
-      out.write(line.getBytes("UTF-8"));
+      out.write(line.getBytes(StandardCharsets.UTF_8));
     }
     out.close();
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMRJobClient.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMRJobClient.java
@@ -47,6 +47,7 @@ import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
@@ -193,7 +194,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     assertEquals("Exit code", -1, exitCode);
 
     runTool(conf, jc, new String[] { "-fail-task", taid.toString() }, out);
-    String answer = new String(out.toByteArray(), "UTF-8");
+    String answer = new String(out.toByteArray(), StandardCharsets.UTF_8);
     assertTrue(answer.contains("Killed task " + taid + " by failing it"));
   }
 
@@ -211,7 +212,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     assertEquals("Exit code", -1, exitCode);
 
     runTool(conf, jc, new String[] { "-kill-task", taid.toString() }, out);
-    String answer = new String(out.toByteArray(), "UTF-8");
+    String answer = new String(out.toByteArray(), StandardCharsets.UTF_8);
     assertTrue(answer.contains("Killed task " + taid));
   }
   
@@ -231,7 +232,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     exitCode = runTool(conf, jc, new String[] { "-kill", jobId }, out);
     assertEquals("Exit code", 0, exitCode);
     
-    String answer = new String(out.toByteArray(), "UTF-8");
+    String answer = new String(out.toByteArray(), StandardCharsets.UTF_8);
     assertTrue(answer.contains("Killed job " + jobId));
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestFixedLengthInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestFixedLengthInputFormat.java
@@ -102,7 +102,7 @@ public class TestFixedLengthInputFormat {
   @Test (timeout=5000)
   public void testNoRecordLength() throws Exception {
     localFs.delete(workDir, true);
-    Path file = new Path(workDir, new String("testFormat.txt"));
+    Path file = new Path(workDir, "testFormat.txt");
     createFile(file, null, 10, 10);
     // Create the job and do not set fixed record length
     Job job = Job.getInstance(defaultConf);
@@ -136,7 +136,7 @@ public class TestFixedLengthInputFormat {
   @Test (timeout=5000)
   public void testZeroRecordLength() throws Exception {
     localFs.delete(workDir, true);
-    Path file = new Path(workDir, new String("testFormat.txt"));
+    Path file = new Path(workDir, "testFormat.txt");
     createFile(file, null, 10, 10);
     Job job = Job.getInstance(defaultConf);
     // Set the fixed length record length config property 
@@ -172,7 +172,7 @@ public class TestFixedLengthInputFormat {
   @Test (timeout=5000)
   public void testNegativeRecordLength() throws Exception {
     localFs.delete(workDir, true);
-    Path file = new Path(workDir, new String("testFormat.txt"));
+    Path file = new Path(workDir, "testFormat.txt");
     createFile(file, null, 10, 10);
     // Set the fixed length record length config property 
     Job job = Job.getInstance(defaultConf);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/java/org/apache/hadoop/mapred/nativetask/NativeMapOutputCollectorDelegator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/java/org/apache/hadoop/mapred/nativetask/NativeMapOutputCollectorDelegator.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.mapred.nativetask;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.io.RawComparator;
@@ -131,7 +131,7 @@ public class NativeMapOutputCollectorDelegator<K, V> implements MapOutputCollect
     if (ret) {
       if (job.getBoolean(MRJobConfig.MAP_OUTPUT_COMPRESS, false)) {
         String codec = job.get(MRJobConfig.MAP_OUTPUT_COMPRESS_CODEC);
-        if (!NativeRuntime.supportsCompressionCodec(codec.getBytes(Charsets.UTF_8))) {
+        if (!NativeRuntime.supportsCompressionCodec(codec.getBytes(StandardCharsets.UTF_8))) {
           String message = "Native output collector doesn't support compression codec " + codec;
           LOG.error(message);
           throw new InvalidJobConfException(message);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/java/org/apache/hadoop/mapred/nativetask/NativeRuntime.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/java/org/apache/hadoop/mapred/nativetask/NativeRuntime.java
@@ -19,8 +19,8 @@
 package org.apache.hadoop.mapred.nativetask;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.DataInputBuffer;
@@ -83,7 +83,7 @@ public class NativeRuntime {
    */
   public synchronized static long createNativeObject(String clazz) {
     assertNativeLibraryLoaded();
-    final long ret = JNICreateNativeObject(clazz.getBytes(Charsets.UTF_8));
+    final long ret = JNICreateNativeObject(clazz.getBytes(StandardCharsets.UTF_8));
     if (ret == 0) {
       LOG.warn("Can't create NativeObject for class " + clazz + ", probably not exist.");
     }
@@ -95,8 +95,8 @@ public class NativeRuntime {
    */
   public synchronized static long registerLibrary(String libraryName, String clazz) {
     assertNativeLibraryLoaded();
-    final long ret = JNIRegisterModule(libraryName.getBytes(Charsets.UTF_8),
-                                       clazz.getBytes(Charsets.UTF_8));
+    final long ret = JNIRegisterModule(libraryName.getBytes(StandardCharsets.UTF_8),
+                                       clazz.getBytes(StandardCharsets.UTF_8));
     if (ret != 0) {
       LOG.warn("Can't create NativeObject for class " + clazz + ", probably not exist.");
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/java/org/apache/hadoop/mapred/nativetask/util/ConfigUtil.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/java/org/apache/hadoop/mapred/nativetask/util/ConfigUtil.java
@@ -17,11 +17,11 @@
  */
 package org.apache.hadoop.mapred.nativetask.util;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.conf.Configuration;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -31,8 +31,8 @@ public abstract class ConfigUtil {
   public static byte[][] toBytes(Configuration conf) {
     List<byte[]> nativeConfigs = new ArrayList<byte[]>();
     for (Map.Entry<String, String> e : conf) {
-      nativeConfigs.add(e.getKey().getBytes(Charsets.UTF_8));
-      nativeConfigs.add(e.getValue().getBytes(Charsets.UTF_8));
+      nativeConfigs.add(e.getKey().getBytes(StandardCharsets.UTF_8));
+      nativeConfigs.add(e.getValue().getBytes(StandardCharsets.UTF_8));
     }
     return nativeConfigs.toArray(new byte[nativeConfigs.size()][]);
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/java/org/apache/hadoop/mapred/nativetask/util/ReadWriteBuffer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/java/org/apache/hadoop/mapred/nativetask/util/ReadWriteBuffer.java
@@ -17,8 +17,9 @@
  */
 package org.apache.hadoop.mapred.nativetask.util;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.classification.InterfaceAudience;
+
+import java.nio.charset.StandardCharsets;
 
 @InterfaceAudience.Private
 public class ReadWriteBuffer {
@@ -135,13 +136,13 @@ public class ReadWriteBuffer {
   }
 
   public void writeString(String str) {
-    final byte[] bytes = str.getBytes(Charsets.UTF_8);
+    final byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
     writeBytes(bytes, 0, bytes.length);
   }
 
   public String readString() {
     final byte[] bytes = readBytes();
-    return new String(bytes, Charsets.UTF_8);
+    return new String(bytes, StandardCharsets.UTF_8);
   }
 
   private void checkWriteSpaceAndResizeIfNecessary(int toBeWritten) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestByteBufferReadWrite.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestByteBufferReadWrite.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.mapred.nativetask.buffer;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.mapred.nativetask.NativeDataTarget;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestByteBufferReadWrite.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestByteBufferReadWrite.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.mapred.nativetask.buffer;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.mapred.nativetask.NativeDataTarget;
 
@@ -143,8 +144,8 @@ public class TestByteBufferReadWrite {
     Mockito.verify(target).finishSendData();
   }
   
-  private static String toString(byte[] str) throws UnsupportedEncodingException {
-    return new String(str, 0, str.length, "UTF-8");
+  private static String toString(byte[] str) {
+    return new String(str, 0, str.length, StandardCharsets.UTF_8);
   }
   
   private static class MockDataTarget implements NativeDataTarget {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/main/java/org/apache/hadoop/mapred/ShuffleChannelHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/main/java/org/apache/hadoop/mapred/ShuffleChannelHandler.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.net.URL;
 import java.nio.channels.ClosedChannelException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,7 +61,6 @@ import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.SecureIOUtils;
 import org.apache.hadoop.mapreduce.security.SecureShuffleUtils;
 import org.apache.hadoop.mapreduce.task.reduce.ShuffleHeader;
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.eclipse.jetty.http.HttpHeader;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
@@ -469,7 +469,7 @@ public class ShuffleChannelHandler extends SimpleChannelInboundHandler<FullHttpR
     // verify - throws exception
     SecureShuffleUtils.verifyReply(urlHashStr, encryptedURL, tokenSecret);
     // verification passed - encode the reply
-    String reply = SecureShuffleUtils.generateHash(urlHashStr.getBytes(Charsets.UTF_8),
+    String reply = SecureShuffleUtils.generateHash(urlHashStr.getBytes(StandardCharsets.UTF_8),
         tokenSecret);
     response.headers().set(
         SecureShuffleUtils.HTTP_HEADER_REPLY_URL_HASH, reply);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/test/java/org/apache/hadoop/mapred/TestShuffleChannelHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/test/java/org/apache/hadoop/mapred/TestShuffleChannelHandler.java
@@ -79,7 +79,6 @@ import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.Token;
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.eclipse.jetty.http.HttpHeader;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
@@ -336,7 +335,7 @@ public class TestShuffleChannelHandler extends TestShuffleHandlerBase {
         SecretKey tokenSecret = ctx.secretManager.retrieveTokenSecret(TEST_JOB_ID);
         headers.set(SecureShuffleUtils.HTTP_HEADER_REPLY_URL_HASH,
             SecureShuffleUtils.generateHash(
-                request.headers().get(HTTP_HEADER_URL_HASH).getBytes(Charsets.UTF_8),
+                request.headers().get(HTTP_HEADER_URL_HASH).getBytes(StandardCharsets.UTF_8),
                 tokenSecret));
       } catch (SecretManager.InvalidToken e) {
         fail("Could not generate reply hash");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/BaileyBorweinPlouffe.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/BaileyBorweinPlouffe.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -53,7 +54,6 @@ import org.apache.hadoop.util.ToolRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
  * A map/reduce program that uses Bailey-Borwein-Plouffe to compute exact 
@@ -158,7 +158,7 @@ public class BaileyBorweinPlouffe extends Configured implements Tool {
         final OutputStream outputstream = fs.create(outfile);
         try {
           final PrintWriter out = new PrintWriter(
-              new OutputStreamWriter(outputstream, Charsets.UTF_8), true);
+              new OutputStreamWriter(outputstream, StandardCharsets.UTF_8), true);
           // write hex text
           print(out, hex.iterator(), "Pi = 0x3.", "%02X", 5, 5);
           out.println("Total number of hexadecimal digits is "

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/WordMean.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/WordMean.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.examples;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.StringTokenizer;
 
 import org.apache.hadoop.conf.Configuration;
@@ -36,8 +37,6 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
-
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 public class WordMean extends Configured implements Tool {
 
@@ -96,7 +95,7 @@ public class WordMean extends Configured implements Tool {
     public void reduce(Text key, Iterable<LongWritable> values, Context context)
         throws IOException, InterruptedException {
 
-      int theSum = 0;
+      long theSum = 0;
       for (LongWritable val : values) {
         theSum += val.get();
       }
@@ -127,7 +126,7 @@ public class WordMean extends Configured implements Tool {
 
     // average = total sum / number of elements;
     try {
-      br = new BufferedReader(new InputStreamReader(fs.open(file), Charsets.UTF_8));
+      br = new BufferedReader(new InputStreamReader(fs.open(file), StandardCharsets.UTF_8));
 
       long count = 0;
       long length = 0;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/WordMedian.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/WordMedian.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.examples;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.StringTokenizer;
 
 import org.apache.hadoop.conf.Configuration;
@@ -39,7 +40,6 @@ import org.apache.hadoop.util.GenericOptionsParser;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 public class WordMedian extends Configured implements Tool {
 
@@ -130,7 +130,7 @@ public class WordMedian extends Configured implements Tool {
     BufferedReader br = null;
 
     try {
-      br = new BufferedReader(new InputStreamReader(fs.open(file), Charsets.UTF_8));
+      br = new BufferedReader(new InputStreamReader(fs.open(file), StandardCharsets.UTF_8));
       int num = 0;
 
       String line;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/WordStandardDeviation.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/WordStandardDeviation.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.examples;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.StringTokenizer;
 
 import org.apache.hadoop.conf.Configuration;
@@ -37,7 +38,6 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 public class WordStandardDeviation extends Configured implements Tool {
 
@@ -137,7 +137,7 @@ public class WordStandardDeviation extends Configured implements Tool {
     double stddev = 0;
     BufferedReader br = null;
     try {
-      br = new BufferedReader(new InputStreamReader(fs.open(file), Charsets.UTF_8));
+      br = new BufferedReader(new InputStreamReader(fs.open(file), StandardCharsets.UTF_8));
       long count = 0;
       long length = 0;
       long square = 0;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/dancing/DistributedPentomino.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/dancing/DistributedPentomino.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.examples.dancing;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.StringTokenizer;
 
@@ -33,7 +34,6 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.util.*;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
  * Launch a distributed pentomino solver.
@@ -141,7 +141,7 @@ public class DistributedPentomino extends Configured implements Tool {
     Path input = new Path(dir, "part1");
     PrintWriter file = 
       new PrintWriter(new OutputStreamWriter(new BufferedOutputStream
-                      (fs.create(input), 64*1024), Charsets.UTF_8));
+                      (fs.create(input), 64*1024), StandardCharsets.UTF_8));
     for(int[] prefix: splits) {
       for(int i=0; i < prefix.length; ++i) {
         if (i != 0) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/dancing/Sudoku.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/dancing/Sudoku.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.examples.dancing;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
  * This class uses the dancing links algorithm from Knuth to solve sudoku
@@ -136,7 +136,7 @@ public class Sudoku {
    */
   public Sudoku(InputStream stream) throws IOException {
     BufferedReader file = new BufferedReader(
-        new InputStreamReader(stream, Charsets.UTF_8));
+        new InputStreamReader(stream, StandardCharsets.UTF_8));
     String line = file.readLine();
     List<int[]> result = new ArrayList<int[]>();
     while (line != null) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/pi/Parser.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/pi/Parser.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -34,7 +35,6 @@ import java.util.TreeMap;
 import org.apache.hadoop.examples.pi.math.Bellard;
 import org.apache.hadoop.examples.pi.math.Bellard.Parameter;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /** A class for parsing outputs */
 public final class Parser {
@@ -80,7 +80,7 @@ public final class Parser {
         m.put(p, new ArrayList<TaskResult>());
 
       final BufferedReader in = new BufferedReader(
-          new InputStreamReader(new FileInputStream(f), Charsets.UTF_8)); 
+          new InputStreamReader(new FileInputStream(f), StandardCharsets.UTF_8));
       try {
         for(String line; (line = in.readLine()) != null; )
           try {
@@ -137,7 +137,7 @@ public final class Parser {
 
         final PrintWriter out = new PrintWriter(
             new OutputStreamWriter(new FileOutputStream(
-                new File(outputdir, p + ".txt")), Charsets.UTF_8), true);
+                new File(outputdir, p + ".txt")), StandardCharsets.UTF_8), true);
         try {
           for(int i = 0; i < results.size(); i++)
             out.println(DistSum.taskResult2string(p + "." + i, results.get(i)));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/pi/Util.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/pi/Util.java
@@ -216,7 +216,8 @@ public class Util {
       final File f = new File(dir,
           prefix + dateFormat.format(new Date(System.currentTimeMillis())) + ".txt");
       if (!f.exists())
-        return new PrintWriter(new OutputStreamWriter(new FileOutputStream(f), StandardCharsets.UTF_8));
+        return new PrintWriter(new OutputStreamWriter(
+                new FileOutputStream(f), StandardCharsets.UTF_8));
 
       try {Thread.sleep(10);} catch (InterruptedException e) {}
     }
@@ -310,13 +311,14 @@ public class Util {
   static void writeResults(String name, List<TaskResult> results, FileSystem fs, String dir) throws IOException {
     final Path outfile = new Path(dir, name + ".txt");
     Util.out.println(name + "> writing results to " + outfile);
-    final PrintWriter out = new PrintWriter(new OutputStreamWriter(fs.create(outfile), StandardCharsets.UTF_8), true);
+    final PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(
+            fs.create(outfile), StandardCharsets.UTF_8), true);
     try {
       for(TaskResult r : results)
-        out.println(r);
+        printWriter.println(r);
     }
     finally {
-      out.close();
+      printWriter.close();
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/pi/Util.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/pi/Util.java
@@ -25,6 +25,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,7 +47,6 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.util.ToolRunner;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 
 /** Utility methods */
@@ -216,7 +216,7 @@ public class Util {
       final File f = new File(dir,
           prefix + dateFormat.format(new Date(System.currentTimeMillis())) + ".txt");
       if (!f.exists())
-        return new PrintWriter(new OutputStreamWriter(new FileOutputStream(f), Charsets.UTF_8));
+        return new PrintWriter(new OutputStreamWriter(new FileOutputStream(f), StandardCharsets.UTF_8));
 
       try {Thread.sleep(10);} catch (InterruptedException e) {}
     }
@@ -291,7 +291,7 @@ public class Util {
     for(FileStatus status : fs.listStatus(outdir)) {
       if (status.getPath().getName().startsWith("part-")) {
         final BufferedReader in = new BufferedReader(
-            new InputStreamReader(fs.open(status.getPath()), Charsets.UTF_8));
+            new InputStreamReader(fs.open(status.getPath()), StandardCharsets.UTF_8));
         try {
           for(String line; (line = in.readLine()) != null; )
             results.add(TaskResult.valueOf(line));
@@ -310,7 +310,7 @@ public class Util {
   static void writeResults(String name, List<TaskResult> results, FileSystem fs, String dir) throws IOException {
     final Path outfile = new Path(dir, name + ".txt");
     Util.out.println(name + "> writing results to " + outfile);
-    final PrintWriter out = new PrintWriter(new OutputStreamWriter(fs.create(outfile), Charsets.UTF_8), true);
+    final PrintWriter out = new PrintWriter(new OutputStreamWriter(fs.create(outfile), StandardCharsets.UTF_8), true);
     try {
       for(TaskResult r : results)
         out.println(r);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/terasort/TeraScheduler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/terasort/TeraScheduler.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.examples.terasort;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import org.apache.hadoop.conf.Configuration;
@@ -28,7 +29,6 @@ import org.apache.hadoop.mapreduce.server.tasktracker.TTConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 class TeraScheduler {
   private static final Logger LOG =
@@ -75,7 +75,7 @@ class TeraScheduler {
   List<String> readFile(String filename) throws IOException {
     List<String> result = new ArrayList<String>(10000);
     try (BufferedReader in = new BufferedReader(
-        new InputStreamReader(new FileInputStream(filename), Charsets.UTF_8))) {
+        new InputStreamReader(new FileInputStream(filename), StandardCharsets.UTF_8))) {
       String line = in.readLine();
       while (line != null) {
         result.add(line);

--- a/hadoop-maven-plugins/src/main/java/org/apache/hadoop/maven/plugin/util/Exec.java
+++ b/hadoop-maven-plugins/src/main/java/org/apache/hadoop/maven/plugin/util/Exec.java
@@ -19,7 +19,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;

--- a/hadoop-maven-plugins/src/main/java/org/apache/hadoop/maven/plugin/util/Exec.java
+++ b/hadoop-maven-plugins/src/main/java/org/apache/hadoop/maven/plugin/util/Exec.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -108,11 +109,7 @@ public class Exec {
     public OutputBufferThread(InputStream is) {
       this.setDaemon(true);
       output = new ArrayList<String>();
-      try {
-        reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
-      } catch (UnsupportedEncodingException e) {
-        throw new RuntimeException("Unsupported encoding " + e.toString());
-      }
+      reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
     }
 
     @Override

--- a/hadoop-tools/hadoop-archives/src/main/java/org/apache/hadoop/tools/HadoopArchives.java
+++ b/hadoop-tools/hadoop-archives/src/main/java/org/apache/hadoop/tools/HadoopArchives.java
@@ -23,6 +23,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -73,8 +74,6 @@ import org.apache.hadoop.mapreduce.JobSubmissionFiles;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
-
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 /**
  * a archive creation utility.
@@ -754,7 +753,7 @@ public class HadoopArchives implements Tool {
         indexStream = fs.create(index);
         outStream = fs.create(masterIndex);
         String version = VERSION + " \n";
-        outStream.write(version.getBytes(Charsets.UTF_8));
+        outStream.write(version.getBytes(StandardCharsets.UTF_8));
         
       } catch(IOException e) {
         throw new RuntimeException(e);
@@ -773,7 +772,7 @@ public class HadoopArchives implements Tool {
       while(values.hasNext()) {
         Text value = values.next();
         String towrite = value.toString() + "\n";
-        indexStream.write(towrite.getBytes(Charsets.UTF_8));
+        indexStream.write(towrite.getBytes(StandardCharsets.UTF_8));
         written++;
         if (written > numIndexes -1) {
           // every 1000 indexes we report status
@@ -782,7 +781,7 @@ public class HadoopArchives implements Tool {
           endIndex = keyVal;
           String masterWrite = startIndex + " " + endIndex + " " + startPos 
                               +  " " + indexStream.getPos() + " \n" ;
-          outStream.write(masterWrite.getBytes(Charsets.UTF_8));
+          outStream.write(masterWrite.getBytes(StandardCharsets.UTF_8));
           startPos = indexStream.getPos();
           startIndex = endIndex;
           written = 0;
@@ -795,7 +794,7 @@ public class HadoopArchives implements Tool {
       if (written > 0) {
         String masterWrite = startIndex + " " + keyVal + " " + startPos  +
                              " " + indexStream.getPos() + " \n";
-        outStream.write(masterWrite.getBytes(Charsets.UTF_8));
+        outStream.write(masterWrite.getBytes(StandardCharsets.UTF_8));
       }
       // close the streams
       outStream.close();

--- a/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
+++ b/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
@@ -23,6 +23,7 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -81,7 +82,7 @@ public class TestHadoopArchives {
   private static String createFile(Path root, FileSystem fs, String... dirsAndFile
       ) throws IOException {
     String fileBaseName = dirsAndFile[dirsAndFile.length - 1]; 
-    return createFile(root, fs, fileBaseName.getBytes("UTF-8"), dirsAndFile);
+    return createFile(root, fs, fileBaseName.getBytes(StandardCharsets.UTF_8), dirsAndFile);
   }
   
   private static String createFile(Path root, FileSystem fs, byte[] fileContent, String... dirsAndFile
@@ -395,7 +396,7 @@ public class TestHadoopArchives {
           } else if ("zero-length".equals(baseName)) {
             assertEquals(0, actualContentSimple.length);
           } else {
-            String actual = new String(actualContentSimple, "UTF-8");
+            String actual = new String(actualContentSimple, StandardCharsets.UTF_8);
             assertEquals(baseName, actual);
           }
           readFileCount++;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractDelegationTokenBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractDelegationTokenBinding.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.fs.s3a.auth.delegation;
 
 import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -304,7 +304,7 @@ public abstract class AbstractDelegationTokenBinding extends AbstractDTService {
    * @return a password.
    */
   protected static byte[] getSecretManagerPasssword() {
-    return "non-password".getBytes(Charset.forName("UTF-8"));
+    return "non-password".getBytes(StandardCharsets.UTF_8);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AMultipartUploader.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AMultipartUploader.java
@@ -25,6 +25,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -39,8 +40,6 @@ import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
-
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -132,7 +131,7 @@ class S3AMultipartUploader extends AbstractMultipartUploader {
               PutObjectOptions.keepingDirs());
           statistics.uploadStarted();
           return BBUploadHandle.from(ByteBuffer.wrap(
-              uploadId.getBytes(Charsets.UTF_8)));
+              uploadId.getBytes(StandardCharsets.UTF_8)));
         }));
   }
 
@@ -151,7 +150,7 @@ class S3AMultipartUploader extends AbstractMultipartUploader {
     checkUploadId(uploadIdBytes);
     String key = context.pathToKey(dest);
     String uploadIdString = new String(uploadIdBytes, 0, uploadIdBytes.length,
-        Charsets.UTF_8);
+        StandardCharsets.UTF_8);
     return context.submit(new CompletableFuture<>(),
         () -> {
           UploadPartRequest request = writeOperations.newUploadPartRequestBuilder(key,
@@ -189,7 +188,7 @@ class S3AMultipartUploader extends AbstractMultipartUploader {
     String key = context.pathToKey(dest);
 
     String uploadIdStr = new String(uploadIdBytes, 0, uploadIdBytes.length,
-        Charsets.UTF_8);
+        StandardCharsets.UTF_8);
     ArrayList<CompletedPart> eTags = new ArrayList<>();
     eTags.ensureCapacity(handles.size());
     long totalLength = 0;
@@ -221,7 +220,7 @@ class S3AMultipartUploader extends AbstractMultipartUploader {
                   finalLen
               );
 
-          byte[] eTag = result.eTag().getBytes(Charsets.UTF_8);
+          byte[] eTag = result.eTag().getBytes(StandardCharsets.UTF_8);
           statistics.uploadCompleted();
           return (PathHandle) () -> ByteBuffer.wrap(eTag);
         }));
@@ -237,7 +236,7 @@ class S3AMultipartUploader extends AbstractMultipartUploader {
     final byte[] uploadIdBytes = uploadId.toByteArray();
     checkUploadId(uploadIdBytes);
     String uploadIdString = new String(uploadIdBytes, 0, uploadIdBytes.length,
-        Charsets.UTF_8);
+        StandardCharsets.UTF_8);
     return context.submit(new CompletableFuture<>(),
         () -> {
           writeOperations.abortMultipartCommit(

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -52,7 +52,6 @@ import org.apache.hadoop.io.retry.RetryPolicies;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.service.Service;
 import org.apache.hadoop.service.ServiceOperations;
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ListeningExecutorService;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
@@ -75,6 +74,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -911,7 +911,7 @@ public final class S3ATestUtils {
     return submit(EXECUTOR, () -> {
       try (DurationInfo ignore =
                new DurationInfo(LOG, false, "Creating %s", path)) {
-        createFile(fs, path, true, text.getBytes(Charsets.UTF_8));
+        createFile(fs, path, true, text.getBytes(StandardCharsets.UTF_8));
         return path;
       }
     });

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ILoadTestSessionCredentials.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ILoadTestSessionCredentials.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.s3a.auth.delegation;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionService;
@@ -134,7 +135,7 @@ public class ILoadTestSessionCredentials extends S3AScaleTestBase {
   @Test
   public void testCreate10Tokens() throws Throwable {
     File file = fetchTokens(10);
-    String csv = FileUtils.readFileToString(file, "UTF-8");
+    String csv = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
     LOG.info("CSV data\n{}", csv);
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperations.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.s3a.commit;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -495,7 +496,7 @@ public class ITestCommitOperations extends AbstractCommitITest {
   public void testUploadSmallFile() throws Throwable {
     File tempFile = File.createTempFile("commit", ".txt");
     String text = "hello, world";
-    FileUtils.write(tempFile, text, "UTF-8");
+    FileUtils.write(tempFile, text, StandardCharsets.UTF_8);
     CommitOperations actions = newCommitOperations();
     Path dest = methodSubPath("testUploadSmallFile");
     S3AFileSystem fs = getFileSystem();

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
@@ -26,7 +26,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -178,7 +178,7 @@ public class NativeAzureFileSystem extends FileSystem {
             "Error reading pending rename file contents -- "
                 + "maximum file size exceeded");
       }
-      String contents = new String(bytes, 0, l, Charset.forName("UTF-8"));
+      String contents = new String(bytes, 0, l, StandardCharsets.UTF_8);
 
       // parse the JSON
       JsonNode json = null;
@@ -301,7 +301,7 @@ public class NativeAzureFileSystem extends FileSystem {
       // Write file.
       try {
         output = fs.createInternal(path, FsPermission.getFileDefault(), false, null);
-        output.write(contents.getBytes(Charset.forName("UTF-8")));
+        output.write(contents.getBytes(StandardCharsets.UTF_8));
       } catch (IOException e) {
         throw new IOException("Unable to write RenamePending file for folder rename from "
             + srcKey + " to " + dstKey, e);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/AzureADAuthenticator.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/AzureADAuthenticator.java
@@ -374,7 +374,7 @@ public final class AzureADAuthenticator {
           conn.getRequestProperties());
       if (httpMethod.equals("POST")) {
         conn.setDoOutput(true);
-        conn.getOutputStream().write(payload.getBytes("UTF-8"));
+        conn.getOutputStream().write(payload.getBytes(StandardCharsets.UTF_8));
       }
 
       int httpResponseCode = conn.getResponseCode();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestBlobOperationDescriptor.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestBlobOperationDescriptor.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Tests for <code>BlobOperationDescriptor</code>.
@@ -71,7 +72,7 @@ public class TestBlobOperationDescriptor extends AbstractWasbTestBase {
       assertEquals(0, lastContentLengthReceived);
 
       String message = "this is a test";
-      output.write(message.getBytes("UTF-8"));
+      output.write(message.getBytes(StandardCharsets.UTF_8));
       output.flush();
       assertEquals(BlobOperationDescriptor.OperationType.AppendBlock,
           lastOperationTypeSent);
@@ -107,7 +108,7 @@ public class TestBlobOperationDescriptor extends AbstractWasbTestBase {
       assertEquals(0, lastContentLengthReceived);
 
       String message = "this is a test";
-      output.write(message.getBytes("UTF-8"));
+      output.write(message.getBytes(StandardCharsets.UTF_8));
       output.flush();
       assertEquals(BlobOperationDescriptor.OperationType.PutBlock,
           lastOperationTypeSent);
@@ -186,7 +187,7 @@ public class TestBlobOperationDescriptor extends AbstractWasbTestBase {
       assertNull(lastOperationTypeReceived);
       assertEquals(0, lastContentLengthReceived);
 
-      output.write(message.getBytes("UTF-8"));
+      output.write(message.getBytes(StandardCharsets.UTF_8));
       output.flush();
       assertEquals(BlobOperationDescriptor.OperationType.PutBlock,
           lastOperationTypeSent);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsConfigurationFieldsValidation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsConfigurationFieldsValidation.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.commons.codec.Charsets;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
 import org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsConfigurationFieldsValidation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsConfigurationFieldsValidation.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.azurebfs;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.codec.Charsets;
 import org.apache.hadoop.conf.Configuration;
@@ -99,8 +100,8 @@ public class TestAbfsConfigurationFieldsValidation {
   public TestAbfsConfigurationFieldsValidation() throws Exception {
     super();
     this.accountName = "testaccount1.blob.core.windows.net";
-    this.encodedString = Base64.encode("base64Value".getBytes(Charsets.UTF_8));
-    this.encodedAccountKey = Base64.encode("someAccountKey".getBytes(Charsets.UTF_8));
+    this.encodedString = Base64.encode("base64Value".getBytes(StandardCharsets.UTF_8));
+    this.encodedAccountKey = Base64.encode("someAccountKey".getBytes(StandardCharsets.UTF_8));
     Configuration configuration = new Configuration();
     configuration.addResource(TestConfigurationKeys.TEST_CONFIGURATION_FILE_NAME);
     configuration.set(INT_KEY, "1234565");

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/extensions/ClassicDelegationTokenManager.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/extensions/ClassicDelegationTokenManager.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.fs.azurebfs.extensions;
 
 import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
@@ -249,8 +249,8 @@ public class ClassicDelegationTokenManager
    * highlighting security risks of shared mutable byte arrays.
    * @return a password.
    */
-  private static byte[] getSecretManagerPasssword() {
-    return "non-password".getBytes(Charset.forName("UTF-8"));
+  private static byte[] getSecretManagerPassword() {
+    return "non-password".getBytes(StandardCharsets.UTF_8);
   }
 
   /**
@@ -265,13 +265,13 @@ public class ClassicDelegationTokenManager
 
     @Override
     protected byte[] createPassword(StubAbfsTokenIdentifier identifier) {
-      return getSecretManagerPasssword();
+      return getSecretManagerPassword();
     }
 
     @Override
     public byte[] retrievePassword(StubAbfsTokenIdentifier identifier)
         throws InvalidToken {
-      return getSecretManagerPasssword();
+      return getSecretManagerPassword();
     }
 
     @Override

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestShellDecryptionKeyProvider.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestShellDecryptionKeyProvider.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.fs.azurebfs.services;
 
 import java.io.File;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -75,7 +75,7 @@ public class TestShellDecryptionKeyProvider {
     // expected result (so that we validate both script input and output)
     File scriptFile = new File(TEST_ROOT_DIR, "testScript.cmd");
     FileUtils.writeStringToFile(scriptFile, "@echo %1 " + expectedResult,
-        Charset.forName("UTF-8"));
+        StandardCharsets.UTF_8);
 
     ShellDecryptionKeyProvider provider = new ShellDecryptionKeyProvider();
     Configuration conf = new Configuration();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestTextFileBasedIdentityHandler.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestTextFileBasedIdentityHandler.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.fs.azurebfs.services;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
 
 import org.junit.Assert;
@@ -71,22 +71,22 @@ public class TestTextFileBasedIdentityHandler {
     groupMappingFile = tempDir.newFile("group-mapping.conf");
 
     //Stage data for user mapping
-    FileUtils.writeStringToFile(userMappingFile, testUserDataLine1, Charset.forName("UTF-8"), true);
-    FileUtils.writeStringToFile(userMappingFile, testUserDataLine2, Charset.forName("UTF-8"), true);
-    FileUtils.writeStringToFile(userMappingFile, testUserDataLine3, Charset.forName("UTF-8"), true);
-    FileUtils.writeStringToFile(userMappingFile, testUserDataLine4, Charset.forName("UTF-8"), true);
-    FileUtils.writeStringToFile(userMappingFile, testUserDataLine5, Charset.forName("UTF-8"), true);
-    FileUtils.writeStringToFile(userMappingFile, testUserDataLine6, Charset.forName("UTF-8"), true);
-    FileUtils.writeStringToFile(userMappingFile, testUserDataLine7, Charset.forName("UTF-8"), true);
-    FileUtils.writeStringToFile(userMappingFile, NEW_LINE, Charset.forName("UTF-8"), true);
+    FileUtils.writeStringToFile(userMappingFile, testUserDataLine1, StandardCharsets.UTF_8, true);
+    FileUtils.writeStringToFile(userMappingFile, testUserDataLine2, StandardCharsets.UTF_8, true);
+    FileUtils.writeStringToFile(userMappingFile, testUserDataLine3, StandardCharsets.UTF_8, true);
+    FileUtils.writeStringToFile(userMappingFile, testUserDataLine4, StandardCharsets.UTF_8, true);
+    FileUtils.writeStringToFile(userMappingFile, testUserDataLine5, StandardCharsets.UTF_8, true);
+    FileUtils.writeStringToFile(userMappingFile, testUserDataLine6, StandardCharsets.UTF_8, true);
+    FileUtils.writeStringToFile(userMappingFile, testUserDataLine7, StandardCharsets.UTF_8, true);
+    FileUtils.writeStringToFile(userMappingFile, NEW_LINE, StandardCharsets.UTF_8, true);
 
     //Stage data for group mapping
-    FileUtils.writeStringToFile(groupMappingFile, testGroupDataLine1, Charset.forName("UTF-8"), true);
-    FileUtils.writeStringToFile(groupMappingFile, testGroupDataLine2, Charset.forName("UTF-8"), true);
-    FileUtils.writeStringToFile(groupMappingFile, testGroupDataLine3, Charset.forName("UTF-8"), true);
-    FileUtils.writeStringToFile(groupMappingFile, testGroupDataLine4, Charset.forName("UTF-8"), true);
-    FileUtils.writeStringToFile(groupMappingFile, testGroupDataLine5, Charset.forName("UTF-8"), true);
-    FileUtils.writeStringToFile(groupMappingFile, NEW_LINE, Charset.forName("UTF-8"), true);
+    FileUtils.writeStringToFile(groupMappingFile, testGroupDataLine1, StandardCharsets.UTF_8, true);
+    FileUtils.writeStringToFile(groupMappingFile, testGroupDataLine2, StandardCharsets.UTF_8, true);
+    FileUtils.writeStringToFile(groupMappingFile, testGroupDataLine3, StandardCharsets.UTF_8, true);
+    FileUtils.writeStringToFile(groupMappingFile, testGroupDataLine4, StandardCharsets.UTF_8, true);
+    FileUtils.writeStringToFile(groupMappingFile, testGroupDataLine5, StandardCharsets.UTF_8, true);
+    FileUtils.writeStringToFile(groupMappingFile, NEW_LINE, StandardCharsets.UTF_8, true);
   }
 
   private void assertUserLookup(TextFileBasedIdentityHandler handler, String userInTest, String expectedUser)

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/FileBasedCopyListing.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/FileBasedCopyListing.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.security.Credentials;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -76,7 +76,7 @@ public class FileBasedCopyListing extends CopyListing {
     BufferedReader input = null;
     try {
       input = new BufferedReader(new InputStreamReader(fs.open(sourceListing),
-          Charset.forName("UTF-8")));
+          StandardCharsets.UTF_8));
       String line = input.readLine();
       while (line != null) {
         result.add(new Path(line));

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/RegexCopyFilter.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/RegexCopyFilter.java
@@ -29,7 +29,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
@@ -66,7 +66,7 @@ public class RegexCopyFilter extends CopyFilter {
     try {
       InputStream is = Files.newInputStream(filtersFile.toPath());
       reader = new BufferedReader(new InputStreamReader(is,
-          Charset.forName("UTF-8")));
+          StandardCharsets.UTF_8));
       String line;
       while ((line = reader.readLine()) != null) {
         Pattern pattern = Pattern.compile(line);

--- a/hadoop-tools/hadoop-extras/src/main/java/org/apache/hadoop/tools/DistTool.java
+++ b/hadoop-tools/hadoop-extras/src/main/java/org/apache/hadoop/tools/DistTool.java
@@ -22,7 +22,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -96,7 +96,7 @@ abstract class DistTool implements org.apache.hadoop.util.Tool {
     List<String> result = new ArrayList<String>();
     FileSystem fs = inputfile.getFileSystem(conf);
     try (BufferedReader input = new BufferedReader(new InputStreamReader(fs.open(inputfile),
-            Charset.forName("UTF-8")))) {
+            StandardCharsets.UTF_8))) {
       for(String line; (line = input.readLine()) != null;) {
         result.add(line);
       }

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/ImageWriter.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/ImageWriter.java
@@ -26,6 +26,7 @@ import java.io.FilterOutputStream;
 import java.io.OutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.util.Arrays;
@@ -35,7 +36,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.protobuf.CodedOutputStream;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -325,7 +325,7 @@ public class ImageWriter implements Closeable {
     Path chk = new Path(outdir, imagename + ".md5");
     try (OutputStream out = outfs.create(chk)) {
       String md5Line = digestString + " *" + imagename + "\n";
-      out.write(md5Line.getBytes(Charsets.UTF_8));
+      out.write(md5Line.getBytes(StandardCharsets.UTF_8));
     }
   }
 

--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/CompressionEmulationUtil.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/CompressionEmulationUtil.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -99,7 +100,7 @@ class CompressionEmulationUtil {
   private static final CompressionRatioLookupTable COMPRESSION_LOOKUP_TABLE = 
     new CompressionRatioLookupTable();
 
-  private static final Charset charsetUTF8 = Charset.forName("UTF-8");
+  private static final Charset charsetUTF8 = StandardCharsets.UTF_8;
 
   /**
    * This is a {@link Mapper} implementation for generating random text data.

--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/DistributedCacheEmulator.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/DistributedCacheEmulator.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -113,7 +114,7 @@ class DistributedCacheEmulator {
 
   Configuration conf; // gridmix configuration
 
-  private static final Charset charsetUTF8 = Charset.forName("UTF-8");
+  private static final Charset charsetUTF8 = StandardCharsets.UTF_8;
 
   // Pseudo local file system where local FS based distributed cache files are
   // created by gridmix.

--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/GenerateDistCacheData.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/GenerateDistCacheData.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.mapred.gridmix;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.List;
@@ -96,7 +97,7 @@ class GenerateDistCacheData extends GridmixJob {
    */
   static final short GRIDMIX_DISTCACHE_FILE_PERM = 0644;
 
-  private static final Charset charsetUTF8 = Charset.forName("UTF-8");
+  private static final Charset charsetUTF8 = StandardCharsets.UTF_8;
 
   public GenerateDistCacheData(Configuration conf) throws IOException {
     super(conf, 0L, JOB_NAME);

--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/GridmixRecord.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/GridmixRecord.java
@@ -21,6 +21,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.EOFException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.hadoop.io.DataInputBuffer;
@@ -111,7 +112,7 @@ class GridmixRecord implements WritableComparable<GridmixRecord> {
     //TODO Should we use long for size. What if the data is more than 4G?
     
     String randomWord = rtg.getRandomWord();
-    byte[] bytes = randomWord.getBytes("UTF-8");
+    byte[] bytes = randomWord.getBytes(StandardCharsets.UTF_8);
     long randomWordSize = bytes.length;
     while (i >= randomWordSize) {
       out.write(bytes);
@@ -119,7 +120,7 @@ class GridmixRecord implements WritableComparable<GridmixRecord> {
       
       // get the next random word
       randomWord = rtg.getRandomWord();
-      bytes = randomWord.getBytes("UTF-8");
+      bytes = randomWord.getBytes(StandardCharsets.UTF_8);
       // determine the random word size
       randomWordSize = bytes.length;
     }

--- a/hadoop-tools/hadoop-kafka/src/main/java/org/apache/hadoop/metrics2/sink/KafkaSink.java
+++ b/hadoop-tools/hadoop-kafka/src/main/java/org/apache/hadoop/metrics2/sink/KafkaSink.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -156,7 +156,7 @@ public class KafkaSink implements MetricsSink, Closeable {
 
     // Create the record to be sent from the json.
     ProducerRecord<Integer, byte[]> data = new ProducerRecord<Integer, byte[]>(
-        topic, jsonLines.toString().getBytes(Charset.forName("UTF-8")));
+        topic, jsonLines.toString().getBytes(StandardCharsets.UTF_8));
 
     // Send the data to the Kafka broker. Here is an example of this data:
     // {"hostname": "...", "timestamp": 1436913651516,

--- a/hadoop-tools/hadoop-kafka/src/test/java/org/apache/hadoop/metrics2/impl/TestKafkaMetrics.java
+++ b/hadoop-tools/hadoop-kafka/src/test/java/org/apache/hadoop/metrics2/impl/TestKafkaMetrics.java
@@ -159,7 +159,7 @@ public class TestKafkaMetrics {
     String date = dateFormat.format(currDate);
     SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm:ss");
     String time = timeFormat.format(currDate);
-    String hostname = new String("null");
+    String hostname = "null";
     try {
       hostname = InetAddress.getLocalHost().getHostName();
     } catch (Exception e) {

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/solver/impl/TestLpSolver.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/solver/impl/TestLpSolver.java
@@ -41,7 +41,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +84,7 @@ public class TestLpSolver extends TestSolver {
     RLESparseResourceAllocation result = solver.solve(jobHistory);
     String file = "src/test/resources/lp/answer.txt";
     Reader fileReader = new InputStreamReader(new FileInputStream(file),
-        Charset.forName("UTF-8"));
+        StandardCharsets.UTF_8);
     BufferedReader bufferedReader = new BufferedReader(fileReader);
     String line = bufferedReader.readLine();
     Configuration config = new Configuration();

--- a/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/RandomSeedGenerator.java
+++ b/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/RandomSeedGenerator.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.tools.rumen;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;

--- a/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/RandomSeedGenerator.java
+++ b/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/RandomSeedGenerator.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.tools.rumen;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -43,8 +44,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RandomSeedGenerator {
   private static Logger LOG = LoggerFactory.getLogger(RandomSeedGenerator.class);
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
-  
+
   /** MD5 algorithm instance, one for each thread. */
   private static final ThreadLocal<MessageDigest> md5Holder =
       new ThreadLocal<MessageDigest>() {
@@ -74,7 +74,7 @@ public class RandomSeedGenerator {
     // We could have fed the bytes of masterSeed one by one to md5.update()
     // instead
     String str = streamId + '/' + masterSeed;
-    byte[] digest = md5.digest(str.getBytes(UTF_8));
+    byte[] digest = md5.digest(str.getBytes(StandardCharsets.UTF_8));
     // Create a long from the first 8 bytes of the digest
     // This is fine as MD5 has the avalanche property.
     // Paranoids could have XOR folded the other 8 bytes in too. 

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/record/Record.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/record/Record.java
@@ -22,6 +22,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -94,8 +95,8 @@ public abstract class Record implements WritableComparable, Cloneable {
       ByteArrayOutputStream s = new ByteArrayOutputStream();
       CsvRecordOutput a = new CsvRecordOutput(s);
       this.serialize(a);
-      return new String(s.toByteArray(), "UTF-8");
-    } catch (Throwable ex) {
+      return new String(s.toByteArray(), StandardCharsets.UTF_8);
+    } catch (Exception ex) {
       throw new RuntimeException(ex);
     }
   }

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/Environment.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/Environment.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.streaming;
 
 import java.io.*;
 import java.net.InetAddress;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -65,7 +65,7 @@ public class Environment extends Properties {
 
     Process pid = Runtime.getRuntime().exec(command);
     BufferedReader in = new BufferedReader(
-        new InputStreamReader(pid.getInputStream(), Charset.forName("UTF-8")));
+        new InputStreamReader(pid.getInputStream(), StandardCharsets.UTF_8));
     try {
       while (true) {
         String line = in.readLine();

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/PipeMapper.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/PipeMapper.java
@@ -76,8 +76,10 @@ public class PipeMapper extends PipeMapRed implements Mapper {
         inputFormatClassName.equals(TextInputFormat.class.getCanonicalName()));
     }
     
-    mapOutputFieldSeparator = job.get("stream.map.output.field.separator", "\t").getBytes(StandardCharsets.UTF_8);
-    mapInputFieldSeparator = job.get("stream.map.input.field.separator", "\t").getBytes(StandardCharsets.UTF_8);
+    mapOutputFieldSeparator = job.get("stream.map.output.field.separator", "\t")
+            .getBytes(StandardCharsets.UTF_8);
+    mapInputFieldSeparator = job.get("stream.map.input.field.separator", "\t")
+            .getBytes(StandardCharsets.UTF_8);
     numOfMapOutputKeyFields = job.getInt("stream.num.map.output.key.fields", 1);
   }
 

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/PipeMapper.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/PipeMapper.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.streaming;
 
 import java.io.*;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.Mapper;
@@ -75,13 +76,9 @@ public class PipeMapper extends PipeMapRed implements Mapper {
         inputFormatClassName.equals(TextInputFormat.class.getCanonicalName()));
     }
     
-    try {
-      mapOutputFieldSeparator = job.get("stream.map.output.field.separator", "\t").getBytes("UTF-8");
-      mapInputFieldSeparator = job.get("stream.map.input.field.separator", "\t").getBytes("UTF-8");
-      numOfMapOutputKeyFields = job.getInt("stream.num.map.output.key.fields", 1);
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException("The current system does not support UTF-8 encoding!", e);
-    }
+    mapOutputFieldSeparator = job.get("stream.map.output.field.separator", "\t").getBytes(StandardCharsets.UTF_8);
+    mapInputFieldSeparator = job.get("stream.map.input.field.separator", "\t").getBytes(StandardCharsets.UTF_8);
+    numOfMapOutputKeyFields = job.getInt("stream.num.map.output.key.fields", 1);
   }
 
   // Do NOT declare default constructor

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/PipeReducer.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/PipeReducer.java
@@ -72,8 +72,10 @@ public class PipeReducer extends PipeMapRed implements Reducer {
     SkipBadRecords.setAutoIncrReducerProcCount(job, false);
     skipping = job.getBoolean(MRJobConfig.SKIP_RECORDS, false);
 
-    reduceOutFieldSeparator = job_.get("stream.reduce.output.field.separator", "\t").getBytes(StandardCharsets.UTF_8);
-    reduceInputFieldSeparator = job_.get("stream.reduce.input.field.separator", "\t").getBytes(StandardCharsets.UTF_8);
+    reduceOutFieldSeparator = job_.get("stream.reduce.output.field.separator", "\t")
+            .getBytes(StandardCharsets.UTF_8);
+    reduceInputFieldSeparator = job_.get("stream.reduce.input.field.separator", "\t")
+            .getBytes(StandardCharsets.UTF_8);
     this.numOfReduceOutputKeyFields = job_.getInt("stream.num.reduce.output.key.fields", 1);
   }
 

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/PipeReducer.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/PipeReducer.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.streaming;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.net.URLDecoder;
 
@@ -71,13 +72,9 @@ public class PipeReducer extends PipeMapRed implements Reducer {
     SkipBadRecords.setAutoIncrReducerProcCount(job, false);
     skipping = job.getBoolean(MRJobConfig.SKIP_RECORDS, false);
 
-    try {
-      reduceOutFieldSeparator = job_.get("stream.reduce.output.field.separator", "\t").getBytes("UTF-8");
-      reduceInputFieldSeparator = job_.get("stream.reduce.input.field.separator", "\t").getBytes("UTF-8");
-      this.numOfReduceOutputKeyFields = job_.getInt("stream.num.reduce.output.key.fields", 1);
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException("The current system does not support UTF-8 encoding!", e);
-    }
+    reduceOutFieldSeparator = job_.get("stream.reduce.output.field.separator", "\t").getBytes(StandardCharsets.UTF_8);
+    reduceInputFieldSeparator = job_.get("stream.reduce.input.field.separator", "\t").getBytes(StandardCharsets.UTF_8);
+    this.numOfReduceOutputKeyFields = job_.getInt("stream.num.reduce.output.key.fields", 1);
   }
 
   public void reduce(Object key, Iterator values, OutputCollector output,

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/StreamBaseRecordReader.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/StreamBaseRecordReader.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.streaming;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
@@ -103,7 +104,7 @@ public abstract class StreamBaseRecordReader implements RecordReader<Text, Text>
   void numRecStats(byte[] record, int start, int len) throws IOException {
     numRec_++;
     if (numRec_ == nextStatusRec_) {
-      String recordStr = new String(record, start, Math.min(len, statusMaxRecordChars_), "UTF-8");
+      String recordStr = new String(record, start, Math.min(len, statusMaxRecordChars_), StandardCharsets.UTF_8);
       nextStatusRec_ += 100;//*= 10;
       String status = getStatus(recordStr);
       LOG.info(status);

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/StreamBaseRecordReader.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/StreamBaseRecordReader.java
@@ -22,9 +22,6 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.Writable;
-import org.apache.hadoop.io.WritableComparable;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.mapred.Reporter;
@@ -104,7 +101,8 @@ public abstract class StreamBaseRecordReader implements RecordReader<Text, Text>
   void numRecStats(byte[] record, int start, int len) throws IOException {
     numRec_++;
     if (numRec_ == nextStatusRec_) {
-      String recordStr = new String(record, start, Math.min(len, statusMaxRecordChars_), StandardCharsets.UTF_8);
+      String recordStr = new String(record, start,
+              Math.min(len, statusMaxRecordChars_), StandardCharsets.UTF_8);
       nextStatusRec_ += 100;//*= 10;
       String status = getStatus(recordStr);
       LOG.info(status);

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/StreamUtil.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/StreamUtil.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
@@ -146,7 +147,7 @@ public class StreamUtil {
     String contents = null;
     try {
       in.read(buf, 0, len);
-      contents = new String(buf, "UTF-8");
+      contents = new String(buf, StandardCharsets.UTF_8);
     } finally {
       in.close();
     }
@@ -160,7 +161,7 @@ public class StreamUtil {
     String contents = null;
     try {
       in.readFully(in.getPos(), buf);
-      contents = new String(buf, "UTF-8");
+      contents = new String(buf, StandardCharsets.UTF_8);
     } finally {
       in.close();
     }

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/StreamXmlRecordReader.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/StreamXmlRecordReader.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.streaming;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.*;
 
 import org.apache.hadoop.io.DataOutputBuffer;
@@ -132,7 +133,7 @@ public class StreamXmlRecordReader extends StreamBaseRecordReader {
     read = bin_.read(buf);
     if (read == -1) return false;
 
-    String sbuf = new String(buf, 0, read, "UTF-8");
+    String sbuf = new String(buf, 0, read, StandardCharsets.UTF_8);
     Matcher match = markPattern.matcher(sbuf);
 
     firstMatchStart_ = NA;
@@ -235,7 +236,7 @@ public class StreamXmlRecordReader extends StreamBaseRecordReader {
   }
 
   boolean fastReadUntilMatch(String textPat, boolean includePat, DataOutputBuffer outBufOrNull) throws IOException {
-    byte[] cpat = textPat.getBytes("UTF-8");
+    byte[] cpat = textPat.getBytes(StandardCharsets.UTF_8);
     int m = 0;
     boolean match = false;
     int msup = cpat.length;

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/io/KeyOnlyTextOutputReader.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/io/KeyOnlyTextOutputReader.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.streaming.io;
 import java.io.DataInput;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
@@ -77,11 +77,7 @@ public class KeyOnlyTextOutputReader extends OutputReader<Text, NullWritable> {
   @Override
   public String getLastOutput() {
     if (bytes != null) {
-      try {
-        return new String(bytes, "UTF-8");
-      } catch (UnsupportedEncodingException e) {
-        return "<undecodable>";
-      }
+      return new String(bytes, StandardCharsets.UTF_8);
     } else {
       return null;
     }

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/io/TextInputWriter.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/io/TextInputWriter.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.streaming.io;
 
 import java.io.DataOutput;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.Text;
@@ -66,7 +67,7 @@ public class TextInputWriter extends InputWriter<Object, Object> {
       valSize = val.getLength();
     } else {
       String sval = object.toString();
-      bval = sval.getBytes("UTF-8");
+      bval = sval.getBytes(StandardCharsets.UTF_8);
       valSize = bval.length;
     }
     clientOut.write(bval, 0, valSize);

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/io/TextOutputReader.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/io/TextOutputReader.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
@@ -84,11 +85,7 @@ public class TextOutputReader extends OutputReader<Text, Text> {
   @Override
   public String getLastOutput() {
     if (bytes != null) {
-      try {
-        return new String(bytes, "UTF-8");
-      } catch (UnsupportedEncodingException e) {
-        return "<undecodable>";
-      }
+      return new String(bytes, StandardCharsets.UTF_8);
     } else {
       return null;
     }

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/io/TextOutputReader.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/io/TextOutputReader.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.streaming.io;
 import java.io.DataInput;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/mapreduce/StreamBaseRecordReader.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/mapreduce/StreamBaseRecordReader.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.streaming.mapreduce;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,7 +108,7 @@ public abstract class StreamBaseRecordReader extends RecordReader<Text, Text> {
     numRec_++;
     if (numRec_ == nextStatusRec_) {
       String recordStr = new String(record, start, Math.min(len,
-          statusMaxRecordChars_), "UTF-8");
+          statusMaxRecordChars_), StandardCharsets.UTF_8);
       nextStatusRec_ += 100;// *= 10;
       String status = getStatus(recordStr);
       LOG.info(status);

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/mapreduce/StreamXmlRecordReader.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/mapreduce/StreamXmlRecordReader.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.streaming.mapreduce;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -139,7 +140,7 @@ public class StreamXmlRecordReader extends StreamBaseRecordReader {
     if (read == -1)
       return false;
 
-    String sbuf = new String(buf, 0, read, "UTF-8");
+    String sbuf = new String(buf, 0, read, StandardCharsets.UTF_8);
     Matcher match = markPattern.matcher(sbuf);
 
     firstMatchStart_ = NA;
@@ -246,7 +247,7 @@ public class StreamXmlRecordReader extends StreamBaseRecordReader {
 
   boolean fastReadUntilMatch(String textPat, boolean includePat,
       DataOutputBuffer outBufOrNull) throws IOException {
-    byte[] cpat = textPat.getBytes("UTF-8");
+    byte[] cpat = textPat.getBytes(StandardCharsets.UTF_8);
     int m = 0;
     boolean match = false;
     int msup = cpat.length;

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/RawBytesMapApp.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/RawBytesMapApp.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.io.IntWritable;
 
@@ -52,7 +53,7 @@ public class RawBytesMapApp {
   }
   
   private void writeString(String str) throws IOException {
-    byte[] bytes = str.getBytes("UTF-8");
+    byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
     dos.writeInt(bytes.length);
     dos.write(bytes);
   }

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/RawBytesReduceApp.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/RawBytesReduceApp.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.streaming;
 import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.io.IntWritable;
 
@@ -62,7 +63,7 @@ public class RawBytesReduceApp {
     }
     byte[] bytes = new byte[length];
     dis.readFully(bytes);
-    return new String(bytes, "UTF-8");
+    return new String(bytes, StandardCharsets.UTF_8);
   }
   
   private int readInt() throws IOException {

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestFileArgs.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestFileArgs.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.streaming;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.apache.hadoop.hdfs.MiniDFSCluster;
@@ -70,7 +71,7 @@ public class TestFileArgs extends TestStreaming
     // Set up side file
     FileSystem localFs = FileSystem.getLocal(conf);
     DataOutputStream dos = localFs.create(new Path("target/sidefile"));
-    dos.write("hello world\n".getBytes("UTF-8"));
+    dos.write("hello world\n".getBytes(StandardCharsets.UTF_8));
     dos.close();
 
     // Since ls doesn't read stdin, we don't want to write anything

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestGzipInput.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestGzipInput.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.streaming;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPOutputStream;
 
 /**
@@ -37,7 +38,7 @@ public class TestGzipInput extends TestStreaming
   {
     GZIPOutputStream out = new GZIPOutputStream(
       new FileOutputStream(INPUT_FILE.getAbsoluteFile()));
-    out.write(input.getBytes("UTF-8"));
+    out.write(input.getBytes(StandardCharsets.UTF_8));
     out.close();
   }
 }

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestMultipleArchiveFiles.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestMultipleArchiveFiles.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.streaming;
 import java.io.File;
 import java.io.IOException;
 import java.io.DataOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -86,14 +87,14 @@ public class TestMultipleArchiveFiles extends TestStreaming
     DataOutputStream dos = fileSys.create(new Path(INPUT_FILE));
     String inputFileString = "symlink1" + File.separator
       + "cacheArchive1\nsymlink2" + File.separator + "cacheArchive2";
-    dos.write(inputFileString.getBytes("UTF-8"));
+    dos.write(inputFileString.getBytes(StandardCharsets.UTF_8));
     dos.close();
 
     DataOutputStream out = fileSys.create(new Path(CACHE_ARCHIVE_1.toString()));
     ZipOutputStream zos = new ZipOutputStream(out);
     ZipEntry ze = new ZipEntry(CACHE_FILE_1.toString());
     zos.putNextEntry(ze);
-    zos.write(input.getBytes("UTF-8"));
+    zos.write(input.getBytes(StandardCharsets.UTF_8));
     zos.closeEntry();
     zos.close();
 
@@ -101,7 +102,7 @@ public class TestMultipleArchiveFiles extends TestStreaming
     zos = new ZipOutputStream(out);
     ze = new ZipEntry(CACHE_FILE_2.toString());
     zos.putNextEntry(ze);
-    zos.write(input.getBytes("UTF-8"));
+    zos.write(input.getBytes(StandardCharsets.UTF_8));
     zos.closeEntry();
     zos.close();
   }

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestRawBytesStreaming.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestRawBytesStreaming.java
@@ -22,6 +22,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
@@ -46,7 +47,7 @@ public class TestRawBytesStreaming {
 
   protected void createInput() throws IOException {
     DataOutputStream out = new DataOutputStream(new FileOutputStream(INPUT_FILE.getAbsoluteFile()));
-    out.write(input.getBytes("UTF-8"));
+    out.write(input.getBytes(StandardCharsets.UTF_8));
     out.close();
   }
 

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestStreamAggregate.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestStreamAggregate.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.streaming;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.mapreduce.MRJobConfig;
@@ -53,7 +54,7 @@ public class TestStreamAggregate
   {
     DataOutputStream out = new DataOutputStream(
                                                 new FileOutputStream(INPUT_FILE.getAbsoluteFile()));
-    out.write(input.getBytes("UTF-8"));
+    out.write(input.getBytes(StandardCharsets.UTF_8));
     out.close();
   }
 

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestUnconsumedInput.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestUnconsumedInput.java
@@ -24,6 +24,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -57,7 +58,7 @@ public class TestUnconsumedInput {
       DataOutputStream out = new DataOutputStream(
           new FileOutputStream(INPUT_FILE.getAbsoluteFile()));
       for (int i=0; i<10000; ++i) {
-        out.write(input.getBytes("UTF-8"));
+        out.write(input.getBytes(StandardCharsets.UTF_8));
       }
       out.close();
   }

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestUnconsumedInput.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestUnconsumedInput.java
@@ -28,11 +28,7 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileUtil;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdfs.HdfsConfiguration;
-import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.junit.Test;
 
 public class TestUnconsumedInput {
@@ -55,12 +51,12 @@ public class TestUnconsumedInput {
 
   protected void createInput() throws IOException
   {
-      DataOutputStream out = new DataOutputStream(
-          new FileOutputStream(INPUT_FILE.getAbsoluteFile()));
+    try (DataOutputStream out = new DataOutputStream(
+            new FileOutputStream(INPUT_FILE.getAbsoluteFile()))) {
       for (int i=0; i<10000; ++i) {
         out.write(input.getBytes(StandardCharsets.UTF_8));
       }
-      out.close();
+    }
   }
 
   protected String[] genArgs() {

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/mapreduce/TestStreamXmlRecordReader.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/mapreduce/TestStreamXmlRecordReader.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -88,7 +89,7 @@ public class TestStreamXmlRecordReader {
     String contents = null;
     try {
       in.readFully(in.getPos(), buf);
-      contents = new String(buf, "UTF-8");
+      contents = new String(buf, StandardCharsets.UTF_8);
     } finally {
       in.close();
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/conf/TestYarnConfigurationFields.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/conf/TestYarnConfigurationFields.java
@@ -36,7 +36,7 @@ public class TestYarnConfigurationFields extends TestConfigurationFieldsBase {
   @SuppressWarnings({"deprecation", "methodlength"})
   @Override
   public void initializeMemberVariables() {
-    xmlFilename = new String("yarn-default.xml");
+    xmlFilename = "yarn-default.xml";
     configurationClasses = new Class[] { YarnConfiguration.class };
 
     // Allocate for usage

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-unmanaged-am-launcher/src/main/java/org/apache/hadoop/yarn/applications/unmanagedamlauncher/UnmanagedAMLauncher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-unmanaged-am-launcher/src/main/java/org/apache/hadoop/yarn/applications/unmanagedamlauncher/UnmanagedAMLauncher.java
@@ -25,7 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.Map;
@@ -235,10 +235,10 @@ public class UnmanagedAMLauncher {
 
     final BufferedReader errReader = 
         new BufferedReader(new InputStreamReader(
-            amProc.getErrorStream(), Charset.forName("UTF-8")));
+            amProc.getErrorStream(), StandardCharsets.UTF_8));
     final BufferedReader inReader = 
         new BufferedReader(new InputStreamReader(
-            amProc.getInputStream(), Charset.forName("UTF-8")));
+            amProc.getInputStream(), StandardCharsets.UTF_8));
     
     // read error and input streams as this would free up the buffers
     // free the error stream buffer

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/utils/PublishedConfigurationOutputter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/utils/PublishedConfigurationOutputter.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.yarn.service.utils;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -72,7 +71,7 @@ public abstract class PublishedConfigurationOutputter {
    * @throws IOException
    */
   public void save(OutputStream out) throws IOException {
-    IOUtils.write(asString(), out, Charsets.UTF_8);
+    IOUtils.write(asString(), out, StandardCharsets.UTF_8);
   }
   /**
    * Convert to a string

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/ApplicationCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/ApplicationCLI.java
@@ -22,7 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.util.*;
 
@@ -357,7 +357,7 @@ public class ApplicationCLI extends YarnCLI {
     // Use PrintWriter.println, which uses correct platform line ending.
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     PrintWriter appAttemptReportStr = new PrintWriter(
-        new OutputStreamWriter(baos, Charset.forName("UTF-8")));
+        new OutputStreamWriter(baos, StandardCharsets.UTF_8));
     if (appAttemptReport != null) {
       appAttemptReportStr.println("Application Attempt Report : ");
       appAttemptReportStr.print("\tApplicationAttempt-Id : ");
@@ -381,11 +381,11 @@ public class ApplicationCLI extends YarnCLI {
       appAttemptReportStr.print("Application Attempt with id '"
           + applicationAttemptId + "' doesn't exist in Timeline Server.");
       appAttemptReportStr.close();
-      sysout.println(baos.toString("UTF-8"));
+      sysout.println(new String(baos.toByteArray(), StandardCharsets.UTF_8));
       return -1;
     }
     appAttemptReportStr.close();
-    sysout.println(baos.toString("UTF-8"));
+    sysout.println(new String(baos.toByteArray(), StandardCharsets.UTF_8));
     return 0;
   }
 
@@ -417,7 +417,7 @@ public class ApplicationCLI extends YarnCLI {
     // Use PrintWriter.println, which uses correct platform line ending.
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     PrintWriter containerReportStr = new PrintWriter(
-        new OutputStreamWriter(baos, Charset.forName("UTF-8")));
+        new OutputStreamWriter(baos, StandardCharsets.UTF_8));
     if (containerReport != null) {
       containerReportStr.println("Container Report : ");
       containerReportStr.print("\tContainer-Id : ");
@@ -446,11 +446,11 @@ public class ApplicationCLI extends YarnCLI {
       containerReportStr.print("Container with id '" + containerId
           + "' doesn't exist in Timeline Server.");
       containerReportStr.close();
-      sysout.println(baos.toString("UTF-8"));
+      sysout.println(new String(baos.toByteArray(), StandardCharsets.UTF_8));
       return -1;
     }
     containerReportStr.close();
-    sysout.println(baos.toString("UTF-8"));
+    sysout.println(new String(baos.toByteArray(), StandardCharsets.UTF_8));
     return 0;
   }
 
@@ -468,7 +468,7 @@ public class ApplicationCLI extends YarnCLI {
       EnumSet<YarnApplicationState> appStates, Set<String> appTags)
       throws YarnException, IOException {
     PrintWriter writer = new PrintWriter(
-        new OutputStreamWriter(sysout, Charset.forName("UTF-8")));
+        new OutputStreamWriter(sysout, StandardCharsets.UTF_8));
     if (allAppStates) {
       for (YarnApplicationState appState : YarnApplicationState.values()) {
         appStates.add(appState);
@@ -610,7 +610,7 @@ public class ApplicationCLI extends YarnCLI {
     // Use PrintWriter.println, which uses correct platform line ending.
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     PrintWriter appReportStr = new PrintWriter(
-        new OutputStreamWriter(baos, Charset.forName("UTF-8")));
+        new OutputStreamWriter(baos, StandardCharsets.UTF_8));
     if (appReport != null) {
       appReportStr.println("Application Report : ");
       appReportStr.print("\tApplication-Id : ");
@@ -673,11 +673,11 @@ public class ApplicationCLI extends YarnCLI {
       appReportStr.print("Application with id '" + applicationId
           + "' doesn't exist in RM.");
       appReportStr.close();
-      sysout.println(baos.toString("UTF-8"));
+      sysout.println(new String(baos.toByteArray(), StandardCharsets.UTF_8));
       return -1;
     }
     appReportStr.close();
-    sysout.println(baos.toString("UTF-8"));
+    sysout.println(new String(baos.toByteArray(), StandardCharsets.UTF_8));
     return 0;
   }
 
@@ -718,7 +718,7 @@ public class ApplicationCLI extends YarnCLI {
   private void listApplicationAttempts(String applicationId) throws YarnException,
       IOException {
     PrintWriter writer = new PrintWriter(
-        new OutputStreamWriter(sysout, Charset.forName("UTF-8")));
+        new OutputStreamWriter(sysout, StandardCharsets.UTF_8));
 
     List<ApplicationAttemptReport> appAttemptsReport = client
         .getApplicationAttempts(ApplicationId.fromString(applicationId));
@@ -746,7 +746,7 @@ public class ApplicationCLI extends YarnCLI {
   private void listContainers(String appAttemptId) throws YarnException,
       IOException {
     PrintWriter writer = new PrintWriter(
-        new OutputStreamWriter(sysout, Charset.forName("UTF-8")));
+        new OutputStreamWriter(sysout, StandardCharsets.UTF_8));
 
     List<ContainerReport> appsReport = client.getContainers(
         ApplicationAttemptId.fromString(appAttemptId));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/ClusterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/ClusterCLI.java
@@ -24,6 +24,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -123,12 +124,12 @@ public class ClusterCLI extends YarnCLI {
   private void printClusterNodeAttributes() throws IOException, YarnException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     PrintWriter pw = new PrintWriter(
-        new OutputStreamWriter(baos, Charset.forName("UTF-8")));
+        new OutputStreamWriter(baos, StandardCharsets.UTF_8));
     for (NodeAttributeInfo attribute : client.getClusterAttributes()) {
       pw.println(attribute.toString());
     }
     pw.close();
-    sysout.println(baos.toString("UTF-8"));
+    sysout.println(new String(baos.toByteArray(), StandardCharsets.UTF_8));
   }
 
   void printClusterNodeLabels() throws YarnException, IOException {
@@ -158,11 +159,11 @@ public class ClusterCLI extends YarnCLI {
   void printUsage(Options opts) throws UnsupportedEncodingException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     PrintWriter pw =
-        new PrintWriter(new OutputStreamWriter(baos, Charset.forName("UTF-8")));
+        new PrintWriter(new OutputStreamWriter(baos, StandardCharsets.UTF_8));
     new HelpFormatter().printHelp(pw, HelpFormatter.DEFAULT_WIDTH, TITLE, null,
         opts, HelpFormatter.DEFAULT_LEFT_PAD, HelpFormatter.DEFAULT_DESC_PAD,
         null);
     pw.close();
-    sysout.println(baos.toString("UTF-8"));
+    sysout.println(new String(baos.toByteArray(), StandardCharsets.UTF_8));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/ClusterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/ClusterCLI.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/NodeAttributesCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/NodeAttributesCLI.java
@@ -58,7 +58,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -141,10 +141,10 @@ public class NodeAttributesCLI extends Configured implements Tool {
       throws UnsupportedEncodingException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     PrintWriter pw =
-        new PrintWriter(new OutputStreamWriter(baos, Charset.forName("UTF-8")));
+        new PrintWriter(new OutputStreamWriter(baos, StandardCharsets.UTF_8));
     pw.write(usageBuilder.toString());
     pw.close();
-    errOut.println(baos.toString("UTF-8"));
+    errOut.println(new String(baos.toByteArray(), StandardCharsets.UTF_8));
   }
 
   private Options buildOptions(CommandHandler... handlers) {
@@ -380,7 +380,7 @@ public class NodeAttributesCLI extends Configured implements Tool {
           protocol.getAttributesToNodes(request);
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       PrintWriter writer = new PrintWriter(
-          new OutputStreamWriter(baos, Charset.forName("UTF-8")));
+          new OutputStreamWriter(baos, StandardCharsets.UTF_8));
       writer.format(HOSTNAMEVAL, "Hostname", "Attribute-value");
       response.getAttributesToNodes().forEach((attributeKey, v) -> {
         writer.println(getKeyString(attributeKey) + " :");
@@ -389,7 +389,7 @@ public class NodeAttributesCLI extends Configured implements Tool {
                 attrVal.getAttributeValue()));
       });
       writer.close();
-      sysOut.println(baos.toString("UTF-8"));
+      sysOut.println(new String(baos.toByteArray(), StandardCharsets.UTF_8));
       return 0;
     }
 
@@ -405,7 +405,7 @@ public class NodeAttributesCLI extends Configured implements Tool {
           response.getNodeToAttributes();
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       PrintWriter writer = new PrintWriter(
-          new OutputStreamWriter(baos, Charset.forName("UTF-8")));
+          new OutputStreamWriter(baos, StandardCharsets.UTF_8));
       writer.printf(NODEATTRIBUTE, "Attribute", "Type", "Value");
       nodeToAttrs.forEach((node, v) -> {
         // print node header
@@ -415,7 +415,7 @@ public class NodeAttributesCLI extends Configured implements Tool {
                 attr.getAttributeType().name(), attr.getAttributeValue()));
       });
       writer.close();
-      sysOut.println(baos.toString("UTF-8"));
+      sysOut.println(new String(baos.toByteArray(), StandardCharsets.UTF_8));
       return 0;
     }
 
@@ -427,14 +427,14 @@ public class NodeAttributesCLI extends Configured implements Tool {
           protocol.getClusterNodeAttributes(request);
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       PrintWriter writer = new PrintWriter(
-          new OutputStreamWriter(baos, Charset.forName("UTF-8")));
+          new OutputStreamWriter(baos, StandardCharsets.UTF_8));
       writer.format(NODEATTRIBUTEINFO, "Attribute", "Type");
       for (NodeAttributeInfo attr : response.getNodeAttributes()) {
         writer.format(NODEATTRIBUTEINFO, getKeyString(attr.getAttributeKey()),
             attr.getAttributeType().name());
       }
       writer.close();
-      sysOut.println(baos.toString("UTF-8"));
+      sysOut.println(new String(baos.toByteArray(), StandardCharsets.UTF_8));
       return 0;
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/NodeCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/NodeCLI.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -177,7 +178,7 @@ public class NodeCLI extends YarnCLI {
   private void listClusterNodes(Set<NodeState> nodeStates) 
             throws YarnException, IOException {
     PrintWriter writer = new PrintWriter(
-        new OutputStreamWriter(sysout, Charset.forName("UTF-8")));
+        new OutputStreamWriter(sysout, StandardCharsets.UTF_8));
     List<NodeReport> nodesReport = client.getNodeReports(
                                        nodeStates.toArray(new NodeState[0]));
     writer.println("Total Nodes:" + nodesReport.size());
@@ -202,7 +203,7 @@ public class NodeCLI extends YarnCLI {
   private void listDetailedClusterNodes(Set<NodeState> nodeStates)
       throws YarnException, IOException {
     PrintWriter writer = new PrintWriter(new OutputStreamWriter(sysout,
-        Charset.forName("UTF-8")));
+        StandardCharsets.UTF_8));
     List<NodeReport> nodesReport = client.getNodeReports(nodeStates
         .toArray(new NodeState[0]));
     writer.println("Total Nodes:" + nodesReport.size());
@@ -265,7 +266,7 @@ public class NodeCLI extends YarnCLI {
     // Use PrintWriter.println, which uses correct platform line ending.
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     PrintWriter nodeReportStr = new PrintWriter(
-        new OutputStreamWriter(baos, Charset.forName("UTF-8")));
+        new OutputStreamWriter(baos, StandardCharsets.UTF_8));
     NodeReport nodeReport = null;
     for (NodeReport report : nodesReport) {
       if (!report.getNodeId().equals(nodeId)) {
@@ -347,7 +348,7 @@ public class NodeCLI extends YarnCLI {
           + nodeIdStr);
     }
     nodeReportStr.close();
-    sysout.println(baos.toString("UTF-8"));
+    sysout.println(new String(baos.toByteArray(), StandardCharsets.UTF_8));
   }
 
   private String getAllValidNodeStates() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/NodeCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/NodeCLI.java
@@ -21,7 +21,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/QueueCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/QueueCLI.java
@@ -123,7 +123,7 @@ public class QueueCLI extends YarnCLI {
   private int listQueue(String queueName) throws YarnException, IOException {
     int rc;
     PrintWriter writer = new PrintWriter(
-        new OutputStreamWriter(sysout, Charset.forName("UTF-8")));
+        new OutputStreamWriter(sysout, StandardCharsets.UTF_8));
 
     QueueInfo queueInfo = client.getQueueInfo(queueName);
     if (queueInfo != null) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestSharedCacheClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestSharedCacheClientImpl.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import java.io.DataOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -173,7 +174,7 @@ public class TestSharedCacheClientImpl {
     DataOutputStream out = null;
     try {
       out = localFs.create(file);
-      out.write(input.getBytes("UTF-8"));
+      out.write(input.getBytes(StandardCharsets.UTF_8));
     } finally {
       if(out != null) {
         out.close();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestNodeAttributesCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestNodeAttributesCLI.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -60,7 +61,6 @@ import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 
 /**
@@ -528,8 +528,8 @@ public class TestNodeAttributesCLI {
     sysOutBytes.reset();
     LOG.info("Running: NodeAttributesCLI " + Joiner.on(" ").join(args));
     int ret = nodeAttributesCLI.run(args);
-    errOutput = new String(errOutBytes.toByteArray(), Charsets.UTF_8);
-    sysOutput = new String(sysOutBytes.toByteArray(), Charsets.UTF_8);
+    errOutput = new String(errOutBytes.toByteArray(), StandardCharsets.UTF_8);
+    sysOutput = new String(sysOutBytes.toByteArray(), StandardCharsets.UTF_8);
     LOG.info("Err_output:\n" + errOutput);
     LOG.info("Sys_output:\n" + sysOutput);
     return ret;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestRMAdminCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestRMAdminCLI.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -85,7 +86,6 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableSet;
 
 public class TestRMAdminCLI {
@@ -1061,7 +1061,7 @@ public class TestRMAdminCLI {
     try {
       String[] args = {"-transitionToActive"};
       assertEquals(-1, rmAdminCLIWithHAEnabled.run(args));
-      String errOut = new String(errOutBytes.toByteArray(), Charsets.UTF_8);
+      String errOut = new String(errOutBytes.toByteArray(), StandardCharsets.UTF_8);
       errOutBytes.reset();
       assertTrue(errOut.contains("Usage: rmadmin"));
     } finally {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/AggregatedLogFormat.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/AggregatedLogFormat.java
@@ -31,7 +31,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.Writer;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
@@ -288,7 +287,7 @@ public class AggregatedLogFormat {
           this.uploadedFiles.add(logFile);
         } catch (IOException e) {
           String message = logErrorMessage(logFile, e);
-          out.write(message.getBytes(Charset.forName("UTF-8")));
+          out.write(message.getBytes(StandardCharsets.UTF_8));
         } finally {
           IOUtils.cleanupWithLogger(LOG, in);
         }
@@ -1067,7 +1066,7 @@ public class AggregatedLogFormat {
             new BoundedInputStream(valueStream, currentLogLength);
         currentLogData.setPropagateClose(false);
         currentLogISR = new InputStreamReader(currentLogData,
-            Charset.forName("UTF-8"));
+            StandardCharsets.UTF_8);
         currentLogType = logType;
       } catch (EOFException e) {
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/LogToolUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/LogToolUtils.java
@@ -25,7 +25,7 @@ import java.io.PrintStream;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.WritableByteChannel;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -68,7 +68,7 @@ public final class LogToolUtils {
         .append("LogLastModifiedTime:" + lastModifiedTime + "\n")
         .append("LogLength:" + fileLength + "\n")
         .append("LogContents:\n");
-    return sb.toString().getBytes(Charset.forName("UTF-8"));
+    return sb.toString().getBytes(StandardCharsets.UTF_8);
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/LogAggregationHtmlBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/LogAggregationHtmlBlock.java
@@ -27,7 +27,7 @@ import com.google.inject.Inject;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
@@ -196,7 +196,7 @@ public abstract class LogAggregationHtmlBlock extends HtmlBlock {
     Hamlet.PRE<Hamlet> pre = html.pre();
 
     while (toRead > 0 && (len = in.read(cbuf, 0, currentToRead)) > 0) {
-      pre.__(new String(cbuf, 0, len, Charset.forName("UTF-8")));
+      pre.__(new String(cbuf, 0, len, StandardCharsets.UTF_8));
       toRead = toRead - len;
       currentToRead = toRead > bufferSize ? bufferSize : (int) toRead;
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
@@ -220,7 +220,7 @@ public class LogAggregationIndexedFileController
             // append a simple character("\n") to move the writer cursor, so
             // we could get the correct position when we call
             // fsOutputStream.getStartPos()
-            final byte[] dummyBytes = "\n".getBytes(Charset.forName("UTF-8"));
+            final byte[] dummyBytes = "\n".getBytes(StandardCharsets.UTF_8);
             fsDataOStream.write(dummyBytes);
             fsDataOStream.flush();
 
@@ -286,7 +286,7 @@ public class LogAggregationIndexedFileController
           int actualLength = b.length;
           if (actualLength == nameLength) {
             String recoveredLogFile = new String(
-                b, Charset.forName("UTF-8"));
+                b, StandardCharsets.UTF_8);
             if (recoveredLogFile.equals(
                 currentRemoteLogFile.getName())) {
               overwriteCheckSum = false;
@@ -340,7 +340,7 @@ public class LogAggregationIndexedFileController
         String fileName = aggregatedLogFile.getName();
         checksumFileOutputStream.writeInt(fileName.length());
         checksumFileOutputStream.write(fileName.getBytes(
-            Charset.forName("UTF-8")));
+            StandardCharsets.UTF_8));
         checksumFileOutputStream.writeLong(
             currentAggregatedLogFileLength);
         checksumFileOutputStream.flush();
@@ -403,7 +403,7 @@ public class LogAggregationIndexedFileController
         if (outputStreamState != null &&
             outputStreamState.getOutputStream() != null) {
           outputStreamState.getOutputStream().write(
-              message.getBytes(Charset.forName("UTF-8")));
+              message.getBytes(StandardCharsets.UTF_8));
         }
       } finally {
         IOUtils.cleanupWithLogger(LOG, in);
@@ -598,7 +598,7 @@ public class LogAggregationIndexedFileController
               Times.format(candidate.getLastModifiedTime()),
               in, os, buf, ContainerLogAggregationType.AGGREGATED);
           byte[] b = aggregatedLogSuffix(candidate.getFileName())
-              .getBytes(Charset.forName("UTF-8"));
+              .getBytes(StandardCharsets.UTF_8);
           os.write(b, 0, b.length);
           findLogs = true;
         } catch (IOException e) {
@@ -769,7 +769,7 @@ public class LogAggregationIndexedFileController
         checksumFileInputStream.readFully(b);
         int actualLength = b.length;
         if (actualLength == nameLength) {
-          nodeName = new String(b, Charset.forName("UTF-8"));
+          nodeName = new String(b, StandardCharsets.UTF_8);
           index = checksumFileInputStream.readLong();
         } else {
           continue;
@@ -950,9 +950,9 @@ public class LogAggregationIndexedFileController
         if (LOG.isDebugEnabled()) {
           LOG.debug("the length of loaded UUID:{}", uuidReadLen);
           LOG.debug("the loaded UUID:{}", new String(uuidRead,
-              Charset.forName("UTF-8")));
+              StandardCharsets.UTF_8));
           LOG.debug("the expected UUID:{}", new String(this.uuid,
-              Charset.forName("UTF-8")));
+              StandardCharsets.UTF_8));
         }
         throw new IOException("The UUID from "
             + remoteLogPath + " is not correct. The offset of loaded UUID is "
@@ -1359,7 +1359,7 @@ public class LogAggregationIndexedFileController
     try {
       MessageDigest digest = MessageDigest.getInstance("SHA-256");
       return digest.digest(appId.toString().getBytes(
-          Charset.forName("UTF-8")));
+          StandardCharsets.UTF_8));
     } catch (NoSuchAlgorithmException ex) {
       throw new IOException(ex);
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/tfile/LogAggregationTFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/tfile/LogAggregationTFileController.java
@@ -22,7 +22,7 @@ import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -217,7 +217,7 @@ public class LogAggregationTFileController
                           valueStream, os, buf,
                           ContainerLogAggregationType.AGGREGATED);
                       byte[] b = aggregatedLogSuffix(fileType).getBytes(
-                          Charset.forName("UTF-8"));
+                          StandardCharsets.UTF_8);
                       os.write(b, 0, b.length);
                       findLogs = true;
                     } else {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/state/Graph.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/state/Graph.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.yarn.state;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -190,7 +190,7 @@ public class Graph {
 
   public void save(String filepath) throws IOException {
     try (OutputStreamWriter fout = new OutputStreamWriter(
-        new FileOutputStream(filepath), Charset.forName("UTF-8"))) {
+        new FileOutputStream(filepath), StandardCharsets.UTF_8)) {
       fout.write(generateGraphViz());
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/DockerClientConfigHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/DockerClientConfigHandler.java
@@ -39,7 +39,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 
@@ -115,7 +114,7 @@ public final class DockerClientConfigHandler {
             new DockerCredentialTokenIdentifier(registryUrl, applicationId);
         Token<DockerCredentialTokenIdentifier> token =
             new Token<>(tokenId.getBytes(),
-                registryCred.getBytes(Charset.forName("UTF-8")),
+                registryCred.getBytes(StandardCharsets.UTF_8),
                 tokenId.getKind(), new Text(registryUrl));
         credentials.addToken(
             new Text(registryUrl + "-" + applicationId), token);
@@ -173,7 +172,7 @@ public final class DockerClientConfigHandler {
           ObjectNode registryCredNode = mapper.createObjectNode();
           registryUrlNode.set(ti.getRegistryUrl(), registryCredNode);
           registryCredNode.put(CONFIG_AUTH_KEY,
-              new String(tk.getPassword(), Charset.forName("UTF-8")));
+              new String(tk.getPassword(), StandardCharsets.UTF_8));
           LOG.debug("Prepared token for write: {}", tk);
         }
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ProcfsBasedProcessTree.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ProcfsBasedProcessTree.java
@@ -26,7 +26,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -519,7 +519,7 @@ public class ProcfsBasedProcessTree extends ResourceCalculatorProcessTree {
       File pidDir = new File(procfsDir, pinfo.getPid());
       fReader = new InputStreamReader(
           new FileInputStream(
-              new File(pidDir, PROCFS_STAT_FILE)), Charset.forName("UTF-8"));
+              new File(pidDir, PROCFS_STAT_FILE)), StandardCharsets.UTF_8);
       in = new BufferedReader(fReader);
     } catch (FileNotFoundException f) {
       // The process vanished in the interim!
@@ -715,7 +715,7 @@ public class ProcfsBasedProcessTree extends ResourceCalculatorProcessTree {
         fReader = new InputStreamReader(
             new FileInputStream(
                 new File(new File(procfsDir, pid.toString()), PROCFS_CMDLINE_FILE)),
-                Charset.forName("UTF-8"));
+                StandardCharsets.UTF_8);
       } catch (FileNotFoundException f) {
         // The process vanished in the interim!
         return ret;
@@ -773,7 +773,7 @@ public class ProcfsBasedProcessTree extends ResourceCalculatorProcessTree {
         return;
       }
       fReader = new InputStreamReader(
-          new FileInputStream(file), Charset.forName("UTF-8"));
+          new FileInputStream(file), StandardCharsets.UTF_8);
       in = new BufferedReader(fReader);
       ProcessSmapMemoryInfo memoryMappingInfo = null;
       List<String> lines = IOUtils.readLines(in);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/TestLogAggregationIndexedFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/TestLogAggregationIndexedFileController.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.Writer;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -267,7 +267,7 @@ public class TestLogAggregationIndexedFileController
       fInput = FileSystem.create(fs, checksumFile, LOG_FILE_UMASK);
       fInput.writeInt(nodeName.length());
       fInput.write(nodeName.getBytes(
-          Charset.forName("UTF-8")));
+          StandardCharsets.UTF_8));
       fInput.writeLong(0);
     } finally {
       IOUtils.closeStream(fInput);
@@ -579,7 +579,7 @@ public class TestLogAggregationIndexedFileController
       fInput = FileSystem.create(fs, checksumFile, LOG_FILE_UMASK);
       fInput.writeInt(nodeName.length());
       fInput.write(nodeName.getBytes(
-          Charset.forName("UTF-8")));
+          StandardCharsets.UTF_8));
       fInput.writeLong(0);
     } finally {
       IOUtils.closeStream(fInput);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/main/java/org/apache/hadoop/yarn/server/timeline/LeveldbTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/main/java/org/apache/hadoop/yarn/server/timeline/LeveldbTimelineStore.java
@@ -48,7 +48,7 @@ import org.iq80.leveldb.*;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.locks.ReentrantLock;
@@ -127,25 +127,25 @@ public class LeveldbTimelineStore extends AbstractService
   //call LevelDb recovery
   static final String BACKUP_EXT = ".backup-";
 
-  private static final byte[] START_TIME_LOOKUP_PREFIX = "k".getBytes(Charset.forName("UTF-8"));
-  private static final byte[] ENTITY_ENTRY_PREFIX = "e".getBytes(Charset.forName("UTF-8"));
-  private static final byte[] INDEXED_ENTRY_PREFIX = "i".getBytes(Charset.forName("UTF-8"));
+  private static final byte[] START_TIME_LOOKUP_PREFIX = "k".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] ENTITY_ENTRY_PREFIX = "e".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] INDEXED_ENTRY_PREFIX = "i".getBytes(StandardCharsets.UTF_8);
 
-  private static final byte[] EVENTS_COLUMN = "e".getBytes(Charset.forName("UTF-8"));
-  private static final byte[] PRIMARY_FILTERS_COLUMN = "f".getBytes(Charset.forName("UTF-8"));
-  private static final byte[] OTHER_INFO_COLUMN = "i".getBytes(Charset.forName("UTF-8"));
-  private static final byte[] RELATED_ENTITIES_COLUMN = "r".getBytes(Charset.forName("UTF-8"));
+  private static final byte[] EVENTS_COLUMN = "e".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] PRIMARY_FILTERS_COLUMN = "f".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] OTHER_INFO_COLUMN = "i".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] RELATED_ENTITIES_COLUMN = "r".getBytes(StandardCharsets.UTF_8);
   private static final byte[] INVISIBLE_REVERSE_RELATED_ENTITIES_COLUMN =
-      "z".getBytes(Charset.forName("UTF-8"));
-  private static final byte[] DOMAIN_ID_COLUMN = "d".getBytes(Charset.forName("UTF-8"));
+      "z".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] DOMAIN_ID_COLUMN = "d".getBytes(StandardCharsets.UTF_8);
 
-  private static final byte[] DOMAIN_ENTRY_PREFIX = "d".getBytes(Charset.forName("UTF-8"));
-  private static final byte[] OWNER_LOOKUP_PREFIX = "o".getBytes(Charset.forName("UTF-8"));
-  private static final byte[] DESCRIPTION_COLUMN = "d".getBytes(Charset.forName("UTF-8"));
-  private static final byte[] OWNER_COLUMN = "o".getBytes(Charset.forName("UTF-8"));
-  private static final byte[] READER_COLUMN = "r".getBytes(Charset.forName("UTF-8"));
-  private static final byte[] WRITER_COLUMN = "w".getBytes(Charset.forName("UTF-8"));
-  private static final byte[] TIMESTAMP_COLUMN = "t".getBytes(Charset.forName("UTF-8"));
+  private static final byte[] DOMAIN_ENTRY_PREFIX = "d".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] OWNER_LOOKUP_PREFIX = "o".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] DESCRIPTION_COLUMN = "d".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] OWNER_COLUMN = "o".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] READER_COLUMN = "r".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] WRITER_COLUMN = "w".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] TIMESTAMP_COLUMN = "t".getBytes(StandardCharsets.UTF_8);
 
   private static final byte[] EMPTY_BYTES = new byte[0];
   
@@ -456,7 +456,7 @@ public class LeveldbTimelineStore extends AbstractService
         }
       } else if (key[prefixlen] == DOMAIN_ID_COLUMN[0]) {
         byte[] v = iterator.peekNext().getValue();
-        String domainId = new String(v, Charset.forName("UTF-8"));
+        String domainId = new String(v, StandardCharsets.UTF_8);
         entity.setDomainId(domainId);
       } else {
         if (key[prefixlen] !=
@@ -839,7 +839,7 @@ public class LeveldbTimelineStore extends AbstractService
               if (domainIdBytes == null) {
                 domainId = TimelineDataManager.DEFAULT_DOMAIN_ID;
               } else {
-                domainId = new String(domainIdBytes, Charset.forName("UTF-8"));
+                domainId = new String(domainIdBytes, StandardCharsets.UTF_8);
               }
               if (!domainId.equals(entity.getDomainId())) {
                 // in this case the entity will be put, but the relation will be
@@ -894,9 +894,9 @@ public class LeveldbTimelineStore extends AbstractService
           return;
         }
       } else {
-        writeBatch.put(key, entity.getDomainId().getBytes(Charset.forName("UTF-8")));
+        writeBatch.put(key, entity.getDomainId().getBytes(StandardCharsets.UTF_8));
         writePrimaryFilterEntries(writeBatch, primaryFilters, key,
-            entity.getDomainId().getBytes(Charset.forName("UTF-8")));
+            entity.getDomainId().getBytes(StandardCharsets.UTF_8));
       }
       db.write(writeBatch);
     } catch (DBException de) {
@@ -928,7 +928,7 @@ public class LeveldbTimelineStore extends AbstractService
           // This is the new entity, the domain should be the same
         byte[] key = createDomainIdKey(relatedEntity.getId(),
             relatedEntity.getType(), relatedEntityStartTime);
-        db.put(key, entity.getDomainId().getBytes(Charset.forName("UTF-8")));
+        db.put(key, entity.getDomainId().getBytes(StandardCharsets.UTF_8));
         db.put(createRelatedEntityKey(relatedEntity.getId(),
             relatedEntity.getType(), relatedEntityStartTime,
             entity.getEntityId(), entity.getEntityType()), EMPTY_BYTES);
@@ -1255,7 +1255,7 @@ public class LeveldbTimelineStore extends AbstractService
    * to the end of the array (for parsing other info keys).
    */
   private static String parseRemainingKey(byte[] b, int offset) {
-    return new String(b, offset, b.length - offset, Charset.forName("UTF-8"));
+    return new String(b, offset, b.length - offset, StandardCharsets.UTF_8);
   }
 
   /**
@@ -1629,9 +1629,9 @@ public class LeveldbTimelineStore extends AbstractService
           domain.getOwner(), domain.getId(), DESCRIPTION_COLUMN);
       if (domain.getDescription() != null) {
         writeBatch.put(domainEntryKey, domain.getDescription().
-                       getBytes(Charset.forName("UTF-8")));
+                       getBytes(StandardCharsets.UTF_8));
         writeBatch.put(ownerLookupEntryKey, domain.getDescription().
-                       getBytes(Charset.forName("UTF-8")));
+                       getBytes(StandardCharsets.UTF_8));
       } else {
         writeBatch.put(domainEntryKey, EMPTY_BYTES);
         writeBatch.put(ownerLookupEntryKey, EMPTY_BYTES);
@@ -1642,17 +1642,17 @@ public class LeveldbTimelineStore extends AbstractService
       ownerLookupEntryKey = createOwnerLookupKey(
           domain.getOwner(), domain.getId(), OWNER_COLUMN);
       // Null check for owner is done before
-      writeBatch.put(domainEntryKey, domain.getOwner().getBytes(Charset.forName("UTF-8")));
-      writeBatch.put(ownerLookupEntryKey, domain.getOwner().getBytes(Charset.forName("UTF-8")));
+      writeBatch.put(domainEntryKey, domain.getOwner().getBytes(StandardCharsets.UTF_8));
+      writeBatch.put(ownerLookupEntryKey, domain.getOwner().getBytes(StandardCharsets.UTF_8));
 
       // Write readers
       domainEntryKey = createDomainEntryKey(domain.getId(), READER_COLUMN);
       ownerLookupEntryKey = createOwnerLookupKey(
           domain.getOwner(), domain.getId(), READER_COLUMN);
       if (domain.getReaders() != null && domain.getReaders().length() > 0) {
-        writeBatch.put(domainEntryKey, domain.getReaders().getBytes(Charset.forName("UTF-8")));
+        writeBatch.put(domainEntryKey, domain.getReaders().getBytes(StandardCharsets.UTF_8));
         writeBatch.put(ownerLookupEntryKey, domain.getReaders().
-                       getBytes(Charset.forName("UTF-8")));
+                       getBytes(StandardCharsets.UTF_8));
       } else {
         writeBatch.put(domainEntryKey, EMPTY_BYTES);
         writeBatch.put(ownerLookupEntryKey, EMPTY_BYTES);
@@ -1663,9 +1663,9 @@ public class LeveldbTimelineStore extends AbstractService
       ownerLookupEntryKey = createOwnerLookupKey(
           domain.getOwner(), domain.getId(), WRITER_COLUMN);
       if (domain.getWriters() != null && domain.getWriters().length() > 0) {
-        writeBatch.put(domainEntryKey, domain.getWriters().getBytes(Charset.forName("UTF-8")));
+        writeBatch.put(domainEntryKey, domain.getWriters().getBytes(StandardCharsets.UTF_8));
         writeBatch.put(ownerLookupEntryKey, domain.getWriters().
-                       getBytes(Charset.forName("UTF-8")));
+                       getBytes(StandardCharsets.UTF_8));
       } else {
         writeBatch.put(domainEntryKey, EMPTY_BYTES);
         writeBatch.put(ownerLookupEntryKey, EMPTY_BYTES);
@@ -1802,13 +1802,13 @@ public class LeveldbTimelineStore extends AbstractService
       byte[] value = iterator.peekNext().getValue();
       if (value != null && value.length > 0) {
         if (key[prefix.length] == DESCRIPTION_COLUMN[0]) {
-          domain.setDescription(new String(value, Charset.forName("UTF-8")));
+          domain.setDescription(new String(value, StandardCharsets.UTF_8));
         } else if (key[prefix.length] == OWNER_COLUMN[0]) {
-          domain.setOwner(new String(value, Charset.forName("UTF-8")));
+          domain.setOwner(new String(value, StandardCharsets.UTF_8));
         } else if (key[prefix.length] == READER_COLUMN[0]) {
-          domain.setReaders(new String(value, Charset.forName("UTF-8")));
+          domain.setReaders(new String(value, StandardCharsets.UTF_8));
         } else if (key[prefix.length] == WRITER_COLUMN[0]) {
-          domain.setWriters(new String(value, Charset.forName("UTF-8")));
+          domain.setWriters(new String(value, StandardCharsets.UTF_8));
         } else if (key[prefix.length] == TIMESTAMP_COLUMN[0]) {
           domain.setCreatedTime(readReverseOrderedLong(value, 0));
           domain.setModifiedTime(readReverseOrderedLong(value, 8));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/lib/ZKClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/lib/ZKClient.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.yarn.lib;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.zookeeper.CreateMode;
@@ -57,7 +57,7 @@ public class ZKClient {
   public void registerService(String path, String data) throws
     IOException, InterruptedException {
     try {
-      zkClient.create(path, data.getBytes(Charset.forName("UTF-8")),
+      zkClient.create(path, data.getBytes(StandardCharsets.UTF_8),
           ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
     } catch(KeeperException ke) {
       throw new IOException(ke);
@@ -114,7 +114,7 @@ public class ZKClient {
     try {
       Stat stat = new Stat();
       byte[] byteData = zkClient.getData(path, false, stat);
-      data = new String(byteData, Charset.forName("UTF-8"));
+      data = new String(byteData, StandardCharsets.UTF_8);
     } catch(KeeperException ke) {
       throw new IOException(ke);
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/LogWebServiceUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/LogWebServiceUtils.java
@@ -46,7 +46,7 @@ import javax.ws.rs.core.StreamingOutput;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -120,7 +120,7 @@ public final class LogWebServiceUtils {
             .readAggregatedLogs(request, os);
         if (!findLogs) {
           os.write(("Can not find logs for container:" + containerIdStr)
-              .getBytes(Charset.forName("UTF-8")));
+              .getBytes(StandardCharsets.UTF_8));
         } else {
           if (printEmptyLocalContainerLog) {
             StringBuilder sb = new StringBuilder();
@@ -129,7 +129,7 @@ public final class LogWebServiceUtils {
                 + "\n");
             sb.append("LogContents:\n");
             sb.append(getNoRedirectWarning() + "\n");
-            os.write(sb.toString().getBytes(Charset.forName("UTF-8")));
+            os.write(sb.toString().getBytes(StandardCharsets.UTF_8));
           }
         }
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/LinuxContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/LinuxContainerExecutor.java
@@ -50,6 +50,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -1064,7 +1065,7 @@ public class LinuxContainerExecutor extends ContainerExecutor {
     if (file.createNewFile()) {
       FileOutputStream output = new FileOutputStream(file);
       try {
-        output.write(spec.getBytes("UTF-8"));
+        output.write(spec.getBytes(StandardCharsets.UTF_8));
       } finally {
         output.close();
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/WindowsSecureContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/WindowsSecureContainerExecutor.java
@@ -29,7 +29,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -502,7 +502,7 @@ public class WindowsSecureContainerExecutor extends DefaultContainerExecutor {
         @Override
         public void run() {
           try (BufferedReader lines = new BufferedReader(
-                   new InputStreamReader(stream, Charset.forName("UTF-8")))) {
+                   new InputStreamReader(stream, StandardCharsets.UTF_8))) {
             char[] buf = new char[512];
             int nRead;
             while ((nRead = lines.read(buf, 0, buf.length)) > 0) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsResourceCalculator.java
@@ -35,7 +35,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -316,7 +316,7 @@ public class CGroupsResourceCalculator extends ResourceCalculatorProcessTree {
       throws YarnException {
     // Read "procfsDir/<pid>/stat" file - typically /proc/<pid>/stat
     try (InputStreamReader fReader = new InputStreamReader(
-        new FileInputStream(file), Charset.forName("UTF-8"))) {
+        new FileInputStream(file), StandardCharsets.UTF_8)) {
       try (BufferedReader in = new BufferedReader(fReader)) {
         try {
           String str;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/ContainerLogsPage.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/ContainerLogsPage.java
@@ -28,7 +28,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -214,7 +214,7 @@ public class ContainerLogsPage extends NMView {
           
           IOUtils.skipFully(logByteStream, start);
           InputStreamReader reader =
-              new InputStreamReader(logByteStream, Charset.forName("UTF-8"));
+              new InputStreamReader(logByteStream, StandardCharsets.UTF_8);
           int bufferSize = 65536;
           char[] cbuf = new char[bufferSize];
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/ContainerShellWebSocket.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/ContainerShellWebSocket.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.yarn.server.nodemanager.webapp;
 
 import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -77,7 +77,7 @@ public class ContainerShellWebSocket {
         if (!message.equals("1{}")) {
           // Send keystroke to process input
           byte[] payload;
-          payload = message.getBytes(Charset.forName("UTF-8"));
+          payload = message.getBytes(StandardCharsets.UTF_8);
           if (payload != null) {
             pair.out.write(payload);
             pair.out.flush();
@@ -86,7 +86,7 @@ public class ContainerShellWebSocket {
         // Render process output
         int no = pair.in.available();
         pair.in.read(buffer, 0, Math.min(no, buffer.length));
-        String formatted = new String(buffer, Charset.forName("UTF-8"))
+        String formatted = new String(buffer, StandardCharsets.UTF_8)
             .replaceAll("\n", "\r\n");
         session.getRemote().sendString(formatted);
       }
@@ -142,7 +142,7 @@ public class ContainerShellWebSocket {
     try {
       LOG.info(session.getRemoteAddress().getHostString() + " closed!");
       String exit = "exit\r\n";
-      pair.out.write(exit.getBytes(Charset.forName("UTF-8")));
+      pair.out.write(exit.getBytes(StandardCharsets.UTF_8));
       pair.out.flush();
       pair.in.close();
       pair.out.close();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/NMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/NMWebServices.java
@@ -21,7 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -490,7 +490,7 @@ public class NMWebServices {
             }
             sb.append(StringUtils.repeat("*", endOfFile.length() + 50)
                 + "\n\n");
-            os.write(sb.toString().getBytes(Charset.forName("UTF-8")));
+            os.write(sb.toString().getBytes(StandardCharsets.UTF_8));
             // If we have aggregated logs for this container,
             // output the aggregation logs as well.
             ApplicationId appId = containerId.getApplicationAttemptId()

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestAuxServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestAuxServices.java
@@ -47,12 +47,12 @@ import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
@@ -426,7 +426,7 @@ public class TestAuxServices {
     Assert.assertTrue(meta.size() == 1);
     for(Entry<String, ByteBuffer> i : meta.entrySet()) {
       auxName = i.getKey();
-      String auxClassPath = Charsets.UTF_8.decode(i.getValue()).toString();
+      String auxClassPath = StandardCharsets.UTF_8.decode(i.getValue()).toString();
       defaultAuxClassPath = new HashSet<String>(Arrays.asList(StringUtils
           .getTrimmedStrings(auxClassPath)));
     }
@@ -478,7 +478,7 @@ public class TestAuxServices {
       Set<String> customizedAuxClassPath = null;
       for(Entry<String, ByteBuffer> i : meta.entrySet()) {
         Assert.assertTrue(auxName.equals(i.getKey()));
-        String classPath = Charsets.UTF_8.decode(i.getValue()).toString();
+        String classPath = StandardCharsets.UTF_8.decode(i.getValue()).toString();
         customizedAuxClassPath = new HashSet<String>(Arrays.asList(StringUtils
             .getTrimmedStrings(classPath)));
         Assert.assertTrue(classPath.contains(testJar.getName()));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
@@ -218,7 +218,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
       //Capture output from prelaunch.out
 
       List<String> output = Files.readAllLines(Paths.get(localLogDir.getAbsolutePath(), ContainerLaunch.CONTAINER_PRE_LAUNCH_STDOUT),
-          Charset.forName("UTF-8"));
+          StandardCharsets.UTF_8);
       assert(output.contains("hello"));
 
       symLinkFile = new File(tmpDir, badSymlink);
@@ -549,7 +549,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
       } catch(ExitCodeException e){
         //Capture diagnostics from prelaunch.stderr
         List<String> error = Files.readAllLines(Paths.get(localLogDir.getAbsolutePath(), ContainerLaunch.CONTAINER_PRE_LAUNCH_STDERR),
-            Charset.forName("UTF-8"));
+            StandardCharsets.UTF_8);
         diagnostics = StringUtils.join("\n", error);
       }
       Assert.assertTrue(diagnostics.contains(Shell.WINDOWS ?

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestTrafficController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestTrafficController.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
@@ -120,7 +120,7 @@ public class TestTrafficController {
     Assert.assertTrue(tcCmdsFile.exists());
 
     List<String> tcCmds = Files.readAllLines(tcCmdsFile.toPath(),
-        Charset.forName("UTF-8"));
+        StandardCharsets.UTF_8);
 
     //Verify that the number of commands is the same as expected and verify
     //that each command is the same, in sequence

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDockerContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDockerContainerRuntime.java
@@ -76,7 +76,7 @@ import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
@@ -1992,7 +1992,7 @@ public class TestDockerContainerRuntime {
         PrivilegedOperation.OperationType.RUN_DOCKER_CMD);
     String dockerCommandFile = op.getArguments().get(0);
     return Files.readAllLines(Paths.get(dockerCommandFile),
-        Charset.forName("UTF-8"));
+        StandardCharsets.UTF_8);
   }
 
   private List<String> getDockerCommandsForSignal(
@@ -2471,7 +2471,7 @@ public class TestDockerContainerRuntime {
     String dockerCommandFile = args.get(argsCounter++);
 
     List<String> dockerCommands = Files
-        .readAllLines(Paths.get(dockerCommandFile), Charset.forName("UTF-8"));
+        .readAllLines(Paths.get(dockerCommandFile), StandardCharsets.UTF_8);
 
     int expected = 14;
     int counter = 0;
@@ -2617,7 +2617,7 @@ public class TestDockerContainerRuntime {
     String dockerCommandFile = args.get((https) ? 14 : 12);
 
     List<String> dockerCommands = Files.readAllLines(
-        Paths.get(dockerCommandFile), Charset.forName("UTF-8"));
+        Paths.get(dockerCommandFile), StandardCharsets.UTF_8);
     return dockerCommands;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerCommandExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerCommandExecutor.java
@@ -37,7 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -408,7 +408,7 @@ public class TestDockerCommandExecutor {
         String dockerCommandFile = op.getArguments().get(0);
         List<String> dockerCommandFileContents = Files
             .readAllLines(Paths.get(dockerCommandFile),
-                Charset.forName("UTF-8"));
+                StandardCharsets.UTF_8);
         dockerCommands.addAll(dockerCommandFileContents);
       }
       return dockerCommands;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/dao/gpu/TestGpuDeviceInformationParser.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/dao/gpu/TestGpuDeviceInformationParser.java
@@ -26,12 +26,12 @@ import org.junit.rules.ExpectedException;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class TestGpuDeviceInformationParser {
-  private static final String UTF_8 = "UTF-8";
   private static final double DELTA = 1e-6;
 
   @Rule
@@ -40,7 +40,7 @@ public class TestGpuDeviceInformationParser {
   @Test
   public void testParse() throws IOException, YarnException {
     File f = new File("src/test/resources/nvidia-smi-sample-output.xml");
-    String s = FileUtils.readFileToString(f, UTF_8);
+    String s = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
 
     GpuDeviceInformationParser parser = new GpuDeviceInformationParser();
     GpuDeviceInformation info = parser.parseXml(s);
@@ -54,7 +54,7 @@ public class TestGpuDeviceInformationParser {
   @Test
   public void testParseExcerpt() throws IOException, YarnException {
     File f = new File("src/test/resources/nvidia-smi-output-excerpt.xml");
-    String s = FileUtils.readFileToString(f, UTF_8);
+    String s = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
 
     GpuDeviceInformationParser parser = new GpuDeviceInformationParser();
     GpuDeviceInformation info = parser.parseXml(s);
@@ -69,7 +69,7 @@ public class TestGpuDeviceInformationParser {
   public void testParseConsecutivelyWithSameParser()
       throws IOException, YarnException {
     File f = new File("src/test/resources/nvidia-smi-sample-output.xml");
-    String s = FileUtils.readFileToString(f, UTF_8);
+    String s = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
 
     for (int i = 0; i < 3; i++) {
       GpuDeviceInformationParser parser = new GpuDeviceInformationParser();
@@ -99,7 +99,7 @@ public class TestGpuDeviceInformationParser {
   @Test
   public void testParseMissingTags() throws IOException, YarnException {
     File f = new File("src/test/resources/nvidia-smi-output-missing-tags.xml");
-    String s = FileUtils.readFileToString(f, UTF_8);
+    String s = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
 
     GpuDeviceInformationParser parser = new GpuDeviceInformationParser();
     GpuDeviceInformation info = parser.parseXml(s);
@@ -119,7 +119,7 @@ public class TestGpuDeviceInformationParser {
   @Test
   public void testParseMissingInnerTags() throws IOException, YarnException {
     File f =new File("src/test/resources/nvidia-smi-output-missing-tags2.xml");
-    String s = FileUtils.readFileToString(f, UTF_8);
+    String s = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
 
     GpuDeviceInformationParser parser = new GpuDeviceInformationParser();
     GpuDeviceInformation info = parser.parseXml(s);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMAuditLogger.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMAuditLogger.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.yarn.server.resourcemanager;
 
-import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -160,12 +160,8 @@ public class RMAuditLogger {
     }
     
     if (signature != null) {
-      try {
-        String sigStr = new String(signature, "UTF-8");
-        add(Keys.CALLERSIGNATURE, sigStr, sb);
-      } catch (UnsupportedEncodingException e) {
-        // ignore this signature
-      }
+      String sigStr = new String(signature, StandardCharsets.UTF_8);
+      add(Keys.CALLERSIGNATURE, sigStr, sb);
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -148,7 +148,7 @@ import java.lang.management.ThreadMXBean;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
 import java.security.SecureRandom;
 import java.util.ArrayList;
@@ -421,7 +421,7 @@ public class ResourceManager extends CompositeService
       String defaultFencingAuth =
           zkRootNodeUsername + ":" + zkRootNodePassword;
       byte[] defaultFencingAuthData =
-          defaultFencingAuth.getBytes(Charset.forName("UTF-8"));
+          defaultFencingAuth.getBytes(StandardCharsets.UTF_8);
       String scheme = new DigestAuthenticationProvider().getScheme();
       AuthInfo authInfo = new AuthInfo(scheme, defaultFencingAuthData);
       authInfos.add(authInfo);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/invariants/MetricsInvariantChecker.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/invariants/MetricsInvariantChecker.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.yarn.server.resourcemanager.monitor.invariants;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.io.Files;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.metrics2.AbstractMetric;
@@ -39,6 +38,7 @@ import javax.script.ScriptException;
 import javax.script.SimpleBindings;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -113,7 +113,7 @@ public class MetricsInvariantChecker extends InvariantsChecker {
     StringBuilder sb = new StringBuilder();
     try {
       List<String> tempInv =
-          Files.readLines(new File(invariantFile), Charsets.UTF_8);
+          Files.readLines(new File(invariantFile), StandardCharsets.UTF_8);
 
 
       boolean first = true;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAppsModification.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAppsModification.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -925,7 +926,7 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     Text key = new Text("secret1");
     assertTrue("Secrets missing from credentials object", cs
         .getAllSecretKeys().contains(key));
-    assertEquals("mysecret", new String(cs.getSecretKey(key), "UTF-8"));
+    assertEquals("mysecret", new String(cs.getSecretKey(key), StandardCharsets.UTF_8));
 
     // Check LogAggregationContext
     ApplicationSubmissionContext asc = app.getApplicationSubmissionContext();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestLogInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestLogInfo.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -199,7 +199,7 @@ public class TestLogInfo {
     try {
       String broken = "{ broken { [[]} broken";
       out = PluginStoreTestUtils.createLogFile(logPath, fs);
-      out.write(broken.getBytes(Charset.forName("UTF-8")));
+      out.write(broken.getBytes(StandardCharsets.UTF_8));
       out.close();
       out = null;
     } finally {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/DocumentStoreTestUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/DocumentStoreTestUtils.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.do
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.document.flowrun.FlowRunDocument;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -41,7 +42,7 @@ public final class DocumentStoreTestUtils {
       throws IOException {
     String jsonStr = IOUtils.toString(
         DocumentStoreTestUtils.class.getClassLoader().getResourceAsStream(
-            "documents/timeline-entities.json"), "UTF-8");
+            "documents/timeline-entities.json"), StandardCharsets.UTF_8);
     return JsonUtils.fromJson(jsonStr,
         new TypeReference<List<TimelineEntity>>(){});
   }
@@ -50,7 +51,7 @@ public final class DocumentStoreTestUtils {
       throws IOException {
     String jsonStr = IOUtils.toString(
         DocumentStoreTestUtils.class.getClassLoader().getResourceAsStream(
-            "documents/test-timeline-entities-doc.json"), "UTF-8");
+            "documents/test-timeline-entities-doc.json"), StandardCharsets.UTF_8);
     return JsonUtils.fromJson(jsonStr,
         new TypeReference<List<TimelineEntityDocument>>() {});
   }
@@ -59,7 +60,7 @@ public final class DocumentStoreTestUtils {
       throws IOException {
     String jsonStr = IOUtils.toString(
         DocumentStoreTestUtils.class.getClassLoader().getResourceAsStream(
-            "documents/timeline-app-doc.json"), "UTF-8");
+            "documents/timeline-app-doc.json"), StandardCharsets.UTF_8);
     return JsonUtils.fromJson(jsonStr,
         new TypeReference<TimelineEntityDocument>() {});
   }
@@ -67,7 +68,7 @@ public final class DocumentStoreTestUtils {
   public static FlowActivityDocument bakeFlowActivityDoc() throws IOException {
     String jsonStr = IOUtils.toString(
         DocumentStoreTestUtils.class.getClassLoader().getResourceAsStream(
-            "documents/flowactivity-doc.json"), "UTF-8");
+            "documents/flowactivity-doc.json"), StandardCharsets.UTF_8);
     return JsonUtils.fromJson(jsonStr,
         new TypeReference<FlowActivityDocument>() {});
   }
@@ -75,7 +76,7 @@ public final class DocumentStoreTestUtils {
   public static FlowRunDocument bakeFlowRunDoc() throws IOException {
     String jsonStr = IOUtils.toString(
         DocumentStoreTestUtils.class.getClassLoader().getResourceAsStream(
-            "documents/flowrun-doc.json"), "UTF-8");
+            "documents/flowrun-doc.json"), StandardCharsets.UTF_8);
     return JsonUtils.fromJson(jsonStr,
         new TypeReference<FlowRunDocument>(){});
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/FileSystemTimelineReaderImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/FileSystemTimelineReaderImpl.java
@@ -23,7 +23,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -174,7 +174,7 @@ public class FileSystemTimelineReaderImpl extends AbstractService
             APP_FLOW_MAPPING_FILE);
     try (BufferedReader reader =
              new BufferedReader(new InputStreamReader(
-                 fs.open(appFlowMappingFilePath), Charset.forName("UTF-8")));
+                 fs.open(appFlowMappingFilePath), StandardCharsets.UTF_8));
          CSVParser parser = new CSVParser(reader, csvFormat)) {
       for (CSVRecord record : parser.getRecords()) {
         if (record.size() < 4) {
@@ -300,7 +300,7 @@ public class FileSystemTimelineReaderImpl extends AbstractService
           }
           try (BufferedReader reader = new BufferedReader(
               new InputStreamReader(fs.open(entityFile),
-                  Charset.forName("UTF-8")))) {
+                  StandardCharsets.UTF_8))) {
             TimelineEntity entity = readEntityFromFile(reader);
             if (!entity.getType().equals(entityType)) {
               continue;
@@ -402,7 +402,7 @@ public class FileSystemTimelineReaderImpl extends AbstractService
     }
     try (BufferedReader reader =
              new BufferedReader(new InputStreamReader(
-                 fs.open(entityFilePath), Charset.forName("UTF-8")))) {
+                 fs.open(entityFilePath), StandardCharsets.UTF_8))) {
       TimelineEntity entity = readEntityFromFile(reader);
       return createEntityToBeReturned(
           entity, dataToRetrieve.getFieldsToRetrieve());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/FileSystemTimelineWriterImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/FileSystemTimelineWriterImpl.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.server.timelineservice.storage;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -139,7 +140,7 @@ public class FileSystemTimelineWriterImpl extends AbstractService
 
       byte[] record =  new StringBuilder()
               .append(TimelineUtils.dumpTimelineRecordtoJSON(entity))
-              .append("\n").toString().getBytes("UTF-8");
+              .append("\n").toString().getBytes(StandardCharsets.UTF_8);
       writeFileWithRetries(filePath, record);
     } catch (Exception ioe) {
       LOG.warn("Interrupted operation:{}", ioe.getMessage());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
@@ -30,6 +30,7 @@ import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Enumeration;
@@ -287,7 +288,7 @@ public class WebAppProxyServlet extends HttpServlet {
       StringBuilder sb = new StringBuilder();
       BufferedReader reader =
           new BufferedReader(
-              new InputStreamReader(req.getInputStream(), "UTF-8"));
+              new InputStreamReader(req.getInputStream(), StandardCharsets.UTF_8));
       String line;
       while ((line = reader.readLine()) != null) {
         sb.append(line);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServlet.java
@@ -30,6 +30,7 @@ import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
@@ -522,7 +523,7 @@ public class TestWebAppProxyServlet {
     while ((read = input.read(buffer)) >= 0) {
       data.write(buffer, 0, read);
     }
-    return new String(data.toByteArray(), "UTF-8");
+    return new String(data.toByteArray(), StandardCharsets.UTF_8);
   }
 
   private boolean isResponseCookiePresent(HttpURLConnection proxyConn,

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,14 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                   </restrictImports>
                   <restrictImports>
                     <includeTestCode>true</includeTestCode>
+                    <reason>Use java.nio.charset.StandardCharsets rather than Guava provided Charsets</reason>
+                    <bannedImports>
+                      <bannedImport>org.apache.hadoop.thirdparty.com.google.common.base.Charsets</bannedImport>
+                      <bannedImport>org.apache.hadoop.thirdparty.com.google.common.base.Charsets.**</bannedImport>
+                    </bannedImports>
+                  </restrictImports>
+                  <restrictImports>
+                    <includeTestCode>true</includeTestCode>
                     <reason>Use alternative to Guava provided Optional</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.base.Optional</bannedImport>


### PR DESCRIPTION
### Description of PR

HADOOP-18957

also tidies up some cases like `new String("xyz")` and just uses `"xyz"`.

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

