### PR TITLE
HDFS-16749. RBF: Gets the wrong directory information from Trash

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/FileSubclusterResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/FileSubclusterResolver.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeSet;
@@ -157,7 +158,8 @@ public interface FileSubclusterResolver {
       MountTable> tree) {
     IdentityHashMap<String,String> childWithSourcePaths = new IdentityHashMap<>();
     boolean exists = false;
-    for (String subPath : tree.keySet()) {
+    for (Map.Entry<String, MountTable> record : tree.entrySet()) {
+      String subPath = record.getKey();
       String child = subPath;
 
       // Special case for /
@@ -181,7 +183,7 @@ public interface FileSubclusterResolver {
           child = child.substring(0, fin);
         }
         if (!child.isEmpty()) {
-          childWithSourcePaths.put(child, tree.get(subPath).getSourcePath());
+          childWithSourcePaths.put(child, record.getValue().getSourcePath());
         }
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -106,9 +106,11 @@ import java.io.Serializable;
 import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -902,13 +904,33 @@ public class RouterClientProtocol implements ClientProtocol {
     }
 
     // Add mount points at this level in the tree
-    final List<String> children = subclusterResolver.getMountPoints(src);
+    IdentityHashMap<String, String> childrenMountTableWithSrc =
+        subclusterResolver.getMountPointsWithSrc(src);
+    List<String> children = null;
+    // Sort the list as the entries from subcluster are also sorted
+    if (childrenMountTableWithSrc != null) {
+      children = new ArrayList<>(childrenMountTableWithSrc.keySet());
+      Collections.sort(children);
+    }
     if (children != null) {
       // Get the dates for each mount point
       Map<String, Long> dates = getMountPointDates(src);
 
       // Create virtual folder with the mount name
-      for (String child : children) {
+      boolean isTrashPath = MountTableResolver.isTrashPath(src);
+      for (int i = 0; i < children.size(); i++) {
+        String child = children.get(i);
+        if (isTrashPath) {
+          HdfsFileStatus dir = getFileInfo(
+              MountTableResolver.getTrashCurrentPath(src) + childrenMountTableWithSrc.get(child),
+              false);
+          if (dir == null) {
+            children.remove(child);
+            i--;
+            continue;
+          }
+        }
+        
         long date = 0;
         if (dates != null && dates.containsKey(child)) {
           date = dates.get(child);
@@ -964,6 +986,10 @@ public class RouterClientProtocol implements ClientProtocol {
 
   @Override
   public HdfsFileStatus getFileInfo(String src) throws IOException {
+    return getFileInfo(src, true);
+  }
+
+  public HdfsFileStatus getFileInfo(String src, boolean withMountTable) throws IOException {
     rpcServer.checkOperation(NameNode.OperationCategory.READ);
 
     HdfsFileStatus ret = null;
@@ -982,6 +1008,10 @@ public class RouterClientProtocol implements ClientProtocol {
       }
     } catch (NoLocationException | RouterResolveException e) {
       noLocationException = e;
+    }
+
+    if (!withMountTable) {
+      return ret;
     }
 
     // If there is no real path, check mount points

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -929,7 +929,6 @@ public class RouterClientProtocol implements ClientProtocol {
             continue;
           }
         }
-        
         long date = 0;
         if (dates != null && dates.containsKey(child)) {
           date = dates.get(child);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -910,7 +910,6 @@ public class RouterClientProtocol implements ClientProtocol {
     // Sort the list as the entries from subcluster are also sorted
     if (childrenMountTableWithSrc != null) {
       children = new ArrayList<>(childrenMountTableWithSrc.keySet());
-      Collections.sort(children);
     }
     if (children != null) {
       // Get the dates for each mount point

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
@@ -24,12 +24,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.IdentityHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.server.federation.resolver.ActiveNamenodeResolver;
 import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeContext;
@@ -391,6 +391,11 @@ public class MockResolver
       }
     }
     return FileSubclusterResolver.getMountPoints(path, mountPoints);
+  }
+
+  @Override
+  public IdentityHashMap<String, String> getMountPointsWithSrc(String path) throws IOException {
+    return null;
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
@@ -29,6 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.server.federation.resolver.ActiveNamenodeResolver;
@@ -42,6 +43,7 @@ import org.apache.hadoop.hdfs.server.federation.resolver.PathLocation;
 import org.apache.hadoop.hdfs.server.federation.resolver.RemoteLocation;
 import org.apache.hadoop.hdfs.server.federation.router.Router;
 import org.apache.hadoop.hdfs.server.federation.store.StateStoreService;
+import org.apache.hadoop.hdfs.server.federation.store.records.MountTable;
 import org.apache.hadoop.util.Time;
 
 /**
@@ -395,7 +397,18 @@ public class MockResolver
 
   @Override
   public IdentityHashMap<String, String> getMountPointsWithSrc(String path) throws IOException {
-    return null;
+    TreeMap<String, MountTable> sortedMap = new TreeMap<>();
+    for (Map.Entry<String, List<RemoteLocation>> record : this.locations.entrySet()) {
+      String mp = record.getKey();
+      if (mp.startsWith(path)) {
+        Map<String, String> map = new HashMap<>();
+        for (RemoteLocation remoteLocation : record.getValue()) {
+          map.put(remoteLocation.getNameserviceId(), remoteLocation.getDest());
+        }
+        sortedMap.put(mp, MountTable.newInstance(mp, map));
+      }
+    }
+    return FileSubclusterResolver.getMountPointsWithSrc(path, sortedMap);
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterTrash.java
@@ -276,7 +276,7 @@ public class TestRouterTrash {
 
     // Client user see global trash view， wo should see all three mount point.
     FileStatus[] fileStatuses = fs.listStatus(new Path("/user/test-trash/.Trash/Current/"));
-    assertEquals(3, fileStatuses.length);
+    assertEquals(2, fileStatuses.length);
 
     // This should return empty fileStatuses rather than NotFound Exception.
     fileStatuses = fs.listStatus(new Path("/user/test-trash/.Trash/Current/" + MOUNT_POINT2));


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

As described  in HDFS-16749.

Purpose ：[RBF] Fix ls user trash path returns mountpoint path that real nameservice's trash path is not exists


There are two nameservices ns0   ns1,  and ns0 is the default nameservice.

(1) Add moutTable 

```
/home/data -> (ns0, /home/data)
/data1/test1 -> (ns1, /data1/test1 )
/data2/test2 -> (ns1, /data2/test2 )
```

(2) add file 

```
/home/data/file1
/data1/test1/file1
```

(3) mv files to trash

```
ns0:   /user/test-user/.Trash/Current/home/data/file1
ns1:   /user/test-user/.Trash/Current/data1/test1/file1
```

(4) client via DFSRouter:  hdfs dfs -ls /user/test-user/.Trash/Current ,this will return

```
/user/test-user/.Trash/Current/home
/user/test-user/.Trash/Current/data1
/user/test-user/.Trash/Current/data2  (But this in fact not exist in ns1)
```

So, this PR is for this purpose, if  a namservice  that mount point  dir in trash is not really exists, it should be not display in user trash view via DFSRouter

