### PR TITLE
HADOOP-18965. ITestS3AHugeFilesEncryption failure

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesEncryption.java
@@ -63,17 +63,24 @@ public class ITestS3AHugeFilesEncryption extends AbstractSTestS3AHugeFiles {
    */
   @Override
   protected boolean isEncrypted(S3AFileSystem fileSystem) {
-    Configuration c = new Configuration();
-    return StringUtils.isNotBlank(getS3EncryptionKey(getTestBucketName(c), c));
+    Configuration conf = new Configuration();
+    return StringUtils.isNotBlank(getS3EncryptionKey(getTestBucketName(conf), conf));
   }
 
+  /**
+   * This test suite will run if the algorithm is set to SSE_KMS or DSSE_KMS;
+   * the assertions validate this.
+   * @param hugeFile file to validate.
+   * @throws IOException problems with encryption lookup.
+   * @throws AssertionError if the encryption is not as expected.
+   */
   @Override
   protected void assertEncrypted(Path hugeFile) throws IOException {
-    Configuration c = new Configuration();
+    Configuration conf = new Configuration();
 
-    final String bucket = getTestBucketName(c);
-    String kmsKey = getS3EncryptionKey(bucket, c);
-    final S3AEncryptionMethods algorithm = getEncryptionAlgorithm(bucket, c);
+    final String bucket = getTestBucketName(conf);
+    String kmsKey = getS3EncryptionKey(bucket, conf);
+    final S3AEncryptionMethods algorithm = getEncryptionAlgorithm(bucket, conf);
     if (SSE_KMS.equals(algorithm)) {
       EncryptionTestUtils.assertEncrypted(getFileSystem(), hugeFile, SSE_KMS, kmsKey);
     } else if (DSSE_KMS.equals(algorithm)) {


### PR DESCRIPTION

### Description of PR

* moves to per-bucket load of encryption algorithm in test
* prints diagnostics on failure

### How was this patch tested?

reran failing test suite


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

