### PR TITLE
HDFS-17284. Fix int overflow in calculating numEcReplicatedTasks and numReplicationTasks during block recovery

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -1853,11 +1853,11 @@ public class DatanodeManager {
         maxECReplicatedTransfers = maxTransfers;
       }
       int numReplicationTasks = (int) Math.ceil(
-          (double) (replicationBlocks * maxTransfers) / totalBlocks);
+          (double) replicationBlocks * maxTransfers / totalBlocks);
       int numEcReplicatedTasks = (int) Math.ceil(
-              (double) (ecBlocksToBeReplicated * maxECReplicatedTransfers) / totalBlocks);
+          (double) ecBlocksToBeReplicated * maxECReplicatedTransfers / totalBlocks);
       int numECReconstructedTasks = (int) Math.ceil(
-          (double) (ecBlocksToBeErasureCoded * maxTransfers) / totalBlocks);
+          (double) ecBlocksToBeErasureCoded * maxTransfers / totalBlocks);
       LOG.debug("Pending replication tasks: {} ec to be replicated tasks: {} " +
                       "ec reconstruction tasks: {}.",
           numReplicationTasks, numEcReplicatedTasks, numECReconstructedTasks);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
@@ -1134,7 +1134,7 @@ public class TestDatanodeManager {
     verifyComputeReconstructedTaskNum(100, 100, 150, 250, 100);
     verifyComputeReconstructedTaskNum(200, 100000, 200000, 300000, 400000);
     verifyComputeReconstructedTaskNum(1000000, 100, 150, 250, 100);
-    verifyComputeReconstructedTaskNum(14000000,200, 200, 400, 200);
+    verifyComputeReconstructedTaskNum(14000000, 200, 200, 400, 200);
 
   }
   public void verifyComputeReconstructedTaskNum(int xmitsInProgress, int numReplicationBlocks,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
@@ -36,6 +36,7 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
 
+import org.apache.hadoop.hdfs.TestLeaseRecoveryStriped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -1125,5 +1126,34 @@ public class TestDatanodeManager {
     public MockDfsNetworkTopology(){
       super();
     }
+  }
+
+  @Test
+  public void testComputeReconstructedTaskNum() {
+    int xmitsInProgress = 13000000;
+    int maxReplicationStreams = 200;
+    int ecBlocksToBeReplicated = 200;
+    int totalBlocks = 500;
+    int maxTransfers = maxReplicationStreams - xmitsInProgress;
+
+    // When maxTransfers is negative, the returned result should also be negative.
+    Assert.assertTrue(checkNumReconstructedTasksFixed(ecBlocksToBeReplicated,
+        maxTransfers, totalBlocks) < 0);
+
+    Assert.assertTrue(checkNumReconstructedTasksOrigin(ecBlocksToBeReplicated,
+        maxTransfers, totalBlocks) > 0);
+  }
+
+  private int checkNumReconstructedTasksFixed(int ecBlocksToBeErasureCoded, int maxTransfers,
+      int totalBlocks) {
+    return (int) Math.ceil(
+        (double) ecBlocksToBeErasureCoded * maxTransfers / totalBlocks);
+
+  }
+
+  private int checkNumReconstructedTasksOrigin(int ecBlocksToBeErasureCoded, int maxTransfers,
+      int totalBlocks) {
+    return (int) Math.ceil(
+        (double) (ecBlocksToBeErasureCoded * maxTransfers) / totalBlocks);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
@@ -36,7 +36,6 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
 
-import org.apache.hadoop.hdfs.TestLeaseRecoveryStriped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -72,6 +71,8 @@ import org.apache.hadoop.test.Whitebox;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
@@ -1129,31 +1130,64 @@ public class TestDatanodeManager {
   }
 
   @Test
-  public void testComputeReconstructedTaskNum() {
-    int xmitsInProgress = 13000000;
-    int maxReplicationStreams = 200;
-    int ecBlocksToBeReplicated = 200;
-    int totalBlocks = 500;
-    int maxTransfers = maxReplicationStreams - xmitsInProgress;
-
-    // When maxTransfers is negative, the returned result should also be negative.
-    Assert.assertTrue(checkNumReconstructedTasksFixed(ecBlocksToBeReplicated,
-        maxTransfers, totalBlocks) < 0);
-
-    Assert.assertTrue(checkNumReconstructedTasksOrigin(ecBlocksToBeReplicated,
-        maxTransfers, totalBlocks) > 0);
-  }
-
-  private int checkNumReconstructedTasksFixed(int ecBlocksToBeErasureCoded, int maxTransfers,
-      int totalBlocks) {
-    return (int) Math.ceil(
-        (double) ecBlocksToBeErasureCoded * maxTransfers / totalBlocks);
+  public void testComputeReconstructedTaskNum() throws IOException {
+    verifyComputeReconstructedTaskNum(100, 100, 150, 250, 100);
+    verifyComputeReconstructedTaskNum(200, 100000, 200000, 300000, 400000);
+    verifyComputeReconstructedTaskNum(1000000, 100, 150, 250, 100);
+    verifyComputeReconstructedTaskNum(14000000,200, 200, 400, 200);
 
   }
+  public void verifyComputeReconstructedTaskNum(int xmitsInProgress, int numReplicationBlocks,
+      int maxTransfers, int numECTasksToBeReplicated, int numBlocksToBeErasureCoded)
+      throws IOException {
+    FSNamesystem fsn = Mockito.mock(FSNamesystem.class);
+    Mockito.when(fsn.hasWriteLock()).thenReturn(true);
+    Configuration conf = new Configuration();
+    conf.setInt(DFSConfigKeys.DFS_NAMENODE_REPLICATION_MAX_STREAMS_KEY, maxTransfers);
+    DatanodeManager dm = Mockito.spy(mockDatanodeManager(fsn, conf));
 
-  private int checkNumReconstructedTasksOrigin(int ecBlocksToBeErasureCoded, int maxTransfers,
-      int totalBlocks) {
-    return (int) Math.ceil(
-        (double) (ecBlocksToBeErasureCoded * maxTransfers) / totalBlocks);
+    DatanodeDescriptor nodeInfo = Mockito.mock(DatanodeDescriptor.class);
+    Mockito.when(nodeInfo.isRegistered()).thenReturn(true);
+    Mockito.when(nodeInfo.getStorageInfos()).thenReturn(new DatanodeStorageInfo[0]);
+
+    Mockito.when(nodeInfo.getNumberOfReplicateBlocks()).thenReturn(numReplicationBlocks);
+    Mockito.when(nodeInfo.getNumberOfECBlocksToBeReplicated()).thenReturn(numECTasksToBeReplicated);
+    Mockito.when(nodeInfo.getNumberOfBlocksToBeErasureCoded())
+        .thenReturn(numBlocksToBeErasureCoded);
+
+    // Create an ArgumentCaptor to capture the counts for numReplicationTasks,
+    // numEcReplicatedTasks,numECReconstructedTasks.
+    ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(Integer.class);
+    Mockito.when(nodeInfo.getErasureCodeCommand(ArgumentMatchers.anyInt()))
+        .thenReturn(Collections.nCopies(0, null));
+    Mockito.when(nodeInfo.getReplicationCommand(ArgumentMatchers.anyInt()))
+        .thenReturn(Collections.nCopies(0, null));
+    Mockito.when(nodeInfo.getECReplicatedCommand(ArgumentMatchers.anyInt()))
+        .thenReturn(Collections.nCopies(0, null));
+
+    DatanodeRegistration nodeReg = Mockito.mock(DatanodeRegistration.class);
+    Mockito.when(dm.getDatanode(nodeReg)).thenReturn(nodeInfo);
+
+
+    dm.handleHeartbeat(nodeReg, new StorageReport[1], "bp-123", 0, 0,
+        10, xmitsInProgress, 0, null, SlowPeerReports.EMPTY_REPORT,
+        SlowDiskReports.EMPTY_REPORT);
+
+    Mockito.verify(nodeInfo).getReplicationCommand(captor.capture());
+    int numReplicationTasks = captor.getValue();
+
+    Mockito.verify(nodeInfo).getECReplicatedCommand(captor.capture());
+    int numEcReplicatedTasks = captor.getValue();
+
+    Mockito.verify(nodeInfo).getErasureCodeCommand(captor.capture());
+    int numECReconstructedTasks = captor.getValue();
+
+    // Verify that when DN xmitsInProgress exceeds maxTransfers,
+    // the number of tasks should be <= 0.
+    if(xmitsInProgress >= maxTransfers){
+      assertTrue(numReplicationTasks <= 0);
+      assertTrue(numEcReplicatedTasks <= 0);
+      assertTrue(numECReconstructedTasks <= 0);
+    }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
@@ -1184,10 +1184,14 @@ public class TestDatanodeManager {
 
     // Verify that when DN xmitsInProgress exceeds maxTransfers,
     // the number of tasks should be <= 0.
-    if(xmitsInProgress >= maxTransfers){
+    if (xmitsInProgress >= maxTransfers) {
       assertTrue(numReplicationTasks <= 0);
       assertTrue(numEcReplicatedTasks <= 0);
       assertTrue(numECReconstructedTasks <= 0);
+    } else {
+      assertTrue(numReplicationTasks >= 0);
+      assertTrue(numEcReplicatedTasks >= 0);
+      assertTrue(numECReconstructedTasks >= 0);
     }
   }
 }


### PR DESCRIPTION
JIRA: HDFS-17284.Fix int overflow in calculating numEcReplicatedTasks and numReplicationTasks during block recovery

Due to an integer overflow in the calculation of numReplicationTasks or numEcReplicatedTasks, the NameNode's configuration parameter '**dfs.namenode.replication.max-streams-hard-limit**' failed to take effect. This led to an excessive number of tasks being sent to the DataNodes, consequently occupying too much of their memory. We may need to address this issue.

DN's xmitsInProgress is as follows:

![image](https://github.com/apache/hadoop/assets/54506205/78aae1dc-ce20-409f-8c14-37b659a5f1ac)



The values of **numReplicationTasks** and **numECReconstructedTasks** in the NameNode log are as follows.
`2023-12-07 14:40:49,485 DEBUG org.apache.hadoop.hdfs.server.blockmanagement.DatanodeManager: Pending replication tasks: -841750 erasure-coded tasks: 3727672`


NameNode retrieves a number of Tasks equal to numECReconstructedTasks (3727672) from the collection and sends them to the DataNode.
https://github.com/apache/hadoop/blob/81de229cf6d8c40f7417488a534af3f1dc71ebdc/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java#L1896-L1903