### PR TITLE
HDFS-17276. Fix the nn fetch editlog forbidden in kerberos environment

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/JspHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/JspHelper.java
@@ -115,7 +115,7 @@ public class JspHelper {
     final String remoteUser;
    
     if (UserGroupInformation.isSecurityEnabled()) {
-      remoteUser = request.getRemoteUser();
+      remoteUser = request.getUserPrincipal().getName();
       final String tokenString = request.getParameter(DELEGATION_PARAMETER_NAME);
       if (tokenString != null) {
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/JspHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/JspHelper.java
@@ -115,6 +115,8 @@ public class JspHelper {
     String remoteUser = null;
    
     if (UserGroupInformation.isSecurityEnabled()) {
+      // If using RemoteUser GetJournalEditServlet.isValidRequestor, it returns false due to 
+      // inability to verify FQDN for more info refer HDFS-17276.
       if (request.getUserPrincipal() != null) {
         remoteUser = request.getUserPrincipal().getName();
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/JspHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/JspHelper.java
@@ -112,10 +112,12 @@ public class JspHelper {
     UserGroupInformation ugi = null;
     final String usernameFromQuery = getUsernameFromQuery(request, tryUgiParameter);
     final String doAsUserFromQuery = request.getParameter(DoAsParam.NAME);
-    final String remoteUser;
+    String remoteUser = null;
    
     if (UserGroupInformation.isSecurityEnabled()) {
-      remoteUser = request.getUserPrincipal().getName();
+      if (request.getUserPrincipal() != null) {
+        remoteUser = request.getUserPrincipal().getName();
+      }
       final String tokenString = request.getParameter(DELEGATION_PARAMETER_NAME);
       if (tokenString != null) {
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/JspHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/JspHelper.java
@@ -115,7 +115,7 @@ public class JspHelper {
     String remoteUser = null;
    
     if (UserGroupInformation.isSecurityEnabled()) {
-      // If using RemoteUser GetJournalEditServlet.isValidRequestor, it returns false due to 
+      // If using RemoteUser GetJournalEditServlet.isValidRequestor, it returns false due to
       // inability to verify FQDN for more info refer HDFS-17276.
       if (request.getUserPrincipal() != null) {
         remoteUser = request.getUserPrincipal().getName();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestGetJournalEditServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestGetJournalEditServlet.java
@@ -67,6 +67,8 @@ public class TestGetJournalEditServlet {
    */
   @Test
   public void testWithoutUser() throws IOException {
+    CONF.set(HADOOP_SECURITY_AUTHENTICATION, "simple");
+    UserGroupInformation.setConfiguration(CONF);
     // Test: Make a request without specifying a user
     HttpServletRequest request = mock(HttpServletRequest.class);
     boolean isValid = SERVLET.isValidRequestor(request, CONF);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestGetJournalEditServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestGetJournalEditServlet.java
@@ -28,7 +28,9 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.security.Principal;
 
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -80,9 +82,30 @@ public class TestGetJournalEditServlet {
    */
   @Test
   public void testRequestNameNode() throws IOException, ServletException {
+    CONF.set(HADOOP_SECURITY_AUTHENTICATION, "simple");
+    UserGroupInformation.setConfiguration(CONF);
     // Test: Make a request from a namenode
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getParameter(UserParam.NAME)).thenReturn("nn/localhost@REALM.TLD");
+    boolean isValid = SERVLET.isValidRequestor(request, CONF);
+
+    assertThat(isValid).isTrue();
+  }
+
+  /**
+   * In the kerberos environment, the full name is required for adaptation.
+   *
+   * @throws IOException for unexpected validation failures
+   */
+  @Test
+  public void testSecurityRequestNameNode() throws IOException {
+    CONF.set(HADOOP_SECURITY_AUTHENTICATION, "kerberos");
+    UserGroupInformation.setConfiguration(CONF);
+    // Test: Make a request from a namenode
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    Principal principal = mock(Principal.class);
+    when(principal.getName()).thenReturn("nn/localhost@REALM.TLD");
+    when(request.getUserPrincipal()).thenReturn(principal);
     boolean isValid = SERVLET.isValidRequestor(request, CONF);
 
     assertThat(isValid).isTrue();
@@ -95,6 +118,8 @@ public class TestGetJournalEditServlet {
    */
   @Test
   public void testRequestShortName() throws IOException {
+    CONF.set(HADOOP_SECURITY_AUTHENTICATION, "simple");
+    UserGroupInformation.setConfiguration(CONF);
     // Test: Make a request from a namenode
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getParameter(UserParam.NAME)).thenReturn("jn/localhost@REALM.TLD");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHdfsTokens.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHdfsTokens.java
@@ -364,7 +364,7 @@ public class TestWebHdfsTokens {
   private void validateLazyTokenFetch(UserGroupInformation ugi,
       final Configuration clusterConf) throws Exception {
 
-    String testUser = ugi.getShortUserName();
+    String testUser = ugi.getUserName();
 
     WebHdfsFileSystem fs = ugi.doAs(
         new PrivilegedExceptionAction<WebHdfsFileSystem>() {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

- In a Kerberos environment, the namenode cannot fetch editlog from journalnode because the request is rejected (403). 
![image-2023-12-05-20-59-33-728](https://github.com/apache/hadoop/assets/22268305/f19c2518-3fa9-4ceb-8570-63b0b38f682a)

- GetJournalEditServlet checks if the request's username meets the requirements through the isValidRequestor function. After [HDFS-16686](https://issues.apache.org/jira/browse/HDFS-16686) is merged, remotePrincipal becomes ugi.getUserName().

- In a Kerberos environment, ugi.getUserName() gets the request.getRemoteUser() via DfsServlet's getUGI to get the username, and this username is not a full name.

- Therefore, the obtained username is similar to namenode01 instead of namenode01/host01@REALM.TLD, which meansit fails to pass the isValidRequestor check. 
![image-2023-12-05-21-05-49-180](https://github.com/apache/hadoop/assets/22268305/1a50c620-c8a3-4499-bdfe-2b064b709d9f)


**reproduction**

- In the TestGetJournalEditServlet add testSecurityRequestNameNode
```
@Test
public void testSecurityRequestNameNode() throws IOException, ServletException {
  // Test: Make a request from a namenode
  CONF.set(HADOOP_SECURITY_AUTHENTICATION, "kerberos");
  UserGroupInformation.setConfiguration(CONF);
  
  HttpServletRequest request = mock(HttpServletRequest.class);
    when(request.getParameter(UserParam.NAME)).thenReturn("nn/localhost@REALM.TLD");
  when(request.getRemoteUser()).thenReturn("jn");
  boolean isValid = SERVLET.isValidRequestor(request, CONF);
  
  assertThat(isValid).isTrue();
} 
```



### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

