### PR TITLE
HDFS-17281 Added support of reporting rpc round-trip time at NN.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -287,7 +287,7 @@ public class Client implements AutoCloseable {
     boolean done;               // true when call is done
     private final Object externalHandler;
     private AlignmentContext alignmentContext;
-    final long createTimeNanos;  // creation time for this call at the client
+    private final long createTimeNanos;  // creation time for this call at the client
 
     private Call(RPC.RpcKind rpcKind, Writable param) {
       this(rpcKind, param, Time.monotonicNowNanos());

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -270,6 +270,10 @@ public class Client implements AutoCloseable {
     return new Call(rpcKind, rpcRequest);
   }
 
+  Call createCall(RPC.RpcKind rpcKind, Writable rpcRequest, long callCreateTime) {
+    return new Call(rpcKind, rpcRequest, callCreateTime);
+  }
+
   /** 
    * Class that represents an RPC call
    */
@@ -283,8 +287,13 @@ public class Client implements AutoCloseable {
     boolean done;               // true when call is done
     private final Object externalHandler;
     private AlignmentContext alignmentContext;
+    final long createTimeNanos;  // creation time for this call at the client
 
     private Call(RPC.RpcKind rpcKind, Writable param) {
+      this(rpcKind, param, Time.monotonicNowNanos());
+    }
+
+    private Call(RPC.RpcKind rpcKind, Writable param, long callCreateTimeNanos) {
       this.rpcKind = rpcKind;
       this.rpcRequest = param;
 
@@ -304,6 +313,7 @@ public class Client implements AutoCloseable {
       }
 
       this.externalHandler = EXTERNAL_CALL_HANDLER.get();
+      this.createTimeNanos = callCreateTimeNanos;
     }
 
     @Override
@@ -1175,7 +1185,7 @@ public class Client implements AutoCloseable {
       // Items '1' and '2' are prepared here. 
       RpcRequestHeaderProto header = ProtoUtil.makeRpcRequestHeader(
           call.rpcKind, OperationProto.RPC_FINAL_PACKET, call.id, call.retry,
-          clientId, call.alignmentContext);
+          clientId, call.alignmentContext, call.createTimeNanos);
 
       final ResponseBuffer buf = new ResponseBuffer();
       header.writeDelimitedTo(buf);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -368,7 +368,18 @@ public abstract class Server {
     Call call = CurCall.get();
     return call != null ? call.callId : RpcConstants.INVALID_CALL_ID;
   }
-  
+
+  /**
+   * Returns the currently active RPC call's create time at client-side.  0
+   * indicates an invalid value.
+   *
+   * @return long call create time at the client-side
+   */
+  public static long getClientCallCreateTime() {
+    Call call = CurCall.get();
+    return call != null ? call.clientCallCreateTimeNanos : 0;
+  }
+
   /**
    * @return The current active RPC call's retry count. -1 indicates the retry
    *         cache is not supported in the client side.
@@ -620,6 +631,7 @@ public abstract class Server {
     long completionTimeNanos = Time.monotonicNowNanos();
     long deltaNanos = completionTimeNanos - processingStartTimeNanos;
     long arrivalTimeNanos = call.timestampNanos;
+    long clientCallCreateTimeNanos = call.clientCallCreateTimeNanos;
 
     ProcessingDetails details = call.getProcessingDetails();
     // queue time is the delta between when the call first arrived and when it
@@ -654,10 +666,16 @@ public abstract class Server {
     processingTime -= waitTime;
     String name = call.getDetailedMetricsName();
     rpcDetailedMetrics.addProcessingTime(name, processingTime);
-    // Overall processing time is from arrival to completion.
+    // Server-side overall processing time is from call enqueuing time to completion.
     long overallProcessingTime = rpcMetrics.getMetricsTimeUnit()
         .convert(completionTimeNanos - arrivalTimeNanos, TimeUnit.NANOSECONDS);
     rpcDetailedMetrics.addOverallProcessingTime(name, overallProcessingTime);
+    // Round-trip time is from client call create time to completion.
+    if (clientCallCreateTimeNanos > 0) {
+      long roundTripTime = rpcMetrics.getMetricsTimeUnit().convert(
+          completionTimeNanos - clientCallCreateTimeNanos, TimeUnit.NANOSECONDS);
+      rpcDetailedMetrics.addRpcRtt(name, roundTripTime);
+    }
     callQueue.addResponseTime(name, call, details);
     if (isLogSlowRPC()) {
       logSlowRpcCalls(name, call, details);
@@ -961,6 +979,7 @@ public abstract class Server {
     private volatile String detailedMetricsName = "";
     final int callId;            // the client's call id
     final int retryCount;        // the retry count of the call
+    long clientCallCreateTimeNanos; // call create time at client side
     private final long timestampNanos; // time the call was received
     long responseTimestampNanos; // time the call was served
     private AtomicInteger responseWaitCount = new AtomicInteger(1);
@@ -984,21 +1003,21 @@ public abstract class Server {
 
     Call(Call call) {
       this(call.callId, call.retryCount, call.rpcKind, call.clientId,
-          call.span, call.callerContext);
+          call.span, call.callerContext, 0);
     }
 
     Call(int id, int retryCount, RPC.RpcKind kind, byte[] clientId) {
-      this(id, retryCount, kind, clientId, null, null);
+      this(id, retryCount, kind, clientId, null, null, 0);
     }
 
     @VisibleForTesting // primarily TestNamenodeRetryCache
     public Call(int id, int retryCount, Void ignore1, Void ignore2,
         RPC.RpcKind kind, byte[] clientId) {
-      this(id, retryCount, kind, clientId, null, null);
+      this(id, retryCount, kind, clientId, null, null, 0);
     }
 
     Call(int id, int retryCount, RPC.RpcKind kind, byte[] clientId,
-        Span span, CallerContext callerContext) {
+        Span span, CallerContext callerContext, long clientCallCreateTimeNanos) {
       this.callId = id;
       this.retryCount = retryCount;
       this.timestampNanos = Time.monotonicNowNanos();
@@ -1009,6 +1028,7 @@ public abstract class Server {
       this.callerContext = callerContext;
       this.clientStateId = Long.MIN_VALUE;
       this.isCallCoordinated = false;
+      this.clientCallCreateTimeNanos = clientCallCreateTimeNanos;
     }
 
     /**
@@ -1189,13 +1209,13 @@ public abstract class Server {
     RpcCall(Connection connection, int id, int retryCount) {
       this(connection, id, retryCount, null,
           RPC.RpcKind.RPC_BUILTIN, RpcConstants.DUMMY_CLIENT_ID,
-          null, null);
+          null, null, 0);
     }
 
     RpcCall(Connection connection, int id, int retryCount,
         Writable param, RPC.RpcKind kind, byte[] clientId,
-        Span span, CallerContext context) {
-      super(id, retryCount, kind, clientId, span, context);
+        Span span, CallerContext context, long clientCallCreateTime) {
+      super(id, retryCount, kind, clientId, span, context, clientCallCreateTime);
       this.connection = connection;
       this.rpcRequest = param;
     }
@@ -2930,7 +2950,7 @@ public abstract class Server {
       RpcCall call = new RpcCall(this, header.getCallId(),
           header.getRetryCount(), rpcRequest,
           ProtoUtil.convert(header.getRpcKind()),
-          header.getClientId().toByteArray(), span, callerContext);
+          header.getClientId().toByteArray(), span, callerContext, header.getCallCreateTime());
 
       // Save the priority level assignment by the scheduler
       call.setPriorityLevel(callQueue.getPriorityLevel(call));

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -194,8 +194,8 @@ public abstract class Server {
   }
 
   /**
-   * ExceptionsHandler manages Exception groups for special handling
-   * e.g., terse exception group for concise logging messages
+   * ExceptionsHandler manages Exception groups for special handling,
+   * such as terse exception group for concise logging messages
    */
   static class ExceptionsHandler {
 
@@ -979,7 +979,7 @@ public abstract class Server {
     private volatile String detailedMetricsName = "";
     final int callId;            // the client's call id
     final int retryCount;        // the retry count of the call
-    long clientCallCreateTimeNanos; // call create time at client side
+    private long clientCallCreateTimeNanos; // call create time at client side
     private final long timestampNanos; // time the call was received
     long responseTimestampNanos; // time the call was served
     private AtomicInteger responseWaitCount = new AtomicInteger(1);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -1003,7 +1003,7 @@ public abstract class Server {
 
     Call(Call call) {
       this(call.callId, call.retryCount, call.rpcKind, call.clientId,
-          call.span, call.callerContext, 0);
+          call.span, call.callerContext, call.clientCallCreateTimeNanos);
     }
 
     Call(int id, int retryCount, RPC.RpcKind kind, byte[] clientId) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcDetailedMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcDetailedMetrics.java
@@ -114,7 +114,7 @@ public class RpcDetailedMetrics {
   }
 
   /**
-   * Add an RPC round-trip time sample
+   * Add an RPC round-trip time sample.
    * @param rpcCallName of the RPC call
    * @param rtt  rpc round-trip time , from call create time at the client to
    *             a response is sent back to the client.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcDetailedMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcDetailedMetrics.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 public class RpcDetailedMetrics {
   static final String DEFERRED_PREFIX = "Deferred";
   static final String OVERALL_PROCESSING_PREFIX = "Overall";
+  static final String ROUND_TRIP_TIME_PREFIX = "RoundTrip";
 
   // per-method RPC processing time
   @Metric MutableRatesWithAggregation rates;
@@ -44,6 +45,11 @@ public class RpcDetailedMetrics {
    * response is sent back.
    */
   @Metric MutableRatesWithAggregation overallRpcProcessingRates;
+  /**
+   * per-method round-trip time, from call create time at the client-side to
+   * when the response is sent back to the client.
+   */
+  @Metric MutableRatesWithAggregation rpcRttRates;
 
   static final Logger LOG = LoggerFactory.getLogger(RpcDetailedMetrics.class);
   final MetricsRegistry registry;
@@ -52,6 +58,11 @@ public class RpcDetailedMetrics {
   // Mainly to facilitate testing in TestRPC.java
   public MutableRatesWithAggregation getOverallRpcProcessingRates() {
     return overallRpcProcessingRates;
+  }
+
+  // Mainly to facilitate testing in TestRPC.java
+  public MutableRatesWithAggregation getRpcRttRates() {
+    return rpcRttRates;
   }
 
   RpcDetailedMetrics(int port) {
@@ -76,6 +87,7 @@ public class RpcDetailedMetrics {
     rates.init(protocol);
     deferredRpcRates.init(protocol, DEFERRED_PREFIX);
     overallRpcProcessingRates.init(protocol, OVERALL_PROCESSING_PREFIX);
+    rpcRttRates.init(protocol, ROUND_TRIP_TIME_PREFIX);
   }
 
   /**
@@ -99,6 +111,17 @@ public class RpcDetailedMetrics {
    */
   public void addOverallProcessingTime(String rpcCallName, long overallProcessingTime) {
     overallRpcProcessingRates.add(rpcCallName, overallProcessingTime);
+  }
+
+  /**
+   * Add an RPC round-trip time sample
+   * @param rpcCallName of the RPC call
+   * @param rtt  rpc round-trip time , from call create time at the client to
+   *             a response is sent back to the client.
+   */
+  public void addRpcRtt(String rpcCallName,
+      long rtt) {
+    rpcRttRates.add(rpcCallName, rtt);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcDetailedMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcDetailedMetrics.java
@@ -41,7 +41,7 @@ public class RpcDetailedMetrics {
   @Metric MutableRatesWithAggregation rates;
   @Metric MutableRatesWithAggregation deferredRpcRates;
   /**
-   * per-method overall RPC processing time, from request arrival to when the
+   * per-method overall RPC processing time at the server-side, from request enqueuing to when the
    * response is sent back.
    */
   @Metric MutableRatesWithAggregation overallRpcProcessingRates;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ProtoUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ProtoUtil.java
@@ -171,16 +171,22 @@ public abstract class ProtoUtil {
   public static RpcRequestHeaderProto makeRpcRequestHeader(RPC.RpcKind rpcKind,
       RpcRequestHeaderProto.OperationProto operation, int callId,
       int retryCount, byte[] uuid) {
+    long callCreateTime = System.currentTimeMillis();
     return makeRpcRequestHeader(rpcKind, operation, callId, retryCount, uuid,
-        null);
+        null, callCreateTime);
   }
 
   public static RpcRequestHeaderProto makeRpcRequestHeader(RPC.RpcKind rpcKind,
       RpcRequestHeaderProto.OperationProto operation, int callId,
-      int retryCount, byte[] uuid, AlignmentContext alignmentContext) {
+      int retryCount, byte[] uuid, AlignmentContext alignmentContext,
+      long callCreateTime) {
     RpcRequestHeaderProto.Builder result = RpcRequestHeaderProto.newBuilder();
-    result.setRpcKind(convert(rpcKind)).setRpcOp(operation).setCallId(callId)
-        .setRetryCount(retryCount).setClientId(ByteString.copyFrom(uuid));
+    result.setRpcKind(convert(rpcKind))
+        .setRpcOp(operation)
+        .setCallId(callId)
+        .setRetryCount(retryCount)
+        .setClientId(ByteString.copyFrom(uuid))
+        .setCallCreateTime(callCreateTime);
 
     // Add tracing info if we are currently tracing.
     Span span = Tracer.getCurrentSpan();

--- a/hadoop-common-project/hadoop-common/src/main/proto/RpcHeader.proto
+++ b/hadoop-common-project/hadoop-common/src/main/proto/RpcHeader.proto
@@ -95,6 +95,7 @@ message RpcRequestHeaderProto { // the header for the RpcRequest
   // The client should not interpret these bytes, but only forward bytes
   // received from RpcResponseHeaderProto.routerFederatedState.
   optional bytes routerFederatedState = 9;
+  optional int64 callCreateTime = 10; // rpc call create time at client-side
 }
 
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -1483,7 +1483,7 @@ public class TestRPC extends TestRpcBase {
   }
 
   /**
-   * Test per-type RPC round-trip time metric
+   * Test per-type RPC round-trip time metric.
    */
   @Test
   public void testRpcRTTMetric() throws Exception {
@@ -1517,7 +1517,8 @@ public class TestRPC extends TestRpcBase {
       // Rpc round-trip time should be longer than server-side overall processing time.
       assertCounter("RoundTripLockAndSleepNumOps", 1L, rttRB);
       double rttLockAndSleepAvgTime = getDoubleGauge("RoundTripLockAndSleepAvgTime", rttRB);
-      double serverSideLockAndSleepAvgTime = getDoubleGauge("OverallLockAndSleepAvgTime", overallRB);
+      double serverSideLockAndSleepAvgTime =
+          getDoubleGauge("OverallLockAndSleepAvgTime", overallRB);
       assertTrue(rttLockAndSleepAvgTime > serverSideLockAndSleepAvgTime);
     } finally {
       stop(server, proxy);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -1481,6 +1481,50 @@ public class TestRPC extends TestRpcBase {
       stop(server, proxy);
     }
   }
+
+  /**
+   * Test per-type RPC round-trip time metric
+   */
+  @Test
+  public void testRpcRTTMetric() throws Exception {
+    final Server server;
+    TestRpcService proxy = null;
+
+    server = setupTestServer(conf, 5);
+    try {
+      proxy = getClient(addr, conf);
+
+      // Sent a ping request and a lockAndSleep request
+      proxy.ping(null, newEmptyRequest());
+      proxy.lockAndSleep(null, newSleepRequest(10));
+
+      MetricsRecordBuilder rttRB = mockMetricsRecordBuilder();
+      MutableRatesWithAggregation rttRates =
+          server.rpcDetailedMetrics.getRpcRttRates();
+      rttRates.snapshot(rttRB, false);
+
+      MetricsRecordBuilder overallRB = mockMetricsRecordBuilder();
+      MutableRatesWithAggregation overallRates =
+          server.rpcDetailedMetrics.getOverallRpcProcessingRates();
+      overallRates.snapshot(overallRB, false);
+
+      // Rpc round-trip time should be longer than server-side overall processing time.
+      assertCounter("RoundTripPingNumOps", 1L, rttRB);
+      double rttPingAvgTime = getDoubleGauge("RoundTripPingAvgTime", rttRB);
+      double serverSidePingAvgTime = getDoubleGauge("OverallPingAvgTime", overallRB);
+      assertTrue(rttPingAvgTime > serverSidePingAvgTime);
+
+      // Rpc round-trip time should be longer than server-side overall processing time.
+      assertCounter("RoundTripLockAndSleepNumOps", 1L, rttRB);
+      double rttLockAndSleepAvgTime = getDoubleGauge("RoundTripLockAndSleepAvgTime", rttRB);
+      double serverSideLockAndSleepAvgTime = getDoubleGauge("OverallLockAndSleepAvgTime", overallRB);
+      assertTrue(rttLockAndSleepAvgTime > serverSideLockAndSleepAvgTime);
+    } finally {
+      stop(server, proxy);
+    }
+  }
+
+
   /**
    *  Test RPC backoff by queue full.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterFederatedState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterFederatedState.java
@@ -53,7 +53,7 @@ public class TestRouterFederatedState {
         0,
         RpcConstants.INVALID_RETRY_COUNT,
         uuid,
-        alignmentContext);
+        alignmentContext, System.currentTimeMillis());
 
     Map<String, Long> stateIdsFromHeader =
         RouterFederatedStateProto.parseFrom(


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
We have come across a few cases where the hdfs clients are reporting very bad latencies, while we don't see similar trends at NN-side. Instead, from NN-side, the latency metrics seem normal as usual. I attached a screenshot which we took during an internal investigation at LinkedIn. What was happening is a token management service was reporting an average latency of 1 sec in fetching delegation tokens from our NN but at the NN-side, we did not see anything abnormal. The recent OverallRpcProcessingTime metric we added in [HDFS-17042](https://issues.apache.org/jira/browse/HDFS-17042) did not seem to be sufficient to identify/signal such cases. 

We propose to extend the IPC header in hadoop, to communicate call create time at client-side to IPC servers, so that for each rpc call, the server can get its round-trip time.

 

**Why is OverallRpcProcessingTime not sufficient?**

OverallRpcProcessingTime captures the time starting from when the reader thread reads in the call from the socket to when the response is sent back to the client. As a result, it does not capture the time it takes to transmit the call from client to the server. Besides, we only have a couple of reader threads to monitor a large number of open connections. It is possible that many connections become ready to read at the same time. Then, the reader thread would need to read each call sequentially, leading to a wait time for many Rpc Calls. We have also hit the case where the callQueue becomes full (with a total of 25600 requests) and thus reader threads are blocked to add new Calls into the callQueue. This would lead to a longer latency for all connections/calls which are ready and wait to be read by reader threads. 

Ideally, we want to measure the time between when a socket/call is ready to read and when it is actually being read by the reader thread. This would give us the wait time that a call is taking to be read. However, after some Google search, we failed to find a way to get this.

### How was this patch tested?

added unit tests.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

