### PR TITLE
MAPREDUCE-7466. WordMedian example fails to compute the right median

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/TestWordStats.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/TestWordStats.java
@@ -148,17 +148,16 @@ public class TestWordStats {
         }
       }
 
-      int medianIndex1 = (int) Math.ceil((this.wordsRead / 2.0));
-      int medianIndex2 = (int) Math.floor((this.wordsRead / 2.0));
+      double medianIndex = this.wordsRead / 2.0;
 
       for (Integer key : this.map.navigableKeySet()) {
         int prevNum = num;
         num += this.map.get(key);
 
-        if (medianIndex2 >= prevNum && medianIndex1 <= num) {
+        if (medianIndex >= prevNum && medianIndex < num) {
           return key;
-        } else if (medianIndex2 >= prevNum && medianIndex1 < num) {
-          Integer nextCurrLen = this.map.navigableKeySet().iterator().next();
+        } else if (medianIndex >= prevNum && medianIndex == num) {
+          Integer nextCurrLen = this.map.higherKey(key);
           double median = (key + nextCurrLen) / 2.0;
           return median;
         }


### PR DESCRIPTION
The WordMedian example does not correctly handle the case where the median falls exactly between two different values (e.g., the median word legth of "Hello Hadoop" should be 5.5).

This affects both the example and its test (i.e., TestWordStats).

See [https://issues.apache.org/jira/browse/MAPREDUCE-7466](https://issues.apache.org/jira/browse/MAPREDUCE-7466)
