### PR TITLE
YARN-11612. [Federation] Fix the name of unmanaged app.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
@@ -1104,7 +1104,7 @@ public final class FederationStateStoreFacade {
   public ApplicationSubmissionContext getApplicationSubmissionContext(ApplicationId appId) {
     try {
       GetApplicationHomeSubClusterResponse response = stateStore.getApplicationHomeSubCluster(
-          GetApplicationHomeSubClusterRequest.newInstance(appId));
+          GetApplicationHomeSubClusterRequest.newInstance(appId, true));
       ApplicationHomeSubCluster appHomeSubCluster = response.getApplicationHomeSubCluster();
       return appHomeSubCluster.getApplicationSubmissionContext();
     } catch (Exception e) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/uam/UnmanagedApplicationManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/uam/UnmanagedApplicationManager.java
@@ -431,6 +431,7 @@ public class UnmanagedApplicationManager {
     context.setResource(resource);
     context.setAMContainerSpec(amContainer);
     if (applicationSubmissionContext != null) {
+      context.setApplicationName(applicationSubmissionContext.getApplicationName());
       context.setApplicationType(applicationSubmissionContext.getApplicationType());
       context.setKeepContainersAcrossApplicationAttempts(
           applicationSubmissionContext.getKeepContainersAcrossApplicationAttempts());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/uam/TestUnmanagedApplicationManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/uam/TestUnmanagedApplicationManager.java
@@ -587,7 +587,8 @@ public class TestUnmanagedApplicationManager {
   @Test(timeout = 5000)
   public void testUnmanagedAppName() throws IOException, InterruptedException, YarnException {
     launchUAM(attemptId);
-    GetApplicationReportRequest request = GetApplicationReportRequest.newInstance(attemptId.getApplicationId());
+    GetApplicationReportRequest request =
+        GetApplicationReportRequest.newInstance(attemptId.getApplicationId());
     GetApplicationReportResponse response = uam.getRMProxy().getApplicationReport(request);
     Assert.assertEquals(APP_NAME, response.getApplicationReport().getName());
   }


### PR DESCRIPTION
### Description of PR

[Federation] Fix the name of unmanaged app.

### How was this patch tested?

unit test and test in cluster

### For code changes:

1 When call GetApplicationHomeSubClusterResponse, return ApplicationSubmissionContext.
2 submit unmanaged app with the app name from original ApplicationSubmissionContext.
