### PR TITLE
MAPREDUCE-7464. Make priority of mapreduce tasks configurable.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/rm/RMContainerAllocator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/rm/RMContainerAllocator.java
@@ -102,10 +102,10 @@ public class RMContainerAllocator extends RMContainerRequestor
   public static final 
   float DEFAULT_COMPLETED_MAPS_PERCENT_FOR_REDUCE_SLOWSTART = 0.05f;
   
-  static final Priority PRIORITY_FAST_FAIL_MAP;
-  static final Priority PRIORITY_REDUCE;
-  static final Priority PRIORITY_MAP;
-  static final Priority PRIORITY_OPPORTUNISTIC_MAP;
+  static Priority PRIORITY_FAST_FAIL_MAP;
+  static Priority PRIORITY_REDUCE;
+  static Priority PRIORITY_MAP;
+  static Priority PRIORITY_OPPORTUNISTIC_MAP;
 
   @VisibleForTesting
   public static final String RAMPDOWN_DIAGNOSTIC = "Reducer preempted "
@@ -116,15 +116,11 @@ public class RMContainerAllocator extends RMContainerRequestor
 
   static {
     PRIORITY_FAST_FAIL_MAP = RecordFactoryProvider.getRecordFactory(null).newRecordInstance(Priority.class);
-    PRIORITY_FAST_FAIL_MAP.setPriority(5);
     PRIORITY_REDUCE = RecordFactoryProvider.getRecordFactory(null).newRecordInstance(Priority.class);
-    PRIORITY_REDUCE.setPriority(10);
     PRIORITY_MAP = RecordFactoryProvider.getRecordFactory(null).newRecordInstance(Priority.class);
-    PRIORITY_MAP.setPriority(20);
     PRIORITY_OPPORTUNISTIC_MAP =
         RecordFactoryProvider.getRecordFactory(null).newRecordInstance(
             Priority.class);
-    PRIORITY_OPPORTUNISTIC_MAP.setPriority(19);
   }
   
   /*
@@ -234,6 +230,18 @@ public class RMContainerAllocator extends RMContainerRequestor
                                 MRJobConfig.DEFAULT_MR_AM_TO_RM_WAIT_INTERVAL_MS);
     mapNodeLabelExpression = conf.get(MRJobConfig.MAP_NODE_LABEL_EXP);
     reduceNodeLabelExpression = conf.get(MRJobConfig.REDUCE_NODE_LABEL_EXP);
+    PRIORITY_FAST_FAIL_MAP.setPriority(conf.getInt(
+        MRJobConfig.MAPREDUCE_JOB_FAIL_MAP_PRIORITY,
+        MRJobConfig.DEFAULT_MAPREDUCE_JOB_FAIL_MAP_PRIORITY));
+    PRIORITY_REDUCE.setPriority(conf.getInt(
+        MRJobConfig.MAPREDUCE_JOB_REDUCE_PRIORITY,
+        MRJobConfig.DEFAULT_MAPREDUCE_JOB_REDUCE_PRIORITY));
+    PRIORITY_MAP.setPriority(conf.getInt(
+        MRJobConfig.MAPREDUCE_JOB_MAP_PRIORITY,
+        MRJobConfig.DEFAULT_MAPREDUCE_JOB_MAP_PRIORITY));
+    PRIORITY_OPPORTUNISTIC_MAP.setPriority(conf.getInt(
+        MRJobConfig.MAPREDUCE_JOB_OPPORTUNISTIC_MAP_PRIORITY,
+        MRJobConfig.DEFAULT_MAPREDUCE_JOB_OPPORTUNISTIC_MAP_PRIORITY));
     // Init startTime to current time. If all goes well, it will be reset after
     // first attempt to contact RM.
     retrystartTime = System.currentTimeMillis();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMContainerAllocator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMContainerAllocator.java
@@ -950,6 +950,91 @@ public class TestRMContainerAllocator {
     }
   }
 
+  @Test
+  public void testMapReducePriority() throws Exception {
+
+    LOG.info("Running testMapReducePriority");
+
+    Configuration conf = new Configuration();
+    conf.setInt(MRJobConfig.MAPREDUCE_JOB_FAIL_MAP_PRIORITY, 5);
+    conf.setInt(MRJobConfig.MAPREDUCE_JOB_MAP_PRIORITY, 10);
+    conf.setInt(MRJobConfig.MAPREDUCE_JOB_REDUCE_PRIORITY, 20);
+    MyResourceManager rm = new MyResourceManager(conf);
+    rm.start();
+
+    // Submit the application
+    RMApp app = MockRMAppSubmitter.submitWithMemory(1024, rm);
+    rm.drainEvents();
+
+    MockNM amNodeManager = rm.registerNode("amNM:1234", 2048);
+    amNodeManager.nodeHeartbeat(true);
+    rm.drainEvents();
+
+    ApplicationAttemptId appAttemptId = app.getCurrentAppAttempt()
+            .getAppAttemptId();
+    rm.sendAMLaunched(appAttemptId);
+    rm.drainEvents();
+
+    JobId jobId = MRBuilderUtils.newJobId(appAttemptId.getApplicationId(), 0);
+    Job mockJob = mock(Job.class);
+    when(mockJob.getReport()).thenReturn(
+            MRBuilderUtils.newJobReport(jobId, "job", "user", JobState.RUNNING, 0,
+                    0, 0, 0, 0, 0, 0, "jobfile", null, false, ""));
+    MyContainerAllocator allocator = new MyContainerAllocator(rm, conf,
+            appAttemptId, mockJob, SystemClock.getInstance());
+
+    // add resources to scheduler
+    MockNM nodeManager1 = rm.registerNode("h1:1234", 1024);
+    MockNM nodeManager2 = rm.registerNode("h2:1234", 10240);
+    MockNM nodeManager3 = rm.registerNode("h3:1234", 10240);
+    rm.drainEvents();
+
+    // create the container request
+    // send failed MAP request
+    ContainerRequestEvent event1 = createRequest(jobId, 1,
+            Resource.newInstance(2048, 1),
+            new String[] {"h1", "h2"}, true, false);
+    allocator.sendRequest(event1);
+
+    // send REDUCE request
+    ContainerRequestEvent event2 = createRequest(jobId, 2,
+            Resource.newInstance(3000, 1),
+            new String[] {"h1"}, false, true);
+    allocator.sendRequest(event2);
+
+    // send MAP request
+    ContainerRequestEvent event3 = createRequest(jobId, 3,
+            Resource.newInstance(2048, 1),
+            new String[] {"h3"}, false, false);
+    allocator.sendRequest(event3);
+
+    // this tells the scheduler about the requests
+    // as nodes are not added, no allocations
+    List<TaskAttemptContainerAssignedEvent> assigned = allocator.schedule();
+    rm.drainEvents();
+    Assert.assertEquals("No of assignments must be 0", 0, assigned.size());
+
+    // update resources in scheduler
+    nodeManager1.nodeHeartbeat(true); // Node heartbeat
+    nodeManager2.nodeHeartbeat(true); // Node heartbeat
+    nodeManager3.nodeHeartbeat(true); // Node heartbeat
+    rm.drainEvents();
+
+    assigned = allocator.schedule();
+    rm.drainEvents();
+
+    for (TaskAttemptContainerAssignedEvent ass : assigned) {
+      int priority = ass.getContainer().getPriority().getPriority();
+      if (ass.getTaskAttemptID().equals(event1.getAttemptID())) {
+        Assert.assertEquals(5, priority);
+      } else if (ass.getTaskAttemptID().equals(event2.getAttemptID())) {
+        Assert.assertEquals(20, priority);
+      } else {
+        Assert.assertEquals(10, priority);
+      }
+    }
+  }
+
   static class MyResourceManager extends MockRM {
 
     private static long fakeClusterTimeStamp = System.currentTimeMillis();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRJobConfig.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRJobConfig.java
@@ -673,6 +673,19 @@ public interface MRJobConfig {
   public static final boolean DEFAULT_MAPREDUCE_JOB_EMIT_TIMELINE_DATA =
       false;
 
+  public static final String MAPREDUCE_JOB_FAIL_MAP_PRIORITY =
+    "mapreduce.job.fail.map.priority";
+  public static final int DEFAULT_MAPREDUCE_JOB_FAIL_MAP_PRIORITY = 5;
+  public static final String MAPREDUCE_JOB_REDUCE_PRIORITY =
+    "mapreduce.job.reduce.priority";
+  public static final int DEFAULT_MAPREDUCE_JOB_REDUCE_PRIORITY = 10;
+  public static final String MAPREDUCE_JOB_MAP_PRIORITY =
+    "mapreduce.job.map.priority";
+  public static final int DEFAULT_MAPREDUCE_JOB_MAP_PRIORITY = 20;
+  public static final String MAPREDUCE_JOB_OPPORTUNISTIC_MAP_PRIORITY =
+    "mapreduce.job.opportunistic.map.priority";
+  public static final int DEFAULT_MAPREDUCE_JOB_OPPORTUNISTIC_MAP_PRIORITY = 19;
+
   public static final String MR_PREFIX = "yarn.app.mapreduce.";
 
   public static final String MR_AM_PREFIX = MR_PREFIX + "am.";

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
@@ -734,6 +734,31 @@
 </property>
 
 <property>
+  <name>mapreduce.job.fail.map.priority</name>
+  <value>5</value>
+  <description>The priority of failed map tasks.
+  </description>
+</property>
+<property>
+  <name>mapreduce.job.reduce.priority</name>
+  <value>10</value>
+  <description>The priority of reduce tasks.
+  </description>
+</property>
+<property>
+  <name>mapreduce.job.map.priority</name>
+  <value>20</value>
+  <description>The priority of map tasks.
+  </description>
+</property>
+<property>
+  <name>mapreduce.job.opportunistic.map.priority</name>
+  <value>19</value>
+  <description>The priority of opportunistic map tasks.
+  </description>
+</property>
+
+<property>
   <name>mapreduce.input.fileinputformat.split.minsize</name>
   <value>0</value>
   <description>The minimum size chunk that map input should be split


### PR DESCRIPTION
### Description of PR
When maps and reduces run simultaneously, if resources are insufficient, reduces will be preempted.

Because the priority of reduce is higher than map, the preempted reduces will first obtain resources when rerun, and then be preempted again, falling into a loop.

We need to configure the priority of map higher than reduce to avoid this situation.

### How was this patch tested?
unit test


