### PR TITLE
YARN-11606. Upgrade fst to 2.57

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -216,8 +216,6 @@ com.aliyun:aliyun-java-sdk-ram:3.1.0
 com.aliyun:aliyun-java-sdk-sts:3.0.0
 com.aliyun.oss:aliyun-sdk-oss:3.13.2
 com.amazonaws:aws-java-sdk-bundle:1.12.499
-com.cedarsoftware:java-util:1.9.0
-com.cedarsoftware:json-io:2.5.1
 com.fasterxml.jackson.core:jackson-annotations:2.12.7
 com.fasterxml.jackson.core:jackson-core:2.12.7
 com.fasterxml.jackson.core:jackson-databind:2.12.7.1
@@ -249,7 +247,7 @@ commons-collections:commons-collections:3.2.2
 commons-daemon:commons-daemon:1.0.13
 commons-io:commons-io:2.14.0
 commons-net:commons-net:3.9.0
-de.ruedigermoeller:fst:2.50
+de.ruedigermoeller:fst:2.57
 io.grpc:grpc-api:1.26.0
 io.grpc:grpc-context:1.26.0
 io.grpc:grpc-core:1.26.0

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
@@ -223,7 +223,7 @@
     <dependency>
       <groupId>de.ruedigermoeller</groupId>
       <artifactId>fst</artifactId>
-      <version>2.50</version>
+      <version>2.57</version>
       <exclusions>
         <exclusion>
           <groupId>org.javassist</groupId>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
 Upgrade fst to 2.57

### How was this patch tested?
Verfied that json-io is not present in the dependency tree after fst version upgrade

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

