### PR TITLE
HDFS-17292. Show the number of times the slowPeerCollectorDaemon thread has collected SlowNodes.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NamenodeBeanMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NamenodeBeanMetrics.java
@@ -890,7 +890,7 @@ public class NamenodeBeanMetrics
   }
 
   @Override
-  public String getCollectSlowNodesIpAddrFrequencyMap() {
+  public String getCollectSlowNodesIpAddrCounts() {
     return "N/A";
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NamenodeBeanMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NamenodeBeanMetrics.java
@@ -889,6 +889,11 @@ public class NamenodeBeanMetrics
     return 0;
   }
 
+  @Override
+  public String getCollectSlowNodesIpAddrFrequencyMap() {
+    return "N/A";
+  }
+
   private Router getRouter() throws IOException {
     if (this.router == null) {
       throw new IOException("Router is not initialized");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -4922,10 +4922,10 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
 
   @Override // FSNamesystemMBean
   @Metric
-  public String getCollectSlowNodesIpAddrFrequencyMap() {
-    Map<String, Integer> recordSlowNodesIpAddr =
-        getBlockManager().getDatanodeManager().getCollectSlowNodesIpAddrFrequencyMap();
-    return JSON.toString(recordSlowNodesIpAddr);
+  public String getCollectSlowNodesIpAddrCounts() {
+    Map<String, Long> recordSlowNodesIpCounts =
+        getBlockManager().getDatanodeManager().getCollectSlowNodesIpAddrCounts();
+    return JSON.toString(recordSlowNodesIpCounts);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -4920,6 +4920,14 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     return blockManager.getReconstructionQueuesInitProgress();
   }
 
+  @Override // FSNamesystemMBean
+  @Metric
+  public String getCollectSlowNodesIpAddrFrequencyMap() {
+    Map<String, Integer> recordSlowNodesIpAddr =
+        getBlockManager().getDatanodeManager().getCollectSlowNodesIpAddrFrequencyMap();
+    return JSON.toString(recordSlowNodesIpAddr);
+  }
+
   /**
    * Returns the length of the wait Queue for the FSNameSystemLock.
    *

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/FSNamesystemMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/FSNamesystemMBean.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.metrics;
 
+import java.util.Map;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 
 /**
@@ -270,10 +272,10 @@ public interface FSNamesystemMBean {
   float getReconstructionQueuesInitProgress();
 
   /**
-   * Returns a nested JSON object listing the collect slowNodesIpAddr frequency Map,
+   * Returns a nested JSON object listing the collect slowNodesIpAddr counts Map,
    * e.g. {"1.1.1.1":4,"2.2.2.2":3}
    *
    * @return JSON string.
    */
-  String getCollectSlowNodesIpAddrFrequencyMap();
+  String getCollectSlowNodesIpAddrCounts();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/FSNamesystemMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/FSNamesystemMBean.java
@@ -268,4 +268,12 @@ public interface FSNamesystemMBean {
    * @return Returns values between 0 and 1 for the progress.
    */
   float getReconstructionQueuesInitProgress();
+
+  /**
+   * Returns a nested JSON object listing the collect slowNodesIpAddr frequency Map,
+   * e.g. {"1.1.1.1":4,"2.2.2.2":3}
+   *
+   * @return JSON string.
+   */
+  String getCollectSlowNodesIpAddrFrequencyMap();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemMBean.java
@@ -308,9 +308,6 @@ public class TestFSNamesystemMBean {
       List<DataNode> dataNodes = cluster.getDataNodes();
       assertEquals(2, dataNodes.size());
 
-      DatanodeManager dnManager = fsNamesystem.getBlockManager().getDatanodeManager();
-
-      dnManager.addSlowPeers(dataNodes.get(1).getDatanodeUuid());
       dataNodes.get(0).getPeerMetrics().setTestOutliers(ImmutableMap.of(
           dataNodes.get(1).getDatanodeHostname() + ":" + dataNodes.get(1).getIpcPort(),
           new OutlierMetrics(1.0, 2.0, 3.0, 4.0)));
@@ -347,6 +344,7 @@ public class TestFSNamesystemMBean {
       }, 100, 10000);
 
       cluster.getNameNode().reconfigureProperty(DFS_DATANODE_PEER_STATS_ENABLED_KEY, "false");
+      DatanodeManager dnManager = fsNamesystem.getBlockManager().getDatanodeManager();
       assertEquals("{}", dnManager.getCollectSlowNodesIpAddrFrequencyMap().toString());
     }
   }


### PR DESCRIPTION
### Description of PR

JIRA: HDFS-17292. Show the number of times the slowPeerCollectorDaemon thread has collected SlowNodes.

1. Add a new metric of the number of times the DatanodeManager#slowPeerCollectorDaemon thread collects SlowNodes, and display it in a map structure.
2. The same SlowNode may always appear in the prod env, so when slowPeerCollectorDaemon is turned on, record the number of times it has been collected by the slowPeerCollectorDaemon thread. If the collection frequency is too high, SRE or DEV need to repair the machine.
3. The following figure shows the number of write request threads(DataNodeWriteXceiversCount) for SlowNodes collected by the slowPeerCollectorDaemon thread at different time periods.
(If "DataNodeWriteXceiversCount" is 0, there is no write request, indicating a SlowNode)<img width="1687" alt="image" src="https://github.com/apache/hadoop/assets/63718681/ca54375f-04a2-456f-9268-cee10e2390da">
4. The legend above shows that the same node was collected three times by the slowPeerCollectorDaemon thread. The network latency will decrease because there are no write requests after being collected. After a period of time, there will be new write requests, and after writing for a period of time, they will be collected as SlowNode again.

### How was this patch tested?
Add Unit Test.

