### PR TITLE
HADOOP-19019: Parallel Maven Build Support for Apache Hadoop

### DIFF
--- a/hadoop-mapreduce-project/pom.xml
+++ b/hadoop-mapreduce-project/pom.xml
@@ -86,6 +86,12 @@
       <artifactId>hadoop-mapreduce-examples</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-hs-plugins</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-yarn-project/pom.xml
+++ b/hadoop-yarn-project/pom.xml
@@ -33,6 +33,7 @@
     <fork.mode>once</fork.mode>
     <hadoop.component>yarn</hadoop.component>
     <is.hadoop.component>true</is.hadoop.component>
+    <yarn.ui.packaging>pom</yarn.ui.packaging>
   </properties>
 
   <modules>
@@ -90,6 +91,56 @@
       <artifactId>hadoop-yarn-applications-catalog-webapp</artifactId>
       <type>war</type>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-applications-distributedshell</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-applications-unmanaged-am-launcher</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-tests</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-timelineservice-hbase-client</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>animal-sniffer-annotations</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-csi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-timelineservice-documentstore</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-timelineservice-hbase-tests</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-ui</artifactId>
+      <version>${project.version}</version>
+      <type>${yarn.ui.packaging}</type>
+    </dependency>
   </dependencies>
 
   <build>
@@ -123,6 +174,32 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>yarn-ui</id>
+      <properties>
+        <yarn.ui.packaging>war</yarn.ui.packaging>
+      </properties>
+    </profile>
+    <profile>
+      <id>hbase1</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-server-timelineservice-hbase-server-1</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>hbase2</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-server-timelineservice-hbase-server-2</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
     <profile>
       <id>dist</id>
       <activation>

--- a/hadoop-yarn-project/pom.xml
+++ b/hadoop-yarn-project/pom.xml
@@ -94,21 +94,25 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-applications-distributedshell</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-applications-unmanaged-am-launcher</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-server-tests</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-server-timelineservice-hbase-client</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>com.google.errorprone</groupId>
@@ -124,22 +128,26 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-csi</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-server-timelineservice-documentstore</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-server-timelineservice-hbase-tests</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-ui</artifactId>
       <version>${project.version}</version>
       <type>${yarn.ui.packaging}</type>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/HDFS-17287

Here's the translation of the Hadoop PR description into English:

**Hadoop Parallel Compilation Submission Logic**
1. Reasons for Parallel Compilation Failure
   - In sequential compilation, as modules are compiled one by one in order, there are no errors because the compilation follows the module sequence.
   - However, in parallel compilation, all modules are compiled simultaneously. The compilation order during multi-module concurrent compilation depends on the inter-module dependencies. If Module A depends on Module B, then Module B will be compiled before Module A. This ensures that the compilation order follows the dependencies between modules.

   But when Hadoop compiles in parallel, for example, compiling `hadoop-yarn-project`, the dependencies between modules are correct. The issue arises during the dist package stage. `dist` packages all other compiled modules.

   **Behavior of `hadoop-yarn-project` in Serial Compilation:**
   - In serial compilation, it compiles modules in the pom one by one in sequence. After all modules are compiled, it compiles `hadoop-yarn-project`. During the `prepare-package` stage, the `maven-assembly-plugin` plugin is executed for packaging. All packages are repackaged according to the description in `hadoop-assemblies/src/main/resources/assemblies/hadoop-yarn-dist.xml`.

   **Behavior of `hadoop-yarn-project` in Parallel Compilation:**
   - Parallel compilation compiles modules according to the dependency order among them. If modules do not declare dependencies on each other through `dependency`, they are compiled in parallel. According to the dependency definition in the pom of `hadoop-yarn-project`, the dependencies are compiled first, followed by `hadoop-yarn-project`, executing its `maven-assembly-plugin`.
   - However, the files needed for packaging in `hadoop-assemblies/src/main/resources/assemblies/hadoop-yarn-dist.xml` are not all included in the `dependency` of `hadoop-yarn-project`. Therefore, when compiling `hadoop-yarn-project` and executing `maven-assembly-plugin`, not all required modules are built yet, leading to errors in parallel compilation.

   **Solution:**
   - The solution is relatively straightforward: organize all modules from `hadoop-assemblies/src/main/resources/assemblies/hadoop-yarn-dist.xml`, and then declare them as dependencies in the pom of `hadoop-yarn-project`.

### How was this patch tested?
manual test on centos8
![image](https://github.com/apache/hadoop/assets/18082602/2f95c1df-6aeb-42fd-98d8-7fe9e47e9401)


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

