### PR TITLE
HDFS-17233. The conf dfs.datanode.lifeline.interval.seconds is not co…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DNConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DNConf.java
@@ -220,10 +220,10 @@ public class DNConf {
         DFS_HEARTBEAT_INTERVAL_DEFAULT, TimeUnit.SECONDS,
         TimeUnit.MILLISECONDS);
     long confLifelineIntervalMs =
-        getConf().getLong(DFS_DATANODE_LIFELINE_INTERVAL_SECONDS_KEY,
-        3 * getConf().getTimeDuration(DFS_HEARTBEAT_INTERVAL_KEY,
-        DFS_HEARTBEAT_INTERVAL_DEFAULT, TimeUnit.SECONDS,
-            TimeUnit.MILLISECONDS));
+        getConf().getTimeDuration(DFS_DATANODE_LIFELINE_INTERVAL_SECONDS_KEY,
+            3 * getConf().getTimeDuration(DFS_HEARTBEAT_INTERVAL_KEY,
+                DFS_HEARTBEAT_INTERVAL_DEFAULT, TimeUnit.SECONDS),
+            TimeUnit.SECONDS, TimeUnit.MILLISECONDS);
     if (confLifelineIntervalMs <= heartBeatInterval) {
       confLifelineIntervalMs = 3 * heartBeatInterval;
       DataNode.LOG.warn(


### PR DESCRIPTION
…nsidering time unit seconds

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The configuration dfs.datanode.lifeline.interval.seconds is not considering the time unit as seconds. Upon configuring the  DFS_DATANODE_LIFELINE_INTERVAL_SECONDS_KEY, the value is not converting to Ms as it should be. 

### How was this patch tested?
Verified from the datanode logs that the config dfs.datanode.lifeline.interval.seconds is considering the time unit as seconds after the fix.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

