### PR TITLE
HDFS-17309. RBF: Fix Router Safemode check condition error

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterSafemodeService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterSafemodeService.java
@@ -169,7 +169,7 @@ public class RouterSafemodeService extends PeriodicService {
     }
     StateStoreService stateStore = router.getStateStore();
     long cacheUpdateTime = stateStore.getCacheUpdateTime();
-    boolean isCacheStale = (now - cacheUpdateTime) > this.staleInterval;
+    boolean isCacheStale = (cacheUpdateTime == 0) || (now - cacheUpdateTime) > this.staleInterval;
 
     // Always update to indicate our cache was updated
     if (isCacheStale) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/StateStoreService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/StateStoreService.java
@@ -116,7 +116,7 @@ public class StateStoreService extends CompositeService {
   /** Service to maintain State Store caches. */
   private StateStoreCacheUpdateService cacheUpdater;
   /** Time the cache was last successfully updated. */
-  private long cacheLastUpdateTime;
+  private long cacheLastUpdateTime = 0;
   /** List of internal caches to update. */
   private final List<StateStoreCache> cachesToUpdateInternal;
   /** List of external caches to update. */

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/StateStoreService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/StateStoreService.java
@@ -116,7 +116,7 @@ public class StateStoreService extends CompositeService {
   /** Service to maintain State Store caches. */
   private StateStoreCacheUpdateService cacheUpdater;
   /** Time the cache was last successfully updated. */
-  private long cacheLastUpdateTime = 0;
+  private long cacheLastUpdateTime;
   /** List of internal caches to update. */
   private final List<StateStoreCache> cachesToUpdateInternal;
   /** List of external caches to update. */
@@ -132,6 +132,8 @@ public class StateStoreService extends CompositeService {
     // Caches to maintain
     this.cachesToUpdateInternal = new ArrayList<>();
     this.cachesToUpdateExternal = new ArrayList<>();
+
+    this.cacheLastUpdateTime = 0;
   }
 
   /**


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HDFS-17309. RBF: Fix Router Safemode check condition error.

With [HDFS-17116](https://issues.apache.org/jira/browse/HDFS-17116), Router safemode check contidition use monotonicNow(). 

For code in  RouterSafemodeService.periodicInvoke()
```
long now = monotonicNow();
long cacheUpdateTime = stateStore.getCacheUpdateTime();
boolean isCacheStale = (now - cacheUpdateTime) > this.staleInterval;
```


 
Function monotonicNow() is implemented with System.nanoTime(). 

System.nanoTime() in javadoc description:
```
This method can only be used to measure elapsed time and is not related to any other notion of system or wall-clock time. The value returned represents nanoseconds since some fixed but arbitrary origin time (perhaps in the future, so values may be negative). 
```

 
The following situation maybe exists ：

If refreshCaches  is not success in the beginning, cacheUpdateTime will be 0 , and now - cacheUpdateTime is arbitrary origin time，so isCacheStale maybe  be true or false.

