### PR TITLE
HDFS-17302. RBF: ProportionRouterRpcFairnessPolicyController-Sharing and isolation.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/AbstractRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/AbstractRouterRpcFairnessPolicyController.java
@@ -106,4 +106,9 @@ public class AbstractRouterRpcFairnessPolicyController
     });
     return json.toString();
   }
+
+  @Override
+  public boolean contains(String nsId) {
+    return permits.containsKey(nsId);
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/NoRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/NoRouterRpcFairnessPolicyController.java
@@ -56,4 +56,9 @@ public class NoRouterRpcFairnessPolicyController implements
   public int getAvailablePermits(String nsId) {
     return 0;
   }
+
+  @Override
+  public boolean contains(String nsId) {
+    return true;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/ProportionRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/ProportionRouterRpcFairnessPolicyController.java
@@ -85,17 +85,15 @@ public class ProportionRouterRpcFairnessPolicyController extends
   public boolean acquirePermit(String nsId) {
     if (contains(nsId)) {
       return super.acquirePermit(nsId);
-    }else {
-      return super.acquirePermit(DEFAULT_NS);
     }
+    return super.acquirePermit(DEFAULT_NS);
   }
 
   @Override
   public void releasePermit(String nsId) {
     if (contains(nsId)) {
       super.releasePermit(nsId);
-    }else {
-      super.releasePermit(DEFAULT_NS);
     }
+    super.releasePermit(DEFAULT_NS);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/ProportionRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/ProportionRouterRpcFairnessPolicyController.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.fairness;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.server.federation.router.FederationUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.Set;
+
+import static org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessConstants.CONCURRENT_NS;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_PROPORTION_DEFAULT;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_PROPORTION_KEY_PREFIX;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_DEFAULT;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_KEY;
+
+/**
+ * Proportion fairness policy extending {@link AbstractRouterRpcFairnessPolicyController}
+ * and fetching proportion of handlers from configuration for all available name services,
+ * based on the proportion and the total number of handlers, calculate the handlers of all ns.
+ * The handlers count will not change for this controller.
+ */
+public class ProportionRouterRpcFairnessPolicyController extends
+    AbstractRouterRpcFairnessPolicyController{
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ProportionRouterRpcFairnessPolicyController.class);
+
+  public ProportionRouterRpcFairnessPolicyController(Configuration conf){
+    init(conf);
+  }
+
+  @Override
+  public void init(Configuration conf) {
+    super.init(conf);
+    // Total handlers configured to process all incoming Rpc.
+    int handlerCount = conf.getInt(DFS_ROUTER_HANDLER_COUNT_KEY, DFS_ROUTER_HANDLER_COUNT_DEFAULT);
+
+    LOG.info("Handlers available for fairness assignment {} ", handlerCount);
+
+    // Get all name services configured
+    Set<String> allConfiguredNS = FederationUtil.getAllConfiguredNS(conf);
+
+    // Insert the concurrent nameservice into the set to process together
+    allConfiguredNS.add(CONCURRENT_NS);
+    for (String nsId : allConfiguredNS) {
+      double dedicatedHandlerProportion = conf.getDouble(
+          DFS_ROUTER_FAIR_HANDLER_PROPORTION_KEY_PREFIX + nsId,
+                DFS_ROUTER_FAIR_HANDLER_PROPORTION_DEFAULT);
+      int dedicatedHandlers = (int) (dedicatedHandlerProportion * handlerCount);
+      LOG.info("Dedicated handlers {} for ns {} ", dedicatedHandlers, nsId);
+      // Each NS should have at least one handler assigned.
+      if (dedicatedHandlers <= 0) {
+        dedicatedHandlers = 1;
+      }
+      insertNameServiceWithPermits(nsId, dedicatedHandlers);
+      LOG.info("Assigned {} handlers to nsId {} ", dedicatedHandlers, nsId);
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/RouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/RouterRpcFairnessPolicyController.java
@@ -77,4 +77,12 @@ public interface RouterRpcFairnessPolicyController {
    * @return the available handler for each name service.
    */
   int getAvailablePermits(String nsId);
+
+  /**
+   * Determine whether ns has registered handlers.
+   *
+   * @param nsId name service id.
+   * @return true if the ns has registered handlers, false in other cases.
+   */
+  boolean contains(String nsId);
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -409,6 +409,10 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
       FEDERATION_ROUTER_FAIRNESS_PREFIX + "acquire.timeout";
   public static final long   DFS_ROUTER_FAIRNESS_ACQUIRE_TIMEOUT_DEFAULT =
       TimeUnit.SECONDS.toMillis(1);
+  public static final String DFS_ROUTER_FAIR_HANDLER_PROPORTION_KEY_PREFIX =
+      FEDERATION_ROUTER_FAIRNESS_PREFIX + "handler.proportion.";
+  public static final double DFS_ROUTER_FAIR_HANDLER_PROPORTION_DEFAULT =
+      0.1;
 
   // HDFS Router Federation Rename.
   public static final String DFS_ROUTER_FEDERATION_RENAME_PREFIX =

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -819,6 +819,19 @@
   </property>
 
   <property>
+    <name>dfs.federation.router.fairness.handler.proportion.EXAMPLENAMESERVICE</name>
+    <value>0.1</value>
+    <description>
+      Dedicated handler proportion for nameservice EXAMPLENAMESERVICE.
+      The range of this value is [0, 1], and the data type is float.
+      If this value is configured as x, and the total number of handlers
+      (configed by dfs.federation.router.handler.count) of the router is y,
+      then the maximum number of handlers for the EXAMPLENAMESERVICE is z=(int) x*y;
+      If z is 0, z is reset to 1, ensuring the ns has at least one handler.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.federation.router.federation.rename.bandwidth</name>
     <value>10</value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestProportionRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestProportionRouterRpcFairnessPolicyController.java
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.fairness;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.server.federation.router.FederationUtil;
+import org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys;
+import org.apache.hadoop.util.Time;
+import org.junit.Test;
+
+
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessConstants.CONCURRENT_NS;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIRNESS_ACQUIRE_TIMEOUT;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_PROPORTION_KEY_PREFIX;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_MONITOR_NAMENODE;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test functionality of {@link ProportionRouterRpcFairnessPolicyController}.
+ */
+public class TestProportionRouterRpcFairnessPolicyController {
+  private static String nameServices =
+      "ns1.nn1, ns1.nn2, ns2.nn1, ns2.nn2";
+
+  @Test
+  public void testHandlerAllocationDefault() {
+    RouterRpcFairnessPolicyController routerRpcFairnessPolicyController
+        = getFairnessPolicyController(30);
+    for (int i=0; i<3; i++) {
+      assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns1"));
+      assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns2"));
+      assertTrue(
+          routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS));
+    }
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns1"));
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns2"));
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS));
+
+    routerRpcFairnessPolicyController.releasePermit("ns1");
+    routerRpcFairnessPolicyController.releasePermit("ns2");
+    routerRpcFairnessPolicyController.releasePermit(CONCURRENT_NS);
+
+    assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns1"));
+    assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns2"));
+    assertTrue(routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS));
+  }
+
+  @Test
+  public void testHandlerAllocationPreconfigured() {
+    Configuration conf = createConf(40);
+    conf.setDouble(DFS_ROUTER_FAIR_HANDLER_PROPORTION_KEY_PREFIX + "ns1", 0.5);
+    RouterRpcFairnessPolicyController routerRpcFairnessPolicyController =
+        FederationUtil.newFairnessPolicyController(conf);
+
+    // ns1 should have 20 permits allocated
+    for (int i=0; i<20; i++) {
+      assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns1"));
+    }
+
+    // ns2 should have 4 permits.
+    // concurrent should have 4 permits.
+    for (int i=0; i<4; i++) {
+      assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns2"));
+      assertTrue(
+          routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS));
+    }
+
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns1"));
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns2"));
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS));
+  }
+
+  @Test
+  public void testAcquireTimeout() {
+    Configuration conf = createConf(40);
+    conf.setDouble(DFS_ROUTER_FAIR_HANDLER_PROPORTION_KEY_PREFIX + "ns1", 0.5);
+    conf.setTimeDuration(DFS_ROUTER_FAIRNESS_ACQUIRE_TIMEOUT, 100, TimeUnit.MILLISECONDS);
+    RouterRpcFairnessPolicyController routerRpcFairnessPolicyController =
+        FederationUtil.newFairnessPolicyController(conf);
+
+    // ns1 should have 30 permits allocated
+    for (int i = 0; i < 20; i++) {
+      assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns1"));
+    }
+    long acquireBeginTimeMs = Time.monotonicNow();
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns1"));
+    long acquireTimeMs = Time.monotonicNow() - acquireBeginTimeMs;
+
+    // There are some other operations, so acquireTimeMs >= 100ms.
+    assertTrue(acquireTimeMs >= 100);
+  }
+
+  @Test
+  public void testAllocationWithZeroProportion() {
+    Configuration conf = createConf(40);
+    conf.setDouble(DFS_ROUTER_FAIR_HANDLER_PROPORTION_KEY_PREFIX + "ns1", 0);
+    RouterRpcFairnessPolicyController routerRpcFairnessPolicyController =
+        FederationUtil.newFairnessPolicyController(conf);
+
+    // ns1 should have 1 permit allocated
+    assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns1"));
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns1"));
+  }
+
+  @Test
+  public void testAllocationHandlersGreaterThanCount() {
+    Configuration conf = createConf(40);
+    conf.setDouble(DFS_ROUTER_FAIR_HANDLER_PROPORTION_KEY_PREFIX + "ns1", 0.8);
+    conf.setDouble(DFS_ROUTER_FAIR_HANDLER_PROPORTION_KEY_PREFIX + "ns2", 0.8);
+    conf.setDouble(DFS_ROUTER_FAIR_HANDLER_PROPORTION_KEY_PREFIX + CONCURRENT_NS, 1);
+    RouterRpcFairnessPolicyController routerRpcFairnessPolicyController =
+        FederationUtil.newFairnessPolicyController(conf);
+
+    // ns1 32 permit allocated
+    // ns2 32 permit allocated
+    for (int i = 0; i < 32; i++) {
+      assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns1"));
+      assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns2"));
+    }
+    // CONCURRENT_NS 40 permit allocated
+    for (int i=0; i < 40; i++) {
+      assertTrue(routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS));
+    }
+  }
+
+  private RouterRpcFairnessPolicyController getFairnessPolicyController(
+      int handlers) {
+    return FederationUtil.newFairnessPolicyController(createConf(handlers));
+  }
+
+  private Configuration createConf(int handlers) {
+    Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFS_ROUTER_HANDLER_COUNT_KEY, handlers);
+    conf.set(DFS_ROUTER_MONITOR_NAMENODE, nameServices);
+    conf.setClass(
+        RBFConfigKeys.DFS_ROUTER_FAIRNESS_POLICY_CONTROLLER_CLASS,
+        ProportionRouterRpcFairnessPolicyController.class,
+        RouterRpcFairnessPolicyController.class);
+    return conf;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
@@ -17,12 +17,19 @@
  */
 package org.apache.hadoop.hdfs.server.federation.fairness;
 
+import static org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessConstants.CONCURRENT_NS;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIRNESS_ACQUIRE_TIMEOUT;
 import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.conf.Configuration;
@@ -37,18 +44,58 @@ import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ipc.StandbyException;
 import org.junit.After;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Test the Router handlers fairness control rejects and accepts requests.
  */
+@RunWith(Parameterized.class)
 public class TestRouterHandlersFairness {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestRouterHandlersFairness.class);
 
   private StateStoreDFSCluster cluster;
+  private Map<String, Integer> expectedHandlerPerNs;
+  private Class<RouterRpcFairnessPolicyController> policyControllerClass;
+  private int handlerCount;
+  private Map<String, String> configuration;
+
+  public TestRouterHandlersFairness(
+      Class<RouterRpcFairnessPolicyController> policyControllerClass, int handlerCount,
+      Map<String, String> configuration, Map<String, Integer> expectedHandlerPerNs) {
+    this.expectedHandlerPerNs = expectedHandlerPerNs;
+    this.policyControllerClass = policyControllerClass;
+    this.handlerCount = handlerCount;
+    this.configuration = configuration;
+  }
+
+  @Parameterized.Parameters
+  public static Collection primes() {
+    return Arrays.asList(new Object[][]{
+        {
+            //  Test StaticRouterRpcFairnessPolicyController.
+            StaticRouterRpcFairnessPolicyController.class,
+            3,
+            setConfiguration(null),
+            expectedHandlerPerNs("ns0:1, ns1:1, concurrent:1")
+        },
+        {
+            // Test ProportionRouterRpcFairnessPolicyController.
+            ProportionRouterRpcFairnessPolicyController.class,
+            20,
+            setConfiguration(
+                "dfs.federation.router.fairness.handler.proportion.ns0=0.5, " +
+                "dfs.federation.router.fairness.handler.proportion.ns1=0.8, " +
+                "dfs.federation.router.fairness.handler.proportion.concurrent=1"
+            ),
+            expectedHandlerPerNs("ns0:10, ns1:16, concurrent:20")
+        }
+    });
+  }
 
   @After
   public void cleanup() {
@@ -60,6 +107,7 @@ public class TestRouterHandlersFairness {
 
   private void setupCluster(boolean fairnessEnable, boolean ha)
       throws Exception {
+    LOG.info("Test {}", policyControllerClass.getSimpleName());
     // Build and start a federated cluster
     cluster = new StateStoreDFSCluster(ha, 2);
     Configuration routerConf = new RouterConfigBuilder()
@@ -71,13 +119,17 @@ public class TestRouterHandlersFairness {
     if (fairnessEnable) {
       routerConf.setClass(
           RBFConfigKeys.DFS_ROUTER_FAIRNESS_POLICY_CONTROLLER_CLASS,
-          StaticRouterRpcFairnessPolicyController.class,
+          this.policyControllerClass,
           RouterRpcFairnessPolicyController.class);
     }
 
-    // With two name services configured, each nameservice has 1 permit and
-    // fan-out calls have 1 permit.
-    routerConf.setInt(RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_KEY, 3);
+    routerConf.setTimeDuration(DFS_ROUTER_FAIRNESS_ACQUIRE_TIMEOUT, 10, TimeUnit.MILLISECONDS);
+
+    routerConf.setInt(RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_KEY, this.handlerCount);
+
+    for(Map.Entry<String, String> conf : configuration.entrySet()) {
+      routerConf.set(conf.getKey(), conf.getValue());
+    }
 
     // Datanodes not needed for this test.
     cluster.setNumDatanodesPerNameservice(0);
@@ -135,15 +187,19 @@ public class TestRouterHandlersFairness {
       if (isConcurrent) {
         LOG.info("Taking fanout lock first");
         // take the lock for concurrent NS to block fanout calls
-        assertTrue(routerContext.getRouter().getRpcServer()
-            .getRPCClient().getRouterRpcFairnessPolicyController()
-            .acquirePermit(RouterRpcFairnessConstants.CONCURRENT_NS));
+        for(int i = 0; i < expectedHandlerPerNs.get(CONCURRENT_NS); i++) {
+          assertTrue(routerContext.getRouter().getRpcServer()
+              .getRPCClient().getRouterRpcFairnessPolicyController()
+              .acquirePermit(CONCURRENT_NS));
+        }
       } else {
         for (String ns : cluster.getNameservices()) {
           LOG.info("Taking lock first for ns: {}", ns);
-          assertTrue(routerContext.getRouter().getRpcServer()
-              .getRPCClient().getRouterRpcFairnessPolicyController()
-              .acquirePermit(ns));
+          for(int i = 0; i < expectedHandlerPerNs.get(ns); i++) {
+            assertTrue(routerContext.getRouter().getRpcServer()
+                .getRPCClient().getRouterRpcFairnessPolicyController()
+                .acquirePermit(ns));
+          }
         }
       }
     }
@@ -161,14 +217,18 @@ public class TestRouterHandlersFairness {
       if (isConcurrent) {
         LOG.info("Release fanout lock that was taken before test");
         // take the lock for concurrent NS to block fanout calls
-        routerContext.getRouter().getRpcServer()
-            .getRPCClient().getRouterRpcFairnessPolicyController()
-            .releasePermit(RouterRpcFairnessConstants.CONCURRENT_NS);
-      } else {
-        for (String ns : cluster.getNameservices()) {
+        for(int i = 0; i < expectedHandlerPerNs.get(CONCURRENT_NS); i++) {
           routerContext.getRouter().getRpcServer()
               .getRPCClient().getRouterRpcFairnessPolicyController()
-              .releasePermit(ns);
+              .releasePermit(CONCURRENT_NS);
+        }
+      } else {
+        for (String ns : cluster.getNameservices()) {
+          for(int i = 0; i < expectedHandlerPerNs.get(ns); i++) {
+            routerContext.getRouter().getRpcServer()
+                .getRPCClient().getRouterRpcFairnessPolicyController()
+                .releasePermit(ns);
+          }
         }
       }
     } else {
@@ -204,7 +264,7 @@ public class TestRouterHandlersFairness {
           .getRejectedPermitForNs(ns);
     }
     totalRejectedPermits += routerContext.getRouterRpcClient()
-        .getRejectedPermitForNs(RouterRpcFairnessConstants.CONCURRENT_NS);
+        .getRejectedPermitForNs(CONCURRENT_NS);
     return totalRejectedPermits;
   }
 
@@ -215,7 +275,7 @@ public class TestRouterHandlersFairness {
           .getAcceptedPermitForNs(ns);
     }
     totalAcceptedPermits += routerContext.getRouterRpcClient()
-        .getAcceptedPermitForNs(RouterRpcFairnessConstants.CONCURRENT_NS);
+        .getAcceptedPermitForNs(CONCURRENT_NS);
     return totalAcceptedPermits;
   }
 
@@ -251,5 +311,29 @@ public class TestRouterHandlersFairness {
       }
       overloadException.get();
     }
+  }
+
+  private static Map<String, Integer> expectedHandlerPerNs(String str) {
+    Map<String, Integer> handlersPerNsMap = new HashMap<>();
+    if (str != null) {
+      String[] tmpStrs = str.split(", ");
+      for(String tmpStr : tmpStrs) {
+        String[] handlersPerNs = tmpStr.split(":");
+        handlersPerNsMap.put(handlersPerNs[0], Integer.valueOf(handlersPerNs[1]));
+      }
+    }
+    return handlersPerNsMap;
+  }
+
+  private static Map<String, String> setConfiguration(String str) {
+    Map<String, String> conf = new HashMap<>();
+    if (str != null) {
+      String[] tmpStrs = str.split(", ");
+      for(String tmpStr : tmpStrs) {
+        String[] configKV = tmpStr.split("=");
+        conf.put(configKV[0], configKV[1]);
+      }
+    }
+    return conf;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
@@ -30,7 +30,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -73,6 +72,14 @@ public class TestRouterHandlersFairness {
   private int handlerCount;
   private Map<String, String> configuration;
 
+  /**
+   * Initialize test parameters.
+   *
+   * @param policyControllerClass RouterRpcFairnessPolicyController type.
+   * @param handlerCount The total number of handlers in the router.
+   * @param configuration Custom configuration.
+   * @param expectedHandlerPerNs The number of handlers expected for each ns.
+   */
   public TestRouterHandlersFairness(
       Class<RouterRpcFairnessPolicyController> policyControllerClass, int handlerCount,
       Map<String, String> configuration, Map<String, Integer> expectedHandlerPerNs) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
@@ -378,24 +378,32 @@ public class TestRouterHandlersFairness {
 
   private static Map<String, Integer> expectedHandlerPerNs(String str) {
     Map<String, Integer> handlersPerNsMap = new HashMap<>();
-    if (str != null) {
-      String[] tmpStrs = str.split(", ");
-      for(String tmpStr : tmpStrs) {
-        String[] handlersPerNs = tmpStr.split(":");
-        handlersPerNsMap.put(handlersPerNs[0], Integer.valueOf(handlersPerNs[1]));
+    if (str == null) {
+      return handlersPerNsMap;
+    }
+    String[] tmpStrs = str.split(", ");
+    for(String tmpStr : tmpStrs) {
+      String[] handlersPerNs = tmpStr.split(":");
+      if (handlersPerNs.length != 2) {
+        continue;
       }
+      handlersPerNsMap.put(handlersPerNs[0], Integer.valueOf(handlersPerNs[1]));
     }
     return handlersPerNsMap;
   }
 
   private static Map<String, String> setConfiguration(String str) {
     Map<String, String> conf = new HashMap<>();
-    if (str != null) {
-      String[] tmpStrs = str.split(", ");
-      for(String tmpStr : tmpStrs) {
-        String[] configKV = tmpStr.split("=");
-        conf.put(configKV[0], configKV[1]);
+    if (str == null) {
+      return conf;
+    }
+    String[] tmpStrs = str.split(", ");
+    for(String tmpStr : tmpStrs) {
+      String[] configKV = tmpStr.split("=");
+      if (configKV.length != 2) {
+        continue;
       }
+      conf.put(configKV[0], configKV[1]);
     }
     return conf;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRBFConfigFields.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRBFConfigFields.java
@@ -49,5 +49,7 @@ public class TestRBFConfigFields extends TestConfigurationFieldsBase {
     xmlPrefixToSkipCompare = new HashSet<String>();
     xmlPrefixToSkipCompare.add(
         RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX);
+    xmlPrefixToSkipCompare.add(
+        RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_PROPORTION_KEY_PREFIX);
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
see also: [HDFS-17302](https://issues.apache.org/jira/browse/HDFS-17302)
#### Current shortcomings
[HDFS-14090](https://issues.apache.org/jira/browse/HDFS-14090) provides a StaticRouterRpcFairnessPolicyController to support configuring different handlers for different ns. Using the StaticRouterRpcFairnessPolicyController allows the router to isolate different ns, and the ns with a higher load will not affect the router's access to the ns with a normal load. But the StaticRouterRpcFairnessPolicyController still falls short in many ways, such as:

1. **Configuration is inconvenient and error-prone**: When I use StaticRouterRpcFairnessPolicyController, I first need to know how many handlers the router has in total, then I have to know how many nameservices the router currently has, and then carefully calculate how many handlers to allocate to each ns so that the sum of handlers for all ns will not exceed the total handlers of the router, and I also need to consider how many handlers to allocate to each ns to achieve better performance. Therefore, I need to be very careful when configuring. Even if I configure only one more handler for a certain ns, the total number is more than the number of handlers owned by the router, which will also cause the router to fail to start. At this time, I had to investigate the reason why the router failed to start. After finding the reason, I had to reconsider the number of handlers for each ns. In addition, when I reconfigure the total number of handlers on the router, I have to re-allocate handlers to each ns, which undoubtedly increases the complexity of operation and maintenance.

2. **Extension ns is not supported**: During the running of the router, if a new ns is added to the cluster and a mount is added for the ns, but because no handler is allocated for the ns, the ns cannot be accessed through the router. We must reconfigure the number of handlers and then refresh the configuration. At this time, the router can access the ns normally. When we reconfigure the number of handlers, we have to face disadvantage 1: Configuration is inconvenient and error-prone.

3. **Waste handlers**: The main purpose of proposing RouterRpcFairnessPolicyController is to enable the router to access ns with normal load and not be affected by ns with higher load. First of all, not all ns have high loads; secondly, ns with high loads do not have high loads 24 hours a day. It may be that only certain time periods, such as 0 to 8 o'clock, have high loads, and other time periods have normal loads. Assume there are 2 ns, and each ns is allocated half of the number of handlers. Assume that ns1 has many requests from 0 to 14 o'clock, and almost no requests from 14 to 24 o'clock, ns2 has many requests from 12 to 24 o'clock, and almost no requests from 0 to 14 o'clock; when it is between 0 o'clock and 12 o'clock and between 14 o'clock and 24 o'clock, only one ns has more requests and the other ns has almost no requests, so we have wasted half of the number of handlers.

4. **Only isolation, no sharing**: The staticRouterRpcFairnessPolicyController does not support sharing, only isolation. I think isolation is just a means to improve the performance of router access to normal ns, not the purpose. It is impossible for all ns in the cluster to have high loads. On the contrary, in most scenarios, only a few ns in the cluster have high loads, and the loads of most other ns are normal. For ns with higher load and ns with normal load, we need to isolate their handlers so that the ns with higher load will not affect the performance of ns with lower load. However, for nameservices that are also under normal load, or are under higher load, we do not need to isolate them, these ns of the same nature can share the handlers of the router; The performance is better than assigning a fixed number of handlers to each ns, because each ns can use all the handlers of the router.

#### New features
Based on the above staticRouterRpcFairnessPolicyController, there are deficiencies in usage and performance. I provide a new RouterRpcFairnessPolicyController: ProportionRouterRpcFairnessPolicyController (maybe with a better name) to solve the above major shortcomings.

1. **More user-friendly configuration** : Supports allocating handlers proportionally to each ns. For example, we can give ns1 a handler ratio of 0.2, then ns1 will use 0.2 of the total number of handlers on the router. Using this method, we do not need to confirm in advance how many handlers the router has.

2. **Sharing and isolation** : Sharing is as important as isolation. We support that the sum of handlers for all ns exceeds the total number of handlers. For example, assuming we have 10 handlers and 3 ns, we can allocate 5 (0.5) handlers to ns1, 5 (0.5) handlers to ns2, and ns3 also allocates 5 (0.5) handlers.This feature is very important,.Consider the following scenarios:

- Only one ns is busy during a period of time: Assume that ns1 has more requests from 0 to 8 o'clock, ns2 has more requests from 8 to 16 o'clock, and ns3 has more requests from 16 o'clock to 24 o'clock. Then, at any time period, the ns with more requests uses at most half of the handlers, and the other two normal ns share the remaining half of the handlers. In this way, the isolation is still satisfied, and compared with StaticRouterRpcFairnessPolicyController, we can use more handlers to handle requests of busy and Normal ns (if you use StaticRouterRpcFairnessPolicyController, each ns uses 3 handlers-[ns1:3 ns2:3 ns3:3], now we can let each ns use 5 handlers).
- Only ns1 is busy: Assuming that only ns1 is busy at any time, the requests for ns2 and ns3 are normal (the requests to access ns2 and ns3 are very few and very fast because the downstream namenode has no pressure). We can give ns1 5(0.5) handlers, ns2 and ns3 both have 10(1) handlers. Since the number of requests for ns2 and ns3 is very small, and the request processing time is very short, it will not have a major impact on the performance of ns1, and we stipulate that ns1 uses at most half of the handlers, so the isolation is still met.
3. **Transparent extension**: Expanding new ns does not require refreshing the configuration. For an ns, if we do not assign handlers to it, we can assign a certain proportion of handlers to it by default.

4. **Fully compatible**: The new RouterRpcFairnessPolicyController fully meets the characteristics of StaticRouterRpcFairnessPolicyController. If we want to only support isolation but not sharing, we can allocate 0.3 to ns2、0.3 to ns3、0.4 to ns1. This is also more convenient than using the original StaticRouterRpcFairnessPolicyController, because we don't need to know how many handlers the router has in total.

Therefore, the new RouterRpcFairnessPolicyController is more flexible, has better performance, and is more suitable for actual production environments.

### How was this patch tested?

I provided new unit test class TestProportionRouterRpcFairnessPolicyController.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

