### PR TITLE
[HADOOP-19010] - NullPointerException in Hadoop Credential Check CLI …

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/CredentialShell.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/CredentialShell.java
@@ -25,6 +25,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.hadoop.security.alias.CredentialProvider.CredentialEntry;
 import org.apache.hadoop.classification.VisibleForTesting;
 
 import org.apache.commons.lang3.StringUtils;
@@ -365,12 +366,17 @@ public class CredentialShell extends CommandShell {
         } else {
           password = c.readPassword("Enter alias password: ");
         }
-        char[] storePassword =
-            provider.getCredentialEntry(alias).getCredential();
-        String beMatch =
-            Arrays.equals(storePassword, password) ? "success" : "failed";
+        CredentialEntry credentialEntry = provider.getCredentialEntry(alias);
+        if(credentialEntry == null) {
+          // Fail the password match when alias not found
+          getOut().println("Password match failed for " + alias + ".");
+        } else {
+          char[] storePassword = credentialEntry.getCredential();
+          String beMatch =
+              Arrays.equals(storePassword, password) ? "success" : "failed";
 
-        getOut().println("Password match " + beMatch + " for " +  alias + ".");
+          getOut().println("Password match " + beMatch + " for " + alias + ".");
+        }
       } catch (IOException e) {
         getOut().println("Cannot check aliases for CredentialProvider: " +
             provider.toString()

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredShell.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredShell.java
@@ -1,5 +1,6 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
+ * Licensed to the Apache Software 
+ ation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
@@ -163,6 +164,21 @@ public class TestCredShell {
     rc = shell.run(args1);
     assertEquals(outContent.toString(), 1, rc);
     assertTrue(outContent.toString().contains("Passwords don't match"));
+  }
+  
+  @Test
+  public void testPromptForCredentialNotFound() throws Exception {
+    String[] args1 = {"check", "credential1", "-provider",
+        jceksProvider};
+    ArrayList<String> password = new ArrayList<String>();
+    password.add("p@ssw0rd");
+    int rc = 0;
+    CredentialShell shell = new CredentialShell();
+    shell.setConf(new Configuration());
+    shell.setPasswordReader(new MockPasswordReader(password));
+    rc = shell.run(args1);
+    assertEquals(0, rc);
+    assertOutputContains("Password match failed for credential1.");
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredShell.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredShell.java
@@ -1,6 +1,5 @@
 /**
- * Licensed to the Apache Software 
- ation (ASF) under one
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
@@ -165,7 +164,7 @@ public class TestCredShell {
     assertEquals(outContent.toString(), 1, rc);
     assertTrue(outContent.toString().contains("Passwords don't match"));
   }
-  
+
   @Test
   public void testPromptForCredentialNotFound() throws Exception {
     String[] args1 = {"check", "credential1", "-provider",


### PR DESCRIPTION
…Command

### Description of PR
The JavaKeyStoreProvider#getCredentialEntry function call returns NULL when credential alias not found in jceks file which is an expected behavior. But, the CredentialShell#check has no null check in place for the function call result which results into NullPointerException at [line#368](https://github.com/apache/hadoop/blob/19b9e6a97b8faa0eb48e7b1855ab37e6d4b6c2a9/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/CredentialShell.java#L368).

Proposed Fix: The check command should display 'password match failed' message when credential alias not found. This is same message that is thrown for incorrect alias value:

Password match failed for javax.jdo.option.ConnectionPassword.

### How was this patch tested?
All hadoop unit tests are passing. For integration testing, This patch is tested locally deploying on hadoop 3.3.5 and 3.3.6 clusters. 

### For code changes:

- [Yes] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [NA ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

