### PR TITLE
HDFS-17267. Client send the same packet multiple times when method markSlowNode throws IOException.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -1206,16 +1206,6 @@ class DataStreamer extends Daemon {
             }
           }
 
-          if (slownodesFromAck.isEmpty()) {
-            if (!slowNodeMap.isEmpty()) {
-              slowNodeMap.clear();
-            }
-          } else {
-            markSlowNode(slownodesFromAck);
-            LOG.debug("SlowNodeMap content: {}.", slowNodeMap);
-          }
-
-
           assert seqno != PipelineAck.UNKOWN_SEQNO :
               "Ack for unknown seqno should be a failed ack: " + ack;
           if (seqno == DFSPacket.HEART_BEAT_SEQNO) {  // a heartbeat ack
@@ -1259,6 +1249,15 @@ class DataStreamer extends Daemon {
             dataQueue.notifyAll();
 
             one.releaseBuffer(byteArrayManager);
+            if (slownodesFromAck.isEmpty()) {
+              if (!slowNodeMap.isEmpty()) {
+                slowNodeMap.clear();
+              }
+            } else {
+              markSlowNode(slownodesFromAck);
+              // TODO remove out of synchronized.
+              LOG.debug("SlowNodeMap content: {}.", slowNodeMap);
+            }
           }
         } catch (Throwable e) {
           if (!responderClosed) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestClientProtocolForPipelineRecovery.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestClientProtocolForPipelineRecovery.java
@@ -934,7 +934,7 @@ public class TestClientProtocolForPipelineRecovery {
       int count = 0;
       Random r = new Random();
       byte[] b = new byte[oneWriteSize];
-      while (count < threshold) {
+      while (count < threshold + 1) {
         r.nextBytes(b);
         o.write(b);
         count++;


### PR DESCRIPTION
### Description of PR

Since we have [HDFS-16348](https://issues.apache.org/jira/browse/HDFS-16348), we can kick out SLOW node in pipeline when writing data to pipeline. 

And I think it introduced a problem, that is the same packet will be sent twice or more times when we kick out SLOW node.

The flow are as below:

1、 DFSPacket p1 is pushed into dataQueue.

2、DataStreamer takes DFSPacket p1 from dataQueue.

3、Remove p1 from dataQueue and   push p1 into ackQueue.

4、sendPacket(p1).

5、In ResponseProcessor#run,  read pipelineAck for p1.

6、We meet SlOW node,  so method markSlowNode throw IOException and does not execute `ackQueue.removeFirst();`.

7、In next loop of DataStreamer#run, we come into method processDatanodeOrExternalError and execute `dataQueue.addAll(0, ackQueue);`.

8、the p1 will be sent repeatedly.

We can debug the unit test method testPipelineRecoveryWithSlowNode to verify this PR.

Set breakpoint in DataStreamer#run : `LOG.debug("{} sending {}", this, one);`.

We can see the DFSPacket with seq=3 sends twice.

BTW, on datanode side. It will not write packet data twice, because if will compare the onDiskLen and offsetInBlock in method receivePacket(). if onDiskLen >= offsetInBlock, there will not happen writing data behavior.