### PR TITLE
HDFS-17297. The NameNode should remove block from the BlocksMap if the block is marked as deleted

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -3815,7 +3815,10 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
         // may be client have crashed before writing data to pipeline.
         // This blocks doesn't need any recovery.
         // We can remove this block and close the file.
-        pendingFile.removeLastBlock(lastBlock);
+        BlockInfo lastBlockInfo = pendingFile.removeLastBlock(lastBlock);
+        if (lastBlockInfo != null) {
+          blockManager.removeBlock(lastBlockInfo);
+        }
         finalizeINodeFileUnderConstruction(src, pendingFile,
             iip.getLatestSnapshotId(), false);
         if (uc.getNumExpectedLocations() == 0) {


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17297

When call internalReleaseLease method:

```
boolean internalReleaseLease(
...
int minLocationsNum = 1;
if (lastBlock.isStriped()) {
  minLocationsNum = ((BlockInfoStriped) lastBlock).getRealDataBlockNum();
}

if (uc.getNumExpectedLocations() < minLocationsNum &&
    lastBlock.getNumBytes() == 0) {
  // There is no datanode reported to this block.
  // may be client have crashed before writing data to pipeline.
  // This blocks doesn't need any recovery.
  // We can remove this block and close the file.
  pendingFile.removeLastBlock(lastBlock);
  finalizeINodeFileUnderConstruction(src, pendingFile,
      iip.getLatestSnapshotId(), false); 
...
}
```
if the condition `uc.getNumExpectedLocations() < minLocationsNum && lastBlock.getNumBytes() == 0` is met during the execution of UNDER_RECOVERY logic, the block is removed from the block list in the inode file and marked as deleted.
However it is not removed from the BlocksMap, it may cause memory leak.

Therefore it is necessary to remove the block from the BlocksMap at this point as well.

