### PR TITLE
HDFS-17293. First packet data + checksum size will be set to 516 bytes when writing to a new block.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
@@ -536,8 +536,13 @@ public class DFSOutputStream extends FSOutputSummer
     }
 
     if (!getStreamer().getAppendChunk()) {
-      final int psize = (int) Math
-          .min(blockSize - getStreamer().getBytesCurBlock(), writePacketSize);
+      int psize = 0;
+      if (blockSize == getStreamer().getBytesCurBlock()) {
+        psize = writePacketSize;
+      } else {
+        psize = (int) Math
+            .min(blockSize - getStreamer().getBytesCurBlock(), writePacketSize);
+      }
       computePacketChunkSize(psize, bytesPerChecksum);
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSOutputStream.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.zip.Checksum;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CreateFlag;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSOutputStream.java
@@ -187,10 +187,10 @@ public class TestDFSOutputStream {
 
   @Test(timeout=60000)
   public void testFirstPacketSizeInNewBlocks() throws IOException {
-    final long BLOCK_SIZE = 1L * 1024 * 1024;
+    final long blockSize = 1L * 1024 * 1024;
     final int numDataNodes = 3;
     final Configuration dfsConf = new Configuration();
-    dfsConf.setLong(DFS_BLOCK_SIZE_KEY, BLOCK_SIZE);
+    dfsConf.setLong(DFS_BLOCK_SIZE_KEY, blockSize);
     MiniDFSCluster dfsCluster = null;
     dfsCluster = new MiniDFSCluster.Builder(dfsConf).numDataNodes(numDataNodes).build();
     dfsCluster.waitActive();
@@ -205,7 +205,7 @@ public class TestDFSOutputStream {
     r.nextBytes(buf);
     fos.write(buf);
     fos.hflush();
-    
+
     while (loop < 20) {
       r.nextBytes(buf);
       fos.write(buf);
@@ -213,7 +213,7 @@ public class TestDFSOutputStream {
       loop++;
       Assert.assertNotEquals(516, ((DFSOutputStream)fos.getWrappedStream()).packetSize);
     }
-    
+
     fos.close();
   }
 


### PR DESCRIPTION
### Description of PR
First packet size(data length + checksum length) will be set to 516 bytes when writing to a new block. It is an unnecessary and wrong behavior.

In  method computePacketChunkSize, the parameters psize and csize would be （0, 512）when writting to a new block. 

It should better use writePacketSize to improve the speed of sending data.
