### PR TITLE
HDFS-17254. DataNode httpServer has too many worker threads

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -975,6 +975,9 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final String  DFS_DATANODE_HTTP_ADDRESS_DEFAULT = "0.0.0.0:" + DFS_DATANODE_HTTP_DEFAULT_PORT;
   public static final String  DFS_DATANODE_HTTP_INTERNAL_PROXY_PORT =
       "dfs.datanode.http.internal-proxy.port";
+  public static final String DFS_DATANODE_NETTY_WORKER_NUM_THREADS_KEY =
+      "dfs.datanode.netty.worker.threads";
+  public static final int DFS_DATANODE_NETTY_WORKER_NUM_THREADS_DEFAULT = 0;
   public static final String  DFS_DATANODE_MAX_RECEIVER_THREADS_KEY =
       HdfsClientConfigKeys.DeprecatedKeys.DFS_DATANODE_MAX_RECEIVER_THREADS_KEY;
   public static final int     DFS_DATANODE_MAX_RECEIVER_THREADS_DEFAULT = 4096;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -155,6 +155,14 @@
 </property>
 
 <property>
+  <name>dfs.datanode.netty.worker.threads</name>
+  <value>0</value>
+  <description>
+    The number of Datanode http server worker threads.
+  </description>
+</property>
+
+<property>
   <name>dfs.datanode.handler.count</name>
   <value>10</value>
   <description>


### PR DESCRIPTION
JIRA: HDFS-17254. DataNode httpServer has too many worker threads