### PR TITLE
HADOOP-18958. UserGroupInformation debug log improve.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -1849,8 +1849,8 @@ public class UserGroupInformation {
   @InterfaceStability.Evolving
   public <T> T doAs(PrivilegedAction<T> action) {
     if (LOG.isDebugEnabled()) {
-      LOG.debug("PrivilegedAction [as: {}][action: {}]", this, action,
-          new Exception());
+      LOG.debug("PrivilegedAction [as: {}][action: {}][from: {}]", this, action,
+              Thread.currentThread().getStackTrace()[2]);
     }
     return Subject.doAs(subject, action);
   }
@@ -1872,8 +1872,8 @@ public class UserGroupInformation {
                     ) throws IOException, InterruptedException {
     try {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("PrivilegedAction [as: {}][action: {}]", this, action,
-            new Exception());
+        LOG.debug("PrivilegedAction [as: {}][action: {}][from: {}]", this, action,
+                Thread.currentThread().getStackTrace()[2]);;
       }
       return Subject.doAs(subject, action);
     } catch (PrivilegedActionException pae) {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: [HADOOP-18958](https://issues.apache.org/jira/browse/HADOOP-18958). 
  Using “new Exception( )” to print the call stack of "doAs Method " in the UserGroupInformation class. Using this way will print meaningless Exception information and too many call stacks, This is not conducive to troubleshooting

### How was this patch tested?
Deploy to the testing environment and observe the print result  of UserGroupInformation Debug logs.
See: [HADOOP-18958](https://issues.apache.org/jira/browse/HADOOP-18958)

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

