### PR TITLE
HADOOP-19001. LD_LIBRARY_PATH is missing HADOOP_COMMON_LIB_NATIVE_DIR

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -1481,7 +1481,7 @@ function hadoop_finalize_libpaths
     hadoop_translate_cygwin_path JAVA_LIBRARY_PATH
     hadoop_add_param HADOOP_OPTS java.library.path \
       "-Djava.library.path=${JAVA_LIBRARY_PATH}"
-    export LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$JAVA_LIBRARY_PATH
   fi
 }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -1309,7 +1309,7 @@
   <property>
     <description>Environment variables that containers may override rather than use NodeManager's default.</description>
     <name>yarn.nodemanager.env-whitelist</name>
-    <value>JAVA_HOME,HADOOP_COMMON_HOME,HADOOP_HDFS_HOME,HADOOP_CONF_DIR,CLASSPATH_PREPEND_DISTCACHE,HADOOP_YARN_HOME,HADOOP_HOME,PATH,LANG,TZ</value>
+    <value>JAVA_HOME,HADOOP_COMMON_HOME,HADOOP_HDFS_HOME,HADOOP_CONF_DIR,CLASSPATH_PREPEND_DISTCACHE,HADOOP_YARN_HOME,HADOOP_HOME,PATH,LANG,TZ,LD_LIBRARY_PATH</value>
   </property>
 
   <property>


### PR DESCRIPTION
Description of PR

LD_LIBRARY_PATH is missing HADOOP_COMMON_LIB_NATIVE_DIR
JIRA: [HADOOP-19001](https://issues.apache.org/jira/browse/HADOOP-19001)

How was this patch tested?

Test in a production environment

For code changes:

 Does the title or this PR starts with the corresponding JIRA issue id (e.g. '[HADOOP-17799](https://issues.apache.org/jira/browse/HADOOP-17799). Your PR title ...')?
 Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
 If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
 If applicable, have you updated the LICENSE, LICENSE-binary, NOTICE-binary files?