### PR TITLE
HDFS-17263. RBF: Fix client ls trash path cannot get except default nameservices trash path

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
@@ -357,7 +357,7 @@ public class MountTableResolver
   @VisibleForTesting
   public static boolean isTrashPath(String path) throws IOException {
     Pattern pattern = Pattern.compile(
-        "^" + getTrashRoot() + TRASH_PATTERN + "/");
+        "^" + getTrashRoot() + TRASH_PATTERN);
     return pattern.matcher(path).find();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -943,7 +943,7 @@ public class RouterClientProtocol implements ClientProtocol {
       }
     }
 
-    if (!namenodeListingExists && nnListing.size() == 0) {
+    if (!namenodeListingExists && nnListing.size() == 0 && children == null) {
       // NN returns a null object if the directory cannot be found and has no
       // listing. If we didn't retrieve any NN listing data, and there are no
       // mount points here, return null.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
@@ -64,12 +64,17 @@ public class TestRouterTrash {
   private static MountTableResolver mountTable;
   private static FileSystem routerFs;
   private static FileSystem nnFs;
+  private static FileSystem nnFs1;
   private static final String TEST_USER = "test-trash";
   private static MiniRouterDFSCluster.NamenodeContext nnContext;
+  private static MiniRouterDFSCluster.NamenodeContext nnContext1;
   private static String ns0;
   private static String ns1;
   private static final String MOUNT_POINT = "/home/data";
   private static final String FILE = MOUNT_POINT + "/file1";
+  private static final String MOUNT_POINT1 = "/data1/test1";
+  private static final String MOUNT_POINT2 = "/data2/test2";
+  private static final String FILE1 = MOUNT_POINT1 + "/file1";
   private static final String TRASH_ROOT = "/user/" + TEST_USER + "/.Trash";
   private static final String CURRENT = "/Current";
 
@@ -96,6 +101,8 @@ public class TestRouterTrash {
     routerFs = routerContext.getFileSystem();
     nnContext = cluster.getNamenode(ns0, null);
     nnFs = nnContext.getFileSystem();
+    nnContext1 = cluster.getNamenode(ns1, null);
+    nnFs1 = nnContext1.getFileSystem();
     Router router = routerContext.getRouter();
     mountTable = (MountTableResolver) router.getSubclusterResolver();
   }
@@ -228,6 +235,61 @@ public class TestRouterTrash {
   }
 
   @Test
+  public void testMultipleMountPoint() throws IOException,
+      URISyntaxException, InterruptedException {
+    MountTable addEntry = MountTable.newInstance(MOUNT_POINT,
+        Collections.singletonMap(ns0, MOUNT_POINT));
+    MountTable addEntry1 = MountTable.newInstance(MOUNT_POINT1,
+        Collections.singletonMap(ns1, MOUNT_POINT1));
+    MountTable addEntry2 = MountTable.newInstance(MOUNT_POINT2,
+        Collections.singletonMap(ns1, MOUNT_POINT2));
+    assertTrue(addMountTable(addEntry));
+    assertTrue(addMountTable(addEntry1));
+    assertTrue(addMountTable(addEntry2));
+
+    // current user client
+    DFSClient client = nnContext.getClient();
+    client.setOwner("/", TEST_USER, TEST_USER);
+
+    DFSClient client1 = nnContext1.getClient();
+    client1.setOwner("/", TEST_USER, TEST_USER);
+
+
+    UserGroupInformation ugi = UserGroupInformation.
+        createRemoteUser(TEST_USER);
+    // test user client
+    client = nnContext.getClient(ugi);
+    client.mkdirs(MOUNT_POINT, new FsPermission("777"), true);
+    client.create(FILE, true);
+
+    client1 = nnContext1.getClient(ugi);
+    client1.mkdirs("/user", new FsPermission("777"), true);
+    client1.mkdirs(MOUNT_POINT1, new FsPermission("777"), true);
+    client1.create(FILE1, true);
+    client1.mkdirs(MOUNT_POINT2, new FsPermission("777"), true);
+
+    // move to Trash
+    Configuration routerConf = routerContext.getConf();
+    FileSystem fs =
+        DFSTestUtil.getFileSystemAs(ugi, routerConf);
+
+    Trash trash = new Trash(fs , routerConf);
+    assertTrue(trash.moveToTrash(new Path(FILE)));
+    assertTrue(trash.moveToTrash(new Path(FILE1)));
+
+
+    //Client user see gloabl trash view， wo should see all three mount point
+    FileStatus[] fileStatuses = fs.listStatus(new Path("/user/test-trash/.Trash/Current/"));
+    assertEquals(3, fileStatuses.length);
+
+    //This should return fileStatuses rather than Not found Exception
+    fileStatuses = fs.listStatus(new Path("/user/test-trash/.Trash/Current/"+MOUNT_POINT2));
+    assertEquals(0, fileStatuses.length);
+
+    client1.delete("/user",true);
+  }
+
+  @Test
   public void testDeleteToTrashExistMountPoint() throws IOException,
       URISyntaxException, InterruptedException {
     MountTable addEntry = MountTable.newInstance(MOUNT_POINT,
@@ -280,6 +342,8 @@ public class TestRouterTrash {
   public void testIsTrashPath() throws IOException {
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
     assertNotNull(ugi);
+    assertTrue(MountTableResolver.isTrashPath(
+        "/user/" + ugi.getUserName() + "/.Trash/Current"));
     assertTrue(MountTableResolver.isTrashPath(
         "/user/" + ugi.getUserName() + "/.Trash/Current" + MOUNT_POINT));
     assertTrue(MountTableResolver.isTrashPath(

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
@@ -247,7 +247,6 @@ public class TestRouterTrash {
     assertTrue(addMountTable(addEntry1));
     assertTrue(addMountTable(addEntry2));
 
-    // current user client
     DFSClient client = nnContext.getClient();
     client.setOwner("/", TEST_USER, TEST_USER);
 
@@ -257,36 +256,35 @@ public class TestRouterTrash {
 
     UserGroupInformation ugi = UserGroupInformation.
         createRemoteUser(TEST_USER);
-    // test user client
+
     client = nnContext.getClient(ugi);
     client.mkdirs(MOUNT_POINT, new FsPermission("777"), true);
     client.create(FILE, true);
 
     client1 = nnContext1.getClient(ugi);
-    client1.mkdirs("/user", new FsPermission("777"), true);
     client1.mkdirs(MOUNT_POINT1, new FsPermission("777"), true);
     client1.create(FILE1, true);
     client1.mkdirs(MOUNT_POINT2, new FsPermission("777"), true);
 
-    // move to Trash
+    //Move two different nameservice file to trash.
     Configuration routerConf = routerContext.getConf();
     FileSystem fs =
         DFSTestUtil.getFileSystemAs(ugi, routerConf);
 
-    Trash trash = new Trash(fs , routerConf);
+    Trash trash = new Trash(fs, routerConf);
     assertTrue(trash.moveToTrash(new Path(FILE)));
     assertTrue(trash.moveToTrash(new Path(FILE1)));
 
 
-    //Client user see gloabl trash view， wo should see all three mount point
+    //Client user see global trash view， wo should see all three mount point.
     FileStatus[] fileStatuses = fs.listStatus(new Path("/user/test-trash/.Trash/Current/"));
     assertEquals(3, fileStatuses.length);
 
-    //This should return fileStatuses rather than Not found Exception
-    fileStatuses = fs.listStatus(new Path("/user/test-trash/.Trash/Current/"+MOUNT_POINT2));
+    //This should return empty fileStatuses rather than NotFound Exception.
+    fileStatuses = fs.listStatus(new Path("/user/test-trash/.Trash/Current/" + MOUNT_POINT2));
     assertEquals(0, fileStatuses.length);
 
-    client1.delete("/user",true);
+    client1.delete("/user", true);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
@@ -253,7 +253,6 @@ public class TestRouterTrash {
     DFSClient client1 = nnContext1.getClient();
     client1.setOwner("/", TEST_USER, TEST_USER);
 
-
     UserGroupInformation ugi = UserGroupInformation.
         createRemoteUser(TEST_USER);
 
@@ -266,7 +265,7 @@ public class TestRouterTrash {
     client1.create(FILE1, true);
     client1.mkdirs(MOUNT_POINT2, new FsPermission("777"), true);
 
-    //Move two different nameservice file to trash.
+    // Move two different nameservice file to trash.
     Configuration routerConf = routerContext.getConf();
     FileSystem fs =
         DFSTestUtil.getFileSystemAs(ugi, routerConf);
@@ -275,12 +274,11 @@ public class TestRouterTrash {
     assertTrue(trash.moveToTrash(new Path(FILE)));
     assertTrue(trash.moveToTrash(new Path(FILE1)));
 
-
-    //Client user see global trash view， wo should see all three mount point.
+    // Client user see global trash view， wo should see all three mount point.
     FileStatus[] fileStatuses = fs.listStatus(new Path("/user/test-trash/.Trash/Current/"));
     assertEquals(3, fileStatuses.length);
 
-    //This should return empty fileStatuses rather than NotFound Exception.
+    // This should return empty fileStatuses rather than NotFound Exception.
     fileStatuses = fs.listStatus(new Path("/user/test-trash/.Trash/Current/" + MOUNT_POINT2));
     assertEquals(0, fileStatuses.length);
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HDFS-17263. RBF: Fix client ls trash path cannot get except default nameservices trash path.

With  [HDFS-16024](https://issues.apache.org/jira/browse/HDFS-16024), we can rename data to the Trash should be based on src locations. That is great for my useage.  After a period of use, I found this cause a issue.

There are two nameservices ns0   ns1,  and ns0 is the default nameservice.

(1) Add moutTable 

/home/data -> (ns0, /home/data)

/data1/test1 -> (ns1, /data1/test1 )

/data2/test2 -> (ns1, /data2/test2 )

(2)mv file to trash

ns0:   /user/test-user/.Trash/Current/home/data/file1

ns1:   /user/test-user/.Trash/Current/data1/test1/file1

(3) client via DFSRouter  ls will not see  /user/test-user/.Trash/Current/data1

(4) client ls  /user/test-user/.Trash/Current/data2/test2 will return exception .