### PR TITLE
HDFS-17275: Judge whether the block has been deleted in the block report

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -3311,7 +3311,7 @@ public class BlockManager implements BlockStatsMXBean {
 
     // find block by blockId
     BlockInfo storedBlock = getStoredBlock(block);
-    if(storedBlock == null) {
+    if (storedBlock == null) {
       // If blocksMap does not contain reported block id,
       // The replica should be removed from Datanode, and set NumBytes to BlockCommand.No_ACK to
       // avoid useless report to NameNode from Datanode when complete to process it.
@@ -3325,8 +3325,8 @@ public class BlockManager implements BlockStatsMXBean {
     // Block is on the NN
     LOG.debug("In memory blockUCState = {}", ucState);
 
-    // Ignore replicas already scheduled to be removed from the DN
-    if(invalidateBlocks.contains(dn, block)) {
+    // Ignore replicas already scheduled to be removed from the DN or had been deleted
+    if (invalidateBlocks.contains(dn, block) || storedBlock.isDeleted()) {
       return storedBlock;
     }
 


### PR DESCRIPTION
Now we use async thread MarkedDeleteBlockScrubber to delete blocks. In order to avoid unnecessary calculation operations on deleted blocks during block reporting, we should determine whether the block has been deleted during block reporting.

