### PR TITLE
HDFS-17300. [SBN READ] Observer should throw ObserverRetryOnActiveException if stateid is always delayed with Active Namenode for a configured time

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -25,6 +25,8 @@ import org.apache.hadoop.crypto.JceSm4CtrCryptoCodec;
 import org.apache.hadoop.crypto.OpensslAesCtrCryptoCodec;
 import org.apache.hadoop.crypto.OpensslSm4CtrCryptoCodec;
 
+import java.util.concurrent.TimeUnit;
+
 /** 
  * This class contains constants for configuration keys used
  * in the common code.
@@ -1076,6 +1078,13 @@ public class CommonConfigurationKeysPublic {
   public static final String IPC_SERVER_METRICS_UPDATE_RUNNER_INTERVAL =
       "ipc.server.metrics.update.runner.interval";
   public static final int IPC_SERVER_METRICS_UPDATE_RUNNER_INTERVAL_DEFAULT = 5000;
+
+  public static final String IPC_SERVER_OBSERVER_STABLE_RPC_ENABLE =
+      "ipc.server.observer.stable.rpc.enable";
+  public static final boolean IPC_SERVER_OBSERVER_STABLE_RPC_ENABLE_DEFAULT = false;
+  public static final String IPC_SERVER_OBSERVER_STABLE_RPC_INTERVAL =
+      "ipc.server.observer.stable.rpc.interval";
+  public static final long IPC_SERVER_OBSERVER_STABLE_RPC_DEFAULT = TimeUnit.SECONDS.toNanos(15);
 
   /**
    * @see

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -494,6 +494,8 @@ public abstract class Server {
   private int socketSendBufferSize;
   private final int maxDataLength;
   private final boolean tcpNoDelay; // if T then disable Nagle's Algorithm
+  private final boolean rpcStableEnable;
+  private final long rpcStableInterval;
 
   volatile private boolean running = true;         // true while server runs
   private CallQueueManager<Call> callQueue;
@@ -976,6 +978,7 @@ public abstract class Server {
     // Serialized RouterFederatedStateProto message to
     // store last seen states for multiple namespaces.
     private ByteString federatedNamespaceState;
+    private boolean isStable;
 
     Call() {
       this(RpcConstants.INVALID_CALL_ID, RpcConstants.INVALID_RETRY_COUNT,
@@ -1009,6 +1012,15 @@ public abstract class Server {
       this.callerContext = callerContext;
       this.clientStateId = Long.MIN_VALUE;
       this.isCallCoordinated = false;
+      this.isStable = false;
+    }
+
+    public boolean isStable() {
+      return isStable;
+    }
+
+    public void setStable(boolean stable) {
+      isStable = stable;
     }
 
     /**
@@ -1243,6 +1255,9 @@ public abstract class Server {
       ResponseParams responseParams = new ResponseParams();
 
       try {
+        if (isStable()) {
+          throw new ObserverRetryOnActiveException("The rpc call in observer is stable.");
+        }
         value = call(
             rpcKind, connection.protocolName, rpcRequest, getTimestampNanos());
       } catch (Throwable e) {
@@ -3177,10 +3192,14 @@ public abstract class Server {
              * In case of Observer, it handles only reads, which are
              * commutative.
              */
-            // Re-queue the call and continue
-            requeueCall(call);
-            call = null;
-            continue;
+            if (rpcStableEnable && startTimeNanos - call.timestampNanos > rpcStableInterval) {
+              call.setStable(true);
+            } else {
+              // Re-queue the call and continue
+              requeueCall(call);
+              call = null;
+              continue;
+            }
           }
           LOG.debug("{}: {} for RpcKind {}.", Thread.currentThread().getName(), call, call.rpcKind);
           CurCall.set(call);
@@ -3340,6 +3359,17 @@ public abstract class Server {
     this.readerPendingConnectionQueue = conf.getInt(
         CommonConfigurationKeys.IPC_SERVER_RPC_READ_CONNECTION_QUEUE_SIZE_KEY,
         CommonConfigurationKeys.IPC_SERVER_RPC_READ_CONNECTION_QUEUE_SIZE_DEFAULT);
+
+    this.rpcStableEnable =
+        conf.getBoolean(CommonConfigurationKeys.IPC_SERVER_OBSERVER_STABLE_RPC_ENABLE,
+            CommonConfigurationKeys.IPC_SERVER_OBSERVER_STABLE_RPC_ENABLE_DEFAULT);
+    if (this.rpcStableEnable) {
+      this.rpcStableInterval =
+          conf.getTimeDuration(CommonConfigurationKeys.IPC_SERVER_OBSERVER_STABLE_RPC_INTERVAL,
+              CommonConfigurationKeys.IPC_SERVER_OBSERVER_STABLE_RPC_DEFAULT, TimeUnit.NANOSECONDS);
+    } else {
+      this.rpcStableInterval = -1;
+    }
 
     // Setup appropriate callqueue
     final String prefix = getQueueClassPrefix();

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -3834,6 +3834,23 @@ The switch to turn S3A auditing on or off.
   </description>
 </property>
 
+<property>
+  <name>ipc.server.observer.stable.rpc.enable</name>
+  <value>true</value>
+  <description>
+     Whether to enable observer stable rpc. If enable when Observer NN's stateid is always
+    delayed it will thrown ObserverRetryOnActiveException after ipc.server.observer.stable.rpc.interval
+    is reached.
+  </description>
+</property>
+
+<property>
+  <name>ipc.server.observer.stable.rpc.interval</name>
+  <value>15</value>
+  <description>
+    Times observer rpc is stable in seconds.
+  </description>
+</property>
 
   <!-- YARN registry -->
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Now when Observer NN is used,  if the stateid is delayed , the rpcServer will be requeued into callqueue. If EditLogTailer is broken or something else wrong , the call will be requeued again and again.  
So Observer should throw ObserverRetryOnActiveException if stateid is always delayed with Active Namenode for a configured time.


