### PR TITLE
HDFS-17304. Update fsck -blockId to display slownode status of blocks.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NamenodeFsck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NamenodeFsck.java
@@ -121,6 +121,7 @@ public class NamenodeFsck implements DataEncryptionKeyFactory {
   // return string marking fsck status
   public static final String CORRUPT_STATUS = "is CORRUPT";
   public static final String HEALTHY_STATUS = "is HEALTHY";
+  public static final String SLOW_STATUS = "is SLOW";
   public static final String DECOMMISSIONING_STATUS = "is DECOMMISSIONING";
   public static final String DECOMMISSIONED_STATUS = "is DECOMMISSIONED";
   public static final String ENTERING_MAINTENANCE_STATUS =
@@ -377,7 +378,11 @@ public class NamenodeFsck implements DataEncryptionKeyFactory {
     } else if (blockManager.isExcess(dn, blockManager.getStoredBlock(block))) {
       out.print(EXCESS_STATUS);
     } else {
-      out.print(HEALTHY_STATUS);
+      if (blockManager.getDatanodeManager().getAllSlowDataNodes().contains(dn)) {
+        out.print(SLOW_STATUS);
+      } else {
+        out.print(HEALTHY_STATUS);
+      }
     }
     out.print("\n");
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSck.java
@@ -398,6 +398,8 @@ public class DFSck extends Configured implements Tool {
       errCode = 0;
     } else if (lastLine.endsWith(NamenodeFsck.EXCESS_STATUS)) {
       errCode = 0;
+    } else if (lastLine.endsWith(NamenodeFsck.SLOW_STATUS)) {
+      errCode = 0;
     } else if (lastLine.endsWith(NamenodeFsck.DECOMMISSIONED_STATUS)) {
       errCode = 2;
     } else if (lastLine.endsWith(NamenodeFsck.DECOMMISSIONING_STATUS)) {


### PR DESCRIPTION
### Description of PR
JIRA: https://issues.apache.org/jira/browse/HDFS-17304

Add a feature to fsck to display the status of SlowNodes.

### How was this patch tested?
Add Unit Test.

