### PR TITLE
HADOOP-18970. Upgrade hadoop2 docker scripts to latest 2.10.2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -14,14 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-set -e
-mkdir -p build
-if [ ! -d "$DIR/build/apache-rat-0.15" ]; then
-	curl -LSs https://dlcdn.apache.org/creadur/apache-rat-0.15/apache-rat-0.15-bin.tar.gz -o "$DIR/build/apache-rat.tar.gz"
-	cd $DIR/build
-	tar zvxf apache-rat.tar.gz
-	cd -
-fi
-java -jar $DIR/build/apache-rat-0.15/apache-rat-0.15.jar $DIR -e public -e apache-rat-0.15 -e .git -e .gitignore
-docker build -t apache/hadoop:2 .
+.git
+.gitignore
+build
+build.sh
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,12 @@
 # limitations under the License.
 
 FROM apache/hadoop-runner
-ARG HADOOP_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/common/hadoop-2.9.0/hadoop-2.9.0.tar.gz
+RUN sudo yum install -y which
+ARG HADOOP_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/common/hadoop-2.10.2/hadoop-2.10.2.tar.gz
 WORKDIR /opt
-RUN sudo rm -rf /opt/hadoop && wget $HADOOP_URL -O hadoop.tar.gz && tar zxf hadoop.tar.gz && rm hadoop.tar.gz && mv hadoop* hadoop && rm -rf /opt/hadoop/share/doc
+RUN sudo rm -rf /opt/hadoop && curl -LSs -o hadoop.tar.gz $HADOOP_URL && tar zxf hadoop.tar.gz && rm hadoop.tar.gz && mv hadoop* hadoop && rm -rf /opt/hadoop/share/doc
 WORKDIR /opt/hadoop
 ADD log4j.properties /opt/hadoop/etc/hadoop/log4j.properties
 RUN sudo chown -R hadoop:users /opt/hadoop/etc/hadoop/*
+ENV HADOOP_HOME /opt/hadoop
+ENV HADOOP_CONF_DIR $HADOOP_HOME/etc/hadoop

--- a/config
+++ b/config
@@ -18,6 +18,9 @@ CORE-SITE.XML_fs.defaultFS=hdfs://namenode
 HDFS-SITE.XML_dfs.namenode.rpc-address=namenode:8020
 HDFS-SITE.XML_dfs.replication=1
 MAPRED-SITE.XML_mapreduce.framework.name=yarn
+MAPRED-SITE.XML_yarn.app.mapreduce.am.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
+MAPRED-SITE.XML_mapreduce.map.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
+MAPRED-SITE.XML_mapreduce.reduce.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
 YARN-SITE.XML_yarn.resourcemanager.hostname=resourcemanager
 YARN-SITE.XML_yarn.nodemanager.pmem-check-enabled=false
 YARN-SITE.XML_yarn.nodemanager.delete.debug-delay-sec=600


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Update to Hadoop 2.10.2 release.
2. Adapted some misc. updates/improvements for the docker build from `docker-hadoop-3` branch.
3. Install `which`, required by `hadoop` bash script in 2.x.

https://issues.apache.org/jira/browse/HADOOP-18970

## How was this patch tested?

Built the new image locally:

```
$ ./build.sh
...
Successfully built c251dc1bdbce
Successfully tagged apache/hadoop:2
```

Verified output from `hadoop version`:

```
$ docker run -it --rm apache/hadoop:2 hadoop version
Hadoop 2.10.2
Subversion Unknown -r 965fd380006fa78b2315668fbc7eb432e1d8200f
Compiled by ubuntu on 2022-05-24T22:35Z
Compiled with protoc 2.5.0
From source with checksum d3ab737f7788f05d467784f0a86573fe
This command was run using /opt/hadoop/share/hadoop/common/hadoop-common-2.10.2.jar
```

Also tested it with the included sample Docker Compose cluster:

```
$ docker-compose up -d --scale datanode=3 --scale nodemanager=3
...
Successfully built c251dc1bdbce
Successfully tagged hadoop_namenode:latest
...
$ docker-compose exec resourcemanager yarn jar /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples-2.10.2.jar pi 3 3
...
Job Finished in 14.464 seconds
Estimated value of Pi is 3.55555555555555555556
```