### PR TITLE
HDFS-17272. NNThroughputBenchmark should support specifying the base directory for multi-client test

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/Benchmarking.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Benchmarking.md
@@ -54,15 +54,15 @@ Following are all the operations supported along with their respective operation
 | OPERATION\_OPTION    | Operation-specific parameters |
 |:---- |:---- |
 |`all` | _options for other operations_ |
-|`create` | [`-threads 3`] [`-files 10`] [`-filesPerDir 4`] [`-close`] |
-|`mkdirs` | [`-threads 3`] [`-dirs 10`] [`-dirsPerDir 2`] |
-|`open` | [`-threads 3`] [`-files 10`] [`-filesPerDir 4`] [`-useExisting`] |
-|`delete` | [`-threads 3`] [`-files 10`] [`-filesPerDir 4`] [`-useExisting`] |
-|`append` | [`-threads 3`] [`-files 10`] [`-filesPerDir 4`] [`-useExisting`] [`-appendNewBlk`] |
-|`fileStatus` | [`-threads 3`] [`-files 10`] [`-filesPerDir 4`] [`-useExisting`] |
-|`rename` | [`-threads 3`] [`-files 10`] [`-filesPerDir 4`] [`-useExisting`] |
-|`blockReport` | [`-datanodes 10`] [`-reports 30`] [`-blocksPerReport 100`] [`-blocksPerFile 10`] |
-|`replication` | [`-datanodes 10`] [`-nodesToDecommission 1`] [`-nodeReplicationLimit 100`] [`-totalBlocks 100`] [`-replication 3`] |
+|`create` | [`-threads 3`] [`-files 10`] [`-filesPerDir 4`] [`-close`] [`-baseDirName /nnThroughputBenchmark`] |
+|`mkdirs` | [`-threads 3`] [`-dirs 10`] [`-dirsPerDir 2`] [`-baseDirName /nnThroughputBenchmark`] |
+|`open` | [`-threads 3`] [`-files 10`] [`-filesPerDir 4`] [`-useExisting`] [`-baseDirName /nnThroughputBenchmark`] |
+|`delete` | [`-threads 3`] [`-files 10`] [`-filesPerDir 4`] [`-useExisting`] [`-baseDirName /nnThroughputBenchmark`] |
+|`append` | [`-threads 3`] [`-files 10`] [`-filesPerDir 4`] [`-useExisting`] [`-appendNewBlk`] [`-baseDirName /nnThroughputBenchmark`] |
+|`fileStatus` | [`-threads 3`] [`-files 10`] [`-filesPerDir 4`] [`-useExisting`] [`-baseDirName /nnThroughputBenchmark`] |
+|`rename` | [`-threads 3`] [`-files 10`] [`-filesPerDir 4`] [`-useExisting`] [`-baseDirName /nnThroughputBenchmark`] |
+|`blockReport` | [`-datanodes 10`] [`-reports 30`] [`-blocksPerReport 100`] [`-blocksPerFile 10`] [`-baseDirName /nnThroughputBenchmark`] |
+|`replication` | [`-datanodes 10`] [`-nodesToDecommission 1`] [`-nodeReplicationLimit 100`] [`-totalBlocks 100`] [`-replication 3`] [`-baseDirName /nnThroughputBenchmark`] |
 |`clean` | N/A |
 
 ##### Operation Options
@@ -86,6 +86,7 @@ When running benchmarks with the above operation(s), please provide operation-sp
 |`-nodeReplicationLimit` | The maximum number of outgoing replication streams for a data-node. |
 |`-totalBlocks` | Number of total blocks to operate. |
 |`-replication` | Replication factor. Will be adjusted to number of data-nodes if it is larger than that. |
+|`-baseDirName` | The base dir name for benchmarks, to support multiple clients submitting benchmark tests at the same time. |
 
 ### Reports
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NNThroughputBenchmark.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NNThroughputBenchmark.java
@@ -746,7 +746,7 @@ public class NNThroughputBenchmark implements Tool {
     static final String OP_OPEN_NAME = "open";
     static final String OP_USAGE_ARGS = 
         " [-threads T] [-files N] [-blockSize S] [-filesPerDir P]"
-        + " [-baseDirName D] [-useExisting]";
+        + " [-useExisting] [-baseDirName D]";
     static final String OP_OPEN_USAGE = 
       "-op " + OP_OPEN_NAME + OP_USAGE_ARGS;
 
@@ -1361,9 +1361,9 @@ public class NNThroughputBenchmark implements Tool {
   class ReplicationStats extends OperationStatsBase {
     static final String OP_REPLICATION_NAME = "replication";
     static final String OP_REPLICATION_USAGE = 
-        "-op replication [-datanodes T] [-nodesToDecommission D] " +
+        "-op replication [-datanodes T] [-nodesToDecommission N] " +
         "[-nodeReplicationLimit C] [-totalBlocks B] [-blockSize S] "
-        + "[-replication R] [-baseDirName N]";
+        + "[-replication R] [-baseDirName D]";
 
     private final BlockReportStats blockReportObject;
     private int numDatanodes;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNThroughputBenchmark.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNThroughputBenchmark.java
@@ -60,6 +60,18 @@ public class TestNNThroughputBenchmark {
     NNThroughputBenchmark.runBenchmark(conf, new String[] {"-op", "all"});
   }
 
+  @Test
+  public void testNNThroughputWithBaseDir() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 16);
+    File nameDir = new File(MiniDFSCluster.getBaseDirectory(), "name");
+    conf.set(DFSConfigKeys.DFS_NAMENODE_NAME_DIR_KEY,
+        nameDir.getAbsolutePath());
+    DFSTestUtil.formatNameNode(conf);
+    NNThroughputBenchmark.runBenchmark(conf,
+        new String[] {"-op", "all", "-baseDirName", "/nnThroughputBenchmark1"});
+  }
+
   /**
    * This test runs all benchmarks defined in {@link NNThroughputBenchmark},
    * with explicit local -fs option.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNThroughputBenchmark.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNThroughputBenchmark.java
@@ -22,8 +22,10 @@ import java.io.File;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.DirectoryListing;
@@ -203,40 +205,18 @@ public class TestNNThroughputBenchmark {
       final Configuration benchConf = new HdfsConfiguration();
       benchConf.setInt(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 16);
       FileSystem.setDefaultUri(benchConf, cluster.getURI());
+      DistributedFileSystem fs = cluster.getFileSystem();
 
       NNThroughputBenchmark.runBenchmark(benchConf,
           new String[] {"-op", "create", "-keepResults", "-files", "3", "-baseDirName",
               "/nnThroughputBenchmark1", "-close"});
-      FSNamesystem fsNamesystem = cluster.getNamesystem();
-      DirectoryListing listing = fsNamesystem.getListing("/", HdfsFileStatus.EMPTY_NAME, false);
-      Boolean b_dir_exist1 = false;
-      Boolean b_dir_exist2 = false;
-      for (HdfsFileStatus f : listing.getPartialListing()) {
-        if (f.getFullName("/").equals("/nnThroughputBenchmark1")) {
-          b_dir_exist1 = true;
-        }
-        if (f.getFullName("/").equals("/nnThroughputBenchmark")) {
-          b_dir_exist2 = true;
-        }
-      }
-      Assert.assertEquals(b_dir_exist1, true);
-      Assert.assertEquals(b_dir_exist2, false);
+      Assert.assertTrue(fs.exists(new Path("/nnThroughputBenchmark1")));
+      Assert.assertFalse(fs.exists(new Path("/nnThroughputBenchmark")));
 
       NNThroughputBenchmark.runBenchmark(benchConf,
           new String[] {"-op", "all", "-baseDirName", "/nnThroughputBenchmark1"});
-      listing = fsNamesystem.getListing("/", HdfsFileStatus.EMPTY_NAME, false);
-      b_dir_exist1 = false;
-      b_dir_exist2 = false;
-      for (HdfsFileStatus f : listing.getPartialListing()) {
-        if (f.getFullName("/").equals("/nnThroughputBenchmark1")) {
-          b_dir_exist1 = true;
-        }
-        if (f.getFullName("/").equals("/nnThroughputBenchmark")) {
-          b_dir_exist2 = true;
-        }
-      }
-      Assert.assertEquals(b_dir_exist1, true);
-      Assert.assertEquals(b_dir_exist2, false);
+      Assert.assertTrue(fs.exists(new Path("/nnThroughputBenchmark1")));
+      Assert.assertFalse(fs.exists(new Path("/nnThroughputBenchmark")));
     } finally {
       if (cluster != null) {
         cluster.shutdown();


### PR DESCRIPTION
Currently, NNThroughputBenchmark does not support specifying the base directory, therefore does not support multiple clients performing stress testing at the same time. However, for high-performance namenode machine, only one client submitting stress test can not make the namenode rpc access reach the bottleneck. Therefore, multiple clients are required for parallel testing to make the namenode pressure reach the level of the large-scale production cluster.

So I specify the base directory through the -baseDirName parameter to support multiple clients submitting stress tests at the same time.