### PR TITLE
YARN-11617. Remove noisy log in SingleConstraintAppPlacementAllocator

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/placement/SingleConstraintAppPlacementAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/placement/SingleConstraintAppPlacementAllocator.java
@@ -225,11 +225,13 @@ public class SingleConstraintAppPlacementAllocator<N extends SchedulerNode>
         ((SchedulingRequestPBImpl) newSchedulingRequest).getProto());
 
 
-    LOG.info("Successfully added SchedulingRequest to app="
-        + appSchedulingInfo.getApplicationAttemptId()
-        + " placementConstraint=["
-        + schedulingRequest.getPlacementConstraint()
-        + "]. nodePartition=" + targetNodePartition);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Successfully added SchedulingRequest to app="
+          + appSchedulingInfo.getApplicationAttemptId()
+          + " placementConstraint=["
+          + schedulingRequest.getPlacementConstraint()
+          + "]. nodePartition=" + targetNodePartition);
+    }
   }
 
   // Tentatively find out potential exist node-partition in the placement


### PR DESCRIPTION

### Description of PR

Too many noisy log in SingleConstraintAppPlacementAllocator like that:

```
2023-11-20 15:14:30,493 INFO org.apache.hadoop.yarn.server.resourcemanager.scheduler.placement.SingleConstraintAppPlacementAllocator: Successfully added SchedulingRequest to app=appattempt_1700464328807_0002_000001 placementConstraint=[
node,EQ,nm.yarn.io/lifecycle=[reserved:true]]. nodePartition=
```

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

