### PR TITLE
HDFS-17312. packetsReceived metric should ignore heartbeat packet.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
@@ -38,6 +38,7 @@ import java.util.zip.Checksum;
 import org.apache.hadoop.fs.ChecksumException;
 import org.apache.hadoop.fs.FSOutputSummer;
 import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdfs.DFSPacket;
 import org.apache.hadoop.hdfs.DFSUtilClient;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
@@ -598,7 +599,9 @@ class BlockReceiver implements Closeable {
       return 0;
     }
 
-    datanode.metrics.incrPacketsReceived();
+    if (seqno != DFSPacket.HEART_BEAT_SEQNO) {
+      datanode.metrics.incrPacketsReceived();
+    }
     //First write the packet to the mirror:
     if (mirrorOut != null && !mirrorError) {
       try {


### PR DESCRIPTION
### Description of PR
Metric packetsReceived should ignore heartbeat packet and only used to count data packets and last packet in block.

![image](https://github.com/apache/hadoop/assets/25115709/4b87784d-1c28-49f7-b848-2931d4ed8650)

As the above documatation shows, Its original goal is counting total packets received by DataNode excluding heartbeat packet from client. We should fix it.