### PR TITLE
HDFS-17291. DataNode metric bytesWritten is not totally accurate in some situations.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
@@ -579,7 +579,6 @@ class BlockReceiver implements Closeable {
       this.dirSyncOnFinalize = true;
     }
 
-    int bytesWritten = 0;
     // update received bytes
     final long firstByteInBlock = offsetInBlock;
     offsetInBlock += len;
@@ -748,7 +747,6 @@ class BlockReceiver implements Closeable {
 
           // Actual number of data bytes to write.
           int numBytesToDisk = (int)(offsetInBlock-onDiskLen);
-          bytesWritten = numBytesToDisk;
           // Write data to disk.
           long begin = Time.monotonicNow();
           streams.writeDataToDisk(dataBuf.array(),
@@ -840,7 +838,7 @@ class BlockReceiver implements Closeable {
           
           replicaInfo.setLastChecksumAndDataLen(offsetInBlock, lastCrc);
 
-          datanode.metrics.incrBytesWritten(bytesWritten);
+          datanode.metrics.incrBytesWritten(numBytesToDisk);
           datanode.metrics.incrTotalWriteTime(duration);
 
           manageWriterOsCache(offsetInBlock, seqno);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
@@ -747,6 +747,7 @@ class BlockReceiver implements Closeable {
 
           // Actual number of data bytes to write.
           int numBytesToDisk = (int)(offsetInBlock-onDiskLen);
+          
           // Write data to disk.
           long begin = Time.monotonicNow();
           streams.writeDataToDisk(dataBuf.array(),

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
@@ -579,6 +579,7 @@ class BlockReceiver implements Closeable {
       this.dirSyncOnFinalize = true;
     }
 
+    int bytesWritten = 0;
     // update received bytes
     final long firstByteInBlock = offsetInBlock;
     offsetInBlock += len;
@@ -747,7 +748,7 @@ class BlockReceiver implements Closeable {
 
           // Actual number of data bytes to write.
           int numBytesToDisk = (int)(offsetInBlock-onDiskLen);
-          
+          bytesWritten = numBytesToDisk;
           // Write data to disk.
           long begin = Time.monotonicNow();
           streams.writeDataToDisk(dataBuf.array(),
@@ -839,7 +840,7 @@ class BlockReceiver implements Closeable {
           
           replicaInfo.setLastChecksumAndDataLen(offsetInBlock, lastCrc);
 
-          datanode.metrics.incrBytesWritten(len);
+          datanode.metrics.incrBytesWritten(bytesWritten);
           datanode.metrics.incrTotalWriteTime(duration);
 
           manageWriterOsCache(offsetInBlock, seqno);


### PR DESCRIPTION
### Description of PR

As the title described, dataNode metric bytesWritten is not totally accurate in some situations, such as failure recovery, re-send data. We should fix it.

Currently, the bytesWritten is accumulated by packet length which packetReceiver receives. It not the real bytes number written to disk.

