### PR TITLE
HDFS-17285. RBF: Add a safe mode check period configuration

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -279,9 +279,9 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
       FEDERATION_ROUTER_PREFIX + "safemode.expiration";
   public static final long DFS_ROUTER_SAFEMODE_EXPIRATION_DEFAULT =
       3 * DFS_ROUTER_CACHE_TIME_TO_LIVE_MS_DEFAULT;
-  public static final String DFS_ROUTER_SAFEMODE_CHECKPERIOD =
+  public static final String DFS_ROUTER_SAFEMODE_CHECKPERIOD_MS =
       FEDERATION_ROUTER_PREFIX + "safemode.checkperiod";
-  public static final long DFS_ROUTER_SAFEMODE_CHECKPERIOD_DEFAULT =
+  public static final long DFS_ROUTER_SAFEMODE_CHECKPERIOD_MS_DEFAULT =
       TimeUnit.SECONDS.toMillis(5);
 
   // HDFS Router-based federation mount table entries

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -279,6 +279,10 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
       FEDERATION_ROUTER_PREFIX + "safemode.expiration";
   public static final long DFS_ROUTER_SAFEMODE_EXPIRATION_DEFAULT =
       3 * DFS_ROUTER_CACHE_TIME_TO_LIVE_MS_DEFAULT;
+  public static final String DFS_ROUTER_SAFEMODE_CHECKPERIOD =
+      FEDERATION_ROUTER_PREFIX + "safemode.checkperiod";
+  public static final long DFS_ROUTER_SAFEMODE_CHECKPERIOD_DEFAULT =
+      TimeUnit.SECONDS.toMillis(5);
 
   // HDFS Router-based federation mount table entries
   /** Maximum number of cache entries to have. */

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterSafemodeService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterSafemodeService.java
@@ -133,8 +133,8 @@ public class RouterSafemodeService extends PeriodicService {
 
     // Use same interval as cache update service
     this.setIntervalMs(conf.getTimeDuration(
-        RBFConfigKeys.DFS_ROUTER_SAFEMODE_CHECKPERIOD,
-        RBFConfigKeys.DFS_ROUTER_SAFEMODE_CHECKPERIOD_DEFAULT,
+        RBFConfigKeys.DFS_ROUTER_SAFEMODE_CHECKPERIOD_MS,
+        RBFConfigKeys.DFS_ROUTER_SAFEMODE_CHECKPERIOD_MS_DEFAULT,
         TimeUnit.MILLISECONDS));
 
     this.startupInterval = conf.getTimeDuration(

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterSafemodeService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterSafemodeService.java
@@ -133,8 +133,8 @@ public class RouterSafemodeService extends PeriodicService {
 
     // Use same interval as cache update service
     this.setIntervalMs(conf.getTimeDuration(
-        RBFConfigKeys.DFS_ROUTER_CACHE_TIME_TO_LIVE_MS,
-        RBFConfigKeys.DFS_ROUTER_CACHE_TIME_TO_LIVE_MS_DEFAULT,
+        RBFConfigKeys.DFS_ROUTER_SAFEMODE_CHECKPERIOD,
+        RBFConfigKeys.DFS_ROUTER_SAFEMODE_CHECKPERIOD_DEFAULT,
         TimeUnit.MILLISECONDS));
 
     this.startupInterval = conf.getTimeDuration(

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -531,6 +531,17 @@
   </property>
 
   <property>
+    <name>dfs.federation.router.safemode.checkperiod</name>
+    <value>5s</value>
+    <description>
+      How often the Router should check safe mode. This
+      setting supports multiple time unit suffixes as described in
+      dfs.heartbeat.interval. If no suffix is specified then milliseconds is
+      assumed.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.federation.router.monitor.namenode</name>
     <value></value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterSafemode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterSafemode.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs.server.federation.router;
 
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_CACHE_TIME_TO_LIVE_MS;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_SAFEMODE_CHECKPERIOD;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_SAFEMODE_EXPIRATION;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_SAFEMODE_EXTENSION;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.deleteStateStore;
@@ -70,6 +71,9 @@ public class TestRouterSafemode {
     // 200 ms cache refresh
     conf.setTimeDuration(DFS_ROUTER_CACHE_TIME_TO_LIVE_MS,
         200, TimeUnit.MILLISECONDS);
+    // 100 ms safemode checkperiod
+    conf.setTimeDuration(DFS_ROUTER_SAFEMODE_CHECKPERIOD,
+        100, TimeUnit.MILLISECONDS);
     // 1 sec post cache update before entering safemode (2 intervals)
     conf.setTimeDuration(DFS_ROUTER_SAFEMODE_EXPIRATION,
         TimeUnit.SECONDS.toMillis(1), TimeUnit.MILLISECONDS);
@@ -133,7 +137,7 @@ public class TestRouterSafemode {
     long interval =
         conf.getTimeDuration(DFS_ROUTER_SAFEMODE_EXTENSION,
             TimeUnit.SECONDS.toMillis(2), TimeUnit.MILLISECONDS) +
-        conf.getTimeDuration(DFS_ROUTER_CACHE_TIME_TO_LIVE_MS,
+        conf.getTimeDuration(DFS_ROUTER_SAFEMODE_CHECKPERIOD,
             TimeUnit.SECONDS.toMillis(1), TimeUnit.MILLISECONDS);
     Thread.sleep(interval);
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterSafemode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterSafemode.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hdfs.server.federation.router;
 
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_CACHE_TIME_TO_LIVE_MS;
-import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_SAFEMODE_CHECKPERIOD;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_SAFEMODE_CHECKPERIOD_MS;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_SAFEMODE_EXPIRATION;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_SAFEMODE_EXTENSION;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.deleteStateStore;
@@ -72,7 +72,7 @@ public class TestRouterSafemode {
     conf.setTimeDuration(DFS_ROUTER_CACHE_TIME_TO_LIVE_MS,
         200, TimeUnit.MILLISECONDS);
     // 100 ms safemode checkperiod
-    conf.setTimeDuration(DFS_ROUTER_SAFEMODE_CHECKPERIOD,
+    conf.setTimeDuration(DFS_ROUTER_SAFEMODE_CHECKPERIOD_MS,
         100, TimeUnit.MILLISECONDS);
     // 1 sec post cache update before entering safemode (2 intervals)
     conf.setTimeDuration(DFS_ROUTER_SAFEMODE_EXPIRATION,
@@ -137,7 +137,7 @@ public class TestRouterSafemode {
     long interval =
         conf.getTimeDuration(DFS_ROUTER_SAFEMODE_EXTENSION,
             TimeUnit.SECONDS.toMillis(2), TimeUnit.MILLISECONDS) +
-        conf.getTimeDuration(DFS_ROUTER_SAFEMODE_CHECKPERIOD,
+        conf.getTimeDuration(DFS_ROUTER_SAFEMODE_CHECKPERIOD_MS,
             TimeUnit.SECONDS.toMillis(1), TimeUnit.MILLISECONDS);
     Thread.sleep(interval);
 


### PR DESCRIPTION
JIRA: HDFS-17285. RBF: Add a safe mode check period configuration.

When dfsrouter start, it enters safe mode. And it will cost 1min to leave.

The log is blow:
```
14:35:23,717 INFO org.apache.hadoop.hdfs.server.federation.router.RouterSafemodeService: Leave startup safe mode after 30000 ms
14:35:23,717 INFO org.apache.hadoop.hdfs.server.federation.router.RouterSafemodeService: Enter safe mode after 180000 ms without reaching the State Store
14:35:23,717 INFO org.apache.hadoop.hdfs.server.federation.router.RouterSafemodeService: Entering safe mode
14:35:24,996 INFO org.apache.hadoop.hdfs.server.federation.router.RouterSafemodeService: Delaying safemode exit for 28721 milliseconds...
14:36:25,037 INFO org.apache.hadoop.hdfs.server.federation.router.RouterSafemodeService: Leaving safe mode after 61319 milliseconds
```
It depends on these configs.
DFS_ROUTER_SAFEMODE_EXTENSION 30s 
DFS_ROUTER_SAFEMODE_EXPIRATION 3min
DFS_ROUTER_CACHE_TIME_TO_LIVE_MS 1min  (it is the period for check safe mode)

Because in safe mode dfsrouter will reject write requests, so it should be shorter in check period if refreshCaches is done.  And we should remove DFS_ROUTER_CACHE_TIME_TO_LIVE_MS from RouterSafemodeService.