### PR TITLE
[HDFS-17244] Avoid affecting the overall logic of checkpoint when I/O…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/StandbyCheckpointer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/StandbyCheckpointer.java
@@ -340,8 +340,10 @@ public class StandbyCheckpointer {
       // that are not doing any work also stop
       executor.awaitTermination(500, TimeUnit.MILLISECONDS);
 
-      // re-throw the exception we got, since one of these two must be non-null
-      throw ie;
+      if (!isSuccess) {
+        // re-throw the exception we got, since one of these two must be non-null
+        throw ie;
+      }
     }
 
     if (!ioes.isEmpty() && !isSuccess) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/StandbyCheckpointer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/StandbyCheckpointer.java
@@ -285,6 +285,7 @@ public class StandbyCheckpointer {
     }
     InterruptedException ie = null;
     List<IOException> ioes = Lists.newArrayList();
+    boolean isSuccess = false;
     for (Map.Entry<String, Future<TransferFsImage.TransferResult>> entry :
         uploads.entrySet()) {
       String url = entry.getKey();
@@ -297,6 +298,7 @@ public class StandbyCheckpointer {
         if (uploadResult == TransferFsImage.TransferResult.SUCCESS) {
           receiverEntry.setLastUploadTime(monotonicNow());
           receiverEntry.setIsPrimary(true);
+          isSuccess = true;
         } else {
           // Getting here means image upload is explicitly rejected
           // by the other node. This could happen if:
@@ -342,7 +344,7 @@ public class StandbyCheckpointer {
       throw ie;
     }
 
-    if (!ioes.isEmpty()) {
+    if (!ioes.isEmpty() && !isSuccess) {
       throw MultipleIOException.createIOException(ioes);
     }
   }


### PR DESCRIPTION

### Description of PR
I think that the snn node should only transfers the fsimage to active nn , so it is ok if sending the fsiamge to the other nodes unsuccessfully.


### How was this patch tested?


### For code changes:


