### PR TITLE
HADOOP-18963. Fix typos in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.DS_Store
+*.DS_Store
 *.iml
 *.ipr
 *.iws


### PR DESCRIPTION
DS_Store is auto generated by Mac in every opened folder, which is useless but annoying. Not only DS_Store file in the repository root directory should be ignored but DS_Store file in its subfolders.

Actually, I don't have jira account. I have applied one just now, I am still waiting AFS create one for me. 

I can't wait to contribute to Hadoop, so I used another resolved jira ticket as this PR tile. Let's make Hadoop better together. 

Thank you.