### PR TITLE
HDFS-17311. RBF: ConnectionManager creatorQueue should offer a pool that is not already in creatorQueue.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/ConnectionManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/ConnectionManager.java
@@ -173,6 +173,11 @@ public class ConnectionManager {
     }
   }
 
+  @VisibleForTesting
+  public void closeConnectionCreator(){
+    this.creator.shutdown();
+  }
+
   /**
    * Fetches the next available proxy client in the pool. Each client connection
    * is reserved for a single user and cannot be reused until free.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/ConnectionManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/ConnectionManager.java
@@ -229,7 +229,7 @@ public class ConnectionManager {
 
     // Add a new connection to the pool if it wasn't usable
     if (conn == null || !conn.isUsable()) {
-      if (!this.creatorQueue.offer(pool)) {
+      if (!this.creatorQueue.contains(pool) && !this.creatorQueue.offer(pool)) {
         LOG.error("Cannot add more than {} connections at the same time",
             this.creatorQueueMaxSize);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestConnectionManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestConnectionManager.java
@@ -366,7 +366,8 @@ public class TestConnectionManager {
   @Test
   public void testConnectionCreatorWithSamePool() throws IOException {
     Configuration tmpConf = new Configuration();
-    // Set DFS_ROUTER_MAX_CONCURRENCY_PER_CONNECTION_KEY to 0 for make pool will be offered in the creatorQueue
+    // Set DFS_ROUTER_MAX_CONCURRENCY_PER_CONNECTION_KEY to 0
+    // for ensuring a pool will be offered in the creatorQueue
     tmpConf.setInt(
         RBFConfigKeys.DFS_ROUTER_MAX_CONCURRENCY_PER_CONNECTION_KEY, 0);
     ConnectionManager tmpConnManager = new ConnectionManager(tmpConf);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestConnectionManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestConnectionManager.java
@@ -363,6 +363,28 @@ public class TestConnectionManager {
     testConnectionCleanup(0.8f, 10, 6, 8);
   }
 
+  @Test
+  public void testConnectionCreatorWithSamePool() throws IOException {
+    Configuration tmpConf = new Configuration();
+    // Set DFS_ROUTER_MAX_CONCURRENCY_PER_CONNECTION_KEY to 0 for make pool will be offered in the creatorQueue
+    tmpConf.setInt(
+        RBFConfigKeys.DFS_ROUTER_MAX_CONCURRENCY_PER_CONNECTION_KEY, 0);
+    ConnectionManager tmpConnManager = new ConnectionManager(tmpConf);
+    tmpConnManager.start();
+    // Close ConnectionCreator thread to make sure that new connection will not initialize.
+    tmpConnManager.closeConnectionCreator();
+    // Create same connection pool for simulating concurrency scenario
+    for (int i = 0; i < 3; i++) {
+      tmpConnManager.getConnection(TEST_USER1, TEST_NN_ADDRESS,
+          NamenodeProtocol.class, "ns0");
+    }
+    assertEquals(1, tmpConnManager.getNumCreatingConnections());
+
+    tmpConnManager.getConnection(TEST_USER2, TEST_NN_ADDRESS,
+        NamenodeProtocol.class, "ns0");
+    assertEquals(2, tmpConnManager.getNumCreatingConnections());
+  }
+
   private void testConnectionCleanup(float ratio, int totalConns,
       int activeConns, int leftConns) throws IOException {
     Configuration tmpConf = new Configuration();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HDFS-17311. RBF: ConnectionManager creatorQueue should offer a pool that is not already in creatorQueue. 


In the Router, find blow log
```
2023-12-29 15:18:54,799 ERROR org.apache.hadoop.hdfs.server.federation.router.ConnectionManager: Cannot add more than 2048 connections at the same time
```

The log indicates that ConnectionManager.creatorQueue is full at a certain point. But  my cluster does not have so many users  cloud reach up  2048 pair of <user,nn>.

This may be due to the following reasons: 
1. ConnectionManager.creatorQueue  is a queue that will  be offered ConnectionPool if ConnectionContext is not enough. 
2. ConnectionCreator thread will consume  from creatorQueue and make more ConnectionContexts for a ConnectionPool.
3.  Client will concurrent invoke for ConnectionManager.getConnection() for a same user. And this maybe lead to add many same ConnectionPool into ConnectionManager.creatorQueue.  
4. When creatorQueue is full,  a new ConnectionPool will not be added in successfully and log this error.  This maybe lead to a really new ConnectionPool clould not produce more ConnectionContexts for new user.

So this pr try to make creatorQueue will not add same ConnectionPool at once.



