### PR TITLE
HADOOP-18969. S3A: AbstractS3ACostTest to clear bucket fs.s3a.create.performance

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/AbstractS3ACostTest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/AbstractS3ACostTest.java
@@ -107,7 +107,8 @@ public class AbstractS3ACostTest extends AbstractS3ATestBase {
 
     removeBaseAndBucketOverrides(bucketName, conf,
         DIRECTORY_MARKER_POLICY,
-        AUTHORITATIVE_PATH);
+        AUTHORITATIVE_PATH,
+        FS_S3A_CREATE_PERFORMANCE);
     // directory marker options
     conf.set(DIRECTORY_MARKER_POLICY,
         keepMarkers
@@ -234,6 +235,21 @@ public class AbstractS3ACostTest extends AbstractS3ATestBase {
     getFileSystem().create(path, overwrite).close();
     return path;
   }
+
+  /**
+   * Create a file with a specific body, returning its path.
+   * @param path path to file.
+   * @param overwrite overwrite flag
+   * @param body body of file
+   * @return path of new file
+   */
+  protected Path file(Path path, final boolean overwrite, byte[] body)
+      throws IOException {
+    ContractTestUtils.createFile(getFileSystem(), path, overwrite, body);
+    return path;
+  }
+
+
 
   /**
    * Touch a file, overwriting.


### PR DESCRIPTION

Add the option to the removeBaseAndBucketOverrides() list


### How was this patch tested?

On a test configuration with a per bucket setting.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

