### PR TITLE
HADOOP-19008. S3A: update aws-sdk version to 2.21.41

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -215,7 +215,7 @@ com.aliyun:aliyun-java-sdk-kms:2.11.0
 com.aliyun:aliyun-java-sdk-ram:3.1.0
 com.aliyun:aliyun-java-sdk-sts:3.0.0
 com.aliyun.oss:aliyun-sdk-oss:3.13.2
-com.amazonaws:aws-java-sdk-bundle:1.12.499
+com.amazonaws:aws-java-sdk-bundle:1.12.565
 com.cedarsoftware:java-util:1.9.0
 com.cedarsoftware:json-io:2.5.1
 com.fasterxml.jackson.core:jackson-annotations:2.12.7
@@ -360,7 +360,7 @@ org.objenesis:objenesis:2.6
 org.xerial.snappy:snappy-java:1.1.10.4
 org.yaml:snakeyaml:2.0
 org.wildfly.openssl:wildfly-openssl:1.1.3.Final
-software.amazon.awssdk:bundle:jar:2.21.33
+software.amazon.awssdk:bundle:jar:2.21.41
 
 
 --------------------------------------------------------------------------------

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -187,7 +187,7 @@
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <surefire.fork.timeout>900</surefire.fork.timeout>
     <aws-java-sdk.version>1.12.565</aws-java-sdk.version>
-    <aws-java-sdk-v2.version>2.21.33</aws-java-sdk-v2.version>
+    <aws-java-sdk-v2.version>2.21.41</aws-java-sdk-v2.version>
     <aws.eventstream.version>1.0.1</aws.eventstream.version>
     <hsqldb.version>2.7.1</hsqldb.version>
     <frontend-maven-plugin.version>1.11.2</frontend-maven-plugin.version>


### PR DESCRIPTION

### Description of PR


HADOOP-19008. S3A: update aws-sdk version to 2.21.41

### How was this patch tested?

* Did a run of pr #6277 with the version updated; errors there are unrelated to sdk updated
* did a release build with cli tests, inc storediag, with new SDK and logging set to debug. all good. See [output.txt](https://github.com/apache/hadoop/files/13615597/output.txt)


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

