### PR TITLE
HDFS-17273. Improve local variables duration of DataStreamer for better debugging.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -959,7 +959,8 @@ class DataStreamer extends Daemon {
       if (TimeUnit.NANOSECONDS.toMillis(duration) > dfsclientSlowLogThresholdMs) {
         LOG.warn("Slow waitForAckedSeqno took {}ms (threshold={}ms). File being"
                 + " written: {}, block: {}, Write pipeline datanodes: {}.",
-            TimeUnit.NANOSECONDS.toMillis(duration), dfsclientSlowLogThresholdMs, src, block, nodes);
+            TimeUnit.NANOSECONDS.toMillis(duration), dfsclientSlowLogThresholdMs,
+            src, block, nodes);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -941,7 +941,7 @@ class DataStreamer extends Daemon {
                 LOG.error("No ack received, took {}ms (threshold={}ms). "
                     + "File being written: {}, block: {}, "
                     + "Write pipeline datanodes: {}.",
-                    duration / NANOSECONDS_PER_MILLISECOND , writeTimeout, src, block, nodes);
+                    duration / NANOSECONDS_PER_MILLISECOND, writeTimeout, src, block, nodes);
                 throw new InterruptedIOException("No ack received after " +
                     duration / 1000 / NANOSECONDS_PER_MILLISECOND + "s and a timeout of " +
                     writeTimeout / 1000 + "s");

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -539,6 +539,8 @@ class DataStreamer extends Daemon {
   private final String[] favoredNodes;
   private final EnumSet<AddBlockFlag> addBlockFlags;
 
+  private static final long NANOSECONDS_PER_MILLISECOND = 1000000;
+
   private DataStreamer(HdfsFileStatus stat, ExtendedBlock block,
                        DFSClient dfsClient, String src,
                        Progressable progress, DataChecksum checksum,
@@ -758,7 +760,7 @@ class DataStreamer extends Daemon {
             scope = null;
             dataQueue.removeFirst();
             ackQueue.addLast(one);
-            packetSendTime.put(one.getSeqno(), Time.monotonicNow());
+            packetSendTime.put(one.getSeqno(), Time.monotonicNowNanos());
             dataQueue.notifyAll();
           }
         }
@@ -924,7 +926,7 @@ class DataStreamer extends Daemon {
         dnodes = nodes != null ? nodes.length : 3;
       }
       int writeTimeout = dfsClient.getDatanodeWriteTimeout(dnodes);
-      long begin = Time.monotonicNow();
+      long begin = Time.monotonicNowNanos();
       try {
         synchronized (dataQueue) {
           while (!streamerClosed) {
@@ -934,14 +936,14 @@ class DataStreamer extends Daemon {
             }
             try {
               dataQueue.wait(1000); // when we receive an ack, we notify on
-              long duration = Time.monotonicNow() - begin;
-              if (duration > writeTimeout) {
+              long duration = Time.monotonicNowNanos() - begin;
+              if (duration > writeTimeout * NANOSECONDS_PER_MILLISECOND) {
                 LOG.error("No ack received, took {}ms (threshold={}ms). "
                     + "File being written: {}, block: {}, "
                     + "Write pipeline datanodes: {}.",
-                    duration, writeTimeout, src, block, nodes);
+                    duration / NANOSECONDS_PER_MILLISECOND , writeTimeout, src, block, nodes);
                 throw new InterruptedIOException("No ack received after " +
-                    duration / 1000 + "s and a timeout of " +
+                    duration / 1000 / NANOSECONDS_PER_MILLISECOND + "s and a timeout of " +
                     writeTimeout / 1000 + "s");
               }
               // dataQueue
@@ -955,11 +957,11 @@ class DataStreamer extends Daemon {
       } catch (ClosedChannelException cce) {
         LOG.debug("Closed channel exception", cce);
       }
-      long duration = Time.monotonicNow() - begin;
-      if (duration > dfsclientSlowLogThresholdMs) {
+      long duration = Time.monotonicNowNanos() - begin;
+      if (duration > dfsclientSlowLogThresholdMs * NANOSECONDS_PER_MILLISECOND) {
         LOG.warn("Slow waitForAckedSeqno took {}ms (threshold={}ms). File being"
                 + " written: {}, block: {}, Write pipeline datanodes: {}.",
-            duration, dfsclientSlowLogThresholdMs, src, block, nodes);
+            duration / NANOSECONDS_PER_MILLISECOND, dfsclientSlowLogThresholdMs, src, block, nodes);
       }
     }
   }
@@ -1150,10 +1152,10 @@ class DataStreamer extends Daemon {
           if (ack.getSeqno() != DFSPacket.HEART_BEAT_SEQNO) {
             Long begin = packetSendTime.get(ack.getSeqno());
             if (begin != null) {
-              long duration = Time.monotonicNow() - begin;
-              if (duration > dfsclientSlowLogThresholdMs) {
+              long duration = Time.monotonicNowNanos() - begin;
+              if (duration > dfsclientSlowLogThresholdMs * NANOSECONDS_PER_MILLISECOND) {
                 LOG.info("Slow ReadProcessor read fields for block " + block
-                    + " took " + duration + "ms (threshold="
+                    + " took " + duration / NANOSECONDS_PER_MILLISECOND + "ms (threshold="
                     + dfsclientSlowLogThresholdMs + "ms); ack: " + ack
                     + ", targets: " + Arrays.asList(targets));
               }


### PR DESCRIPTION
### Description of PR

```java
Long begin = packetSendTime.get(ack.getSeqno());
long duration = Time.monotonicNow() - begin;
```

Since Time.monotonicNow() use System.nanoTime() / 1000，it maybe return 0 when we are debugging and make us confused.
So, we'd better change the way of computing duration.