### PR TITLE
HDFS-17249. Fix TestDFSUtil.testIsValidName() unit test failure

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSUtilClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSUtilClient.java
@@ -662,7 +662,7 @@ public class DFSUtilClient {
     for (int i = 0; i < components.length; i++) {
       String element = components[i];
       // For Windows, we must allow the : in the drive letter.
-      if (Shell.WINDOWS && i == 1 && element.contains(":")) {
+      if (Shell.WINDOWS && i == 1 && element.endsWith(":")) {
         continue;
       }
       if (element.equals(".")  ||

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSUtilClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSUtilClient.java
@@ -661,9 +661,12 @@ public class DFSUtilClient {
     String[] components = StringUtils.split(src, '/');
     for (int i = 0; i < components.length; i++) {
       String element = components[i];
+      // For Windows, we must allow the : in the drive letter.
+      if (Shell.WINDOWS && i == 1 && element.contains(":")) {
+        continue;
+      }
       if (element.equals(".")  ||
-          // For Windows, we must allow the : in the drive letter.
-          (!Shell.WINDOWS && i == 1 && element.contains(":"))  ||
+          (element.contains(":"))  ||
           (element.contains("/"))) {
         return false;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
@@ -83,6 +83,7 @@ import org.apache.hadoop.security.alias.CredentialProviderFactory;
 import org.apache.hadoop.security.alias.JavaKeyStoreProvider;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
+import org.apache.hadoop.util.Shell;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -872,6 +873,11 @@ public class TestDFSUtil {
     assertTrue(DFSUtil.isValidName("/bar/"));
     assertFalse(DFSUtil.isValidName("/foo/:/bar"));
     assertFalse(DFSUtil.isValidName("/foo:bar"));
+    if (Shell.WINDOWS) {
+      assertTrue(DFSUtil.isValidName("/C:/some/path"));
+    } else {
+      assertFalse(DFSUtil.isValidName("/C:/some/path"));
+    }
   }
   
   @Test(timeout=5000)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
@@ -866,17 +866,24 @@ public class TestDFSUtil {
 
   @Test (timeout=15000)
   public void testIsValidName() {
-    assertFalse(DFSUtil.isValidName("/foo/../bar"));
-    assertFalse(DFSUtil.isValidName("/foo/./bar"));
-    assertFalse(DFSUtil.isValidName("/foo//bar"));
-    assertTrue(DFSUtil.isValidName("/"));
-    assertTrue(DFSUtil.isValidName("/bar/"));
-    assertFalse(DFSUtil.isValidName("/foo/:/bar"));
-    assertFalse(DFSUtil.isValidName("/foo:bar"));
+    String validPaths[] = new String[]{"/", "/bar/"};
+    for (String path : validPaths) {
+      assertTrue("Should have been accepted '" + path + "'", DFSUtil.isValidName(path));
+    }
+
+    String invalidPaths[] =
+        new String[]{"/foo/../bar", "/foo/./bar", "/foo//bar", "/foo/:/bar", "/foo:bar"};
+    for (String path : invalidPaths) {
+      assertFalse("Should have been rejected '" + path + "'", DFSUtil.isValidName(path));
+    }
+
+    String windowsPath = "/C:/foo/bar";
     if (Shell.WINDOWS) {
-      assertTrue(DFSUtil.isValidName("/C:/some/path"));
+      assertTrue("Should have been accepted '" + windowsPath + "' in windows os.",
+          DFSUtil.isValidName(windowsPath));
     } else {
-      assertFalse(DFSUtil.isValidName("/C:/some/path"));
+      assertFalse("Should have been rejected '" + windowsPath + "' in unix os.",
+          DFSUtil.isValidName(windowsPath));
     }
   }
   


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
TestDFSUtil.testIsValidName runs failed when  assertFalse(DFSUtil.isValidName("/foo/:/bar")) , fixed it.
[HDFS-17249](https://issues.apache.org/jira/browse/HDFS-17249).

### How was this patch tested?
Add test case in TestDFSUtil.testIsValidName.