### PR TITLE
HADOOP-18973. Clean yum cache after installing which in hadoop2 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,11 @@
 # limitations under the License.
 
 FROM apache/hadoop-runner
-RUN sudo yum install -y which
 ARG HADOOP_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/common/hadoop-2.10.2/hadoop-2.10.2.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && curl -LSs -o hadoop.tar.gz $HADOOP_URL && tar zxf hadoop.tar.gz && rm hadoop.tar.gz && mv hadoop* hadoop && rm -rf /opt/hadoop/share/doc
+RUN sudo yum install -y which && \
+      sudo yum clean all
 WORKDIR /opt/hadoop
 ADD log4j.properties /opt/hadoop/etc/hadoop/log4j.properties
 RUN sudo chown -R hadoop:users /opt/hadoop/etc/hadoop/*


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Clean yum cache after installing `which` to reduce image size.
* Reorder installation of Hadoop and `which`.  Hadoop release bits are not going to change, but we may want to install other packages in the image.  The updated order reduces the number of image layers that have to be downloaded after such future change.

https://issues.apache.org/jira/browse/HADOOP-18973

## How was this patch tested?

```
$ docker pull apache/hadoop:2
$ docker run -it --rm apache/hadoop:2 du -sh /var/cache/yum
234M	/var/cache/yum

$ ./build.sh
...
Successfully built c88de0d4d5c2
Successfully tagged apache/hadoop:2

$ docker run -it --rm apache/hadoop:2 du -sh /var/cache/yum
64K	/var/cache/yum

$ docker image ls | head -3
REPOSITORY                                            TAG                            IMAGE ID       CREATED          SIZE
apache/hadoop                                         2                              c88de0d4d5c2   9 minutes ago    1.18GB
apache/hadoop                                         <none>                         ba716169c882   49 minutes ago   1.43GB
```