### PR TITLE
HDFS-17314. Add a metrics to record congestion backoff counts.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -1102,7 +1102,8 @@ public class DataNode extends ReconfigurableBase
     double load = ManagementFactory.getOperatingSystemMXBean()
         .getSystemLoadAverage();
     double threshold = NUM_CORES * congestionRatio;
-    if (load > threshold) {
+
+    if (load > threshold || DataNodeFaultInjector.get().mockCongestedForTest()) {
       metrics.incrCongestedCount();
     }
     return load > threshold ? PipelineAck.ECN.CONGESTED :

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -1101,7 +1101,11 @@ public class DataNode extends ReconfigurableBase
     }
     double load = ManagementFactory.getOperatingSystemMXBean()
         .getSystemLoadAverage();
-    return load > NUM_CORES * congestionRatio ? PipelineAck.ECN.CONGESTED :
+    double threshold = NUM_CORES * congestionRatio;
+    if (load > threshold) {
+      metrics.incrCongestedCount();
+    }
+    return load > threshold ? PipelineAck.ECN.CONGESTED :
         PipelineAck.ECN.SUPPORTED;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeFaultInjector.java
@@ -162,4 +162,8 @@ public class DataNodeFaultInjector {
    * Just delay delete replica a while.
    */
   public void delayDeleteReplica() {}
+
+  public boolean mockCongestedForTest() {
+    return false;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
@@ -210,6 +210,8 @@ public class DataNodeMetrics {
   private MutableCounterLong replaceBlockOpOnSameMount;
   @Metric("Number of replaceBlock ops to another node")
   private MutableCounterLong replaceBlockOpToOtherHost;
+  @Metric("Number of congested count")
+  private MutableCounterLong congestedCount;
 
   final MetricsRegistry registry = new MetricsRegistry("datanode");
   @Metric("Milliseconds spent on calling NN rpc")
@@ -807,4 +809,7 @@ public class DataNodeMetrics {
     replaceBlockOpToOtherHost.incr();
   }
 
+  public void incrCongestedCount() {
+    congestedCount.incr();
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
@@ -835,7 +835,8 @@ public class TestDataNodeMetrics {
         }
       });
       PipelineAck.ECN ecn = cluster.getDataNodes().get(0).getECN();
-      MetricsRecordBuilder dnMetrics = getMetrics(cluster.getDataNodes().get(0).getMetrics().name());
+      MetricsRecordBuilder dnMetrics = getMetrics(cluster.getDataNodes().get(0)
+          .getMetrics().name());
       Assert.assertEquals(1L, getLongCounter("CongestedCount", dnMetrics));
     } finally {
       if (cluster != null) {


### PR DESCRIPTION
### Description of PR
When we enable congestion backoff, we should better know how many times datanodes have told client backoff.  This metrics can help us know better about congestion function.

### How was this patch tested?
Add an UT

