### PR TITLE
HDFS-17271. Fix dead DN sorting in DN report web UI

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/federationhealth.html
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/federationhealth.html
@@ -383,7 +383,7 @@
     <td ng-value="{state}">{state}</td>
     <td ng-value="{state}-{name}" class="dfshealth-node-icon dfshealth-node-{state}">{location}/{name} ({xferaddr})</td>
     <td></td>
-    <td>{#helper_relative_time value="{lastContact}"/}</td>
+    <td ng-value="{lastContact}">{#helper_relative_time value="{lastContact}"/}</td>
     <td></td>
     <td></td>
     <td></td>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
@@ -356,7 +356,7 @@
     <td ng-value="{state}">{state}</td>
     <td ng-value="{state}-{name}" class="dfshealth-node-icon dfshealth-node-{state}">{location}/{name} ({xferaddr})</td>
     <td></td>
-    <td>{#helper_relative_time value="{lastContact}"/}</td>
+    <td ng-value="{lastContact}">{#helper_relative_time value="{lastContact}"/}</td>
     <td></td>
     <td></td>
     <td></td>


### PR DESCRIPTION
### Description of PR
In DN report web UI in NN and routers, when sorted by "last contact" in ascending order, dead nodes come up on top in a random order.

![Screenshot 2023-12-01 at 10 46 37 PM](https://github.com/apache/hadoop/assets/23214709/9d12576d-57fe-44b2-a630-6cec9f7cb52d)


### How was this patch tested?
Local deployment. Looks like this after fixed. Notice the sorting order is descending

![Screenshot 2023-12-01 at 10 47 40 PM](https://github.com/apache/hadoop/assets/23214709/fa17f081-cdd1-4af8-aa7b-07661af4bee6)


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?