### PR TITLE
HDFS-17290: Adds disconnected client rpc backoff metrics

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -3133,13 +3133,11 @@ public abstract class Server {
       // For example, IPC clients using FailoverOnNetworkExceptionRetry handle
       // RetriableException.
       rpcMetrics.incrClientBackoff();
-      // Track throttled client backoff count.
-      // Throttled clients are clients in lowest priority queue which are
-      // back off and disconnected.
+      // Clients that are directly put into lowest priority queue are backoff and disconnected.
       if (cqe.getCause() instanceof RpcServerException) {
         RpcServerException ex = (RpcServerException) cqe.getCause();
         if (ex.getRpcStatusProto() == RpcStatusProto.FATAL) {
-          rpcMetrics.incrClientBackoffThrottled();
+          rpcMetrics.incrClientBackoffDisconnected();
         }
       }
       // unwrap retriable exception.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -3133,7 +3133,7 @@ public abstract class Server {
       // For example, IPC clients using FailoverOnNetworkExceptionRetry handle
       // RetriableException.
       rpcMetrics.incrClientBackoff();
-      // Clients that are directly put into lowest priority queue are backoff and disconnected.
+      // Clients that are directly put into lowest priority queue are backed off and disconnected.
       if (cqe.getCause() instanceof RpcServerException) {
         RpcServerException ex = (RpcServerException) cqe.getCause();
         if (ex.getRpcStatusProto() == RpcStatusProto.FATAL) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -3133,6 +3133,15 @@ public abstract class Server {
       // For example, IPC clients using FailoverOnNetworkExceptionRetry handle
       // RetriableException.
       rpcMetrics.incrClientBackoff();
+      // Track throttled client backoff count.
+      // Throttled clients are clients in lowest priority queue which are
+      // back off and disconnected.
+      if (cqe.getCause() instanceof RpcServerException) {
+        RpcServerException ex = (RpcServerException) cqe.getCause();
+        if (ex.getRpcStatusProto() == RpcStatusProto.FATAL) {
+          rpcMetrics.incrClientBackoffThrottled();
+        }
+      }
       // unwrap retriable exception.
       throw cqe.getCause();
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -207,6 +207,7 @@ public class RpcMetrics {
   // abstract class if we decide to do custom instrumentation classes a la
   // JobTrackerInstrumentation. The methods with //@Override comment are
   // candidates for abstract methods in a abstract instrumentation class.
+
   /**
    * One authentication failure event
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -141,8 +141,8 @@ public class RpcMetrics {
   MutableCounterLong rpcAuthorizationSuccesses;
   @Metric("Number of client backoff requests")
   MutableCounterLong rpcClientBackoff;
-  @Metric("Number of throttled client backoff requests")
-  MutableCounterLong rpcClientBackoffThrottled;
+  @Metric("Number of disconnected client backoff requests")
+  MutableCounterLong rpcClientBackoffDisconnected;
   @Metric("Number of slow RPC calls")
   MutableCounterLong rpcSlowCalls;
   @Metric("Number of requeue calls")
@@ -345,11 +345,10 @@ public class RpcMetrics {
   }
 
   /**
-   * Client was backoff due to throttling
+   * Client was backoff due to disconnection
    */
-  //@Override
-  public void incrClientBackoffThrottled() {
-    rpcClientBackoffThrottled.incr();
+  public void incrClientBackoffDisconnected() {
+    rpcClientBackoffDisconnected.incr();
   }
 
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -350,6 +350,14 @@ public class RpcMetrics {
     rpcClientBackoffDisconnected.incr();
   }
 
+  /**
+   * Returns the number of disconnected backoffs.
+   * @return long
+   */
+  public long getClientBackoffDisconnected() {
+    return rpcClientBackoffDisconnected.value();
+  }
+
 
   /**
    * Increments the Slow RPC counter.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -141,6 +141,8 @@ public class RpcMetrics {
   MutableCounterLong rpcAuthorizationSuccesses;
   @Metric("Number of client backoff requests")
   MutableCounterLong rpcClientBackoff;
+  @Metric("Number of throttled client backoff requests")
+  MutableCounterLong rpcClientBackoffThrottled;
   @Metric("Number of slow RPC calls")
   MutableCounterLong rpcSlowCalls;
   @Metric("Number of requeue calls")
@@ -341,6 +343,15 @@ public class RpcMetrics {
   public void incrClientBackoff() {
     rpcClientBackoff.incr();
   }
+
+  /**
+   * Client was backoff due to throttling
+   */
+  //@Override
+  public void incrClientBackoffThrottled() {
+    rpcClientBackoffThrottled.incr();
+  }
+
 
   /**
    * Increments the Slow RPC counter.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -142,7 +142,7 @@ public class RpcMetrics {
   @Metric("Number of client backoff requests")
   MutableCounterLong rpcClientBackoff;
   @Metric("Number of disconnected client backoff requests")
-  MutableCounterLong rpcClientBackoffDisconnected;
+  private MutableCounterLong rpcClientBackoffDisconnected;
   @Metric("Number of slow RPC calls")
   MutableCounterLong rpcSlowCalls;
   @Metric("Number of requeue calls")
@@ -207,7 +207,6 @@ public class RpcMetrics {
   // abstract class if we decide to do custom instrumentation classes a la
   // JobTrackerInstrumentation. The methods with //@Override comment are
   // candidates for abstract methods in a abstract instrumentation class.
-
   /**
    * One authentication failure event
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -142,7 +142,7 @@ public class RpcMetrics {
   @Metric("Number of client backoff requests")
   MutableCounterLong rpcClientBackoff;
   @Metric("Number of disconnected client backoff requests")
-  private MutableCounterLong rpcClientBackoffDisconnected;
+  MutableCounterLong rpcClientBackoffDisconnected;
   @Metric("Number of slow RPC calls")
   MutableCounterLong rpcSlowCalls;
   @Metric("Number of requeue calls")

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -345,7 +345,7 @@ public class RpcMetrics {
   }
 
   /**
-   * Client was backoff due to disconnection
+   * Client was disconnected due to backoff
    */
   public void incrClientBackoffDisconnected() {
     rpcClientBackoffDisconnected.incr();

--- a/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
@@ -87,7 +87,7 @@ The default timeunit used for RPC metrics is milliseconds (as per the below desc
 | `RpcAuthorizationFailures` | Total number of authorization failures |
 | `RpcAuthorizationSuccesses` | Total number of authorization successes |
 | `RpcClientBackoff` | Total number of client backoff requests |
-| `RpcClientBackoffThrottled` | Total number of throttled client backoff requests |
+| `RpcClientBackoffDisconnected` | Total number of client backoff requests that are disconnected. This is a subset of RpcClientBackoff |
 | `RpcSlowCalls` | Total number of slow RPC calls |
 | `RpcRequeueCalls` | Total number of requeue RPC calls |
 | `RpcCallsSuccesses` | Total number of RPC calls that are successfully processed |

--- a/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
@@ -87,6 +87,7 @@ The default timeunit used for RPC metrics is milliseconds (as per the below desc
 | `RpcAuthorizationFailures` | Total number of authorization failures |
 | `RpcAuthorizationSuccesses` | Total number of authorization successes |
 | `RpcClientBackoff` | Total number of client backoff requests |
+| `RpcClientBackoffThrottled` | Total number of throttled client backoff requests |
 | `RpcSlowCalls` | Total number of slow RPC calls |
 | `RpcRequeueCalls` | Total number of requeue RPC calls |
 | `RpcCallsSuccesses` | Total number of RPC calls that are successfully processed |

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -1528,7 +1528,9 @@ public class TestRPC extends TestRpcBase {
         IOException unwrapExeption = re.unwrapRemoteException();
         if (unwrapExeption instanceof RetriableException) {
           succeeded = true;
+          assertEquals(1L, server.getRpcMetrics().getClientBackoffDisconnected());
         } else {
+          lastException = unwrapExeption;
           lastException = unwrapExeption;
         }
       }
@@ -1539,6 +1541,7 @@ public class TestRPC extends TestRpcBase {
     if (lastException != null) {
       LOG.error("Last received non-RetriableException:", lastException);
     }
+
     assertTrue("RetriableException not received", succeeded);
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -1531,7 +1531,6 @@ public class TestRPC extends TestRpcBase {
           assertEquals(1L, server.getRpcMetrics().getClientBackoffDisconnected());
         } else {
           lastException = unwrapExeption;
-          lastException = unwrapExeption;
         }
       }
     } finally {
@@ -1541,7 +1540,6 @@ public class TestRPC extends TestRpcBase {
     if (lastException != null) {
       LOG.error("Last received non-RetriableException:", lastException);
     }
-
     assertTrue("RetriableException not received", succeeded);
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
HDFS-17290
Add a metrics that indicates # of backoffs due to disconnection from namenode. 

### How was this patch tested?
This patch only added a new metrics and does not require adding new test cases.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

