### PR TITLE
HADOOP-18972: Copy SASL properties map when returning from SaslPropertiesResolver

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SaslPropertiesResolver.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SaslPropertiesResolver.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.security;
 
 import java.net.InetAddress;
 import java.util.Map;
+import java.util.SortedMap;
 import java.util.TreeMap;
 
 import javax.security.sasl.Sasl;
@@ -38,7 +39,7 @@ import org.apache.hadoop.util.StringUtils;
  *
  */
 public class SaslPropertiesResolver implements Configurable{
-  private Map<String,String> properties;
+  private SortedMap<String,String> properties;
   Configuration conf;
 
   /**
@@ -82,7 +83,7 @@ public class SaslPropertiesResolver implements Configurable{
    * @return sasl Properties
    */
   public Map<String,String> getDefaultProperties() {
-    return properties;
+    return new TreeMap<>(properties);
   }
 
   /**
@@ -91,7 +92,7 @@ public class SaslPropertiesResolver implements Configurable{
    * @return the sasl properties to be used for the connection.
    */
   public Map<String, String> getServerProperties(InetAddress clientAddress){
-    return properties;
+    return new TreeMap<>(properties);
   }
 
   /**
@@ -111,7 +112,7 @@ public class SaslPropertiesResolver implements Configurable{
    * @return the sasl properties to be used for the connection.
    */
   public Map<String, String> getClientProperties(InetAddress serverAddress){
-    return properties;
+    return new TreeMap<>(properties);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SaslPropertiesResolver.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SaslPropertiesResolver.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.security.SaslRpcServer.QualityOfProtection;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.StringUtils;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Provides SaslProperties to be used for a connection.
  * The default implementation is to read the values from configuration.
@@ -39,7 +41,7 @@ import org.apache.hadoop.util.StringUtils;
  *
  */
 public class SaslPropertiesResolver implements Configurable{
-  private SortedMap<String,String> properties;
+  private SortedMap<String, String> properties;
   Configuration conf;
 
   /**
@@ -83,7 +85,7 @@ public class SaslPropertiesResolver implements Configurable{
    * @return sasl Properties
    */
   public Map<String,String> getDefaultProperties() {
-    return new TreeMap<>(properties);
+    return cloneProperties();
   }
 
   /**
@@ -92,7 +94,7 @@ public class SaslPropertiesResolver implements Configurable{
    * @return the sasl properties to be used for the connection.
    */
   public Map<String, String> getServerProperties(InetAddress clientAddress){
-    return new TreeMap<>(properties);
+    return cloneProperties();
   }
 
   /**
@@ -112,7 +114,7 @@ public class SaslPropertiesResolver implements Configurable{
    * @return the sasl properties to be used for the connection.
    */
   public Map<String, String> getClientProperties(InetAddress serverAddress){
-    return new TreeMap<>(properties);
+    return cloneProperties();
   }
 
   /**
@@ -124,6 +126,12 @@ public class SaslPropertiesResolver implements Configurable{
   public Map<String, String> getClientProperties(InetAddress serverAddress,
       int ingressPort) {
     return getClientProperties(serverAddress);
+  }
+
+  private Map<String, String> cloneProperties() {
+    requireNonNull(properties,
+        "properties map in SaslPropertiesResolver was null, did you call setConf()?");
+    return new TreeMap<>(properties);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestSaslPropertiesResolver.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestSaslPropertiesResolver.java
@@ -1,0 +1,49 @@
+package org.apache.hadoop.security;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import javax.security.sasl.Sasl;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_RPC_PROTECTION;
+import static org.junit.Assert.assertEquals;
+
+public class TestSaslPropertiesResolver {
+
+  private static final SaslRpcServer.QualityOfProtection PRIVACY_QOP = SaslRpcServer.QualityOfProtection.PRIVACY;
+  private static final SaslRpcServer.QualityOfProtection AUTHENTICATION_QOP = SaslRpcServer.QualityOfProtection.AUTHENTICATION;
+  private static final InetAddress LOCALHOST = new InetSocketAddress("127.0.0.1", 1).getAddress();
+
+  private SaslPropertiesResolver resolver;
+
+  @Before
+  public void setup() {
+    Configuration conf = new Configuration();
+    conf.set(HADOOP_RPC_PROTECTION, "privacy");
+    resolver = new SaslPropertiesResolver();
+    resolver.setConf(conf);
+  }
+
+  @Test
+  public void testResolverDoesNotMutate() {
+    assertEquals(PRIVACY_QOP.getSaslQop(), resolver.getDefaultProperties().get(Sasl.QOP));
+    resolver.getDefaultProperties().put(Sasl.QOP, AUTHENTICATION_QOP.getSaslQop());
+    // Even after changing the map returned by SaslPropertiesResolver, it does not change its future responses
+    assertEquals(PRIVACY_QOP.getSaslQop(), resolver.getDefaultProperties().get(Sasl.QOP));
+
+    assertEquals(PRIVACY_QOP.getSaslQop(), resolver.getClientProperties(LOCALHOST).get(Sasl.QOP));
+    resolver.getDefaultProperties().put(Sasl.QOP, AUTHENTICATION_QOP.getSaslQop());
+    // Even after changing the map returned by SaslPropertiesResolver, it does not change its future responses
+    assertEquals(PRIVACY_QOP.getSaslQop(), resolver.getClientProperties(LOCALHOST).get(Sasl.QOP));
+
+    assertEquals(PRIVACY_QOP.getSaslQop(), resolver.getServerProperties(LOCALHOST).get(Sasl.QOP));
+    resolver.getDefaultProperties().put(Sasl.QOP, AUTHENTICATION_QOP.getSaslQop());
+    // Even after changing the map returned by SaslPropertiesResolver, it does not change its future responses
+    assertEquals(PRIVACY_QOP.getSaslQop(), resolver.getServerProperties(LOCALHOST).get(Sasl.QOP));
+  }
+
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestSaslPropertiesResolver.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestSaslPropertiesResolver.java
@@ -1,21 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.security;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.Map;
 import javax.security.sasl.Sasl;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_RPC_PROTECTION;
 import static org.junit.Assert.assertEquals;
 
-public class TestSaslPropertiesResolver {
+public class TestSaslPropertiesResolver extends AbstractHadoopTestBase {
 
-  private static final SaslRpcServer.QualityOfProtection PRIVACY_QOP = SaslRpcServer.QualityOfProtection.PRIVACY;
-  private static final SaslRpcServer.QualityOfProtection AUTHENTICATION_QOP = SaslRpcServer.QualityOfProtection.AUTHENTICATION;
   private static final InetAddress LOCALHOST = new InetSocketAddress("127.0.0.1", 1).getAddress();
 
   private SaslPropertiesResolver resolver;
@@ -30,20 +47,29 @@ public class TestSaslPropertiesResolver {
 
   @Test
   public void testResolverDoesNotMutate() {
-    assertEquals(PRIVACY_QOP.getSaslQop(), resolver.getDefaultProperties().get(Sasl.QOP));
-    resolver.getDefaultProperties().put(Sasl.QOP, AUTHENTICATION_QOP.getSaslQop());
-    // Even after changing the map returned by SaslPropertiesResolver, it does not change its future responses
-    assertEquals(PRIVACY_QOP.getSaslQop(), resolver.getDefaultProperties().get(Sasl.QOP));
+    assertPrivacyQop(resolver.getDefaultProperties());
+    setAuthenticationQop(resolver.getDefaultProperties());
+    // After changing the map returned by SaslPropertiesResolver, future maps are not affected
+    assertPrivacyQop(resolver.getDefaultProperties());
 
-    assertEquals(PRIVACY_QOP.getSaslQop(), resolver.getClientProperties(LOCALHOST).get(Sasl.QOP));
-    resolver.getDefaultProperties().put(Sasl.QOP, AUTHENTICATION_QOP.getSaslQop());
-    // Even after changing the map returned by SaslPropertiesResolver, it does not change its future responses
-    assertEquals(PRIVACY_QOP.getSaslQop(), resolver.getClientProperties(LOCALHOST).get(Sasl.QOP));
+    assertPrivacyQop(resolver.getClientProperties(LOCALHOST));
+    setAuthenticationQop(resolver.getClientProperties(LOCALHOST));
+    // After changing the map returned by SaslPropertiesResolver, future maps are not affected
+    assertPrivacyQop(resolver.getClientProperties(LOCALHOST));
 
-    assertEquals(PRIVACY_QOP.getSaslQop(), resolver.getServerProperties(LOCALHOST).get(Sasl.QOP));
-    resolver.getDefaultProperties().put(Sasl.QOP, AUTHENTICATION_QOP.getSaslQop());
-    // Even after changing the map returned by SaslPropertiesResolver, it does not change its future responses
-    assertEquals(PRIVACY_QOP.getSaslQop(), resolver.getServerProperties(LOCALHOST).get(Sasl.QOP));
+    assertPrivacyQop(resolver.getServerProperties(LOCALHOST));
+    setAuthenticationQop(resolver.getServerProperties(LOCALHOST));
+    // After changing the map returned by SaslPropertiesResolver, future maps are not affected
+    assertPrivacyQop(resolver.getServerProperties(LOCALHOST));
+  }
+
+  private static void setAuthenticationQop(Map<String, String> saslProperties) {
+    saslProperties.put(Sasl.QOP, SaslRpcServer.QualityOfProtection.AUTHENTICATION.getSaslQop());
+  }
+
+  private static void assertPrivacyQop(Map<String, String> saslProperties) {
+    assertEquals(SaslRpcServer.QualityOfProtection.PRIVACY.getSaslQop(),
+        saslProperties.get(Sasl.QOP));
   }
 
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestSaslPropertiesResolver.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestSaslPropertiesResolver.java
@@ -17,19 +17,17 @@
  */
 package org.apache.hadoop.security;
 
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_RPC_PROTECTION;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Map;
 import javax.security.sasl.Sasl;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
-
-import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_RPC_PROTECTION;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestSaslPropertiesResolver extends AbstractHadoopTestBase {
 
@@ -37,7 +35,7 @@ public class TestSaslPropertiesResolver extends AbstractHadoopTestBase {
 
   private SaslPropertiesResolver resolver;
 
-  @Before
+  @BeforeEach
   public void setup() {
     Configuration conf = new Configuration();
     conf.set(HADOOP_RPC_PROTECTION, "privacy");
@@ -68,7 +66,7 @@ public class TestSaslPropertiesResolver extends AbstractHadoopTestBase {
   }
 
   private static void assertPrivacyQop(Map<String, String> saslProperties) {
-    assertEquals(SaslRpcServer.QualityOfProtection.PRIVACY.getSaslQop(),
+    assertThat(SaslRpcServer.QualityOfProtection.PRIVACY.getSaslQop()).isEqualTo(
         saslProperties.get(Sasl.QOP));
   }
 


### PR DESCRIPTION
### Description of PR

When `SaslDataTransferServer` or `SaslDataTranferClient` want to get a SASL properties map to do a handshake, they call `SaslPropertiesResolver#getServerProperties()` or `SaslPropertiesResolver#getClientProperties()`, and they get back a `Map<String, String>`. Every call gets the same Map object back, and then the callers sometimes call [put()](https://github.com/apache/hadoop/blob/rel/release-3.3.6/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java#L385) on it. This means that future users of `SaslPropertiesResolver` get back the wrong information.

In this PR, `SaslPropretiesResolver` gives out copies of its internal map, so that users can safety modify them.

### How was this patch tested?

My employer has [effectively the same patch](https://github.com/HubSpot/hadoop/commit/6761522efd5f6ac6117ee151c44edb7d97ca0031) already committed to our fork of Hadoop 3.3.1. We are running this in production, and have found that this patch fixes the problem we were experiencing, described in the JIRA ticket.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

