### PR TITLE
YARN-11622. Fix ResourceManager asynchronous switch from Standy to Active exception

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/pom.xml
@@ -271,6 +271,13 @@
       <artifactId>jersey-test-framework-grizzly2</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/TransitionToActiveStandbyRunner.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/TransitionToActiveStandbyRunner.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.resourcemanager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.hadoop.yarn.server.resourcemanager.TransitionToActiveStandbyRunner.TransitionToActiveStandbyResult;
+
+import java.util.concurrent.Callable;
+
+/**
+ * The TransitionToActiveStandbyRunner is an abstract class applied in the HA
+ * for performing ToActive and ToStandby tasks.
+ */
+public abstract class TransitionToActiveStandbyRunner implements
+    Callable<TransitionToActiveStandbyResult> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      TransitionToActiveStandbyRunner.class);
+
+  //ClusterTimeStamp is epoch tag
+  private final long clusterTimeStamp;
+
+  public TransitionToActiveStandbyRunner(long clusterTimeStamp) {
+    this.clusterTimeStamp = clusterTimeStamp;
+  }
+
+  @Override
+  public TransitionToActiveStandbyResult call() {
+
+    Long startTime = System.currentTimeMillis();
+
+    try {
+      LOG.info("The {} task starts", this.getClass().getSimpleName());
+      doTransaction();
+      Long entTime = System.currentTimeMillis() - startTime;
+      LOG.info("The {} task finished, took {}ms", this.getClass().getSimpleName(), entTime);
+    } catch (Exception ex) {
+      LOG.warn("The {} task failed.", this.getClass().getSimpleName(), ex);
+      return new TransitionToActiveStandbyResult(false, ex);
+    }
+
+    return new TransitionToActiveStandbyResult(true);
+  }
+
+  public abstract void doTransaction() throws Exception;
+
+  public static class TransitionToActiveStandbyResult {
+    private boolean isSuccess;
+    private Exception ex;
+
+    public TransitionToActiveStandbyResult(boolean isSuccess, Exception ex) {
+      this.isSuccess = isSuccess;
+      this.ex = ex;
+    }
+
+    public TransitionToActiveStandbyResult(boolean isSuccess) {
+      this.isSuccess = isSuccess;
+    }
+
+    public boolean isSuccess() {
+      return isSuccess;
+    }
+
+    public Exception getException() {
+      return ex;
+    }
+  }
+
+  public long getClusterTimeStamp() {
+    return clusterTimeStamp;
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMHAFatal.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMHAFatal.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.resourcemanager;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.ha.HAServiceProtocol;
+import org.apache.hadoop.ha.HealthCheckFailedException;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.util.ExitUtil;
+import org.apache.hadoop.yarn.conf.HAUtil;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.resourcemanager.recovery.MemoryRMStateStore;
+import org.apache.hadoop.yarn.server.resourcemanager.recovery.StoreFencedException;
+import org.apache.hadoop.yarn.server.resourcemanager.recovery.records.ApplicationStateData;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.QueueMetrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+public class TestRMHAFatal {
+  private Configuration configuration;
+  private MockRM rm = null;
+  private static final String STATE_ERR =
+      "ResourceManager is in wrong HA state";
+  private static final String RM1_ADDRESS = "1.1.1.1:1";
+  private static final String RM1_NODE_ID = "rm1";
+
+  private static final String RM2_ADDRESS = "0.0.0.0:0";
+  private static final String RM2_NODE_ID = "rm2";
+
+  private static final String RM3_ADDRESS = "2.2.2.2:2";
+  private static final String RM3_NODE_ID = "rm3";
+
+  @Before
+  public void setUp() throws Exception {
+    configuration = new Configuration();
+    UserGroupInformation.setConfiguration(configuration);
+    configuration.setBoolean(YarnConfiguration.RM_HA_ENABLED, true);
+    configuration.set(YarnConfiguration.RM_HA_IDS, RM1_NODE_ID + ","
+        + RM2_NODE_ID);
+    for (String confKey : YarnConfiguration
+        .getServiceAddressConfKeys(configuration)) {
+      configuration.set(HAUtil.addSuffix(confKey, RM1_NODE_ID), RM1_ADDRESS);
+      configuration.set(HAUtil.addSuffix(confKey, RM2_NODE_ID), RM2_ADDRESS);
+      configuration.set(HAUtil.addSuffix(confKey, RM3_NODE_ID), RM3_ADDRESS);
+    }
+
+    // Enable webapp to test web-services also
+    configuration.setBoolean(MockRM.ENABLE_WEBAPP, true);
+    configuration.setBoolean(YarnConfiguration.YARN_ACL_ENABLE, true);
+    ClusterMetrics.destroy();
+    QueueMetrics.clearQueueMetrics();
+    DefaultMetricsSystem.shutdown();
+
+    ExitUtil.disableSystemExit();
+    ExitUtil.disableSystemHalt();
+    ExitUtil.resetFirstExitException();
+    ExitUtil.resetFirstHaltException();
+  }
+
+  @Test
+  public void testHandleTransitionToStandByInNewThreadFatalExit()
+      throws Exception {
+    configuration.setBoolean(YarnConfiguration.AUTO_FAILOVER_ENABLED, false);
+    Configuration conf = new YarnConfiguration(configuration);
+
+    //1. Prepare a MockMemoryRMStateStore object
+    MemoryRMStateStore memStore = new MockMemoryRMStateStore() {
+      @Override
+      public void updateApplicationState(ApplicationStateData appState) {
+        notifyStoreOperationFailed(new StoreFencedException());
+      }
+    };
+    memStore.init(conf);
+
+    //2. start RM
+    rm = new MockRM(conf, memStore);
+    rm.init(conf);
+    final HAServiceProtocol.StateChangeRequestInfo requestInfo =
+        new HAServiceProtocol.StateChangeRequestInfo(
+            HAServiceProtocol.RequestSource.REQUEST_BY_USER);
+
+    assertEquals(STATE_ERR, HAServiceProtocol.HAServiceState.INITIALIZING,
+        rm.adminService.getServiceStatus().getState());
+    assertFalse("RM is ready to become active before being started",
+        rm.adminService.getServiceStatus().isReadyToBecomeActive());
+    checkMonitorHealth();
+
+    rm.start();
+    checkMonitorHealth();
+
+    //3. Transition to Active.
+    rm.adminService.transitionToActive(requestInfo);
+    //4. stop toActiveStandbyExecutor
+    rm.stopToActiveStandbyExecutor();
+
+    //5. STATE_STORE_FENCED to standby
+    rm.getRMContext().getStateStore().updateApplicationState(null);
+
+    GenericTestUtils.waitFor(
+        new org.apache.hadoop.thirdparty.com.google.common.base.Supplier<Boolean>() {
+          @Override
+          public Boolean get() {
+            return (ExitUtil.terminateCalled());
+          }
+        }, 100, 3000);
+    //6. Check Result
+    Assert.assertTrue(
+        ExitUtil.getFirstExitException().getMessage().contains("RejectedExecutionException"));
+  }
+
+  private void checkMonitorHealth() throws IOException {
+    try {
+      rm.adminService.monitorHealth();
+    } catch (HealthCheckFailedException e) {
+      fail("The RM is in bad health: it is Active, but the active services " +
+          "are not running");
+    }
+  }
+
+  @After
+  public void after() {
+    ExitUtil.resetFirstExitException();
+    ExitUtil.resetFirstHaltException();
+  }
+
+
+}


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
YARN-11622 Fix ResourceManager asynchronous switch from Standy to Active exception

### How was this patch tested?
add TestRMHA.testTransitionToActiveFailedAfterToStandbyNotSkip
add TestRMHA.testLessEpochRMFatalToStandbyRunnerShouldNotExecute

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

