### PR TITLE
HDFS-17298. Fix NPE in DataNode.handleBadBlock and BlockSender

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hdfs.protocol.datatransfer.PacketHeader;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.ReplicaState;
 import org.apache.hadoop.hdfs.server.common.DataNodeLockManager.LockLevel;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsVolumeReference;
+import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsVolumeSpi;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.LengthInputStream;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.ReplicaInputStreams;
 import org.apache.hadoop.hdfs.util.DataTransferThrottler;
@@ -295,7 +296,12 @@ class BlockSender implements java.io.Closeable {
         (!is32Bit || length <= Integer.MAX_VALUE);
 
       // Obtain a reference before reading data
-      volumeRef = datanode.data.getVolume(block).obtainReference();
+      FsVolumeSpi volume = datanode.data.getVolume(block);
+      if (volume == null) {
+        LOG.warn("Cannot find FsVolumeSpi to obtain a reference for block: {}", block);
+        throw new ReplicaNotFoundException(block);
+      }
+      volumeRef = volume.obtainReference();
 
       /* 
        * (corruptChecksumOK, meta_file_exist): operation

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -4107,8 +4107,12 @@ public class DataNode extends ReconfigurableBase
       return;
     }
     if (!fromScanner && blockScanner.isEnabled()) {
-      blockScanner.markSuspectBlock(data.getVolume(block).getStorageID(),
-          block);
+      FsVolumeSpi volume = data.getVolume(block);
+      if (volume == null) {
+        LOG.warn("Cannot find FsVolumeSpi to handle bad block: {}", block);
+        return;
+      }
+      blockScanner.markSuspectBlock(volume.getStorageID(), block);
     } else {
       try {
         reportBadBlocks(block);


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17298

There are some NPE issues on the DataNode side of our online environment.

The detailed exception information is

```
2023-12-20 13:58:25,449 ERROR datanode.DataNode (DataXceiver.java:run(330)) [DataXceiver for client DFSClient_NONMAPREDUCE_xxx at /xxx:41452 [Sending block BP-xxx:blk_xxx]] - xxx:50010:DataXceiver error processing READ_BLOCK operation  src: /xxx:41452 dst: /xxx:50010
java.lang.NullPointerException
        at org.apache.hadoop.hdfs.server.datanode.BlockSender.<init>(BlockSender.java:301)
        at org.apache.hadoop.hdfs.server.datanode.DataXceiver.readBlock(DataXceiver.java:607)
        at org.apache.hadoop.hdfs.protocol.datatransfer.Receiver.opReadBlock(Receiver.java:152)
        at org.apache.hadoop.hdfs.protocol.datatransfer.Receiver.processOp(Receiver.java:104)
        at org.apache.hadoop.hdfs.server.datanode.DataXceiver.run(DataXceiver.java:298)
        at java.lang.Thread.run(Thread.java:748)
```
NPE Code logic:

```
if (!fromScanner && blockScanner.isEnabled()) {
  // data.getVolume(block) is null
  blockScanner.markSuspectBlock(data.getVolume(block).getStorageID(),
      block);
} 
```

```
2023-12-20 13:52:18,844 ERROR datanode.DataNode (DataXceiver.java:run(330)) [DataXceiver for client /xxx:61052 [Copying block BP-xxx:blk_xxx]] - xxx:50010:DataXceiver error processing COPY_BLOCK operation  src: /xxx:61052 dst: /xxx:50010
java.lang.NullPointerException
        at org.apache.hadoop.hdfs.server.datanode.DataNode.handleBadBlock(DataNode.java:4045)
        at org.apache.hadoop.hdfs.server.datanode.DataXceiver.copyBlock(DataXceiver.java:1163)
        at org.apache.hadoop.hdfs.protocol.datatransfer.Receiver.opCopyBlock(Receiver.java:291)
        at org.apache.hadoop.hdfs.protocol.datatransfer.Receiver.processOp(Receiver.java:113)
        at org.apache.hadoop.hdfs.server.datanode.DataXceiver.run(DataXceiver.java:298)
        at java.lang.Thread.run(Thread.java:748)
```
NPE Code logic:

```
// Obtain a reference before reading data
volumeRef = datanode.data.getVolume(block).obtainReference(); //datanode.data.getVolume(block) is null  
```

We need to fix it.