### PR TITLE
HDFS-17289. Considering the size of non-lastBlocks equals to complete block size can cause append failure.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
@@ -356,7 +356,7 @@ public class DFSOutputStream extends FSOutputSummer
       streamer = new DataStreamer(lastBlock, stat, dfsClient, src, progress,
           checksum, cachingStrategy, byteArrayManager);
       getStreamer().setBytesCurBlock(lastBlock.getBlockSize());
-      adjustPacketChunkSize(stat);
+      adjustPacketChunkSize(lastBlock);
       getStreamer().setPipelineInConstruction(lastBlock);
     } else {
       computePacketChunkSize(dfsClient.getConf().getWritePacketSize(),
@@ -368,14 +368,14 @@ public class DFSOutputStream extends FSOutputSummer
     }
   }
 
-  private void adjustPacketChunkSize(HdfsFileStatus stat) throws IOException{
+  private void adjustPacketChunkSize(LocatedBlock lastBlock) throws IOException{
 
-    long usedInLastBlock = stat.getLen() % blockSize;
+    long usedInLastBlock = lastBlock.getBlockSize() % blockSize;
     int freeInLastBlock = (int)(blockSize - usedInLastBlock);
 
     // calculate the amount of free space in the pre-existing
     // last crc chunk
-    int usedInCksum = (int)(stat.getLen() % bytesPerChecksum);
+    int usedInCksum = (int)(lastBlock.getBlockSize() % bytesPerChecksum);
     int freeInCksum = bytesPerChecksum - usedInCksum;
 
     // if there is space in the last block, then we have to

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
@@ -370,7 +370,7 @@ public class DFSOutputStream extends FSOutputSummer
 
   private void adjustPacketChunkSize(LocatedBlock lastBlock) throws IOException{
 
-    long usedInLastBlock = lastBlock.getBlockSize() % blockSize;
+    long usedInLastBlock = lastBlock.getBlockSize();
     int freeInLastBlock = (int)(blockSize - usedInLastBlock);
 
     // calculate the amount of free space in the pre-existing

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileAppend3.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileAppend3.java
@@ -597,39 +597,31 @@ public class TestFileAppend3  {
 
     //a. Create file and write one block of data. Close file.
     final int len1 = (int) BLOCK_SIZE;
-    {
-      FSDataOutputStream out = fs.create(p, false, buffersize, REPLICATION,
-          BLOCK_SIZE);
+    try (FSDataOutputStream out = fs.create(p, false, buffersize, REPLICATION,
+        BLOCK_SIZE)) {
       AppendTestUtil.write(out, 0, len1);
-      out.close();
     }
 
     // Reopen file to append. This length is not the multiple of 512.
     final int len2 = (int) BLOCK_SIZE / 2 + 68;
-    {
-      FSDataOutputStream out = fs.append(p,
-          EnumSet.of(CreateFlag.APPEND, CreateFlag.NEW_BLOCK), 4096, null);
+    try (FSDataOutputStream out = fs.append(p,
+        EnumSet.of(CreateFlag.APPEND, CreateFlag.NEW_BLOCK), 4096, null)) {
       AppendTestUtil.write(out, len1, len2);
-      out.close();
     }
 
     // Reopen file to append with NEW_BLOCK flag again, this will make middle block
     // in file /TC8/foo not full.
     final int len3 = (int) BLOCK_SIZE / 2;
-    {
-      FSDataOutputStream out = fs.append(p,
-          EnumSet.of(CreateFlag.APPEND, CreateFlag.NEW_BLOCK), 4096, null);
+    try (FSDataOutputStream out = fs.append(p,
+        EnumSet.of(CreateFlag.APPEND, CreateFlag.NEW_BLOCK), 4096, null)) {
       AppendTestUtil.write(out, len1 + len2, len3);
-      out.close();
     }
 
     // Not use NEW_BLOCK flag.
     final int len4 = 600;
-    {
-      FSDataOutputStream out = fs.append(p,
-          EnumSet.of(CreateFlag.APPEND), 4096, null);
+    try(FSDataOutputStream out = fs.append(p,
+        EnumSet.of(CreateFlag.APPEND), 4096, null)) {
       AppendTestUtil.write(out, len1 + len2 + len3, len4);
-      out.close();
     }
 
     AppendTestUtil.check(fs, p, len1 + len2 + len3 + len4);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileAppend3.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileAppend3.java
@@ -590,4 +590,48 @@ public class TestFileAppend3  {
   public void testAppendToPartialChunkforAppend2() throws IOException {
     testAppendToPartialChunk(true);
   }
+
+  @Test
+  public void testApppendToPartialChunkWithMiddleBlockNotComplete() throws IOException {
+    final Path p = new Path("/TC8/foo");
+
+    //a. Create file and write one block of data. Close file.
+    final int len1 = (int) BLOCK_SIZE;
+    {
+      FSDataOutputStream out = fs.create(p, false, buffersize, REPLICATION,
+          BLOCK_SIZE);
+      AppendTestUtil.write(out, 0, len1);
+      out.close();
+    }
+
+    // Reopen file to append. This length is not the multiple of 512.
+    final int len2 = (int) BLOCK_SIZE / 2 + 68;
+    {
+      FSDataOutputStream out = fs.append(p,
+          EnumSet.of(CreateFlag.APPEND, CreateFlag.NEW_BLOCK), 4096, null);
+      AppendTestUtil.write(out, len1, len2);
+      out.close();
+    }
+
+    // Reopen file to append with NEW_BLOCK flag again, this will make middle block
+    // in file /TC8/foo not full.
+    final int len3 = (int) BLOCK_SIZE / 2;
+    {
+      FSDataOutputStream out = fs.append(p,
+          EnumSet.of(CreateFlag.APPEND, CreateFlag.NEW_BLOCK), 4096, null);
+      AppendTestUtil.write(out, len1 + len2, len3);
+      out.close();
+    }
+
+    // Not use NEW_BLOCK flag.
+    final int len4 = 600;
+    {
+      FSDataOutputStream out = fs.append(p,
+          EnumSet.of(CreateFlag.APPEND), 4096, null);
+      AppendTestUtil.write(out, len1 + len2 + len3, len4);
+      out.close();
+    }
+
+    AppendTestUtil.check(fs, p, len1 + len2 + len3 + len4);
+  }
 }


### PR DESCRIPTION
### Description of PR

Currently, some codes in HDFS use an implicit condition that all blocks which are not last block in file have full blocksize(default 128MB).

This is not right and can cause append operation fail,  we should change those codes.

Let me take an example to explain which situation can cause non-lastBlock be not equal to complete block size.
If we append a file with `CreateFlag.NEW_BLOCK`，it will add new block to file rather than write following last block.
As below picture shows:

<img width="1415" alt="image" src="https://github.com/apache/hadoop/assets/25115709/8eeaeb60-c5f0-441f-aaac-ca65a5150b8f">

