### PR TITLE
HADOOP-19011. Possible ConcurrentModificationException if Exec command fails

### DIFF
--- a/hadoop-maven-plugins/src/main/java/org/apache/hadoop/maven/plugin/util/Exec.java
+++ b/hadoop-maven-plugins/src/main/java/org/apache/hadoop/maven/plugin/util/Exec.java
@@ -72,14 +72,14 @@ public class Exec {
       stdOut.start();
       stdErr.start();
       retCode = p.waitFor();
+      stdOut.join();
+      stdErr.join();
       if (retCode != 0) {
         mojo.getLog().warn(command + " failed with error code " + retCode);
         for (String s : stdErr.getOutput()) {
           mojo.getLog().debug(s);
         }
       }
-      stdOut.join();
-      stdErr.join();
       output.addAll(stdOut.getOutput());
       if (errors != null) {
         errors.addAll(stdErr.getOutput());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix:

```
ConcurrentModificationException
    at java.util.ArrayList$Itr.checkForComodification (ArrayList.java:1013)
    at java.util.ArrayList$Itr.next (ArrayList.java:967)
    at org.apache.hadoop.maven.plugin.util.Exec.run (Exec.java:77)
    at org.apache.hadoop.maven.plugin.util.Exec.run (Exec.java:52)
    at org.apache.hadoop.maven.plugin.versioninfo.VersionInfoMojo.determineSCM (VersionInfoMojo.java:115)
    at org.apache.hadoop.maven.plugin.versioninfo.VersionInfoMojo.execute (VersionInfoMojo.java:80)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
```

which is possible if the process exits with error:

```
[INFO] --- hadoop-maven-plugins:3.3.6:version-info (version-info) @ ozone-common ---
[WARNING] [git, branch] failed with error code 128
...
[INFO] BUILD FAILURE
...
[ERROR] Failed to execute goal org.apache.hadoop:hadoop-maven-plugins:3.3.6:version-info (version-info) on project ozone-common: java.util.ConcurrentModificationException
```

which happens when building sources from tarball, not from git repo.

https://issues.apache.org/jira/browse/HADOOP-19011