### PR TITLE
HADOOP-18982. Fix doc about loading native libraries.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/NativeLibraries.md.vm
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/NativeLibraries.md.vm
@@ -128,8 +128,8 @@ You can load any native shared library using DistributedCache for distributing a
 
 This example shows you how to distribute a shared library, mylib.so, and load it from a MapReduce task.
 
-1.  First copy the library to the HDFS: `bin/hadoop fs -copyFromLocal mylib.so.1 /libraries/mylib.so.1`
-2.  The job launching program should contain the following: `DistributedCache.createSymlink(conf);` `DistributedCache.addCacheFile("hdfs://host:port/libraries/mylib.so. 1#mylib.so", conf);`
-3.  The MapReduce task can contain: `System.loadLibrary("mylib.so");`
+1.  First copy the library to the HDFS: `bin/hadoop fs -copyFromLocal libmyexample.so.1 /libraries/libmyexample.so.1`
+2.  The job launching program should contain the following: `DistributedCache.createSymlink(conf);` `DistributedCache.addCacheFile("hdfs://host:port/libraries/libmyexample.so.1#libmyexample.so", conf);`
+3.  The MapReduce task can contain: `System.loadLibrary("myexample");`
 
 Note: If you downloaded or built the native hadoop library, you don’t need to use DistibutedCache to make the library available to your MapReduce tasks.

--- a/hadoop-common-project/hadoop-common/src/site/markdown/NativeLibraries.md.vm
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/NativeLibraries.md.vm
@@ -126,7 +126,7 @@ Native Shared Libraries
 
 You can load any native shared library using DistributedCache for distributing and symlinking the library files.
 
-This example shows you how to distribute a shared library, mylib.so, and load it from a MapReduce task.
+This example shows you how to distribute a shared library in Unix-like systems, mylib.so, and load it from a MapReduce task.
 
 1.  First copy the library to the HDFS: `bin/hadoop fs -copyFromLocal libmyexample.so.1 /libraries/libmyexample.so.1`
 2.  The job launching program should contain the following: `DistributedCache.createSymlink(conf);` `DistributedCache.addCacheFile("hdfs://host:port/libraries/libmyexample.so.1#libmyexample.so", conf);`


### PR DESCRIPTION
### Description of PR
When we want load a native library libmyexample.so, the right way is to call 
`System.loadLibrary("myexample")` rather than `System.loadLibrary("libmyexample.so")`.