### PR TITLE
YARN-11630. Passing admin Java options to container localizers

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2225,6 +2225,11 @@ public class YarnConfiguration extends Configuration {
   public static final String NM_HEALTH_CHECK_SCRIPT_INTERVAL_MS_TEMPLATE =
       NM_PREFIX + "health-checker.%s.interval-ms";
 
+  /** The admin JVM options used on forking ContainerLocalizer process
+   by container executor. */
+  public static final String NM_CONTAINER_LOCALIZER_ADMIN_JAVA_OPTS_KEY =
+      NM_PREFIX + "container-localizer.admin.java.opts";
+
   /** The JVM options used on forking ContainerLocalizer process
       by container executor. */
   public static final String NM_CONTAINER_LOCALIZER_JAVA_OPTS_KEY =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2225,17 +2225,19 @@ public class YarnConfiguration extends Configuration {
   public static final String NM_HEALTH_CHECK_SCRIPT_INTERVAL_MS_TEMPLATE =
       NM_PREFIX + "health-checker.%s.interval-ms";
 
-  /** The admin JVM options used on forking ContainerLocalizer process
-   by container executor. */
-  public static final String NM_CONTAINER_LOCALIZER_ADMIN_JAVA_OPTS_KEY =
-      NM_PREFIX + "container-localizer.admin.java.opts";
-
   /** The JVM options used on forking ContainerLocalizer process
       by container executor. */
   public static final String NM_CONTAINER_LOCALIZER_JAVA_OPTS_KEY =
       NM_PREFIX + "container-localizer.java.opts";
   public static final String NM_CONTAINER_LOCALIZER_JAVA_OPTS_DEFAULT =
       "-Xmx256m";
+
+  /** The admin JVM options used on forking ContainerLocalizer process
+      by container executor. */
+  public static final String NM_CONTAINER_LOCALIZER_ADMIN_JAVA_OPTS_KEY =
+      NM_PREFIX + "container-localizer.admin.java.opts";
+
+  public static final String NM_CONTAINER_LOCALIZER_ADMIN_JAVA_OPTS_DEFAULT = "";
 
   /*
    * Flag to indicate whether JDK17's required add-exports flags should be added to

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -1489,6 +1489,16 @@
   </property>
 
   <property>
+    <description>
+    </description>
+    <name>yarn.nodemanager.container-localizer.admin.java.opts</name>
+    <value></value>
+    <description>The admin JVM options used on forking ContainerLocalizer process
+      by the container executor.
+    </description>
+  </property>
+
+  <property>
     <name>yarn.nodemanager.container-localizer.java.opts.add-exports-as-default</name>
     <value>true</value>
     <description>Since on JDK17 it is no longer possible to use the reflection API to

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -1490,12 +1490,11 @@
 
   <property>
     <description>
+      The admin JVM options used on forking ContainerLocalizer process
+      by the container executor.
     </description>
     <name>yarn.nodemanager.container-localizer.admin.java.opts</name>
     <value></value>
-    <description>The admin JVM options used on forking ContainerLocalizer process
-      by the container executor.
-    </description>
   </property>
 
   <property>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ContainerLocalizer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ContainerLocalizer.java
@@ -408,7 +408,8 @@ public class ContainerLocalizer {
    * @param conf the configuration properties to launch the resource localizer.
    */
   public static List<String> getJavaOpts(Configuration conf) {
-    String adminOpts = conf.get(YarnConfiguration.NM_CONTAINER_LOCALIZER_ADMIN_JAVA_OPTS_KEY, "");
+    String adminOpts = conf.get(YarnConfiguration.NM_CONTAINER_LOCALIZER_ADMIN_JAVA_OPTS_KEY,
+        YarnConfiguration.NM_CONTAINER_LOCALIZER_ADMIN_JAVA_OPTS_DEFAULT);
     String userOpts = conf.get(YarnConfiguration.NM_CONTAINER_LOCALIZER_JAVA_OPTS_KEY,
         YarnConfiguration.NM_CONTAINER_LOCALIZER_JAVA_OPTS_DEFAULT);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ContainerLocalizer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ContainerLocalizer.java
@@ -47,6 +47,8 @@ import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.conf.Configuration;
@@ -406,16 +408,24 @@ public class ContainerLocalizer {
    * @param conf the configuration properties to launch the resource localizer.
    */
   public static List<String> getJavaOpts(Configuration conf) {
-    String opts = conf.get(YarnConfiguration.NM_CONTAINER_LOCALIZER_JAVA_OPTS_KEY,
+    String adminOpts = conf.get(YarnConfiguration.NM_CONTAINER_LOCALIZER_ADMIN_JAVA_OPTS_KEY, "");
+    String userOpts = conf.get(YarnConfiguration.NM_CONTAINER_LOCALIZER_JAVA_OPTS_KEY,
         YarnConfiguration.NM_CONTAINER_LOCALIZER_JAVA_OPTS_DEFAULT);
+
     boolean isExtraJDK17OptionsConfigured =
         conf.getBoolean(YarnConfiguration.NM_CONTAINER_LOCALIZER_JAVA_OPTS_ADD_EXPORTS_KEY,
         YarnConfiguration.NM_CONTAINER_LOCALIZER_JAVA_OPTS_ADD_EXPORTS_DEFAULT);
 
     if (Shell.isJavaVersionAtLeast(17) && isExtraJDK17OptionsConfigured) {
-      opts = opts.trim().concat(" " + ADDITIONAL_JDK17_PLUS_OPTIONS);
+      userOpts = userOpts.trim().concat(" " + ADDITIONAL_JDK17_PLUS_OPTIONS);
     }
-    return Arrays.asList(opts.split(" "));
+
+    List<String> adminOptionList = Arrays.asList(adminOpts.split("\\s+"));
+    List<String> userOptionList = Arrays.asList(userOpts.split("\\s+"));
+
+    return Stream.concat(adminOptionList.stream(), userOptionList.stream())
+        .filter(s -> !s.isEmpty())
+        .collect(Collectors.toList());
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestContainerLocalizer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestContainerLocalizer.java
@@ -737,4 +737,66 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
     }
     Assert.assertTrue(javaOpts.contains("-Xmx256m"));
   }
+
+  @Test
+  public void testAdminOptionsPrecedeUserDefinedJavaOptions() throws Exception {
+    ContainerLocalizerWrapper wrapper = new ContainerLocalizerWrapper();
+    ContainerLocalizer localizer = wrapper.setupContainerLocalizerForTest();
+
+    Configuration conf = new Configuration();
+    conf.setStrings(YarnConfiguration.NM_CONTAINER_LOCALIZER_ADMIN_JAVA_OPTS_KEY,
+        "adminOption1 adminOption2");
+    conf.setStrings(YarnConfiguration.NM_CONTAINER_LOCALIZER_JAVA_OPTS_KEY,
+        " userOption1 userOption2");
+    List<String> javaOpts = localizer.getJavaOpts(conf);
+
+    Assert.assertEquals(4, javaOpts.size());
+    Assert.assertTrue(javaOpts.get(0).equals("adminOption1"));
+    Assert.assertTrue(javaOpts.get(1).equals("adminOption2"));
+    Assert.assertTrue(javaOpts.get(2).equals("userOption1"));
+    Assert.assertTrue(javaOpts.get(3).equals("userOption2"));
+  }
+
+  @Test
+  public void testAdminOptionsPrecedeDefaultUserOptions() throws Exception {
+    ContainerLocalizerWrapper wrapper = new ContainerLocalizerWrapper();
+    ContainerLocalizer localizer = wrapper.setupContainerLocalizerForTest();
+
+    Configuration conf = new Configuration();
+    conf.setStrings(YarnConfiguration.NM_CONTAINER_LOCALIZER_ADMIN_JAVA_OPTS_KEY,
+        "adminOption1 adminOption2");
+    List<String> javaOpts = localizer.getJavaOpts(conf);
+
+    Assert.assertEquals(3, javaOpts.size());
+    Assert.assertTrue(javaOpts.get(0).equals("adminOption1"));
+    Assert.assertTrue(javaOpts.get(1).equals("adminOption2"));
+    Assert.assertTrue(javaOpts.get(2).equals("-Xmx256m"));
+  }
+
+  @Test
+  public void testUserOptionsWhenAdminOptionsAreNotDefined() throws Exception {
+    ContainerLocalizerWrapper wrapper = new ContainerLocalizerWrapper();
+    ContainerLocalizer localizer = wrapper.setupContainerLocalizerForTest();
+
+    Configuration conf = new Configuration();
+    conf.setStrings(YarnConfiguration.NM_CONTAINER_LOCALIZER_JAVA_OPTS_KEY,
+        "userOption1 userOption2");
+    List<String> javaOpts = localizer.getJavaOpts(conf);
+
+    Assert.assertEquals(2, javaOpts.size());
+    Assert.assertTrue(javaOpts.get(0).equals("userOption1"));
+    Assert.assertTrue(javaOpts.get(1).equals("userOption2"));
+  }
+
+  @Test
+  public void testJavaOptionsWithoutDefinedAdminOrUserOptions() throws Exception {
+    ContainerLocalizerWrapper wrapper = new ContainerLocalizerWrapper();
+    ContainerLocalizer localizer = wrapper.setupContainerLocalizerForTest();
+
+    Configuration conf = new Configuration();
+    List<String> javaOpts = localizer.getJavaOpts(conf);
+
+    Assert.assertEquals(1, javaOpts.size());
+    Assert.assertTrue(javaOpts.get(0).equals("-Xmx256m"));
+  }
 }


### PR DESCRIPTION
Change-Id: I493eda1180604f8a85bbbee843b59f8ae9eba34c

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Currently we can specify Java options for container localizers in "yarn.nodemanager.container-localizer.java.opts" parameter.

The aim of this ticket is to create a parameter which we can use to pass admin options as well. It would work similarly as the admin Java options we can pass for Mapreduce jobs, first we should pass the admin options to the container executor, then the user-defined ones.

### How was this patch tested?
Unit tests

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

