### PR TITLE
only create cluster and create file system on it once to speed up tests

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewerWithStripedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewerWithStripedBlocks.java
@@ -40,24 +40,24 @@ import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfoStriped;
 import org.apache.hadoop.hdfs.server.namenode.FSDirectory;
 import org.apache.hadoop.hdfs.server.namenode.FSImageTestUtil;
 import org.apache.hadoop.hdfs.server.namenode.INodeFile;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestOfflineImageViewerWithStripedBlocks {
-  private final ErasureCodingPolicy ecPolicy =
+  private final static ErasureCodingPolicy ecPolicy =
       StripedFileTestUtil.getDefaultECPolicy();
-  private int dataBlocks = ecPolicy.getNumDataUnits();
-  private int parityBlocks = ecPolicy.getNumParityUnits();
+  private static int dataBlocks = ecPolicy.getNumDataUnits();
+  private static int parityBlocks = ecPolicy.getNumParityUnits();
 
   private static MiniDFSCluster cluster;
   private static DistributedFileSystem fs;
-  private final int cellSize = ecPolicy.getCellSize();
-  private final int stripesPerBlock = 3;
-  private final int blockSize = cellSize * stripesPerBlock;
+  private final static int cellSize = ecPolicy.getCellSize();
+  private final static int stripesPerBlock = 3;
+  private final static int blockSize = cellSize * stripesPerBlock;
 
-  @Before
-  public void setup() throws IOException {
+  @BeforeClass
+  public static void setup() throws IOException {
     int numDNs = dataBlocks + parityBlocks + 2;
     Configuration conf = new Configuration();
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, blockSize);
@@ -72,8 +72,8 @@ public class TestOfflineImageViewerWithStripedBlocks {
     fs.mkdirs(eczone);
   }
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     if (cluster != null) {
       cluster.shutdown();
     }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
This pull request tries to only create/close the cluster and create the file system once in the test class `TestOfflineImageViewerWithStripedBlocks` to speed up tests.

There are seven tests in the test class `TestOfflineImageViewerWithStripedBlocks`. However, all of them call `testFileSize` with the number of bytes and they are not trying to modify the file system located in the cluster. They are also not modifying the cluster. There is no need to always make the same cluster, create the same file system before every test runs and close the cluster after every test runs, which makes tests in the test class `TestOfflineImageViewerWithStripedBlocks` run slower.

### How was this patch tested?
When run on our own machine, the test runtime for the test class `TestOfflineImageViewerWithStripedBlocks` jumps from `8.87 s` to `4.336 s` after applying the change.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

