### PR TITLE
HDFS-17305. Add avoid datanode reason count related metrics to namenode.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
@@ -256,6 +256,13 @@ Each metrics record contains tags such as ProcessName, SessionId, and Hostname a
 | `EditLogTailIntervalAvgTime` | Average time of intervals between edit log tailings by standby NameNode in milliseconds |
 | `EditLogTailInterval`*num*`s(50/75/90/95/99)thPercentileLatency` | The 50/75/90/95/99th percentile of time between edit log tailings by standby NameNode in milliseconds (*num* seconds granularity). Percentile measurement is off by default, by watching no intervals. The intervals are specified by `dfs.metrics.percentiles.intervals`. |
 | `PendingEditsCount` | Current number of pending edits |
+| `AvoidNotInServiceNodeCount` | Total number of avoid not in service node |
+| `AvoidStaleNodeCount` | Total number of avoid stale node |
+| `AvoidXceiverOverLoadNodeCount` | Total number of avoid xceiver over load node |
+| `AvoidVolumeOverLoadNodeCount` | Total number of avoid volume over load node |
+| `AvoidPerRackOverStorageLimitNodeCount` | Total number of avoid per rack over storage limit node |
+| `AvoidSlowNodeCount` | Total number of avoid slow node |
+| `TotalAvoidDataNodeCount`| Total number of avoid datanode |
 
 FSNamesystem
 ------------

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/NameNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/NameNodeMetrics.java
@@ -94,6 +94,19 @@ public class NameNodeMetrics {
   @Metric("Number of pending deletion blocks")
   MutableGaugeInt pendingDeleteBlocksCount;
 
+  @Metric("Number of avoid not in service node")
+  private MutableCounterLong avoidNotInServiceNodeCount;
+  @Metric("Number of avoid stale node")
+  private MutableCounterLong avoidStaleNodeCount;
+  @Metric("Number of avoid xceiver over load node")
+  private MutableCounterLong avoidXceiverOverLoadNodeCount;
+  @Metric("Number of avoid volume over load node")
+  private MutableCounterLong avoidVolumeOverLoadNodeCount;
+  @Metric("Number of avoid per rack over storage limit node")
+  private MutableCounterLong avoidPerRackOverStorageLimitNodeCount;
+  @Metric("Number of avoid slow node")
+  private MutableCounterLong avoidSlowNodeCount;
+
   @Metric("Number of file system operations")
   public long totalFileOps(){
     return
@@ -119,6 +132,12 @@ public class NameNodeMetrics {
       snapshotDiffReportOps.value();
   }
 
+  @Metric("Total number of avoid datanode")
+  public long totalAvoidDataNodeOps() {
+    return avoidNotInServiceNodeCount.value() + avoidStaleNodeCount.value()
+        + avoidXceiverOverLoadNodeCount.value() + avoidVolumeOverLoadNodeCount.value()
+        + avoidPerRackOverStorageLimitNodeCount.value() + avoidSlowNodeCount.value();
+  }
 
   @Metric("Journal transactions") MutableRate transactions;
   @Metric("Journal syncs") MutableRate syncs;
@@ -480,5 +499,29 @@ public class NameNodeMetrics {
     for (MutableQuantiles q : editLogTailIntervalQuantiles) {
       q.add(elapsed);
     }
+  }
+
+  public void incrAvoidNotInServiceNodeCount() {
+    avoidNotInServiceNodeCount.incr();
+  }
+
+  public void incrAvoidStaleNodeCount() {
+    avoidStaleNodeCount.incr();
+  }
+
+  public void incrAvoidXceiverOverLoadNodeCount() {
+    avoidXceiverOverLoadNodeCount.incr();
+  }
+
+  public void incrAvoidVolumeOverLoadNodeCount() {
+    avoidVolumeOverLoadNodeCount.incr();
+  }
+
+  public void incrAvoidPerRackOverStorageLimitNodeCount() {
+    avoidPerRackOverStorageLimitNodeCount.incr();
+  }
+
+  public void incrAvoidSlowNodeCount() {
+    avoidSlowNodeCount.incr();
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: https://issues.apache.org/jira/browse/HDFS-17305

Now, there are slownode and load avoidance functions, mainly implemented in the  BlockPlacementPolicyDefault class.

1. After triggering the exclusion condition, some logs will be printed on nn, which can be used to troubleshoot anomalies in nn by checking the logs, the code is as follows:
```java
...
if (!node.isInService()) {
  logNodeIsNotChosen(node, NodeNotChosenReason.NOT_IN_SERVICE);
  return false;
}

if (avoidStaleNodes) {
  if (node.isStale(this.staleInterval)) {
    logNodeIsNotChosen(node, NodeNotChosenReason.NODE_STALE);
    return false;
  }
}
...
```
2. If the exclusion condition is triggered, we can record it through metrics and count the total number of exclusions.

### How was this patch tested?
 Add TestNameNodeMetrics#testAvoidTargetDataNodeMetrics UnitTest.