### PR TITLE
HDFS-17313. dfsadmin -reconfig option to start/query reconfig on all live namenodes.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSCommands.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSCommands.md
@@ -419,7 +419,7 @@ Usage:
 | `-refreshSuperUserGroupsConfiguration` | Refresh superuser proxy groups mappings |
 | `-refreshCallQueue` | Reload the call queue from config. |
 | `-refresh` \<host:ipc\_port\> \<key\> [arg1..argn] | Triggers a runtime-refresh of the resource specified by \<key\> on \<host:ipc\_port\>. All other args after are sent to the host. |
-| `-reconfig` \<datanode \|namenode\> \<host:ipc\_port\|livenodes> \<start\|status\|properties\> | Starts reconfiguration or gets the status of an ongoing reconfiguration, or gets a list of reconfigurable properties. The second parameter specifies the node type. The third parameter specifies host address. For start or status, datanode supports livenodes as third parameter, which will start or retrieve reconfiguration on all live datanodes. |
+| `-reconfig` \<datanode \|namenode\> \<host:ipc\_port\|livenodes> \<start\|status\|properties\> | Starts reconfiguration or gets the status of an ongoing reconfiguration, or gets a list of reconfigurable properties. The second parameter specifies the node type. The third parameter specifies host address. For start or status, namenode or datanode supports livenodes as third parameter, which will start or retrieve reconfiguration on all live namenodes(active and standby) or datanodes. |
 | `-printTopology` | Print a tree of the racks and their nodes as reported by the Namenode |
 | `-refreshNamenodes` datanodehost:port | For the given datanode, reloads the configuration files, stops serving the removed block-pools and starts serving new block-pools. |
 | `-getVolumeReport` datanodehost:port | For the given datanode, get the volume report. |

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HdfsUserGuide.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HdfsUserGuide.md
@@ -352,12 +352,12 @@ Datanode supports hot swappable drives. The user can add or replace HDFS data vo
   the reconfiguration process. The user can use
   `dfsadmin -reconfig datanode HOST:PORT status`
   to query the running status of the reconfiguration task. In place of
-  HOST:PORT, we can also specify livenodes for datanode. It would allow
-  start or query reconfiguration on all live datanodes, whereas specifying
+  HOST:PORT, we can also specify livenodes for namenode or datanode. It would allow
+  start or query reconfiguration on all live namenodes(active and standby) or datanodes, whereas specifying
   HOST:PORT would only allow start or query of reconfiguration on the
-  particular datanode represented by HOST:PORT. The examples for livenodes
-  queries are `dfsadmin -reconfig datanode livenodes start` and
-  `dfsadmin -reconfig datanode livenodes status`.
+  particular namenode or datanode represented by HOST:PORT. The examples for livenodes
+  queries are `dfsadmin -reconfig <namenode|datanode> livenodes start` and
+  `dfsadmin -reconfig <namenode|datanode> livenodes status`.
 
 * Once the reconfiguration task has completed, the user can safely `umount`
   the removed data volume directories and physically remove the disks.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -1287,11 +1287,10 @@ public class TestDFSAdmin {
 
   @Test
   public void testAllNamenodesReconfig() throws Exception {
-    final int NUM_NS = 2;
     final HdfsConfiguration clusterConf = new HdfsConfiguration();
     clusterConf.setLong(DFS_HEARTBEAT_INTERVAL_KEY, 5);
     try (MiniDFSCluster miniCluster = new MiniDFSCluster.Builder(clusterConf).nnTopology(
-        MiniDFSNNTopology.simpleHAFederatedTopology(NUM_NS)).build()) {
+        MiniDFSNNTopology.simpleHAFederatedTopology(2)).build()) {
       miniCluster.waitActive();
 
       final HdfsConfiguration clientConf = new HdfsConfiguration();
@@ -1301,7 +1300,7 @@ public class TestDFSAdmin {
 
       ReconfigurationUtil reconfigurationUtil = mock(ReconfigurationUtil.class);
       // Active and Standby have a total of 4
-      for (int i = 0; i < 2 * NUM_NS; i++) {
+      for (int i = 0; i < 4; i++) {
         NameNode nn = miniCluster.getNameNode(i);
         nn.setReconfigurationUtil(reconfigurationUtil);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -64,6 +64,7 @@ import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
@@ -1282,5 +1283,72 @@ public class TestDFSAdmin {
 
     Assertions.assertThat(outs.subList(1, 5)).containsSubsequence(success, from, to);
     Assertions.assertThat(outs.subList(5, 9)).containsSubsequence(success, from, to, retrieval);
+  }
+
+  @Test
+  public void testAllNamenodesReconfig() throws Exception {
+    final int NUM_NS = 2;
+    final HdfsConfiguration clusterConf = new HdfsConfiguration();
+    clusterConf.setLong(DFS_HEARTBEAT_INTERVAL_KEY, 5);
+    try (MiniDFSCluster miniCluster = new MiniDFSCluster.Builder(clusterConf).nnTopology(
+        MiniDFSNNTopology.simpleHAFederatedTopology(NUM_NS)).build()) {
+      miniCluster.waitActive();
+
+      final HdfsConfiguration clientConf = new HdfsConfiguration();
+      // Parse FederatedHAConf
+      DFSTestUtil.setFederatedHAConfiguration(miniCluster, clientConf);
+      admin = new DFSAdmin(clientConf);
+
+      ReconfigurationUtil reconfigurationUtil = mock(ReconfigurationUtil.class);
+      // Active and Standby have a total of 4
+      for (int i = 0; i < 2 * NUM_NS; i++) {
+        NameNode nn = miniCluster.getNameNode(i);
+        nn.setReconfigurationUtil(reconfigurationUtil);
+      }
+
+      List<ReconfigurationUtil.PropertyChange> changes = new ArrayList<>();
+      changes.add(new ReconfigurationUtil.PropertyChange(DFS_HEARTBEAT_INTERVAL_KEY, "3",
+          miniCluster.getNameNode(0).getConf().get(DFS_HEARTBEAT_INTERVAL_KEY)));
+      when(reconfigurationUtil.parseChangedProperties(any(Configuration.class),
+          any(Configuration.class))).thenReturn(changes);
+
+      int result = admin.startReconfiguration("namenode", "livenodes");
+      Assertions.assertThat(result).isEqualTo(0);
+
+      List<String> outsForStartReconfig = new ArrayList<>();
+      List<String> errsForStartReconfig = new ArrayList<>();
+      reconfigurationOutErrFormatter("startReconfiguration", "namenode", "livenodes",
+          outsForStartReconfig, errsForStartReconfig);
+
+      String started = "Started reconfiguration task on node";
+      String starting =
+          "Starting of reconfiguration task successful on 4 nodes, failed on 0 nodes.";
+      Assertions.assertThat(outsForStartReconfig).hasSize(5);
+      Assertions.assertThat(errsForStartReconfig).hasSize(0);
+      Assertions.assertThat(outsForStartReconfig.get(0)).startsWith(started);
+      Assertions.assertThat(outsForStartReconfig.get(1)).startsWith(started);
+      Assertions.assertThat(outsForStartReconfig.get(2)).startsWith(started);
+      Assertions.assertThat(outsForStartReconfig.get(3)).startsWith(started);
+      Assertions.assertThat(outsForStartReconfig.get(4)).startsWith(starting);
+
+      List<String> outs = new ArrayList<>();
+      List<String> errs = new ArrayList<>();
+      awaitReconfigurationFinished("namenode", "livenodes", outs, errs);
+      Assertions.assertThat(outs).hasSize(17);
+      Assertions.assertThat(errs).hasSize(0);
+      LOG.info("dfsadmin -reconfig namenode livenodes status output:");
+      outs.forEach(s -> LOG.info("{}", s));
+
+      Assertions.assertThat(outs.get(0)).startsWith("Reconfiguring status for node");
+
+      String success = "SUCCESS: Changed property dfs.heartbeat.interval";
+      String from = "\tFrom: \"5\"";
+      String to = "\tTo: \"3\"";
+      String retrieval =
+          "Retrieval of reconfiguration status successful on 4 nodes, failed on 0 nodes.";
+
+      Assertions.assertThat(outs.subList(1, 5)).containsSubsequence(success, from, to);
+      Assertions.assertThat(outs.subList(5, 17)).containsSubsequence(success, from, to, retrieval);
+    }
   }
 }


### PR DESCRIPTION
### Description of PR
JIRA: https://issues.apache.org/jira/browse/HDFS-17313

https://issues.apache.org/jira/browse/HDFS-16568 Support batch refreshing of datanode configurations.
There are several nn in the HA or Federated Cluster, and this ticket implements batch refreshing of nn configurations.

**Implementation method**
1. Use the DFSUtil.getNNServiceRpcAddressesForCluster method to parse the configuration and obtain the addresses of all nn's
2. Using two worker threads, currently does not support configuring the number of worker threads (will be implemented in other ticket if necessary)

### How was this patch tested?
Add Unit Test.

**Sample outputs**
```shell
$ bin/hdfs dfsadmin -reconfig namenode livenodes start
Started reconfiguration task on node [localhost:50034].
Started reconfiguration task on node [localhost:50036].
Started reconfiguration task on node [localhost:50038].
Started reconfiguration task on node [localhost:50040].
Starting of reconfiguration task successful on 4 nodes, failed on 0 nodes.

$ bin/hdfs dfsadmin -reconfig namenode livenodes status
Reconfiguring status for node [localhost:50034]
SUCCESS: Changed property dfs.heartbeat.interval
	From: "5"
	To: "3"
Reconfiguring status for node [localhost:50036]
SUCCESS: Changed property dfs.heartbeat.interval
	From: "5"
	To: "3"
Reconfiguring status for node [localhost:50038]
SUCCESS: Changed property dfs.heartbeat.interval
	From: "5"
	To: "3"
Reconfiguring status for node [localhost:50040]
SUCCESS: Changed property dfs.heartbeat.interval
	From: "5"
	To: "3"
Retrieval of reconfiguration status successful on 4 nodes, failed on 0 nodes.
```