### PR TITLE
HDFS-17283. Change the name of variable SECOND in HdfsClientConfigKeys.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -25,8 +25,8 @@ import java.util.concurrent.TimeUnit;
 /** Client configuration properties */
 @InterfaceAudience.Private
 public interface HdfsClientConfigKeys {
-  long SECOND = 1000L;
-  long MINUTE = 60 * SECOND;
+  long MS_PER_SECOND = 1000L;
+  long MINUTE = 60 * MS_PER_SECOND;
 
   String  DFS_BLOCK_SIZE_KEY = "dfs.blocksize";
   long    DFS_BLOCK_SIZE_DEFAULT = 128*1024*1024;
@@ -414,7 +414,7 @@ public interface HdfsClientConfigKeys {
       int     COUNT_LIMIT_DEFAULT = 2048;
       String  COUNT_RESET_TIME_PERIOD_MS_KEY =
           PREFIX + "count-reset-time-period-ms";
-      long    COUNT_RESET_TIME_PERIOD_MS_DEFAULT = 10*SECOND;
+      long    COUNT_RESET_TIME_PERIOD_MS_DEFAULT = 10 * MS_PER_SECOND;
     }
   }
 


### PR DESCRIPTION
### Description of PR
Currently, the value of variable SECOND in HdfsClientConfigKeys is 1000.
But i think the name of variable SECOND is not proper. So i change it to MS_PER_SECOND.


