### PR TITLE
YARN-11616. Fast fail for NodeConstraintParser when having multi attribute kvs

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/util/constraint/PlacementConstraintParser.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/util/constraint/PlacementConstraintParser.java
@@ -406,6 +406,10 @@ public final class PlacementConstraintParser {
         // multiple values are present for same attribute, it will also be
         // coming as next token. for example, java=1.8,1.9 or python!=2.
         if (attributeKV.countTokens() > 1) {
+          if (!constraintEntities.isEmpty()) {
+            throw new PlacementConstraintParseException(
+                "expecting valid expression like k=v or k!=v or k=v1,v2");
+          }
           opCode = getAttributeOpCode(currentTag);
           attributeName = attributeKV.nextToken();
           currentTag = attributeKV.nextToken();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/api/resource/TestPlacementConstraintParser.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/api/resource/TestPlacementConstraintParser.java
@@ -571,6 +571,18 @@ class TestPlacementConstraintParser {
   }
 
   @Test
+  public void testParseIllegalExprShouldThrowException() {
+    // A single node attribute constraint w/o source tags, it should fail when multiple
+    // attribute kvs are specified.
+    try {
+      PlacementConstraintParser.parseExpression("rm.yarn.io/foo=true,rm.yarn.io/bar=true");
+      fail("Expected a failure!");
+    } catch (PlacementConstraintParseException e) {
+      // ignore
+    }
+  }
+
+  @Test
   void testParseAllocationTagNameSpace()
       throws PlacementConstraintParseException {
     Map<SourceTags, PlacementConstraint> result;


### PR DESCRIPTION
### Description of PR

In the `NodeConstraintParser`, it won't throw exception when multiple attribute kvs are specified. It will return incorrect placement constraint, which will mislead users. Like the

`rm.yarn.io/foo=1,rm.yarn.io/bar=2`, it will parse it to `node,EQ,rm.yarn.io/bar=[1:2]`

### How was this patch tested?

Verified in our internal cluster.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

