### PR TITLE
HADOOP-18995. Upgrades SDK version to 2.21.33 for S3 Express One Zone support.

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -360,7 +360,7 @@ org.objenesis:objenesis:2.6
 org.xerial.snappy:snappy-java:1.1.10.4
 org.yaml:snakeyaml:2.0
 org.wildfly.openssl:wildfly-openssl:1.1.3.Final
-software.amazon.awssdk:bundle:jar:2.20.160
+software.amazon.awssdk:bundle:jar:2.21.33
 
 
 --------------------------------------------------------------------------------

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -187,7 +187,7 @@
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <surefire.fork.timeout>900</surefire.fork.timeout>
     <aws-java-sdk.version>1.12.565</aws-java-sdk.version>
-    <aws-java-sdk-v2.version>2.20.160</aws-java-sdk-v2.version>
+    <aws-java-sdk-v2.version>2.21.33</aws-java-sdk-v2.version>
     <aws.eventstream.version>1.0.1</aws.eventstream.version>
     <hsqldb.version>2.7.1</hsqldb.version>
     <frontend-maven-plugin.version>1.11.2</frontend-maven-plugin.version>


### PR DESCRIPTION
### Description of PR

Upgrades SDK version to 2.21.33, which adds in S3 Express One Zone support. 

With this upgrade, it is possible to connect to an One Zone bucket.  Some tests from the S3A test suite will currently fail against a one zone bucket, as one zone buckets do not support some S3 standard features (eg: SSE-KMS), and certain operations behave slightly differently (eg: listMPU will return a directory that has incomplete MPUs). These will be addressed in [HADOOP-18996](https://issues.apache.org/jira/browse/HADOOP-18996).

### How was this patch tested?

Tested in eu-west-1 with `mvn -Dparallel-tests -DtestsThreadCount=16 clean verify` and scale config, against S3 Standard. All good.


