### PR TITLE
HDFS-17306. RBF: Router should not return nameservices that does not enable observer nodes in RpcResponseHeaderProto

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterStateIdContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterStateIdContext.java
@@ -101,7 +101,7 @@ class RouterStateIdContext implements AlignmentContext {
     return Collections.list(namespaceIdMap.keys());
   }
 
-  public ConcurrentHashMap<String,LongAccumulator> getNamespaceIdMap() {
+  public ConcurrentHashMap<String, LongAccumulator> getNamespaceIdMap() {
     return namespaceIdMap;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterStateIdContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterStateIdContext.java
@@ -85,7 +85,11 @@ class RouterStateIdContext implements AlignmentContext {
       return;
     }
     RouterFederatedStateProto.Builder builder = RouterFederatedStateProto.newBuilder();
-    namespaceIdMap.forEach((k, v) -> builder.putNamespaceStateIds(k, v.get()));
+    namespaceIdMap.forEach((k, v) -> {
+      if (v.get() != Long.MIN_VALUE) {
+        builder.putNamespaceStateIds(k, v.get());
+      }
+    });
     headerBuilder.setRouterFederatedState(builder.build().toByteString());
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterStateIdContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterStateIdContext.java
@@ -101,6 +101,10 @@ class RouterStateIdContext implements AlignmentContext {
     return Collections.list(namespaceIdMap.keys());
   }
 
+  public ConcurrentHashMap<String,LongAccumulator> getNamespaceIdMap() {
+    return namespaceIdMap;
+  }
+
   public void removeNamespaceStateId(String nsId) {
     namespaceIdMap.remove(nsId);
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HDFS-17306. RBF: Router should not return nameservices that does not enable observer nodes in RpcResponseHeaderProto.

If a cluster has 3 nameservices: ns1, ns2,ns3, and  ns1 has observer nodes, and client  comminutes with nameservices via DFSRouter.

If DFS_ROUTER_OBSERVER_READ_DEFAULT_KEY enable,  the client will receive all nameservices in RpcResponseHeaderProto.  And ns2,ns3 statidid is Long.MIN_VALUE,that is not necessary.

We should reduce rpc response size if nameservices don't enable observer nodes.
