### PR TITLE
HDFS-17056. EC: Fix verifyClusterSetup output in case of an invalid param.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/ECAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/ECAdmin.java
@@ -642,6 +642,10 @@ public class ECAdmin extends Configured implements Tool {
           throw e;
         }
       } else {
+        if (args.size() > 0) {
+          System.err.println(getName() + ": Too many arguments");
+          return 1;
+        }
         result = dfs.getECTopologyResultForPolicies();
       }
       System.out.println(result.getResultMessage());


### PR DESCRIPTION
### Description of PR
JIRA: https://issues.apache.org/jira/browse/HDFS-17056

### How was this patch tested?
Add Unit Test.