### PR TITLE
HDFS-17247. Improve AvailableSpaceRackFaultTolerantBlockPlacementPolicy logic

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1271,14 +1271,27 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       "dfs.namenode.available-space-rack-fault-tolerant-block-placement-policy"
           + ".balanced-space-tolerance";
   public static final int
-      DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_RACK_FAULT_TOLERANT_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT =
+      DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT =
       5;
+  public static final String
+      DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY =
+      "dfs.namenode.available-space-rack-fault-tolerant-block-placement-policy.balanced-space-tolerance-limit";
+  public static final int
+      DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT =
+      100;
   public static final String
       DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCE_LOCAL_NODE_KEY =
       "dfs.namenode.available-space-block-placement-policy.balance-local-node";
   public static final boolean
       DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCE_LOCAL_NODE_DEFAULT =
       false;
+  public static final String
+      DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCE_LOCAL_NODE_KEY =
+      "dfs.namenode.available-space-rack-fault-tolerant-block-placement-policy.balance-local-node";
+  public static final boolean
+      DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCE__NODE_DEFAULT =
+      false;
+
   public static final String  DFS_NAMENODE_BLOCKPLACEMENTPOLICY_DEFAULT_PREFER_LOCAL_NODE_KEY =
       "dfs.namenode.block-placement-policy.default.prefer-local-node";
   public static final boolean  DFS_NAMENODE_BLOCKPLACEMENTPOLICY_DEFAULT_PREFER_LOCAL_NODE_DEFAULT = true;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1289,7 +1289,7 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCE_LOCAL_NODE_KEY =
       "dfs.namenode.available-space-rack-fault-tolerant-block-placement-policy.balance-local-node";
   public static final boolean
-      DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCE__NODE_DEFAULT =
+      DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCE_LOCAL_NODE_DEFAULT =
       false;
 
   public static final String  DFS_NAMENODE_BLOCKPLACEMENTPOLICY_DEFAULT_PREFER_LOCAL_NODE_KEY =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicy.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.net.DFSNetworkTopology;
+import org.apache.hadoop.hdfs.server.blockmanagement.AvailableSpaceBlockPlacementPolicyUtils.AvailableSpaceContext;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.net.Node;
 
@@ -130,7 +131,8 @@ public class AvailableSpaceBlockPlacementPolicy extends
     DatanodeDescriptor b = (DatanodeDescriptor) dfsClusterMap
         .chooseRandomWithStorageTypeTwoTrial(scope, excludedNode, type);
     return AvailableSpaceBlockPlacementPolicyUtils.select(a, b, false,
-        balancedPreference, balancedSpaceToleranceLimit, balancedSpaceTolerance);
+        new AvailableSpaceContext(balancedPreference, balancedSpaceToleranceLimit,
+            balancedSpaceTolerance));
   }
 
   @Override
@@ -146,8 +148,9 @@ public class AvailableSpaceBlockPlacementPolicy extends
     }
     return AvailableSpaceBlockPlacementPolicyUtils.chooseLocalStorage(
         localMachine, excludedNodes, blocksize, maxNodesPerRack, results,
-        avoidStaleNodes, storageTypes, fallbackToLocalRack, balancedPreference,
-        balancedSpaceToleranceLimit, balancedSpaceTolerance, this);
+        avoidStaleNodes, storageTypes, fallbackToLocalRack,
+        new AvailableSpaceContext(balancedPreference, balancedSpaceToleranceLimit,
+            balancedSpaceTolerance, this));
   }
 
   @Override
@@ -158,7 +161,8 @@ public class AvailableSpaceBlockPlacementPolicy extends
     DatanodeDescriptor b =
         (DatanodeDescriptor) clusterMap.chooseRandom(scope, excludedNode);
     return AvailableSpaceBlockPlacementPolicyUtils.select(a, b, false,
-        balancedPreference, balancedSpaceToleranceLimit, balancedSpaceTolerance);
+        new AvailableSpaceContext(balancedPreference, balancedSpaceToleranceLimit,
+            balancedSpaceTolerance));
   }
 
   @VisibleForTesting

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicy.java
@@ -28,9 +28,9 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_AVAILABLE_SPACE_
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +48,6 @@ public class AvailableSpaceBlockPlacementPolicy extends
     BlockPlacementPolicyDefault {
   private static final Logger LOG = LoggerFactory
       .getLogger(AvailableSpaceBlockPlacementPolicy.class);
-  private static final Random RAND = new Random();
   private int balancedPreference =
       (int) (100 * DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_DEFAULT);
   private int balancedSpaceTolerance =
@@ -130,7 +129,8 @@ public class AvailableSpaceBlockPlacementPolicy extends
         .chooseRandomWithStorageTypeTwoTrial(scope, excludedNode, type);
     DatanodeDescriptor b = (DatanodeDescriptor) dfsClusterMap
         .chooseRandomWithStorageTypeTwoTrial(scope, excludedNode, type);
-    return select(a, b, false);
+    return AvailableSpaceBlockPlacementPolicyUtils.select(a, b, false,
+        balancedPreference, balancedSpaceToleranceLimit, balancedSpaceTolerance);
   }
 
   @Override
@@ -144,51 +144,10 @@ public class AvailableSpaceBlockPlacementPolicy extends
           maxNodesPerRack, results, avoidStaleNodes, storageTypes,
           fallbackToLocalRack);
     }
-    final EnumMap<StorageType, Integer> initialStorageTypesLocal =
-        storageTypes.clone();
-    final EnumMap<StorageType, Integer> initialStorageTypesLocalRack =
-        storageTypes.clone();
-    DatanodeStorageInfo local =
-        chooseLocalStorage(localMachine, excludedNodes, blocksize,
-            maxNodesPerRack, results, avoidStaleNodes,
-            initialStorageTypesLocal);
-    if (!fallbackToLocalRack) {
-      return local;
-    }
-    if (local != null) {
-      results.remove(local);
-    }
-    DatanodeStorageInfo localRack =
-        chooseLocalRack(localMachine, excludedNodes, blocksize, maxNodesPerRack,
-            results, avoidStaleNodes, initialStorageTypesLocalRack);
-    if (local != null && localRack != null) {
-      if (select(local.getDatanodeDescriptor(),
-          localRack.getDatanodeDescriptor(), true) == local
-          .getDatanodeDescriptor()) {
-        results.remove(localRack);
-        results.add(local);
-        swapStorageTypes(initialStorageTypesLocal, storageTypes);
-        excludedNodes.remove(localRack.getDatanodeDescriptor());
-        return local;
-      } else {
-        swapStorageTypes(initialStorageTypesLocalRack, storageTypes);
-        excludedNodes.remove(local.getDatanodeDescriptor());
-        return localRack;
-      }
-    } else if (localRack == null && local != null) {
-      results.add(local);
-      swapStorageTypes(initialStorageTypesLocal, storageTypes);
-      return local;
-    } else {
-      swapStorageTypes(initialStorageTypesLocalRack, storageTypes);
-      return localRack;
-    }
-  }
-
-  private void swapStorageTypes(EnumMap<StorageType, Integer> fromStorageTypes,
-      EnumMap<StorageType, Integer> toStorageTypes) {
-    toStorageTypes.clear();
-    toStorageTypes.putAll(fromStorageTypes);
+    return AvailableSpaceBlockPlacementPolicyUtils.chooseLocalStorage(
+        localMachine, excludedNodes, blocksize, maxNodesPerRack, results,
+        avoidStaleNodes, storageTypes, fallbackToLocalRack, balancedPreference,
+        balancedSpaceToleranceLimit, balancedSpaceTolerance, this);
   }
 
   @Override
@@ -198,39 +157,22 @@ public class AvailableSpaceBlockPlacementPolicy extends
         (DatanodeDescriptor) clusterMap.chooseRandom(scope, excludedNode);
     DatanodeDescriptor b =
         (DatanodeDescriptor) clusterMap.chooseRandom(scope, excludedNode);
-    return select(a, b, false);
+    return AvailableSpaceBlockPlacementPolicyUtils.select(a, b, false,
+        balancedPreference, balancedSpaceToleranceLimit, balancedSpaceTolerance);
   }
 
-  private DatanodeDescriptor select(DatanodeDescriptor a, DatanodeDescriptor b,
-      boolean isBalanceLocal) {
-    if (a != null && b != null){
-      int ret = compareDataNode(a, b, isBalanceLocal);
-      if (ret == 0) {
-        return a;
-      } else if (ret < 0) {
-        return (RAND.nextInt(100) < balancedPreference) ? a : b;
-      } else {
-        return (RAND.nextInt(100) < balancedPreference) ? b : a;
-      }
-    } else {
-      return a == null ? b : a;
-    }
+  @VisibleForTesting
+  public int getBalancedPreference() {
+    return balancedPreference;
   }
 
-  /**
-   * Compare the two data nodes.
-   */
-  protected int compareDataNode(final DatanodeDescriptor a,
-      final DatanodeDescriptor b, boolean isBalanceLocal) {
+  @VisibleForTesting
+  public int getBalancedSpaceToleranceLimit() {
+    return balancedSpaceToleranceLimit;
+  }
 
-    boolean toleranceLimit = Math.max(a.getDfsUsedPercent(), b.getDfsUsedPercent())
-        < balancedSpaceToleranceLimit;
-    if (a.equals(b)
-        || (toleranceLimit && Math.abs(a.getDfsUsedPercent() - b.getDfsUsedPercent())
-            < balancedSpaceTolerance) || ((
-        isBalanceLocal && a.getDfsUsedPercent() < 50))) {
-      return 0;
-    }
-    return a.getDfsUsedPercent() < b.getDfsUsedPercent() ? -1 : 1;
+  @VisibleForTesting
+  public int getBalancedSpaceTolerance() {
+    return balancedSpaceTolerance;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicyUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicyUtils.java
@@ -129,7 +129,7 @@ public class AvailableSpaceBlockPlacementPolicyUtils {
     return a.getDfsUsedPercent() < b.getDfsUsedPercent() ? -1 : 1;
   }
 
-  protected static class AvailableSpaceContext {
+  protected final static class AvailableSpaceContext {
     private final int balancedPreference;
     private final int balancedSpaceToleranceLimit;
     private final int balancedSpaceTolerance;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicyUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicyUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.net.Node;
 
@@ -33,21 +34,24 @@ import java.util.Set;
  */
 public class AvailableSpaceBlockPlacementPolicyUtils {
 
+  private AvailableSpaceBlockPlacementPolicyUtils() {
+    /* Hidden constructor */
+  }
+
   private static final Random RAND = new Random();
 
-  protected static DatanodeStorageInfo chooseLocalStorage(Node localMachine,
-      Set<Node> excludedNodes, long blocksize, int maxNodesPerRack,
-      List<DatanodeStorageInfo> results, boolean avoidStaleNodes,
-      EnumMap<StorageType, Integer> storageTypes, boolean fallbackToLocalRack,
-      int balancedPreference, int balancedSpaceToleranceLimit,
-      int balancedSpaceTolerance, BlockPlacementPolicyDefault placementPolicy)
+  protected static DatanodeStorageInfo chooseLocalStorage(
+      Node localMachine, Set<Node> excludedNodes, long blocksize,
+      int maxNodesPerRack, List<DatanodeStorageInfo> results,
+      boolean avoidStaleNodes, EnumMap<StorageType, Integer> storageTypes,
+      boolean fallbackToLocalRack, AvailableSpaceContext context)
       throws BlockPlacementPolicy.NotEnoughReplicasException {
     final EnumMap<StorageType, Integer> initialStorageTypesLocal =
         storageTypes.clone();
     final EnumMap<StorageType, Integer> initialStorageTypesLocalRack =
         storageTypes.clone();
     DatanodeStorageInfo local =
-        placementPolicy.chooseLocalStorage(localMachine, excludedNodes, blocksize,
+        context.getPlacementPolicy().chooseLocalStorage(localMachine, excludedNodes, blocksize,
             maxNodesPerRack, results, avoidStaleNodes,
             initialStorageTypesLocal);
     if (!fallbackToLocalRack) {
@@ -57,12 +61,11 @@ public class AvailableSpaceBlockPlacementPolicyUtils {
       results.remove(local);
     }
     DatanodeStorageInfo localRack =
-        placementPolicy.chooseLocalRack(localMachine, excludedNodes, blocksize, maxNodesPerRack,
-            results, avoidStaleNodes, initialStorageTypesLocalRack);
+        context.getPlacementPolicy().chooseLocalRack(localMachine, excludedNodes,
+            blocksize, maxNodesPerRack, results, avoidStaleNodes, initialStorageTypesLocalRack);
     if (local != null && localRack != null) {
       if (select(local.getDatanodeDescriptor(),
-          localRack.getDatanodeDescriptor(), true, balancedPreference,
-          balancedSpaceToleranceLimit, balancedSpaceTolerance) == local
+          localRack.getDatanodeDescriptor(), true, context) == local
           .getDatanodeDescriptor()) {
         results.remove(localRack);
         results.add(local);
@@ -91,17 +94,16 @@ public class AvailableSpaceBlockPlacementPolicyUtils {
   }
 
   protected static DatanodeDescriptor select(DatanodeDescriptor a, DatanodeDescriptor b,
-      boolean isBalanceLocal, int balancedPreference,
-      int balancedSpaceToleranceLimit, int balancedSpaceTolerance) {
+      boolean isBalanceLocal, AvailableSpaceContext context) {
     if (a != null && b != null){
-      int ret = compareDataNode(a, b, isBalanceLocal, balancedSpaceToleranceLimit,
-          balancedSpaceTolerance);
+      int ret = compareDataNode(a, b, isBalanceLocal, context.getBalancedSpaceToleranceLimit(),
+          context.getBalancedSpaceTolerance());
       if (ret == 0) {
         return a;
       } else if (ret < 0) {
-        return (RAND.nextInt(100) < balancedPreference) ? a : b;
+        return (RAND.nextInt(100) < context.getBalancedPreference()) ? a : b;
       } else {
-        return (RAND.nextInt(100) < balancedPreference) ? b : a;
+        return (RAND.nextInt(100) < context.getBalancedPreference()) ? b : a;
       }
     } else {
       return a == null ? b : a;
@@ -111,6 +113,7 @@ public class AvailableSpaceBlockPlacementPolicyUtils {
   /**
    * Compare the two data nodes.
    */
+  @VisibleForTesting
   protected static int compareDataNode(final DatanodeDescriptor a,
       final DatanodeDescriptor b, boolean isBalanceLocal,
       int balancedSpaceToleranceLimit, int balancedSpaceTolerance) {
@@ -124,5 +127,43 @@ public class AvailableSpaceBlockPlacementPolicyUtils {
       return 0;
     }
     return a.getDfsUsedPercent() < b.getDfsUsedPercent() ? -1 : 1;
+  }
+
+  protected static class AvailableSpaceContext {
+    private final int balancedPreference;
+    private final int balancedSpaceToleranceLimit;
+    private final int balancedSpaceTolerance;
+    private BlockPlacementPolicyDefault placementPolicy;
+
+    public AvailableSpaceContext(int balancedPreference, int balancedSpaceToleranceLimit,
+        int balancedSpaceTolerance) {
+      this.balancedPreference = balancedPreference;
+      this.balancedSpaceToleranceLimit = balancedSpaceToleranceLimit;
+      this.balancedSpaceTolerance = balancedSpaceTolerance;
+    }
+
+    public AvailableSpaceContext(int balancedPreference, int balancedSpaceToleranceLimit,
+        int balancedSpaceTolerance, BlockPlacementPolicyDefault placementPolicy) {
+      this.balancedPreference = balancedPreference;
+      this.balancedSpaceToleranceLimit = balancedSpaceToleranceLimit;
+      this.balancedSpaceTolerance = balancedSpaceTolerance;
+      this.placementPolicy = placementPolicy;
+    }
+
+    public int getBalancedPreference() {
+      return balancedPreference;
+    }
+
+    public int getBalancedSpaceToleranceLimit() {
+      return balancedSpaceToleranceLimit;
+    }
+
+    public int getBalancedSpaceTolerance() {
+      return balancedSpaceTolerance;
+    }
+
+    public BlockPlacementPolicyDefault getPlacementPolicy() {
+      return placementPolicy;
+    }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicyUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceBlockPlacementPolicyUtils.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.blockmanagement;
+
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.net.Node;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * Utility class for the Available Space Block Placement Policy.
+ * This class contains methods that help with block placement
+ * decision-making based on available storage space.
+ */
+public class AvailableSpaceBlockPlacementPolicyUtils {
+
+  private static final Random RAND = new Random();
+
+  protected static DatanodeStorageInfo chooseLocalStorage(Node localMachine,
+      Set<Node> excludedNodes, long blocksize, int maxNodesPerRack,
+      List<DatanodeStorageInfo> results, boolean avoidStaleNodes,
+      EnumMap<StorageType, Integer> storageTypes, boolean fallbackToLocalRack,
+      int balancedPreference, int balancedSpaceToleranceLimit,
+      int balancedSpaceTolerance, BlockPlacementPolicyDefault placementPolicy)
+      throws BlockPlacementPolicy.NotEnoughReplicasException {
+    final EnumMap<StorageType, Integer> initialStorageTypesLocal =
+        storageTypes.clone();
+    final EnumMap<StorageType, Integer> initialStorageTypesLocalRack =
+        storageTypes.clone();
+    DatanodeStorageInfo local =
+        placementPolicy.chooseLocalStorage(localMachine, excludedNodes, blocksize,
+            maxNodesPerRack, results, avoidStaleNodes,
+            initialStorageTypesLocal);
+    if (!fallbackToLocalRack) {
+      return local;
+    }
+    if (local != null) {
+      results.remove(local);
+    }
+    DatanodeStorageInfo localRack =
+        placementPolicy.chooseLocalRack(localMachine, excludedNodes, blocksize, maxNodesPerRack,
+            results, avoidStaleNodes, initialStorageTypesLocalRack);
+    if (local != null && localRack != null) {
+      if (select(local.getDatanodeDescriptor(),
+          localRack.getDatanodeDescriptor(), true, balancedPreference,
+          balancedSpaceToleranceLimit, balancedSpaceTolerance) == local
+          .getDatanodeDescriptor()) {
+        results.remove(localRack);
+        results.add(local);
+        swapStorageTypes(initialStorageTypesLocal, storageTypes);
+        excludedNodes.remove(localRack.getDatanodeDescriptor());
+        return local;
+      } else {
+        swapStorageTypes(initialStorageTypesLocalRack, storageTypes);
+        excludedNodes.remove(local.getDatanodeDescriptor());
+        return localRack;
+      }
+    } else if (localRack == null && local != null) {
+      results.add(local);
+      swapStorageTypes(initialStorageTypesLocal, storageTypes);
+      return local;
+    } else {
+      swapStorageTypes(initialStorageTypesLocalRack, storageTypes);
+      return localRack;
+    }
+  }
+
+  private static void swapStorageTypes(EnumMap<StorageType, Integer> fromStorageTypes,
+      EnumMap<StorageType, Integer> toStorageTypes) {
+    toStorageTypes.clear();
+    toStorageTypes.putAll(fromStorageTypes);
+  }
+
+  protected static DatanodeDescriptor select(DatanodeDescriptor a, DatanodeDescriptor b,
+      boolean isBalanceLocal, int balancedPreference,
+      int balancedSpaceToleranceLimit, int balancedSpaceTolerance) {
+    if (a != null && b != null){
+      int ret = compareDataNode(a, b, isBalanceLocal, balancedSpaceToleranceLimit,
+          balancedSpaceTolerance);
+      if (ret == 0) {
+        return a;
+      } else if (ret < 0) {
+        return (RAND.nextInt(100) < balancedPreference) ? a : b;
+      } else {
+        return (RAND.nextInt(100) < balancedPreference) ? b : a;
+      }
+    } else {
+      return a == null ? b : a;
+    }
+  }
+
+  /**
+   * Compare the two data nodes.
+   */
+  protected static int compareDataNode(final DatanodeDescriptor a,
+      final DatanodeDescriptor b, boolean isBalanceLocal,
+      int balancedSpaceToleranceLimit, int balancedSpaceTolerance) {
+
+    boolean toleranceLimit = Math.max(a.getDfsUsedPercent(), b.getDfsUsedPercent())
+        < balancedSpaceToleranceLimit;
+    if (a.equals(b)
+        || (toleranceLimit && Math.abs(a.getDfsUsedPercent() - b.getDfsUsedPercent())
+        < balancedSpaceTolerance) || ((
+        isBalanceLocal && a.getDfsUsedPercent() < 50))) {
+      return 0;
+    }
+    return a.getDfsUsedPercent() < b.getDfsUsedPercent() ? -1 : 1;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceRackFaultTolerantBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceRackFaultTolerantBlockPlacementPolicy.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.net.DFSNetworkTopology;
+import org.apache.hadoop.hdfs.server.blockmanagement.AvailableSpaceBlockPlacementPolicyUtils.AvailableSpaceContext;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.net.Node;
 import org.slf4j.Logger;
@@ -82,7 +83,7 @@ public class AvailableSpaceRackFaultTolerantBlockPlacementPolicy
         DFSConfigKeys.
             DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCE_LOCAL_NODE_KEY,
         DFSConfigKeys.
-            DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCE__NODE_DEFAULT);
+            DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCE_LOCAL_NODE_DEFAULT);
 
     LOG.info("Available space rack fault tolerant block placement policy "
         + "initialized: "
@@ -136,7 +137,8 @@ public class AvailableSpaceRackFaultTolerantBlockPlacementPolicy
     DatanodeDescriptor b = (DatanodeDescriptor) dfsClusterMap
         .chooseRandomWithStorageTypeTwoTrial(scope, excludedNode, type);
     return AvailableSpaceBlockPlacementPolicyUtils.select(a, b, false,
-        balancedPreference, balancedSpaceToleranceLimit, balancedSpaceTolerance);
+        new AvailableSpaceContext(balancedPreference, balancedSpaceToleranceLimit,
+            balancedSpaceTolerance));
   }
 
   @Override
@@ -150,10 +152,11 @@ public class AvailableSpaceRackFaultTolerantBlockPlacementPolicy
           maxNodesPerRack, results, avoidStaleNodes, storageTypes,
           fallbackToLocalRack);
     }
-    return AvailableSpaceBlockPlacementPolicyUtils.chooseLocalStorage(localMachine, excludedNodes,
-        blocksize, maxNodesPerRack, results, avoidStaleNodes, storageTypes,
-        fallbackToLocalRack, balancedPreference,
-        balancedSpaceToleranceLimit, balancedSpaceTolerance, this);
+    return AvailableSpaceBlockPlacementPolicyUtils.chooseLocalStorage(
+        localMachine, excludedNodes, blocksize, maxNodesPerRack, results,
+        avoidStaleNodes, storageTypes, fallbackToLocalRack,
+        new AvailableSpaceContext(balancedPreference, balancedSpaceToleranceLimit,
+            balancedSpaceTolerance, this));
   }
 
   @Override
@@ -164,7 +167,8 @@ public class AvailableSpaceRackFaultTolerantBlockPlacementPolicy
     DatanodeDescriptor b =
         (DatanodeDescriptor) clusterMap.chooseRandom(scope, excludedNode);
     return AvailableSpaceBlockPlacementPolicyUtils.select(a, b, false,
-        balancedPreference, balancedSpaceToleranceLimit, balancedSpaceTolerance);
+        new AvailableSpaceContext(balancedPreference, balancedSpaceToleranceLimit,
+            balancedSpaceTolerance));
   }
 
   @VisibleForTesting

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceRackFaultTolerantBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/AvailableSpaceRackFaultTolerantBlockPlacementPolicy.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.StorageType;
@@ -29,12 +30,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.Random;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Set;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_RACK_FAULT_TOLERANT_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_DEFAULT;
-import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_RACK_FAULT_TOLERANT_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY;
 
 /**
  * Space balanced rack fault tolerant block placement policy.
@@ -44,11 +49,18 @@ public class AvailableSpaceRackFaultTolerantBlockPlacementPolicy
 
   private static final Logger LOG = LoggerFactory
       .getLogger(AvailableSpaceRackFaultTolerantBlockPlacementPolicy.class);
-  private static final Random RAND = new Random();
+
   private int balancedPreference = (int) (100
       * DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_RACK_FAULT_TOLERANT_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_DEFAULT);
+
   private int balancedSpaceTolerance =
-        DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_RACK_FAULT_TOLERANT_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT;
+      DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT;
+
+  private int balancedSpaceToleranceLimit =
+      DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT;
+
+  private boolean optimizeLocal;
+
   @Override
   public void initialize(Configuration conf, FSClusterStats stats,
       NetworkTopology clusterMap, Host2NodesMap host2datanodeMap) {
@@ -58,8 +70,19 @@ public class AvailableSpaceRackFaultTolerantBlockPlacementPolicy
         DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_RACK_FAULT_TOLERANT_PLACEMENT_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_DEFAULT);
 
     balancedSpaceTolerance = conf.getInt(
-            DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_KEY,
-            DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_RACK_FAULT_TOLERANT_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT);
+        DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_KEY,
+        DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT);
+
+    balancedSpaceToleranceLimit =
+        conf.getInt(
+            DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY,
+            DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT);
+
+    optimizeLocal = conf.getBoolean(
+        DFSConfigKeys.
+            DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCE_LOCAL_NODE_KEY,
+        DFSConfigKeys.
+            DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCE__NODE_DEFAULT);
 
     LOG.info("Available space rack fault tolerant block placement policy "
         + "initialized: "
@@ -78,15 +101,25 @@ public class AvailableSpaceRackFaultTolerantBlockPlacementPolicy
           + " receive  more block allocations.");
     }
 
+    if (balancedSpaceToleranceLimit > 100 || balancedSpaceToleranceLimit < 0) {
+      LOG.warn("The value of "
+          + DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_KEY
+          + " is invalid, Current value is " + balancedSpaceToleranceLimit + ", Default value "
+          + DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT
+          + " will be used instead.");
+
+      balancedSpaceToleranceLimit =
+          DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_LIMIT_DEFAULT;
+    }
 
     if (balancedSpaceTolerance > 20 || balancedSpaceTolerance < 0) {
       LOG.warn("The value of "
           + DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_KEY
           + " is invalid, Current value is " + balancedSpaceTolerance + ", Default value " +
-            DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_RACK_FAULT_TOLERANT_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT
+          DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT
           + " will be used instead.");
       balancedSpaceTolerance =
-            DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_RACK_FAULT_TOLERANT_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT;
+          DFS_NAMENODE_AVAILABLE_SPACE_RACK_FAULT_TOLERANT_BLOCK_PLACEMENT_POLICY_BALANCED_SPACE_TOLERANCE_DEFAULT;
     }
 
     balancedPreference = (int) (100 * balancedPreferencePercent);
@@ -102,7 +135,25 @@ public class AvailableSpaceRackFaultTolerantBlockPlacementPolicy
         .chooseRandomWithStorageTypeTwoTrial(scope, excludedNode, type);
     DatanodeDescriptor b = (DatanodeDescriptor) dfsClusterMap
         .chooseRandomWithStorageTypeTwoTrial(scope, excludedNode, type);
-    return select(a, b);
+    return AvailableSpaceBlockPlacementPolicyUtils.select(a, b, false,
+        balancedPreference, balancedSpaceToleranceLimit, balancedSpaceTolerance);
+  }
+
+  @Override
+  protected DatanodeStorageInfo chooseLocalStorage(Node localMachine,
+      Set<Node> excludedNodes, long blocksize, int maxNodesPerRack,
+      List<DatanodeStorageInfo> results, boolean avoidStaleNodes,
+      EnumMap<StorageType, Integer> storageTypes, boolean fallbackToLocalRack)
+      throws NotEnoughReplicasException {
+    if (!optimizeLocal) {
+      return super.chooseLocalStorage(localMachine, excludedNodes, blocksize,
+          maxNodesPerRack, results, avoidStaleNodes, storageTypes,
+          fallbackToLocalRack);
+    }
+    return AvailableSpaceBlockPlacementPolicyUtils.chooseLocalStorage(localMachine, excludedNodes,
+        blocksize, maxNodesPerRack, results, avoidStaleNodes, storageTypes,
+        fallbackToLocalRack, balancedPreference,
+        balancedSpaceToleranceLimit, balancedSpaceTolerance, this);
   }
 
   @Override
@@ -112,34 +163,22 @@ public class AvailableSpaceRackFaultTolerantBlockPlacementPolicy
         (DatanodeDescriptor) clusterMap.chooseRandom(scope, excludedNode);
     DatanodeDescriptor b =
         (DatanodeDescriptor) clusterMap.chooseRandom(scope, excludedNode);
-    return select(a, b);
+    return AvailableSpaceBlockPlacementPolicyUtils.select(a, b, false,
+        balancedPreference, balancedSpaceToleranceLimit, balancedSpaceTolerance);
   }
 
-  private DatanodeDescriptor select(DatanodeDescriptor a,
-      DatanodeDescriptor b) {
-    if (a != null && b != null) {
-      int ret = compareDataNode(a, b);
-      if (ret == 0) {
-        return a;
-      } else if (ret < 0) {
-        return (RAND.nextInt(100) < balancedPreference) ? a : b;
-      } else {
-        return (RAND.nextInt(100) < balancedPreference) ? b : a;
-      }
-    } else {
-      return a == null ? b : a;
-    }
+  @VisibleForTesting
+  public int getBalancedPreference() {
+    return balancedPreference;
   }
 
-  /**
-   * Compare the two data nodes.
-   */
-  protected int compareDataNode(final DatanodeDescriptor a,
-      final DatanodeDescriptor b) {
-    if (a.equals(b)
-        || Math.abs(a.getDfsUsedPercent() - b.getDfsUsedPercent()) < balancedSpaceTolerance) {
-      return 0;
-    }
-    return a.getDfsUsedPercent() < b.getDfsUsedPercent() ? -1 : 1;
+  @VisibleForTesting
+  public int getBalancedSpaceToleranceLimit() {
+    return balancedSpaceToleranceLimit;
+  }
+
+  @VisibleForTesting
+  public int getBalancedSpaceTolerance() {
+    return balancedSpaceTolerance;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -4313,7 +4313,8 @@
   <name>dfs.block.placement.ec.classname</name>
   <value>org.apache.hadoop.hdfs.server.blockmanagement.BlockPlacementPolicyRackFaultTolerant</value>
   <description>
-    Placement policy class for striped files.
+    There are two block placement policies currently being supported:
+    BlockPlacementPolicyRackFaultTolerant.class and AvailableSpaceRackFaultTolerantBlockPlacementPolicy.class.
     Defaults to BlockPlacementPolicyRackFaultTolerant.class
   </description>
 </property>
@@ -5253,6 +5254,25 @@
     Special value between 0 and 20, inclusive. if the value is set beyond the scope,
     this value will be set as 5 by default, Increases tolerance of
     placing blocks on Datanodes with similar disk space used.
+  </description>
+</property>
+<property>
+  <name>dfs.namenode.available-space-rack-fault-tolerant-block-placement-policy.balanced-space-tolerance-limit</name>
+  <value>100</value>
+  <description>
+    Only used when the dfs.block.replicator.classname is set to
+    org.apache.hadoop.hdfs.server.blockmanagement.AvailableSpaceRackFaultTolerantBlockPlacementPolicy.
+    Special value between 0 and 100, inclusive. if the value is set beyond the scope,
+    this value will be set as 100 by default.
+  </description>
+</property>
+<property>
+  <name>dfs.namenode.available-space-rack-fault-tolerant-block-placement-policy.balance-local-node</name>
+  <value>false</value>
+  <description>
+    Only used when the dfs.block.replicator.classname is set to
+    org.apache.hadoop.hdfs.server.blockmanagement.AvailableSpaceRackFaultTolerantBlockPlacementPolicy.
+    If true, balances the local node too.
   </description>
 </property>
 <property>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -4313,6 +4313,7 @@
   <name>dfs.block.placement.ec.classname</name>
   <value>org.apache.hadoop.hdfs.server.blockmanagement.BlockPlacementPolicyRackFaultTolerant</value>
   <description>
+    Placement policy class for striped files.
     There are two block placement policies currently being supported:
     BlockPlacementPolicyRackFaultTolerant.class and AvailableSpaceRackFaultTolerantBlockPlacementPolicy.class.
     Defaults to BlockPlacementPolicyRackFaultTolerant.class

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
@@ -212,14 +212,22 @@ public class TestAvailableSpaceBlockPlacementPolicy {
             HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
                     * blockSize, 0L, 0L, 0L, 0, 0);
 
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[0],
-            tolerateDataNodes[1], false) == 0);
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[1],
-            tolerateDataNodes[0], false) == 0);
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[0],
-            tolerateDataNodes[2], false) == -1);
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[2],
-            tolerateDataNodes[0], false) == 1);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[0],
+            tolerateDataNodes[1], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == 0);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[1],
+            tolerateDataNodes[0], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == 0);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[0],
+            tolerateDataNodes[2], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == -1);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[2],
+            tolerateDataNodes[0], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == 1);
   }
 
 
@@ -276,22 +284,38 @@ public class TestAvailableSpaceBlockPlacementPolicy {
         HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
         * blockSize, 0L, 0L, 0L, 0, 0);
 
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[0],
-        tolerateDataNodes[1], false) == 1);
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[1],
-        tolerateDataNodes[0], false) == -1);
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[1],
-        tolerateDataNodes[2], false) == 1);
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[2],
-        tolerateDataNodes[1], false) == -1);
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[2],
-        tolerateDataNodes[3], false) == 0);
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[3],
-        tolerateDataNodes[2], false) == 0);
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[2],
-        tolerateDataNodes[4], false) == 1);
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[4],
-        tolerateDataNodes[2], false) == -1);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[0],
+        tolerateDataNodes[1], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == 1);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[1],
+        tolerateDataNodes[0], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == -1);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[1],
+        tolerateDataNodes[2], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == 1);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[2],
+        tolerateDataNodes[1], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == -1);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[2],
+        tolerateDataNodes[3], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == 0);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[3],
+        tolerateDataNodes[2], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == 0);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[2],
+        tolerateDataNodes[4], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == 1);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[4],
+        tolerateDataNodes[2], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == -1);
   }
 
   @AfterClass

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceRackFaultTolerantBPP.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceRackFaultTolerantBPP.java
@@ -243,14 +243,22 @@ public class TestAvailableSpaceRackFaultTolerantBPP {
             HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
                     * BLOCK_SIZE, 0L, 0L, 0L, 0, 0);
 
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[0],
-            tolerateDataNodes[1]) == 0);
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[1],
-            tolerateDataNodes[0]) == 0);
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[0],
-            tolerateDataNodes[2]) == -1);
-    assertTrue(toleratePlacementPolicy.compareDataNode(tolerateDataNodes[2],
-            tolerateDataNodes[0]) == 1);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[0],
+            tolerateDataNodes[1], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == 0);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[1],
+            tolerateDataNodes[0], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == 0);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[0],
+            tolerateDataNodes[2], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == -1);
+    assertTrue(AvailableSpaceBlockPlacementPolicyUtils.compareDataNode(tolerateDataNodes[2],
+            tolerateDataNodes[0], false,
+        toleratePlacementPolicy.getBalancedSpaceToleranceLimit(),
+        toleratePlacementPolicy.getBalancedSpaceTolerance()) == 1);
   }
 
   @AfterClass


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17247

- The AvailableSpaceBlockPlacementPolicy has made some optimizations such as [HDFS-14578](https://issues.apache.org/jira/browse/HDFS-14578) can have local node optimization and [HDFS-17210](https://issues.apache.org/jira/browse/HDFS-17210) can avoid choosing nodes with higher storage, the AvailableSpaceRackFaultTolerantBlockPlacementPolicy need keep same logics of optimization same as ASBPP.

- Currently considering implementing a public class, such as AvailableSpaceBlockPlacementPolicyUtils, and abstract some public methods such as `chooseLocalStorage, swapStorageTypes, select, compareDataNode`, the AvailableSpaceBlockPlacementPolicy and AvailableSpaceRackFaultTolerantBlockPlacementPolicy can call related methods in AvailableSpaceBlockPlacementPolicyUtils. If there are related optimizations later, they can be modified based on AvailableSpaceBlockPlacementPolicyUtils.

- Improve some doc descriptions and configuration parameters
