### PR TITLE
HDFS-17300. [SBN READ] A rpc call in Observer should throw ObserverRetryOnActiveException if its stateid is always lower than client stateid for a configured time.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -25,6 +25,8 @@ import org.apache.hadoop.crypto.JceSm4CtrCryptoCodec;
 import org.apache.hadoop.crypto.OpensslAesCtrCryptoCodec;
 import org.apache.hadoop.crypto.OpensslSm4CtrCryptoCodec;
 
+import java.util.concurrent.TimeUnit;
+
 /** 
  * This class contains constants for configuration keys used
  * in the common code.
@@ -1076,6 +1078,13 @@ public class CommonConfigurationKeysPublic {
   public static final String IPC_SERVER_METRICS_UPDATE_RUNNER_INTERVAL =
       "ipc.server.metrics.update.runner.interval";
   public static final int IPC_SERVER_METRICS_UPDATE_RUNNER_INTERVAL_DEFAULT = 5000;
+
+  public static final String IPC_SERVER_OBSERVER_STALE_RPC_ENABLE =
+      "ipc.server.observer.stale.rpc.enable";
+  public static final boolean IPC_SERVER_OBSERVER_STALE_RPC_ENABLE_DEFAULT = false;
+  public static final String IPC_SERVER_OBSERVER_STALE_RPC_INTERVAL =
+      "ipc.server.observer.stale.rpc.interval";
+  public static final long IPC_SERVER_OBSERVER_STALE_RPC_DEFAULT = TimeUnit.SECONDS.toNanos(15);
 
   /**
    * @see

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -147,6 +147,8 @@ public class RpcMetrics {
   MutableCounterLong rpcRequeueCalls;
   @Metric("Number of successful RPC calls")
   MutableCounterLong rpcCallSuccesses;
+  @Metric("Number of stale calls")
+  private MutableCounterLong rpcStaleCalls;
 
   @Metric("Number of open connections") public int numOpenConnections() {
     return server.getNumOpenConnections();
@@ -364,6 +366,13 @@ public class RpcMetrics {
   }
 
   /**
+   * Increments the stale calls counter.
+   */
+  public void incrStableCalls() {
+    rpcStaleCalls.incr();
+  }
+
+  /**
    * Returns a MutableRate Counter.
    * @return Mutable Rate
    */
@@ -410,6 +419,15 @@ public class RpcMetrics {
   @VisibleForTesting
   public long getRpcRequeueCalls() {
     return rpcRequeueCalls.value();
+  }
+
+  /**
+   * Returns the number of stale calls.
+   * @return long
+   */
+  @VisibleForTesting
+  public long getRpcStaleCalls() {
+    return rpcStaleCalls.value();
   }
 
   public MutableRate getDeferredRpcProcessingTime() {

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -3834,6 +3834,23 @@ The switch to turn S3A auditing on or off.
   </description>
 </property>
 
+<property>
+  <name>ipc.server.observer.stale.rpc.enable</name>
+  <value>true</value>
+  <description>
+     Whether to enable observer stale rpc. If enable when Observer's stateid is always
+    delayed it will thrown ObserverRetryOnActiveException after ipc.server.observer.stable.rpc.interval
+    is reached.
+  </description>
+</property>
+
+<property>
+  <name>ipc.server.observer.stale.rpc.interval</name>
+  <value>15s</value>
+  <description>
+    The interval that observer rpc is marked stale.
+  </description>
+</property>
 
   <!-- YARN registry -->
 


### PR DESCRIPTION
…ateid is always delayed with Active Namenode for a period of time

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA:       [HDFS-17300](https://issues.apache.org/jira/browse/HDFS-17300) 



Now when Observer is enable, Observer will update its stateid through that EditLogTailer near-real-time tailing editlog form Active Namenode.  And if a rpc call's stateid is lower than client stateid which may update from active namenode with msync, the call will be requeued into callqueue. 


This PR is intend to if a rpc call's stateid is always lower than client statid for a configured time , the call should throw ObserverRetryOnActiveException for client and client will go to active namenode for processing.


