### PR TITLE
HDFS-17320. seekToNewSource uses ignoredNodes to get a new node other than the current node.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -1661,7 +1661,9 @@ public class DFSInputStream extends FSInputStream
     if (currentNode == null) {
       return seekToBlockSource(targetPos);
     }
-    DatanodeInfo newNode = blockSeekTo(targetPos, Collections.singletonList(currentNode));
+    List<DatanodeInfo> ignoredNodes = new ArrayList<>(1);
+    ignoredNodes.add(currentNode);
+    DatanodeInfo newNode = blockSeekTo(targetPos, ignoredNodes);
     if (!currentNode.getDatanodeUuid().equals(newNode.getDatanodeUuid())) {
       currentNode = newNode;
       return true;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -27,6 +27,7 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -601,6 +602,19 @@ public class DFSInputStream extends FSInputStream
    */
   private synchronized DatanodeInfo blockSeekTo(long target)
       throws IOException {
+    return blockSeekTo(target, null);
+  }
+
+  /**
+   * Open a DataInputStream to a DataNode so that it can be read from.
+   * We get block ID and the IDs of the destinations at startup, from the namenode.
+   *
+   * @param target block corresponding to this target offset in file is returned.
+   * @param ignoredNodes Ignored nodes inside.
+   * @return best DataNode for desired Block, with potential offset.
+   */
+  private synchronized DatanodeInfo blockSeekTo(
+      long target, Collection<DatanodeInfo> ignoredNodes) throws IOException {
     if (target >= getFileLength()) {
       throw new IOException("Attempted to read past end of file");
     }
@@ -634,7 +648,7 @@ public class DFSInputStream extends FSInputStream
 
       long offsetIntoBlock = target - targetBlock.getStartOffset();
 
-      DNAddrPair retval = chooseDataNode(targetBlock, null);
+      DNAddrPair retval = chooseDataNode(targetBlock, ignoredNodes);
       chosenNode = retval.info;
       InetSocketAddress targetAddr = retval.addr;
       StorageType storageType = retval.storageType;
@@ -1647,16 +1661,8 @@ public class DFSInputStream extends FSInputStream
     if (currentNode == null) {
       return seekToBlockSource(targetPos);
     }
-    boolean markedDead = dfsClient.isDeadNode(this, currentNode);
-    addToLocalDeadNodes(currentNode);
-    DatanodeInfo oldNode = currentNode;
-    DatanodeInfo newNode = blockSeekTo(targetPos);
-    if (!markedDead) {
-      /* remove it from deadNodes. blockSeekTo could have cleared
-       * deadNodes and added currentNode again. Thats ok. */
-      removeFromLocalDeadNodes(oldNode);
-    }
-    if (!oldNode.getDatanodeUuid().equals(newNode.getDatanodeUuid())) {
+    DatanodeInfo newNode = blockSeekTo(targetPos, Collections.singletonList(currentNode));
+    if (!currentNode.getDatanodeUuid().equals(newNode.getDatanodeUuid())) {
       currentNode = newNode;
       return true;
     } else {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSInputStream.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -137,23 +136,7 @@ public class TestDFSInputStream {
     Path path = new Path("/testfile");
     DFSTestUtil.createFile(fs, path, 1024, (short) 3, 0);
     DFSInputStream fin = fs.dfs.open("/testfile");
-    ConcurrentHashMap<DatanodeInfo, DatanodeInfo> localDeadNodes
-        = fin.getLocalDeadNodes();
     try {
-      // Loop to check if there are dead nodes.
-      Thread deadNodesDetector = new Thread(() -> {
-        while (!Thread.interrupted()) {
-          try {
-            Thread.sleep(10);
-          } catch (InterruptedException e) {
-            break;
-          }
-          // There are no dead nodes in the execution of
-          // the SeekToNewSource method.
-          assertTrue(localDeadNodes.isEmpty());
-        }
-      });
-      deadNodesDetector.start();
       fin.seekToNewSource(100);
       assertEquals(100, fin.getPos());
       DatanodeInfo firstNode = fin.getCurrentDatanode();
@@ -161,7 +144,6 @@ public class TestDFSInputStream {
       fin.seekToNewSource(100);
       assertEquals(100, fin.getPos());
       assertFalse(firstNode.equals(fin.getCurrentDatanode()));
-      deadNodesDetector.interrupt();
     } finally {
       fin.close();
       cluster.shutdown();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Currently, when using the DFSInputStream#seekToNewSource() method to obtain a new datanode, the current datanode will be marked as deadnode first, thus preventing the new datanode from being equal to the current datanode.

If the current datanode is indeed a dead node, after obtaining the new datanode, there is no need to mark the current datanode as a non-dead node; but if the current node is not a dead node, after obtaining the new datanode, the current node needs to be marked as Non-dead nodes (removed from the deadnodes collection), the current implementation method has no problem with its function, but it is very inelegant.

Currently, when selecting a new datanode (DFSInputStream#getBestNodeDNAddrPair), you can filter out unnecessary datanodes through the parameter ignoredNodes. Therefore, we only need to pass the current datanode into ignoredNodes to elegantly implement the function of the seekToNewSource method.

### How was this patch tested?

see ut TestDFSInputStream#testSeekToNewSource()

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

