### PR TITLE
HDFS-17277. Delete invalid code logic  in namenode format

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -1378,9 +1378,6 @@ public class NameNode extends ReconfigurableBase implements
     
     Collection<URI> nameDirsToFormat = FSNamesystem.getNamespaceDirs(conf);
     List<URI> sharedDirs = FSNamesystem.getSharedEditsDirs(conf);
-    List<URI> dirsToPrompt = new ArrayList<URI>();
-    dirsToPrompt.addAll(nameDirsToFormat);
-    dirsToPrompt.addAll(sharedDirs);
     List<URI> editDirsToFormat = 
                  FSNamesystem.getNamespaceEditsDirs(conf);
 
@@ -1423,9 +1420,7 @@ public class NameNode extends ReconfigurableBase implements
       LOG.warn("Encountered exception during format", ioe);
       throw ioe;
     } finally {
-      if (fsImage != null) {
-        fsImage.close();
-      }
+      fsImage.close();
       if (fsn != null) {
         fsn.close();
       }


### PR DESCRIPTION
There is invalid logical processing in the namenode format process,It needs to be deleted