### PR TITLE
HDFS-17261. RBF: Fix getFileInfo return wrong path when get mountTable path which is multi-level

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -915,7 +915,7 @@ public class RouterClientProtocol implements ClientProtocol {
         }
         Path childPath = new Path(src, child);
         HdfsFileStatus dirStatus =
-            getMountPointStatus(childPath.toString(), 0, date);
+            getMountPointStatus(childPath.toString(), 0, date, true);
 
         // if there is no subcluster path, always add mount point
         byte[] bChild = DFSUtil.string2Bytes(child);
@@ -993,10 +993,10 @@ public class RouterClientProtocol implements ClientProtocol {
         if (dates != null && dates.containsKey(src)) {
           date = dates.get(src);
         }
-        ret = getMountPointStatus(src, children.size(), date);
+        ret = getMountPointStatus(src, children.size(), date, false);
       } else if (children != null) {
         // The src is a mount point, but there are no files or directories
-        ret = getMountPointStatus(src, 0, 0);
+        ret = getMountPointStatus(src, 0, 0, false);
       }
     }
 
@@ -2188,11 +2188,12 @@ public class RouterClientProtocol implements ClientProtocol {
    * @param name Name of the mount point.
    * @param childrenNum Number of children.
    * @param date Map with the dates.
+   * @param setPath if true should set path in HdfsFileStatus
    * @return New HDFS file status representing a mount point.
    */
   @VisibleForTesting
   HdfsFileStatus getMountPointStatus(
-      String name, int childrenNum, long date) {
+      String name, int childrenNum, long date, boolean setPath) {
     long modTime = date;
     long accessTime = date;
     FsPermission permission = FsPermission.getDirDefault();
@@ -2242,17 +2243,20 @@ public class RouterClientProtocol implements ClientProtocol {
       }
     }
     long inodeId = 0;
-    Path path = new Path(name);
-    String nameStr = path.getName();
-    return new HdfsFileStatus.Builder()
-        .isdir(true)
+    HdfsFileStatus.Builder builder = new HdfsFileStatus.Builder();
+    if (setPath) {
+      Path path = new Path(name);
+      String nameStr = path.getName();
+      builder.path(DFSUtil.string2Bytes(nameStr));
+    }
+
+    return builder.isdir(true)
         .mtime(modTime)
         .atime(accessTime)
         .perm(permission)
         .owner(owner)
         .group(group)
         .symlink(new byte[0])
-        .path(DFSUtil.string2Bytes(nameStr))
         .fileId(inodeId)
         .children(childrenNum)
         .flags(flags)

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -915,7 +915,7 @@ public class RouterClientProtocol implements ClientProtocol {
         }
         Path childPath = new Path(src, child);
         HdfsFileStatus dirStatus =
-            getMountPointStatus(childPath.toString(), 0, date, true);
+            getMountPointStatus(childPath.toString(), 0, date);
 
         // if there is no subcluster path, always add mount point
         byte[] bChild = DFSUtil.string2Bytes(child);
@@ -2180,6 +2180,20 @@ public class RouterClientProtocol implements ClientProtocol {
         mask.getGroupAction(),
         mask.getOtherAction());
     return ret;
+  }
+
+  /**
+   * Create a new file status for a mount point.
+   *
+   * @param name Name of the mount point.
+   * @param childrenNum Number of children.
+   * @param date Map with the dates.
+   * @return New HDFS file status representing a mount point.
+   */
+  @VisibleForTesting
+  HdfsFileStatus getMountPointStatus(
+      String name, int childrenNum, long date) {
+    return getMountPointStatus(name, childrenNum, date, true);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTable.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTable.java
@@ -373,11 +373,8 @@ public class TestRouterMountTable {
         clientProtocol.getMountPointStatus(childPath2.toString(), 0, 0);
     assertEquals(child2, dirStatus2.getLocalName());
 
-    String src3 = "/testA/testB";
-    String child3 = "testC";
-    Path childPath3 = new Path(src2, child2);
     HdfsFileStatus dirStatus3 =
-        clientProtocol.getMountPointStatus(childPath3.toString(), 0, 0, false);
+        clientProtocol.getMountPointStatus(childPath2.toString(), 0, 0, false);
     assertTrue(dirStatus3.isEmptyLocalName());
   }
   /**
@@ -683,10 +680,10 @@ public class TestRouterMountTable {
       nnFs1.mkdirs(new Path("/testgetfileinfo/ns1/dir"));
 
       FileStatus fileStatus = routerFs.getFileStatus(new Path("/testgetfileinfo/ns1"));
-      assertTrue(fileStatus.getPath().toString().endsWith("/testgetfileinfo/ns1"));
+      assertEquals(fileStatus.getPath().toUri().getPath(), "/testgetfileinfo/ns1");
 
-      FileStatus fileStatus1 = routerFs.getFileStatus(new Path("/testgetfileinfo/ns1/dir"));
-      assertTrue(fileStatus1.getPath().toString().endsWith("/testgetfileinfo/ns1/dir"));
+      fileStatus = routerFs.getFileStatus(new Path("/testgetfileinfo/ns1/dir"));
+      assertEquals(fileStatus.getPath().toUri().getPath(), "/testgetfileinfo/ns1/dir");
     } finally {
       nnFs1.delete(new Path("/testgetfileinfo/ns1/dir"), true);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTable.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTable.java
@@ -356,21 +356,21 @@ public class TestRouterMountTable {
     String child = "testA";
     Path childPath = new Path(src, child);
     HdfsFileStatus dirStatus =
-        clientProtocol.getMountPointStatus(childPath.toString(), 0, 0, true);
+        clientProtocol.getMountPointStatus(childPath.toString(), 0, 0);
     assertEquals(child, dirStatus.getLocalName());
 
     String src1 = "/testA";
     String child1 = "testB";
     Path childPath1 = new Path(src1, child1);
     HdfsFileStatus dirStatus1 =
-        clientProtocol.getMountPointStatus(childPath1.toString(), 0, 0, true);
+        clientProtocol.getMountPointStatus(childPath1.toString(), 0, 0);
     assertEquals(child1, dirStatus1.getLocalName());
 
     String src2 = "/testA/testB";
     String child2 = "testC";
     Path childPath2 = new Path(src2, child2);
     HdfsFileStatus dirStatus2 =
-        clientProtocol.getMountPointStatus(childPath2.toString(), 0, 0, true);
+        clientProtocol.getMountPointStatus(childPath2.toString(), 0, 0);
     assertEquals(child2, dirStatus2.getLocalName());
 
     String src3 = "/testA/testB";

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTable.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTable.java
@@ -356,22 +356,29 @@ public class TestRouterMountTable {
     String child = "testA";
     Path childPath = new Path(src, child);
     HdfsFileStatus dirStatus =
-        clientProtocol.getMountPointStatus(childPath.toString(), 0, 0);
+        clientProtocol.getMountPointStatus(childPath.toString(), 0, 0, true);
     assertEquals(child, dirStatus.getLocalName());
 
     String src1 = "/testA";
     String child1 = "testB";
     Path childPath1 = new Path(src1, child1);
     HdfsFileStatus dirStatus1 =
-        clientProtocol.getMountPointStatus(childPath1.toString(), 0, 0);
+        clientProtocol.getMountPointStatus(childPath1.toString(), 0, 0, true);
     assertEquals(child1, dirStatus1.getLocalName());
 
     String src2 = "/testA/testB";
     String child2 = "testC";
     Path childPath2 = new Path(src2, child2);
     HdfsFileStatus dirStatus2 =
-        clientProtocol.getMountPointStatus(childPath2.toString(), 0, 0);
+        clientProtocol.getMountPointStatus(childPath2.toString(), 0, 0, true);
     assertEquals(child2, dirStatus2.getLocalName());
+
+    String src3 = "/testA/testB";
+    String child3 = "testC";
+    Path childPath3 = new Path(src2, child2);
+    HdfsFileStatus dirStatus3 =
+        clientProtocol.getMountPointStatus(childPath3.toString(), 0, 0, false);
+    assertTrue(dirStatus3.isEmptyLocalName());
   }
   /**
    * GetListing of testPath through router.
@@ -663,6 +670,25 @@ public class TestRouterMountTable {
     } finally {
       nnFs0.delete(new Path("/testlist/tmp0"), true);
       nnFs1.delete(new Path("/testlist/tmp1"), true);
+    }
+  }
+
+  @Test
+  public void testGetFileInfoWithMountPoint() throws IOException {
+    try {
+      // Add mount table entry
+      MountTable addEntry = MountTable.newInstance("/testgetfileinfo/ns1/dir",
+          Collections.singletonMap("ns1", "/testgetfileinfo/ns1/dir"));
+      assertTrue(addMountTable(addEntry));
+      nnFs1.mkdirs(new Path("/testgetfileinfo/ns1/dir"));
+
+      FileStatus fileStatus = routerFs.getFileStatus(new Path("/testgetfileinfo/ns1"));
+      assertTrue(fileStatus.getPath().toString().endsWith("/testgetfileinfo/ns1"));
+
+      FileStatus fileStatus1 = routerFs.getFileStatus(new Path("/testgetfileinfo/ns1/dir"));
+      assertTrue(fileStatus1.getPath().toString().endsWith("/testgetfileinfo/ns1/dir"));
+    } finally {
+      nnFs1.delete(new Path("/testgetfileinfo/ns1/dir"), true);
     }
   }
 


### PR DESCRIPTION
…i-level dirs

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
With DFSRouter, Suppose there are two nameservices ： ns0，ns1 , and ns0 is the default nameservice.

Add mountTable      /testgetfileinfo/ns1/dir  -> (ns1 -> /testgetfileinfo/ns1/dir) 
hdfs client via DFSRouter accesses a directory：   hdfs dfs -ls -d /testgetfileinfo
it will return worng path :    /testgetfileinfo/testgetfileinfo


