### PR TITLE
HDFS-17269. RBF: Listing trash directory should return subdirs from all subclusters.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/FileSubclusterResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/FileSubclusterResolver.java
@@ -82,6 +82,13 @@ public interface FileSubclusterResolver {
   String getDefaultNamespace();
 
   /**
+   * Get all namespaces which have mountpoints for the cluster.
+   *
+   * @return a set of namespace identifiers.
+   */
+  Set<String> getAllNamespaces();
+
+  /**
    * Get a list of mount points for a path.
    *
    * @param path Path to get the mount points under.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.hdfs.server.federation.resolver;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_DEFAULT_NAMESERVICE;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_DEFAULT_NAMESERVICE_ENABLE;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_DEFAULT_NAMESERVICE_ENABLE_DEFAULT;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FEDERATION_LIST_ALL_NAMESERVICES_TRASH;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FEDERATION_LIST_ALL_NAMESERVICES_TRASH_DEFAULT;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.FEDERATION_MOUNT_TABLE_MAX_CACHE_SIZE;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.FEDERATION_MOUNT_TABLE_MAX_CACHE_SIZE_DEFAULT;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.FEDERATION_MOUNT_TABLE_CACHE_ENABLE;
@@ -107,6 +109,7 @@ public class MountTableResolver
   private String defaultNameService = "";
   /** If use default nameservice to read and write files. */
   private boolean defaultNSEnable = true;
+  private boolean listAllNameservicesTrash;
 
   /** Synchronization for both the tree and the cache. */
   private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
@@ -153,6 +156,9 @@ public class MountTableResolver
     } else {
       this.locationCache = null;
     }
+
+    listAllNameservicesTrash = conf.getBoolean(DFS_ROUTER_FEDERATION_LIST_ALL_NAMESERVICES_TRASH,
+        DFS_ROUTER_FEDERATION_LIST_ALL_NAMESERVICES_TRASH_DEFAULT);
 
     registerCacheExternal();
     initDefaultNameService(conf);
@@ -456,7 +462,7 @@ public class MountTableResolver
     readLock.lock();
     try {
       // First process user trash root path.
-      if (MountTableResolver.isTrashRoot(path)) {
+      if (listAllNameservicesTrash && MountTableResolver.isTrashRoot(path)) {
         return lookupLocationForUserTrashRoot(path);
       }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -376,6 +376,10 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
   public static final long DFS_ROUTER_QUOTA_CACHE_UPDATE_INTERVAL_DEFAULT =
       60000;
 
+  public static final String DFS_ROUTER_FEDERATION_LIST_ALL_NAMESERVICES_TRASH =
+      FEDERATION_ROUTER_PREFIX + "list.all.nameservices.trash";
+  public static final boolean DFS_ROUTER_FEDERATION_LIST_ALL_NAMESERVICES_TRASH_DEFAULT = false;
+
   // HDFS Router security
   public static final String DFS_ROUTER_KEYTAB_FILE_KEY =
       FEDERATION_ROUTER_PREFIX + "keytab.file";

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -608,6 +608,14 @@
   </property>
 
   <property>
+    <name>dfs.federation.router.list.all.nameservices.trash</name>
+    <value>true</value>
+    <description>
+      If true, client listatus TrashRoot will return all nameservices's trash.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.federation.router.client.thread-size</name>
     <value>32</value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
@@ -417,4 +417,9 @@ public class MockResolver
     }
     return defaultNamespace;
   }
+
+  @Override
+  public Set<String> getAllNamespaces() {
+    return null;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
@@ -287,7 +287,8 @@ public class TestRouterTrash {
     client1.mkdirs(trashPath, new FsPermission("770"),
         true);
     fileStatuses = fs.listStatus(new Path("/user/test-trash/.Trash"));
-    assertEquals(2, fileStatuses.length);
+    assertEquals(trashPath, fileStatuses[0].getPath().toUri().getPath());
+    assertEquals("/user/test-trash/.Trash/Current", fileStatuses[1].getPath().toUri().getPath());
 
     client1.delete("/user", true);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
@@ -282,6 +282,13 @@ public class TestRouterTrash {
     fileStatuses = fs.listStatus(new Path("/user/test-trash/.Trash/Current/" + MOUNT_POINT2));
     assertEquals(0, fileStatuses.length);
 
+    // In ns1, make a trash path with timestamp to simulate a trash path.
+    String trashPath = "/user/test-trash/.Trash/" + System.currentTimeMillis();
+    client1.mkdirs(trashPath, new FsPermission("770"),
+        true);
+    fileStatuses = fs.listStatus(new Path("/user/test-trash/.Trash"));
+    assertEquals(2, fileStatuses.length);
+
     client1.delete("/user", true);
   }
 


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Same scenario  as [HDFS-17263](https://issues.apache.org/jira/browse/HDFS-17263) 

If user trash config  fs.trash.checkpoint.interval set to 10min in namenodes, the trash root dir /user/$USER/.Trash/Current will be very 10 min renamed to /user/$USER/.Trash/timestamp .

 

When user  ls  /user/$USER/.Trash, it should be return blow:

/user/$USER/.Trash/Current

/user/$USER/.Trash/timestamp (This is invisible now)

 

So we should  make  that user ls trash root dir can see all trash subdirs in all nameservices which user has any mountpoint in nameservice.



