### PR TITLE
HDFS-17325. Doc: Fix the documentation of fs expunge command in FileSystemShell.md

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/FileSystemShell.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/FileSystemShell.md
@@ -289,7 +289,7 @@ rather than the default filesystem and checkpoint is created.
 For example
 
 ```
-hadoop fs -expunge --immediate -fs s3a://landsat-pds/
+hadoop fs -expunge -immediate -fs s3a://landsat-pds/
 ```
 
 Refer to the


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HDFS-17325 Doc: Fix the documentation of fs expunge command in FileSystemShell.md

Fix doc in FileSystemShell.md.

hadoop fs -expunge --immediate   should be hadoop fs -expunge -immediate

```
Usage: hadoop fs [generic options] -expunge [-immediate] [-fs <path>]
```