### PR TITLE
MAPREDUCE-7461: Fixed assertionComparision failure by resolving xml path for 'name'

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java
@@ -32,6 +32,9 @@ import java.util.Map;
 import javax.ws.rs.core.MediaType;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.JettyUtils;
@@ -483,9 +486,11 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
   }
 
-  public void verifyAMJobXML(NodeList nodes, AppContext appContext) {
-
+  public void verifyAMJobXML(NodeList nodes, AppContext appContext) throws XPathExpressionException {
     assertEquals("incorrect number of elements", 1, nodes.getLength());
+
+    XPathFactory xPathfactory = XPathFactory.newInstance();
+    XPath xpath = xPathfactory.newXPath();
 
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
@@ -496,7 +501,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
       verifyAMJobGeneric(job, WebServicesTestUtils.getXmlString(element, "id"),
           WebServicesTestUtils.getXmlString(element, "user"),
-          WebServicesTestUtils.getXmlString(element, "name"),
+          xpath.evaluate("name", element),
           WebServicesTestUtils.getXmlString(element, "state"),
           WebServicesTestUtils.getXmlLong(element, "startTime"),
           WebServicesTestUtils.getXmlLong(element, "finishTime"),

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesJobs.java
@@ -34,6 +34,9 @@ import java.util.Map;
 import javax.ws.rs.core.MediaType;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
 
 import com.google.inject.util.Providers;
 import org.apache.hadoop.conf.Configuration;
@@ -229,9 +232,11 @@ public class TestHsWebServicesJobs extends JerseyTestBase {
     }
   }
   
-  public void verifyHsJobXML(NodeList nodes, AppContext appContext) {
+  public void verifyHsJobXML(NodeList nodes, AppContext appContext) throws XPathExpressionException {
 
     assertEquals("incorrect number of elements", 1, nodes.getLength());
+    XPathFactory xPathfactory = XPathFactory.newInstance();
+    XPath xpath = xPathfactory.newXPath();
 
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
@@ -243,7 +248,7 @@ public class TestHsWebServicesJobs extends JerseyTestBase {
       VerifyJobsUtils.verifyHsJobGeneric(job,
           WebServicesTestUtils.getXmlString(element, "id"),
           WebServicesTestUtils.getXmlString(element, "user"),
-          WebServicesTestUtils.getXmlString(element, "name"),
+          xpath.evaluate("name", element),
           WebServicesTestUtils.getXmlString(element, "state"),
           WebServicesTestUtils.getXmlString(element, "queue"),
           WebServicesTestUtils.getXmlLong(element, "startTime"),


### PR DESCRIPTION
**Setup:**
Java version: openjdk 11.0.20.1
Maven version: Apache Maven 3.6.3

### **Issue**: https://issues.apache.org/jira/browse/MAPREDUCE-7461

### Description of PR
The following tests can fail due to flakiness while comparing the contents of the generated XML response.
**Module**: hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app
`org.apache.hadoop.mapreduce.v2.app.webapp.TestAMWebServicesJobs#testJobIdXML`
`org.apache.hadoop.mapreduce.v2.app.webapp.TestAMWebServicesJobs#testJobsXML`

**Module**: hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs
`org.apache.hadoop.mapreduce.v2.hs.webapp.TestHsWebServicesJobs#testJobIdXML`


### Steps to reproduce
1. `git clone https://github.com/apache/hadoop`
2. `mvn install -pl hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app -am -DskipTests`
3. Run the tests 
`mvn -pl hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app test -Dtests=org.apache.hadoop.mapreduce.v2.app.webapp.TestAMWebServicesJobs#testJobIdXML`
4. Run the test with the Nondex tool and observe the test results
    `mvn -pl hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app  edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.hadoop.mapreduce.v2.app.webapp.TestAMWebServicesJobs#testJobsIdXML`
     - Test Fails when Running Nondex in ONE mode (Assumes deterministic implementation of code but shuffled once different from underlying implementation) `-DnondexMode=ONE`  & FULL Mode ` -DnondexMode=FULL` (shuffles differently for each call)
     
### Root Cause
The test attempts to send a HTTP GET request to a specific URL and expects a response in XML format. However, elements in the XML response order is not necessarily guaranteed. The contents of the XML and the tags are compared with Job contents from `appContext` based on [job Id](https://github.com/kavvya97/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java#L493-L494) in [verifyAMJobXML](https://github.com/kavvya97/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java#L486) / [verifyHsJobXML](https://github.com/kavvya97/hadoop/blob/9c621fcea72a988c930ef614a7c22de00d0c7d21/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesJobs.java#L232).  When comparing the the XML contents,  The `<name>` tag occurs in multiple places inside `<job>` field. The current test utlization [WebServicesTestUtils.java getXmlString](https://github.com/kavvya97/hadoop/blob/trunk/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/WebServicesTestUtils.java#L78) always takes the first <name> tag irrespective of whether it is nested tag or in the direct child tag which causes the test to fail and become flaky.

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 8.377 s <<< FAILURE! - in org.apache.hadoop.mapreduce.v2.app.webapp.TestAMWebServicesJobs
[ERROR] testJobIdXML(org.apache.hadoop.mapreduce.v2.app.webapp.TestAMWebServicesJobs)  Time elapsed: 8.361 s  <<< FAILURE!
java.lang.AssertionError:
[name]
Expecting:
 "mapreduce.job.acl-view-job"
to match pattern:
 "RandomWriter"
```

### Fix

Since [WebServicesTestUtils.java getXmlString](https://github.com/kavvya97/hadoop/blob/trunk/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/WebServicesTestUtils.java#L78) compares the first <name> tag only which might not necessary be the direct child <name> tag, The Fix uses Xpath to resolve the conflicts and identify the direct child <name> tag. Thus the test passes since the direct child tag is always retrieved irrespective of xml order.

### How was this patch tested?
The fix was tested by running the Nondex plugin again and ensuring that all the tests pass in FULL Mode and ONE Mode of the Nondex runs. 