### PR TITLE
HDFS-17308. docker-compose.yaml sets namenode directory wrong causing datanode failures on restart

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       env_file:
         - ./config
       environment:
-          ENSURE_NAMENODE_DIR: "/tmp/hadoop-root/dfs/name"
+          ENSURE_NAMENODE_DIR: "/tmp/hadoop-hadoop/dfs/name"
    datanode:
       build: .
       command: ["hdfs", "datanode"]


### PR DESCRIPTION
It is possible to reproduce issue HDFS-17307 also using the docker-compose.yaml in branch `docker-hadoop-2`.

Beeing unsure how to proceed, considering this issue applies to a different branch, I created a duplicated issue. Please let me know if this was not the correct way to proceed.

See [https://issues.apache.org/jira/browse/HDFS-17308](https://issues.apache.org/jira/browse/HDFS-17308).