### PR TITLE
HDFS-17251. RBF: Optimize MountTableResolver#TRASH_PATTERN

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
@@ -113,7 +113,7 @@ public class MountTableResolver
   private final Lock writeLock = readWriteLock.writeLock();
 
   /** Trash Current matching pattern. */
-  private static final String TRASH_PATTERN = "/(Current|[0-9]+)";
+  private static final String TRASH_PATTERN = "/(Current|[0-9]{12})";
 
   @VisibleForTesting
   public MountTableResolver(Configuration conf) {


### PR DESCRIPTION
### Description of PR
We should make the length of date string of MountTableResolver#TRASH_PATTERN have fixed length.

because the trash dirs look like below pattern:

/user/hdfs/.Trash/231113002000

the data string has a fixed length of 12.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?