### PR TITLE
HDFS-17294. Reconfigure the scheduling cycle of the slowPeerCollectorDaemon thread.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -2684,7 +2684,7 @@ public class NameNode extends ReconfigurableBase implements
               getConf().getTimeDuration(DFS_NAMENODE_SLOWPEER_COLLECT_INTERVAL_KEY,
                   DFS_NAMENODE_SLOWPEER_COLLECT_INTERVAL_DEFAULT, TimeUnit.MILLISECONDS);
           datanodeManager.restartSlowPeerCollector(defaultInterval);
-          result = DFS_NAMENODE_SLOWPEER_COLLECT_INTERVAL_DEFAULT;
+          result = Long.toString(defaultInterval);
         } else {
           // set to other value
           long newInterval =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -143,6 +143,8 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_LOCK_DETAILED_ME
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_LOCK_DETAILED_METRICS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_READ_LOCK_REPORTING_THRESHOLD_MS_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_READ_LOCK_REPORTING_THRESHOLD_MS_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SLOWPEER_COLLECT_INTERVAL_DEFAULT;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SLOWPEER_COLLECT_INTERVAL_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_WRITE_LOCK_REPORTING_THRESHOLD_MS_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_WRITE_LOCK_REPORTING_THRESHOLD_MS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_BLOCKPLACEMENTPOLICY_MIN_BLOCKS_FOR_WRITE_DEFAULT;
@@ -380,7 +382,8 @@ public class NameNode extends ReconfigurableBase implements
           IPC_SERVER_LOG_SLOW_RPC_THRESHOLD_MS_KEY,
           DFS_NAMENODE_LOCK_DETAILED_METRICS_KEY,
           DFS_NAMENODE_WRITE_LOCK_REPORTING_THRESHOLD_MS_KEY,
-          DFS_NAMENODE_READ_LOCK_REPORTING_THRESHOLD_MS_KEY));
+          DFS_NAMENODE_READ_LOCK_REPORTING_THRESHOLD_MS_KEY,
+          DFS_NAMENODE_SLOWPEER_COLLECT_INTERVAL_KEY));
 
   private static final String USAGE = "Usage: hdfs namenode ["
       + StartupOption.BACKUP.getName() + "] | \n\t["
@@ -2374,7 +2377,8 @@ public class NameNode extends ReconfigurableBase implements
         DFS_NAMENODE_BLOCKPLACEMENTPOLICY_EXCLUDE_SLOW_NODES_ENABLED_KEY)) || (property.equals(
         DFS_NAMENODE_MAX_SLOWPEER_COLLECT_NODES_KEY)) || (property.equals(
         DFS_DATANODE_PEER_STATS_ENABLED_KEY)) || property.equals(
-        DFS_DATANODE_MAX_NODES_TO_REPORT_KEY)) {
+        DFS_DATANODE_MAX_NODES_TO_REPORT_KEY) || property.equals(
+        DFS_NAMENODE_SLOWPEER_COLLECT_INTERVAL_KEY)) {
       return reconfigureSlowNodesParameters(datanodeManager, property, newVal);
     } else if (property.equals(DFS_BLOCK_INVALIDATE_LIMIT_KEY)) {
       return reconfigureBlockInvalidateLimit(datanodeManager, property, newVal);
@@ -2671,6 +2675,24 @@ public class NameNode extends ReconfigurableBase implements
             ? DFS_DATANODE_MAX_NODES_TO_REPORT_DEFAULT : Integer.parseInt(newVal));
         result = Integer.toString(maxSlowPeersToReport);
         datanodeManager.setMaxSlowPeersToReport(maxSlowPeersToReport);
+        break;
+      }
+      case DFS_NAMENODE_SLOWPEER_COLLECT_INTERVAL_KEY: {
+        if (newVal == null) {
+          // set to the value of the current system or default
+          long defaultInterval =
+              getConf().getTimeDuration(DFS_NAMENODE_SLOWPEER_COLLECT_INTERVAL_KEY,
+                  DFS_NAMENODE_SLOWPEER_COLLECT_INTERVAL_DEFAULT, TimeUnit.MILLISECONDS);
+          datanodeManager.restartSlowPeerCollector(defaultInterval);
+          result = DFS_NAMENODE_SLOWPEER_COLLECT_INTERVAL_DEFAULT;
+        } else {
+          // set to other value
+          long newInterval =
+              getConf().getTimeDurationHelper(DFS_NAMENODE_SLOWPEER_COLLECT_INTERVAL_DEFAULT,
+                  newVal, TimeUnit.MILLISECONDS);
+          datanodeManager.restartSlowPeerCollector(newInterval);
+          result = newVal;
+        }
         break;
       }
       default: {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -442,7 +442,7 @@ public class TestDFSAdmin {
     final List<String> outs = Lists.newArrayList();
     final List<String> errs = Lists.newArrayList();
     getReconfigurableProperties("namenode", address, outs, errs);
-    assertEquals(28, outs.size());
+    assertEquals(29, outs.size());
     assertTrue(outs.get(0).contains("Reconfigurable properties:"));
     assertEquals(DFS_BLOCK_INVALIDATE_LIMIT_KEY, outs.get(1));
     assertEquals(DFS_BLOCK_PLACEMENT_EC_CLASSNAME_KEY, outs.get(2));


### PR DESCRIPTION
### Description of PR
JIRA: [HDFS-17294](https://issues.apache.org/jira/browse/HDFS-17294)

1. [HDFS-16397](https://issues.apache.org/jira/browse/hdfs-16397) supports dynamic reconfig of `DFS_DATANODE_OUTLIERS_REPORT_INTERVAL_KEY` parameters for datanode.
2. The Outlier Detection is regularly reported to namnode, and the scheduling cycle of the slowPeerCollectorDaemon thread on the namenode should be consistent with the reporting cycle of abnormal values on the dn end as much as possible.
3. Therefore, when slowPeerCollectorDaemonthread is currently running, restarting the thread updates the scheduling cycle of the thread.

### How was this patch tested?
Add Unit Test.

