### PR TITLE
HADOOP-18999. Debug level logging within AWS V2 SDK httpclient

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -166,8 +166,11 @@ public class DefaultS3ClientFactory extends Configured
   @VisibleForTesting
   public static boolean maybeTurnOnSdkLogging() {
     if (LOG_SDK.isDebugEnabled()) {
-      LOG_SDK.debug("Enabling SDK logging at {} level", SDK_LOG_LEVEL);
+      LOG_SDK.debug("Enabling SDK logging at {}", SDK_LOG_LEVEL);
       return enableLogging(SDK_LOG_LEVEL, SDK_LOGS);
+    } else if (LOG_SDK.isTraceEnabled()) {
+      LOG_SDK.debug("Enabling SDK logging at {}", LogControl.LogLevel.TRACE);
+      return enableLogging(LogControl.LogLevel.TRACE, SDK_LOGS);
     }
     return false;
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/logging/Log4J1Controller.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/logging/Log4J1Controller.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.logging;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.Priority;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A controller for logging in log4j 1.x.
+ * Must be loaded through reflection to ensure no use of log4j APIs
+ * elsewhere.
+ */
+@SuppressWarnings("unused")
+public class Log4J1Controller implements LogControl {
+
+  @Override
+  public void setLogLevel(final String log, final LogLevel level) {
+    getLogger(log).setLevel(Level.toLevel(level.name()));
+  }
+
+  @Override
+  public LogLevel getLogLevel(final String name) {
+    final Logger log = getLogger(name);
+    if (log.isTraceEnabled()) {
+      return LogLevel.TRACE;
+    }
+    if (log.isDebugEnabled()) {
+      return LogLevel.DEBUG;
+    }
+    if (log.isInfoEnabled()) {
+      return LogLevel.INFO;
+    }
+    if (log.isEnabledFor(Priority.WARN)) {
+      return LogLevel.WARN;
+    }
+    if (log.isEnabledFor(Priority.FATAL)) {
+      return LogLevel.FATAL;
+    }
+
+    return LogLevel.OFF;
+  }
+
+
+  /**
+   * Get a logger.
+   * @param log log name
+   * @return logger
+   */
+  private static Logger getLogger(final String log) {
+    return requireNonNull(Logger.getLogger(log),
+        () -> "No logger for " + log);
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/logging/LogControl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/logging/LogControl.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.logging;
+
+import java.util.logging.Level;
+
+/**
+ * Interface for a long controller; allows for log levels to be set
+ * via reflection.
+ */
+public interface LogControl {
+
+  /**
+   * Log levels.
+   */
+  enum LogLevel {
+    OFF("OFF", Level.OFF),
+    ALL("ALL", Level.ALL),
+    FATAL("FATAL", Level.SEVERE),
+    ERROR("ERROR", Level.SEVERE),
+    WARN("WARN",Level.WARNING),
+    INFO("INFO", Level.INFO),
+    DEBUG("DEBUG", Level.FINE),
+    TRACE("TRACE", Level.FINEST);
+
+    /**
+     * Log name/key.
+     */
+     final String key;
+
+    /**
+     * JDK level.
+     */
+    final Level jdkLevel;
+
+    LogLevel(final String key, final Level jdkLevel) {
+      this.key = key;
+      this.jdkLevel = jdkLevel;
+    }
+
+  }
+
+  /**
+   * Sets a log level for a class/package.
+   * @param log log to set
+   * @param level level to set
+   */
+  void setLogLevel(String log, LogLevel level);
+
+
+  /**
+   * Gets the log level for a class/package.
+   * @param log log to get
+   * @return log level or null if you can't get it.
+   */
+  LogLevel getLogLevel(String log);
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/logging/LogControllerFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/logging/LogControllerFactory.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.logging;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.fs.store.LogExactlyOnce;
+
+/**
+ * Factory to create a log controller; this uses reflection.
+ */
+public final class LogControllerFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LogControllerFactory.class);
+
+  /**
+   * Log once if a controller can't be created.
+   */
+  private static final LogExactlyOnce WARN_CONTROLLER_NOT_CREATED =
+      new LogExactlyOnce(LOG);
+
+  /**
+   * The log4j controller class: {@value}.
+   */
+  static final String LOG4J1CONTROLLER =
+      "org.apache.hadoop.fs.s3a.impl.logging.Log4J1Controller";
+
+
+  /**
+   * Create a controller.
+   * @return the instantiated controller or empty of the class can't be instantiated.
+   */
+  public static Optional<LogControl> createController(String classname) {
+    try {
+      Class<?> clazz = Class.forName(classname);
+      return Optional.of((LogControl) clazz.newInstance());
+    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+             | ClassCastException e) {
+      WARN_CONTROLLER_NOT_CREATED.warn("Failed to create controller {}: {}", classname, e, e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Enable logging through reflection.
+   * @param level desired level
+   * @param logs loggers to enable
+   * @return true if logging was enabled.
+   */
+  public static boolean enableLogging(LogControl.LogLevel level,
+      String... logs) {
+
+    final Optional<LogControl> control =
+        LogControllerFactory.createController(LOG4J1CONTROLLER);
+    if (control.isPresent()) {
+      final LogControl logControl = control.get();
+      Arrays.stream(logs).forEach(
+          log -> {
+            LOG.debug("Setting log level of {} to {}", log, level);
+            logControl.setLogLevel(log, level);
+          });
+      return true;
+    } else {
+      return false;
+    }
+
+  }
+
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/logging/package-info.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/logging/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Reflection-based log management, designed to allow logs to be controlled
+ * if the relevant log classes are on the classpath.
+ * Do not use outside of the hadoop-aws module.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+package org.apache.hadoop.fs.s3a.impl.logging;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/aws_sdk_upgrade.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/aws_sdk_upgrade.md
@@ -53,7 +53,22 @@ As before: the exact set of dependencies used by the S3A connector
 is neither defined nor comes with any commitments of stability
 or compatibility of dependent libraries.
 
+### Logging
 
+The `bundle.jar` shading somehow stops its embedded SLF4J version from binding to SLF4J back ends
+
+```
+SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
+SLF4J: Defaulting to no-operation (NOP) logger implementation
+SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
+```
+
+To mitigate this, if the log `org.apache.hadoop.fs.s3a.logging.sdk`
+
+```properties
+# AWS v2 low level logging
+log4j.logger.org.apache.hadoop.fs.s3a.logging.sdk=DEBUG
+```
 
 ## Credential Provider changes and migration
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEndpointRegion.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEndpointRegion.java
@@ -274,8 +274,7 @@ public class ITestS3AEndpointRegion extends AbstractS3ATestBase {
     interceptors.add(new RegionInterceptor(endpoint, expectedRegion));
 
     DefaultS3ClientFactory factory
-        = new DefaultS3ClientFactory();
-    factory.setConf(conf);
+        = new DefaultS3ClientFactory(conf);
     S3ClientFactory.S3ClientCreationParameters parameters
         = new S3ClientFactory.S3ClientCreationParameters()
         .withCredentialSet(new AnonymousAWSCredentialsProvider())

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFilesystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFilesystem.java
@@ -585,9 +585,7 @@ public class ITestSessionDelegationInFilesystem extends AbstractDelegationIT {
 
     URI landsat = new URI(DEFAULT_CSVTEST_FILE);
     DefaultS3ClientFactory factory
-        = new DefaultS3ClientFactory();
-    Configuration conf = delegatedFS.getConf();
-    factory.setConf(conf);
+        = new DefaultS3ClientFactory(delegatedFS.getConf());
     String host = landsat.getHost();
     S3ClientFactory.S3ClientCreationParameters parameters = null;
     parameters = new S3ClientFactory.S3ClientCreationParameters()

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/logging/TestLogController.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/logging/TestLogController.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.logging;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static org.apache.hadoop.fs.s3a.DefaultS3ClientFactory.SDK_LOG_LEVEL;
+import static org.apache.hadoop.fs.s3a.DefaultS3ClientFactory.SDK_LOG_NAME;
+import static org.apache.hadoop.fs.s3a.DefaultS3ClientFactory.maybeTurnOnSdkLogging;
+import static org.apache.hadoop.fs.s3a.impl.logging.LogControllerFactory.LOG4J1CONTROLLER;
+import static org.apache.hadoop.fs.s3a.impl.logging.LogControllerFactory.enableLogging;
+
+/**
+ * Test the log controller by verifying that the log can be controlled.
+ */
+public class TestLogController extends AbstractHadoopTestBase {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestLogController.class);
+
+  private static final String NAME = TestLogController.class.getName();
+
+  /**
+   * Controller.
+   */
+  private LogControl controller;
+  
+  /**
+   * Special internal log which is used to drive whether or not
+   * internal logs are enabled.
+   */
+  private static final Logger LOG_SDK =
+      LoggerFactory.getLogger(SDK_LOG_NAME);
+
+  /**
+   * The Shaded HTTP client log.
+   */
+  private static final String HTTP_CLIENT_LOG_NAME =
+      "software.amazon.awssdk.thirdparty.org.apache.http";
+
+  private static final Logger HTTP_CLIENT_LOG =
+      LoggerFactory.getLogger(HTTP_CLIENT_LOG_NAME);
+
+  @Before
+  public void setup() throws Exception {
+    controller =
+          LogControllerFactory.createController(LOG4J1CONTROLLER).get();
+  }
+  
+  
+  @Test
+  public void testLogLevel() throws Throwable {
+    
+    // log at info
+    setLogLevel(NAME, LogControl.LogLevel.INFO);
+
+    // switch to debug
+    Assertions.assertThat(enableLogging(LogControl.LogLevel.DEBUG, NAME))
+        .describedAs("Log level of %s", NAME)
+        .isTrue();
+    
+    // check
+    assertLogLevel(NAME, LogControl.LogLevel.DEBUG);
+    
+  }
+
+  /**
+   * Set a log level; assert that it is set.
+   * @param log log to set
+   * @param level level to set
+   */
+  private void setLogLevel(final String log, final LogControl.LogLevel level) {
+    controller.setLogLevel(log, level);
+    assertLogLevel(log, level);
+  }
+
+
+  /**
+   * Get the log level of a log.
+   * @param name log name
+   * @return the log level
+   */
+  private LogControl.LogLevel getLogLevel(final String name) {
+    return controller.getLogLevel(name);
+  }
+
+  /**
+   * Assert a log is at a given level.
+   * @param name log name
+   * @param expected expected value
+   */
+  private void assertLogLevel(final String name, final LogControl.LogLevel expected) {
+    Assertions.assertThat(getLogLevel(name))
+        .describedAs("Log level of %s", name)
+        .isEqualTo(expected);
+  }
+
+  /**
+   * Test the log enabling code in DefaultS3ClientFactory.
+   */
+  @Test
+  public void testMaybeTurnOnSdkLogging() {
+    // save the original log level
+    final LogControl.LogLevel clientOriginal = getLogLevel(HTTP_CLIENT_LOG_NAME);
+    // sdk log is forced to info
+    final LogControl.LogLevel sdkOriginal = getLogLevel(SDK_LOG_NAME);
+    try {
+      setLogLevel(HTTP_CLIENT_LOG_NAME, LogControl.LogLevel.INFO);
+      setLogLevel(SDK_LOG_NAME, LogControl.LogLevel.DEBUG);
+
+      // turn on logging
+      Assertions.assertThat(maybeTurnOnSdkLogging())
+          .describedAs("maybeTurnOnSdkLogging()")
+          .isTrue();
+      // and the inner log is now at debug
+      assertLogLevel(HTTP_CLIENT_LOG_NAME, SDK_LOG_LEVEL);
+      HTTP_CLIENT_LOG.debug("HTTP client at debug");
+      HTTP_CLIENT_LOG.trace("HTTP client at trace");
+    } finally {
+      // put things back
+      setLogLevel(HTTP_CLIENT_LOG_NAME, clientOriginal);
+      setLogLevel(SDK_LOG_NAME, sdkOriginal);
+    }
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/resources/log4j.properties
+++ b/hadoop-tools/hadoop-aws/src/test/resources/log4j.properties
@@ -96,3 +96,6 @@ log4j.logger.org.apache.hadoop.fs.s3a.S3AStorageStatistics=INFO
 # uncomment this to get S3 Delete requests to return the list of deleted objects
 # log4.logger.org.apache.hadoop.fs.s3a.impl.RequestFactoryImpl=TRACE
 
+# set to DEBUG to get log of HTTP traffic from s3a client to S3
+# through the AWS bundle SDK
+#log4.logger.org.apache.hadoop.fs.s3a.logging.sdk=INFO


### PR DESCRIPTION

Aims to set debug logging of http messages if the log org.apache.hadoop.fs.s3a.logging.sdk is set to debug.

```properties
# AWS v2 low level logging
log4j.logger.org.apache.hadoop.fs.s3a.logging.sdk=DEBUG
```


This doesn't work in production, even though it's based on the cloudstore StoreEntryPoint code which does. No idea why not


### How was this patch tested?

* new test to show logs can be changed
* running some itests doesn't show new value
* nor does CLI

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

