### PR TITLE
HDFS-17280. Pipeline recovery should better end block in advance when bytes acked greater than half of blocksize.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
@@ -565,10 +565,11 @@ public class DFSOutputStream extends FSOutputSummer
    * @throws IOException
    */
   void endBlock() throws IOException {
-    if (getStreamer().getBytesCurBlock() == blockSize) {
+    if (getStreamer().getBytesCurBlock() == blockSize || getStreamer().isEndBlockFlag()) {
       setCurrentPacketToEmpty();
       enqueueCurrentPacket();
       getStreamer().setBytesCurBlock(0);
+      getStreamer().setEndBlockFlag(false);
       lastFlushOffset = 0;
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSPacket.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSPacket.java
@@ -42,7 +42,7 @@ public class DFSPacket {
   public static final long HEART_BEAT_SEQNO = -1L;
   private static final SpanContext[] EMPTY = new SpanContext[0];
   private final long seqno; // sequence number of buffer in block
-  private final long offsetInBlock; // offset in block
+  private long offsetInBlock; // offset in block
   private boolean syncBlock; // this packet forces the current block to disk
   private int numChunks; // number of chunks currently in packet
   private final int maxChunks; // max chunks in packet
@@ -359,5 +359,13 @@ public class DFSPacket {
 
   public Span getSpan() {
     return span;
+  }
+
+  public void setOffsetInBlock(long offsetInBlock) {
+    this.offsetInBlock = offsetInBlock;
+  }
+
+  public long getOffsetInBlock() {
+    return offsetInBlock;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -1313,7 +1313,8 @@ class DataStreamer extends Daemon {
               String exceptionMsg = "Receive reply from slowNode " + slowNode +
                   " for continuous " + markSlowNodeAsBadNodeThreshold +
                   " times, treating it as badNode";
-              if (!isEndBlockFlag() && getBytesCurBlock() << 1 > dfsClient.getConf().getDefaultBlockSize()) {
+              if (!isEndBlockFlag() && getBytesCurBlock() << 1
+                  > dfsClient.getConf().getDefaultBlockSize()) {
                 LOG.warn(exceptionMsg);
                 needEndBlockInAdvance = true;
                 skipHandleSlowNode = true;
@@ -1380,7 +1381,7 @@ class DataStreamer extends Daemon {
       return true;
     }
     closeStream();
-    
+
     // move packets from ack queue to front of the data queue
     synchronized (dataQueue) {
       dataQueue.addAll(0, ackQueue);

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -1313,12 +1313,12 @@ class DataStreamer extends Daemon {
               String exceptionMsg = "Receive reply from slowNode " + slowNode +
                   " for continuous " + markSlowNodeAsBadNodeThreshold +
                   " times, treating it as badNode";
-              errorState.setInternalError();
-              errorState.setBadNodeIndex(index);
               if (!isEndBlockFlag() && getBytesCurBlock() << 1 > dfsClient.getConf().getDefaultBlockSize()) {
                 LOG.warn(exceptionMsg);
                 needEndBlockInAdvance = true;
                 skipHandleSlowNode = true;
+                errorState.setInternalError();
+                errorState.setBadNodeIndex(index);
                 return;
               } else {
                 throw new IOException(exceptionMsg);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestClientProtocolForPipelineRecovery.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestClientProtocolForPipelineRecovery.java
@@ -161,7 +161,7 @@ public class TestClientProtocolForPipelineRecovery {
     MiniDFSCluster cluster = null;
 
     try {
-      int numDataNodes = 3;
+      int numDataNodes = 5;
       cluster = new MiniDFSCluster.Builder(conf).numDataNodes(numDataNodes).build();
       cluster.waitActive();
       FileSystem fileSys = cluster.getFileSystem();
@@ -934,7 +934,7 @@ public class TestClientProtocolForPipelineRecovery {
       int count = 0;
       Random r = new Random();
       byte[] b = new byte[oneWriteSize];
-      while (count < threshold) {
+      while (count < threshold + 1) {
         r.nextBytes(b);
         o.write(b);
         count++;


### PR DESCRIPTION
### Description of PR
Refer to HDFS-17280

Pipeline recovery should better end block in advance when bytes acked greater than half of blocksize.
I think this should be configurable by a swtich.