### PR TITLE
HDFS-17317. Improve the resource release for metaOut in DebugAdmin

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DebugAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DebugAdmin.java
@@ -295,24 +295,29 @@ public class DebugAdmin extends Configured implements Tool {
       }
 
       DataOutputStream metaOut = null;
-      final Configuration conf = new Configuration();
-      final Options.ChecksumOpt checksumOpt =
-          DfsClientConf.getChecksumOptFromConf(conf);
-      final DataChecksum checksum = createChecksum(checksumOpt);
+      try {
+        final Configuration conf = new Configuration();
+        final Options.ChecksumOpt checksumOpt =
+                DfsClientConf.getChecksumOptFromConf(conf);
+        final DataChecksum checksum = createChecksum(checksumOpt);
 
-      final int smallBufferSize = DFSUtilClient.getSmallBufferSize(conf);
-      metaOut = new DataOutputStream(
-          new BufferedOutputStream(Files.newOutputStream(srcMeta.toPath()),
-              smallBufferSize));
-      BlockMetadataHeader.writeHeader(metaOut, checksum);
-      metaOut.close();
-      metaOut = null;
-      FsDatasetUtil.computeChecksum(
-          srcMeta, srcMeta, blockFile, smallBufferSize, conf);
-      System.out.println(
-          "Checksum calculation succeeded on block file " + name
-              + " saved metadata to meta file " + outFile);
-      return 0;
+        final int smallBufferSize = DFSUtilClient.getSmallBufferSize(conf);
+        metaOut = new DataOutputStream(
+                new BufferedOutputStream(Files.newOutputStream(srcMeta.toPath()),
+                        smallBufferSize));
+        BlockMetadataHeader.writeHeader(metaOut, checksum);
+        metaOut.close();
+        metaOut = null;
+        FsDatasetUtil.computeChecksum(
+                srcMeta, srcMeta, blockFile, smallBufferSize, conf);
+        System.out.println(
+                "Checksum calculation succeeded on block file " + name
+                        + " saved metadata to meta file " + outFile);
+        return 0;
+      } finally {
+        IOUtils.cleanupWithLogger(null, metaOut);
+      }
+
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DebugAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DebugAdmin.java
@@ -317,7 +317,6 @@ public class DebugAdmin extends Configured implements Tool {
       } finally {
         IOUtils.cleanupWithLogger(null, metaOut);
       }
-
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DebugAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DebugAdmin.java
@@ -306,6 +306,7 @@ public class DebugAdmin extends Configured implements Tool {
             new BufferedOutputStream(Files.newOutputStream(srcMeta.toPath()),
                 smallBufferSize));
         BlockMetadataHeader.writeHeader(metaOut, checksum);
+        metaOut.flush();
         FsDatasetUtil.computeChecksum(
             srcMeta, srcMeta, blockFile, smallBufferSize, conf);
         System.out.println(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DebugAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DebugAdmin.java
@@ -295,27 +295,24 @@ public class DebugAdmin extends Configured implements Tool {
       }
 
       DataOutputStream metaOut = null;
-      try {
-        final Configuration conf = new Configuration();
-        final Options.ChecksumOpt checksumOpt =
-            DfsClientConf.getChecksumOptFromConf(conf);
-        final DataChecksum checksum = createChecksum(checksumOpt);
+      final Configuration conf = new Configuration();
+      final Options.ChecksumOpt checksumOpt =
+          DfsClientConf.getChecksumOptFromConf(conf);
+      final DataChecksum checksum = createChecksum(checksumOpt);
 
-        final int smallBufferSize = DFSUtilClient.getSmallBufferSize(conf);
-        metaOut = new DataOutputStream(
-            new BufferedOutputStream(Files.newOutputStream(srcMeta.toPath()),
-                smallBufferSize));
-        BlockMetadataHeader.writeHeader(metaOut, checksum);
-        metaOut.flush();
-        FsDatasetUtil.computeChecksum(
-            srcMeta, srcMeta, blockFile, smallBufferSize, conf);
-        System.out.println(
-            "Checksum calculation succeeded on block file " + name
-                + " saved metadata to meta file " + outFile);
-        return 0;
-      } finally {
-        IOUtils.cleanupWithLogger(null, metaOut);
-      }
+      final int smallBufferSize = DFSUtilClient.getSmallBufferSize(conf);
+      metaOut = new DataOutputStream(
+          new BufferedOutputStream(Files.newOutputStream(srcMeta.toPath()),
+              smallBufferSize));
+      BlockMetadataHeader.writeHeader(metaOut, checksum);
+      metaOut.close();
+      metaOut = null;
+      FsDatasetUtil.computeChecksum(
+          srcMeta, srcMeta, blockFile, smallBufferSize, conf);
+      System.out.println(
+          "Checksum calculation succeeded on block file " + name
+              + " saved metadata to meta file " + outFile);
+      return 0;
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DebugAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DebugAdmin.java
@@ -306,7 +306,6 @@ public class DebugAdmin extends Configured implements Tool {
             new BufferedOutputStream(Files.newOutputStream(srcMeta.toPath()),
                 smallBufferSize));
         BlockMetadataHeader.writeHeader(metaOut, checksum);
-        metaOut.close();
         FsDatasetUtil.computeChecksum(
             srcMeta, srcMeta, blockFile, smallBufferSize, conf);
         System.out.println(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DebugAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DebugAdmin.java
@@ -298,21 +298,21 @@ public class DebugAdmin extends Configured implements Tool {
       try {
         final Configuration conf = new Configuration();
         final Options.ChecksumOpt checksumOpt =
-                DfsClientConf.getChecksumOptFromConf(conf);
+            DfsClientConf.getChecksumOptFromConf(conf);
         final DataChecksum checksum = createChecksum(checksumOpt);
 
         final int smallBufferSize = DFSUtilClient.getSmallBufferSize(conf);
         metaOut = new DataOutputStream(
-                new BufferedOutputStream(Files.newOutputStream(srcMeta.toPath()),
-                        smallBufferSize));
+            new BufferedOutputStream(Files.newOutputStream(srcMeta.toPath()),
+                smallBufferSize));
         BlockMetadataHeader.writeHeader(metaOut, checksum);
         metaOut.close();
         metaOut = null;
         FsDatasetUtil.computeChecksum(
-                srcMeta, srcMeta, blockFile, smallBufferSize, conf);
+            srcMeta, srcMeta, blockFile, smallBufferSize, conf);
         System.out.println(
-                "Checksum calculation succeeded on block file " + name
-                        + " saved metadata to meta file " + outFile);
+            "Checksum calculation succeeded on block file " + name
+                + " saved metadata to meta file " + outFile);
         return 0;
       } finally {
         IOUtils.cleanupWithLogger(null, metaOut);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
DebugAdmin metaOut not need multiple close


### How was this patch tested?
not need


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

