### PR TITLE
YARN-11634. Speed-up TestTimelineClient

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineConnector.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineConnector.java
@@ -78,7 +78,8 @@ public class TimelineConnector extends AbstractService {
   private static final Joiner JOINER = Joiner.on("");
   private static final Logger LOG =
       LoggerFactory.getLogger(TimelineConnector.class);
-  public final static int DEFAULT_SOCKET_TIMEOUT = 1 * 60 * 1000; // 1 minute
+  @VisibleForTesting
+  public static int DEFAULT_SOCKET_TIMEOUT = 60_000; // 1 minute
 
   private SSLFactory sslFactory;
   Client client;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestTimelineClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestTimelineClient.java
@@ -78,6 +78,7 @@ public class TestTimelineClient {
     conf.setBoolean(YarnConfiguration.TIMELINE_SERVICE_ENABLED, true);
     conf.setFloat(YarnConfiguration.TIMELINE_SERVICE_VERSION, 1.0f);
     client = createTimelineClient(conf);
+    TimelineConnector.DEFAULT_SOCKET_TIMEOUT = 10;
   }
 
   @AfterEach
@@ -88,6 +89,7 @@ public class TestTimelineClient {
     if (isSSLConfigured()) {
       KeyStoreTestUtil.cleanupSSLConfig(keystoresDir, sslConfDir);
     }
+    TimelineConnector.DEFAULT_SOCKET_TIMEOUT = 60_000;
   }
 
   @Test


### PR DESCRIPTION
### Description of PR

The TimelineConnector.class has a hardcoded 1 minute connection time out, what makes the TestTimelineClient to a long running test (~15:30 min). Decrease the timeout to 10ms will speed up the test run (~56 sec).

### How was this patch tested?

- Unit test