### PR TITLE
HADOOP-18989. Use thread pool to improve the speed of creating control files in TestDFSIO

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
@@ -34,9 +34,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.StringTokenizer;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
@@ -131,7 +129,7 @@ public class TestDFSIO implements Tool {
       "test.io.erasure.code.policy";
   private ExecutorService excutorService = Executors.newFixedThreadPool(
       2 * Runtime.getRuntime().availableProcessors());
-  CompletionService<String> completionService = new ExecutorCompletionService<>(excutorService);
+  private CompletionService<String> completionService = new ExecutorCompletionService<>(excutorService);
 
   static{
     Configuration.addDefaultResource("hdfs-default.xml");
@@ -365,8 +363,8 @@ public class TestDFSIO implements Tool {
                                            Text.class, LongWritable.class,
                                            CompressionType.NONE);
         Runnable controlFileCreateTask = new ControlFileCreateTask(writer, name, nrBytes);
-        Future<String> createTaskFuture = completionService.submit(controlFileCreateTask, "success");
-        futureList.add(createTaskFuture);
+        Future<String> createFuture = completionService.submit(controlFileCreateTask, "success");
+        futureList.add(createFuture);
       } catch(Exception e) {
         throw new IOException(e.getLocalizedMessage());
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
@@ -29,10 +29,8 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.text.DecimalFormat;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
-import java.util.List;
 import java.util.StringTokenizer;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
@@ -129,7 +127,8 @@ public class TestDFSIO implements Tool {
       "test.io.erasure.code.policy";
   private ExecutorService excutorService = Executors.newFixedThreadPool(
       2 * Runtime.getRuntime().availableProcessors());
-  private CompletionService<String> completionService = new ExecutorCompletionService<>(excutorService);
+  private CompletionService<String> completionService =
+      new ExecutorCompletionService<>(excutorService);
 
   static{
     Configuration.addDefaultResource("hdfs-default.xml");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
@@ -353,7 +353,6 @@ public class TestDFSIO implements Tool {
 
     fs.delete(controlDir, true);
 
-    List<Future<String>> futureList = new ArrayList<>();
     for (int i = 0; i < nrFiles; i++) {
       String name = getFileName(i);
       Path controlFile = new Path(controlDir, "in_file_" + name);
@@ -363,8 +362,7 @@ public class TestDFSIO implements Tool {
                                            Text.class, LongWritable.class,
                                            CompressionType.NONE);
         Runnable controlFileCreateTask = new ControlFileCreateTask(writer, name, nrBytes);
-        Future<String> createFuture = completionService.submit(controlFileCreateTask, "success");
-        futureList.add(createFuture);
+        completionService.submit(controlFileCreateTask, "success");
       } catch(Exception e) {
         throw new IOException(e.getLocalizedMessage());
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
@@ -383,18 +383,19 @@ public class TestDFSIO implements Tool {
       } catch (ExecutionException | InterruptedException | TimeoutException e) {
         throw new IOException(e);
       }
+    }
 
-      if (count == nrFiles) {
-        isSuccess = true;
-      }
+    if (count == nrFiles) {
+      isSuccess = true;
+    }
 
-      if (isSuccess) {
-        LOG.info("created control files for: " + nrFiles + " files");
-      } else {
-        throw new IOException("Create control files timeout.");
-      }
+    if (isSuccess) {
+      LOG.info("created control files for: " + nrFiles + " files");
+    } else {
+      throw new IOException("Create control files timeout.");
     }
   }
+
 
   private static String getFileName(int fIdx) {
     return BASE_FILE_NAME + Integer.toString(fIdx);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
@@ -131,7 +131,7 @@ public class TestDFSIO implements Tool {
       "test.io.erasure.code.policy";
   private ExecutorService excutorService = Executors.newFixedThreadPool(
       2 * Runtime.getRuntime().availableProcessors());
-  CompletionService<String> completionService = new ExecutorCompletionService<>(excutorService); 
+  CompletionService<String> completionService = new ExecutorCompletionService<>(excutorService);
 
   static{
     Configuration.addDefaultResource("hdfs-default.xml");
@@ -371,7 +371,7 @@ public class TestDFSIO implements Tool {
         throw new IOException(e.getLocalizedMessage());
       }
     }
-    
+
     boolean isSuccess = false;
     int count = 0;
     for (int i = 0; i < nrFiles; i++) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
@@ -32,7 +32,13 @@ import java.text.DecimalFormat;
 import java.util.Collection;
 import java.util.Date;
 import java.util.StringTokenizer;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
@@ -116,6 +122,8 @@ public class TestDFSIO implements Tool {
       "test.io.block.storage.policy";
   private static final String ERASURE_CODE_POLICY_NAME_KEY =
       "test.io.erasure.code.policy";
+  private ExecutorService excutorService = Executors.newFixedThreadPool(
+      2 * Runtime.getRuntime().availableProcessors());
 
   static{
     Configuration.addDefaultResource("hdfs-default.xml");
@@ -289,12 +297,43 @@ public class TestDFSIO implements Tool {
     bench.analyzeResult(fs, TestType.TEST_TYPE_TRUNCATE, execTime);
   }
 
+  private class ControlFileCreateTask implements Callable<Void> {
+    private SequenceFile.Writer writer = null;
+    private String name;
+    private long nrBytes;
+    private CountDownLatch latch;
+
+    ControlFileCreateTask(SequenceFile.Writer writer, String name,
+                                 long nrBytes, CountDownLatch countDownLatch) {
+      this.writer = writer;
+      this.name = name;
+      this.nrBytes = nrBytes;
+      this.latch = countDownLatch;
+    }
+
+    @Override
+    public Void call() throws Exception {
+      try {
+        writer.append(new Text(name), new LongWritable(nrBytes));
+        latch.countDown();
+      } catch (Exception e) {
+        throw new IOException(e.getLocalizedMessage());
+      } finally {
+        if (writer != null) {
+          writer.close();
+        }
+        writer = null;
+      }
+      return null;
+    }
+  }
+
   @SuppressWarnings("deprecation")
   private void createControlFile(FileSystem fs,
                                   long nrBytes, // in bytes
                                   int nrFiles
-                                ) throws IOException {
-    LOG.info("creating control file: "+nrBytes+" bytes, "+nrFiles+" files");
+                                ) throws IOException, InterruptedException {
+    LOG.info("creating control file: " + nrBytes + " bytes, " + nrFiles + " files");
     final int maxDirItems = config.getInt(
         DFSConfigKeys.DFS_NAMENODE_MAX_DIRECTORY_ITEMS_KEY,
         DFSConfigKeys.DFS_NAMENODE_MAX_DIRECTORY_ITEMS_DEFAULT);
@@ -308,7 +347,8 @@ public class TestDFSIO implements Tool {
 
     fs.delete(controlDir, true);
 
-    for(int i=0; i < nrFiles; i++) {
+    CountDownLatch countDownLatch = new CountDownLatch(nrFiles);
+    for (int i = 0; i < nrFiles; i++) {
       String name = getFileName(i);
       Path controlFile = new Path(controlDir, "in_file_" + name);
       SequenceFile.Writer writer = null;
@@ -316,17 +356,19 @@ public class TestDFSIO implements Tool {
         writer = SequenceFile.createWriter(fs, config, controlFile,
                                            Text.class, LongWritable.class,
                                            CompressionType.NONE);
-        writer.append(new Text(name), new LongWritable(nrBytes));
+        Callable controlFileCreateTask = new ControlFileCreateTask(writer, name,
+            nrBytes, countDownLatch);
+        excutorService.submit(controlFileCreateTask);
       } catch(Exception e) {
         throw new IOException(e.getLocalizedMessage());
-      } finally {
-        if (writer != null) {
-          writer.close();
-        }
-        writer = null;
       }
     }
-    LOG.info("created control files for: " + nrFiles + " files");
+    boolean isSuccess = countDownLatch.await(10, TimeUnit.MINUTES);
+    if (isSuccess) {
+      LOG.info("created control files for: " + nrFiles + " files");
+    } else {
+      throw new IOException("Create control files timeout. Beyond 10 minutes.");
+    }
   }
 
   private static String getFileName(int fIdx) {
@@ -865,7 +907,12 @@ public class TestDFSIO implements Tool {
       cleanup(fs);
       return 0;
     }
-    createControlFile(fs, nrBytes, nrFiles);
+    try {
+      createControlFile(fs, nrBytes, nrFiles);
+    } catch (InterruptedException e) {
+      LOG.warn(e.getLocalizedMessage());
+      throw new IOException(e);
+    }
     long tStart = System.currentTimeMillis();
     switch(testType) {
     case TEST_TYPE_WRITE:


### PR DESCRIPTION
### Description of PR
When we use TestDFSIO tool to test the throughouts of HDFS clusters, we found it is so slow in the creating controll files stage. 

After refering to the source code, we found that method createControlFile try to create control files serially. It can be improved by using thread pool.

After optimizing, the TestDFSIO tool runs quicker than before.

### How was this patch tested?
In our product cluster.