### PR TITLE
HADOOP-19025. Migrate contract tests in hadoop-common to AssertJ

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractCopyFromLocalTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractCopyFromLocalTest.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathExistsException;
+import org.assertj.core.api.Assertions;
 
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
@@ -65,12 +66,15 @@ public abstract class AbstractContractCopyFromLocalTest extends
     Path dest = copyFromLocal(file, true);
 
     assertPathExists("uploaded file not found", dest);
-    assertTrue("source file deleted", Files.exists(file.toPath()));
+    Assertions.assertThat(file.toPath())
+        .withFailMessage("source file deleted")
+        .exists();
 
     FileSystem fs = getFileSystem();
     FileStatus status = fs.getFileStatus(dest);
-    assertEquals("File length not equal " + status,
-        message.getBytes(ASCII).length, status.getLen());
+    Assertions.assertThat(status.getLen())
+        .withFailMessage("File length not equal " + status)
+        .isEqualTo(message.getBytes(ASCII).length);
     assertFileTextEquals(dest, message);
   }
 
@@ -109,7 +113,9 @@ public abstract class AbstractContractCopyFromLocalTest extends
     file = createTempFile("test");
     copyFromLocal(file, false, true);
 
-    assertFalse("Source file not deleted", Files.exists(file.toPath()));
+    Assertions.assertThat(file.toPath())
+        .withFailMessage("Source file not deleted")
+        .doesNotExist();
   }
 
   @Test
@@ -215,7 +221,9 @@ public abstract class AbstractContractCopyFromLocalTest extends
     copyFromLocal(source, false, true);
     Path dest = fileToPath(child, source.getParentFile());
 
-    assertFalse("Directory not deleted", Files.exists(source.toPath()));
+    Assertions.assertThat(source.toPath())
+        .withFailMessage("Directory not deleted")
+        .doesNotExist();
     assertFileTextEquals(dest, contents);
   }
 
@@ -258,8 +266,9 @@ public abstract class AbstractContractCopyFromLocalTest extends
     Path dst = path(srcDir.getFileName().toString());
     getFileSystem().copyFromLocalFile(true, true, src, dst);
 
-    assertFalse("Source directory was not deleted",
-        Files.exists(srcDir));
+    Assertions.assertThat(srcDir)
+        .withFailMessage("Source directory was not deleted")
+        .doesNotExist();
   }
 
   @Test
@@ -330,7 +339,8 @@ public abstract class AbstractContractCopyFromLocalTest extends
 
   private void assertFileTextEquals(Path path, String expected)
       throws IOException {
-    assertEquals("Wrong data in " + path,
-        expected, IOUtils.toString(getFileSystem().open(path), ASCII));
+    Assertions.assertThat(IOUtils.toString(getFileSystem().open(path), ASCII))
+        .withFailMessage("Wrong data in " + path)
+        .isEqualTo(expected);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractCreateTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractCreateTest.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.fs.StreamCapabilities;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
-import org.junit.AssumptionViolatedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +43,7 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.writeTextFile;
 import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsSourceToString;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * Test creating files, overwrite options etc.
@@ -171,10 +171,10 @@ public abstract class AbstractContractCreateTest extends
     try {
       assertIsDirectory(path);
     } catch (AssertionError failure) {
-      if (isSupported(CREATE_OVERWRITES_DIRECTORY)) {
-        // file/directory hack surfaces here
-        throw new AssumptionViolatedException(failure.toString(), failure);
-      }
+      // file/directory hack surfaces here
+      assumeThat(isSupported(CREATE_OVERWRITES_DIRECTORY))
+          .withFailMessage(failure.toString())
+          .isFalse();
       // else: rethrow
       throw failure;
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractCreateTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractCreateTest.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.ParentNotDirectoryException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.StreamCapabilities;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.AssumptionViolatedException;
 import org.slf4j.Logger;
@@ -278,8 +279,9 @@ public abstract class AbstractContractCreateTest extends
     FileSystem fs = getFileSystem();
 
     long rootPath = fs.getDefaultBlockSize(path("/"));
-    assertTrue("Root block size is invalid " + rootPath,
-        rootPath > 0);
+    Assertions.assertThat(rootPath)
+        .withFailMessage("Root block size is invalid " + rootPath)
+        .isPositive();
 
     Path path = path("testFileStatusBlocksizeNonEmptyFile");
     byte[] data = dataset(256, 'a', 'z');
@@ -303,13 +305,15 @@ public abstract class AbstractContractCreateTest extends
     FileStatus status =
         getFileStatusEventually(fs, path, CREATE_TIMEOUT);
     String statusDetails = status.toString();
-    assertTrue("File status block size too low:  " + statusDetails
-            + " min value: " + minValue,
-        status.getBlockSize() >= minValue);
+    Assertions.assertThat(status.getBlockSize())
+        .withFailMessage("File status block size too low:  " +
+            statusDetails + " min value: " + minValue)
+        .isGreaterThanOrEqualTo(minValue);
     long defaultBlockSize = fs.getDefaultBlockSize(path);
-    assertTrue("fs.getDefaultBlockSize(" + path + ") size " +
-            defaultBlockSize + " is below the minimum of " + minValue,
-        defaultBlockSize >= minValue);
+    Assertions.assertThat(defaultBlockSize)
+        .withFailMessage("fs.getDefaultBlockSize(" + path + ") size " +
+            defaultBlockSize + " is below the minimum of " + minValue)
+        .isGreaterThanOrEqualTo(minValue);
   }
 
   @Test
@@ -320,14 +324,18 @@ public abstract class AbstractContractCreateTest extends
     Path parent = new Path(grandparent, "parent");
     Path child = new Path(parent, "child");
     touch(fs, child);
-    assertEquals("List status of parent should include the 1 child file",
-        1, fs.listStatus(parent).length);
-    assertTrue("Parent directory does not appear to be a directory",
-        fs.getFileStatus(parent).isDirectory());
-    assertEquals("List status of grandparent should include the 1 parent dir",
-        1, fs.listStatus(grandparent).length);
-    assertTrue("Grandparent directory does not appear to be a directory",
-        fs.getFileStatus(grandparent).isDirectory());
+    Assertions.assertThat(fs.listStatus(parent))
+        .withFailMessage("List status of parent should include the 1 child file")
+        .hasSize(1);
+    Assertions.assertThat(fs.getFileStatus(parent).isDirectory())
+        .withFailMessage("Parent directory does not appear to be a directory")
+        .isTrue();
+    Assertions.assertThat(fs.listStatus(grandparent))
+        .withFailMessage("List status of grandparent should include the 1 parent dir")
+        .hasSize(1);
+    Assertions.assertThat(fs.getFileStatus(grandparent).isDirectory())
+        .withFailMessage("Grandparent directory does not appear to be a directory")
+        .isTrue();
   }
 
   @Test
@@ -531,17 +539,18 @@ public abstract class AbstractContractCreateTest extends
         final FileStatus st = fs.getFileStatus(path);
         if (metadataUpdatedOnHSync) {
           // not all stores reliably update it, HDFS/webHDFS in particular
-          assertEquals("Metadata not updated during write " + st,
-              2, st.getLen());
+          Assertions.assertThat(st.getLen())
+              .withFailMessage("Metadata not updated during write " + st)
+              .isEqualTo(2);
         }
 
         // there's no way to verify durability, but we can
         // at least verify a new file input stream reads
         // the data
         try (FSDataInputStream in = fs.open(path)) {
-          assertEquals('a', in.read());
-          assertEquals('b', in.read());
-          assertEquals(-1, in.read());
+          Assertions.assertThat(in.read()).isEqualTo('a');
+          Assertions.assertThat(in.read()).isEqualTo('b');
+          Assertions.assertThat(in.read()).isEqualTo(-1);
           LOG.info("Successfully read synced data on a new reader {}", in);
         }
       } else {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractDeleteTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractDeleteTest.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.contract;
 
 import org.apache.hadoop.fs.Path;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -49,9 +50,10 @@ public abstract class AbstractContractDeleteTest extends
     Path path = path("testDeleteNonexistentPathRecursive");
     assertPathDoesNotExist("leftover", path);
     ContractTestUtils.rejectRootOperation(path);
-    assertFalse("Returned true attempting to recursively delete"
-                + " a nonexistent path " + path,
-                getFileSystem().delete(path, true));
+    Assertions.assertThat(getFileSystem().delete(path, true))
+        .withFailMessage("Returned true attempting to recursively delete"
+            + " a nonexistent path " + path)
+        .isFalse();
   }
 
   @Test
@@ -59,9 +61,10 @@ public abstract class AbstractContractDeleteTest extends
     Path path = path("testDeleteNonexistentPathNonRecursive");
     assertPathDoesNotExist("leftover", path);
     ContractTestUtils.rejectRootOperation(path);
-    assertFalse("Returned true attempting to non recursively delete"
-                + " a nonexistent path " + path,
-                getFileSystem().delete(path, false));
+    Assertions.assertThat(getFileSystem().delete(path, false))
+        .withFailMessage("Returned true attempting to non recursively delete"
+            + " a nonexistent path " + path)
+        .isFalse();
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractEtagTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractEtagTest.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.fs.contract;
 import java.nio.charset.StandardCharsets;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Assume;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +33,7 @@ import org.apache.hadoop.fs.Path;
 
 import static org.apache.hadoop.fs.CommonPathCapabilities.ETAGS_AVAILABLE;
 import static org.apache.hadoop.fs.CommonPathCapabilities.ETAGS_PRESERVED_IN_RENAME;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * For filesystems which support etags, validate correctness
@@ -132,9 +132,9 @@ public abstract class AbstractContractEtagTest extends
     describe("Verify that when a file is renamed, the etag remains unchanged");
     final Path path = methodPath();
     final FileSystem fs = getFileSystem();
-    Assume.assumeTrue(
-        "Filesystem does not declare that etags are preserved across renames",
-        fs.hasPathCapability(path, ETAGS_PRESERVED_IN_RENAME));
+    assumeThat(fs.hasPathCapability(path, ETAGS_PRESERVED_IN_RENAME))
+        .withFailMessage("Filesystem does not declare that etags are preserved across renames")
+        .isTrue();
     Path src = new Path(path, "src");
     Path dest = new Path(path, "dest");
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractGetEnclosingRoot.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractGetEnclosingRoot.java
@@ -22,6 +22,7 @@ import java.security.PrivilegedExceptionAction;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,23 +37,27 @@ public abstract class AbstractContractGetEnclosingRoot extends AbstractFSContrac
     Path root = path("/");
     Path foobar = path("/foo/bar");
 
-    assertEquals("Ensure getEnclosingRoot on the root directory returns the root directory",
-        root, fs.getEnclosingRoot(foobar));
-    assertEquals("Ensure getEnclosingRoot called on itself returns the root directory",
-        root, fs.getEnclosingRoot(fs.getEnclosingRoot(foobar)));
-    assertEquals(
-        "Ensure getEnclosingRoot for different paths in the same enclosing root "
-            + "returns the same path",
-        fs.getEnclosingRoot(root), fs.getEnclosingRoot(foobar));
-    assertEquals("Ensure getEnclosingRoot on a path returns the root directory",
-        root, fs.getEnclosingRoot(methodPath()));
-    assertEquals("Ensure getEnclosingRoot called on itself on a path returns the root directory",
-        root, fs.getEnclosingRoot(fs.getEnclosingRoot(methodPath())));
-    assertEquals(
-        "Ensure getEnclosingRoot for different paths in the same enclosing root "
-            + "returns the same path",
-        fs.getEnclosingRoot(root),
-        fs.getEnclosingRoot(methodPath()));
+    Assertions.assertThat(fs.getEnclosingRoot(foobar))
+        .withFailMessage("Ensure getEnclosingRoot on the root directory"
+            + " returns the root directory")
+        .isEqualTo(root);
+    Assertions.assertThat(fs.getEnclosingRoot(fs.getEnclosingRoot(foobar)))
+        .withFailMessage("Ensure getEnclosingRoot called on itself returns the root directory")
+        .isEqualTo(root);
+    Assertions.assertThat(fs.getEnclosingRoot(foobar))
+        .withFailMessage("Ensure getEnclosingRoot for different paths in the same enclosing root"
+            + " returns the same path")
+        .isEqualTo(fs.getEnclosingRoot(root));
+    Assertions.assertThat(fs.getEnclosingRoot(methodPath()))
+        .withFailMessage("Ensure getEnclosingRoot on a path returns the root directory")
+        .isEqualTo(root);
+    Assertions.assertThat(fs.getEnclosingRoot(fs.getEnclosingRoot(methodPath())))
+        .withFailMessage("Ensure getEnclosingRoot called on itself on a path returns the root directory")
+        .isEqualTo(root);
+    Assertions.assertThat(fs.getEnclosingRoot(methodPath()))
+        .withFailMessage("Ensure getEnclosingRoot for different paths in the same enclosing root"
+            + " returns the same path")
+        .isEqualTo(fs.getEnclosingRoot(root));
   }
 
 
@@ -63,11 +68,12 @@ public abstract class AbstractContractGetEnclosingRoot extends AbstractFSContrac
     Path foobar = methodPath();
     fs.mkdirs(foobar);
 
-    assertEquals(
-        "Ensure getEnclosingRoot returns the root directory when the root directory exists",
-        root, fs.getEnclosingRoot(foobar));
-    assertEquals("Ensure getEnclosingRoot returns the root directory when the directory exists",
-        root, fs.getEnclosingRoot(foobar));
+    Assertions.assertThat(fs.getEnclosingRoot(foobar))
+        .withFailMessage("Ensure getEnclosingRoot returns the root directory when the root directory exists")
+        .isEqualTo(root);
+    Assertions.assertThat(fs.getEnclosingRoot(foobar))
+        .withFailMessage("Ensure getEnclosingRoot returns the root directory when the directory exists")
+        .isEqualTo(root);
   }
 
   @Test
@@ -77,12 +83,12 @@ public abstract class AbstractContractGetEnclosingRoot extends AbstractFSContrac
     Path root = path("/");
 
     // .
-    assertEquals(
-        "Ensure getEnclosingRoot returns the root directory even when the path does not exist",
-        root, fs.getEnclosingRoot(foobar));
-    assertEquals(
-        "Ensure getEnclosingRoot returns the root directory even when the path does not exist",
-        root, fs.getEnclosingRoot(methodPath()));
+    Assertions.assertThat(fs.getEnclosingRoot(foobar))
+        .withFailMessage("Ensure getEnclosingRoot returns the root directory even when the path does not exist")
+        .isEqualTo(root);
+    Assertions.assertThat(fs.getEnclosingRoot(methodPath()))
+        .withFailMessage("Ensure getEnclosingRoot returns the root directory even when the path does not exist")
+        .isEqualTo(root);
   }
 
   @Test
@@ -90,14 +96,17 @@ public abstract class AbstractContractGetEnclosingRoot extends AbstractFSContrac
     FileSystem fs = getFileSystem();
     Path root = path("/");
 
-    assertEquals("Ensure getEnclosingRoot returns the root directory when the directory exists",
-        root, fs.getEnclosingRoot(new Path("/foo/bar")));
+    Assertions.assertThat(fs.getEnclosingRoot(new Path("/foo/bar")))
+        .withFailMessage("Ensure getEnclosingRoot returns the root directory when the directory exists")
+        .isEqualTo(root);
 
     UserGroupInformation ugi = UserGroupInformation.createRemoteUser("foo");
     Path p = ugi.doAs((PrivilegedExceptionAction<Path>) () -> {
       FileSystem wFs = getContract().getTestFileSystem();
       return wFs.getEnclosingRoot(new Path("/foo/bar"));
     });
-    assertEquals("Ensure getEnclosingRoot works correctly within a wrapped FileSystem", root, p);
+    Assertions.assertThat(p)
+        .withFailMessage("Ensure getEnclosingRoot works correctly within a wrapped FileSystem")
+        .isEqualTo(root);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractGetFileStatusTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractGetFileStatusTest.java
@@ -284,10 +284,9 @@ public abstract class AbstractContractGetFileStatusTest extends
     treeWalk.assertFieldsEquivalent("files", listing,
         treeWalk.getFiles(),
         listing.getFiles());
-    assertEquals("Size of status list through next() calls",
-        count,
-        toListThroughNextCallsAlone(
-            fs.listFiles(tree.getBasePath(), true)).size());
+    Assertions.assertThat(toListThroughNextCallsAlone(fs.listFiles(tree.getBasePath(), true)))
+        .withFailMessage("Size of status list through next() calls")
+        .hasSize(count);
   }
 
   @Test
@@ -343,7 +342,8 @@ public abstract class AbstractContractGetFileStatusTest extends
   public void testListStatusFilteredFile() throws Throwable {
     describe("test the listStatus(path, filter) on a file");
     Path f = touchf("liststatus");
-    assertEquals(0, getFileSystem().listStatus(f, NO_PATHS).length);
+    Assertions.assertThat(getFileSystem().listStatus(f, NO_PATHS))
+        .isEmpty();
   }
 
   @Test
@@ -398,12 +398,15 @@ public abstract class AbstractContractGetFileStatusTest extends
     Path f = touchf("listfilesfile");
     List<LocatedFileStatus> statusList = toList(
         getFileSystem().listFiles(f, false));
-    assertEquals("size of file list returned", 1, statusList.size());
+    Assertions.assertThat(statusList)
+        .withFailMessage("size of file list returned")
+        .hasSize(1);
     assertIsNamedFile(f, statusList.get(0));
     List<LocatedFileStatus> statusList2 = toListThroughNextCallsAlone(
         getFileSystem().listFiles(f, false));
-    assertEquals("size of file list returned through next() calls",
-        1, statusList2.size());
+    Assertions.assertThat(statusList2)
+        .withFailMessage("size of file list returned through next() calls")
+        .hasSize(1);
     assertIsNamedFile(f, statusList2.get(0));
   }
 
@@ -413,11 +416,15 @@ public abstract class AbstractContractGetFileStatusTest extends
     Path f = touchf("listfilesRecursive");
     List<LocatedFileStatus> statusList = toList(
         getFileSystem().listFiles(f, true));
-    assertEquals("size of file list returned", 1, statusList.size());
+    Assertions.assertThat(statusList)
+        .withFailMessage("size of file list returned")
+        .hasSize(1);
     assertIsNamedFile(f, statusList.get(0));
     List<LocatedFileStatus> statusList2 = toListThroughNextCallsAlone(
         getFileSystem().listFiles(f, true));
-    assertEquals("size of file list returned", 1, statusList2.size());
+    Assertions.assertThat(statusList2)
+        .withFailMessage("size of file list returned")
+        .hasSize(1);
   }
 
   @Test
@@ -426,12 +433,15 @@ public abstract class AbstractContractGetFileStatusTest extends
     Path f = touchf("listLocatedStatus");
     List<LocatedFileStatus> statusList = toList(
         getFileSystem().listLocatedStatus(f));
-    assertEquals("size of file list returned", 1, statusList.size());
+    Assertions.assertThat(statusList)
+        .withFailMessage("size of file list returned")
+        .hasSize(1);
     assertIsNamedFile(f, statusList.get(0));
     List<LocatedFileStatus> statusList2 = toListThroughNextCallsAlone(
         getFileSystem().listLocatedStatus(f));
-    assertEquals("size of file list returned through next() calls",
-        1, statusList2.size());
+    Assertions.assertThat(statusList2)
+        .withFailMessage("size of file list returned through next() calls")
+        .hasSize(1);
   }
 
   /**
@@ -440,7 +450,7 @@ public abstract class AbstractContractGetFileStatusTest extends
    * @param status status array
    */
   private void verifyStatusArrayMatchesFile(Path f, FileStatus[] status) {
-    assertEquals(1, status.length);
+    Assertions.assertThat(status).hasSize(1);
     FileStatus fileStatus = status[0];
     assertIsNamedFile(f, fileStatus);
   }
@@ -451,8 +461,12 @@ public abstract class AbstractContractGetFileStatusTest extends
    * @param fileStatus status to validate
    */
   private void assertIsNamedFile(Path f, FileStatus fileStatus) {
-    assertEquals("Wrong pathname in " + fileStatus, f, fileStatus.getPath());
-    assertTrue("Not a file: " + fileStatus, fileStatus.isFile());
+    Assertions.assertThat(fileStatus.getPath())
+        .withFailMessage("Wrong pathname in " + fileStatus)
+        .isEqualTo(f);
+    Assertions.assertThat(fileStatus.isFile())
+        .withFailMessage("Not a file: " + fileStatus)
+        .isTrue();
   }
 
   /**
@@ -515,10 +529,18 @@ public abstract class AbstractContractGetFileStatusTest extends
       count++;
       LocatedFileStatus next = results.next();
       FileStatus fileStatus = getFileSystem().getFileStatus(next.getPath());
-      assertEquals("isDirectory", fileStatus.isDirectory(), next.isDirectory());
-      assertEquals("isFile", fileStatus.isFile(), next.isFile());
-      assertEquals("getLen", fileStatus.getLen(), next.getLen());
-      assertEquals("getOwner", fileStatus.getOwner(), next.getOwner());
+      Assertions.assertThat(next.isDirectory())
+          .withFailMessage("isDirectory")
+          .isEqualTo(fileStatus.isDirectory());
+      Assertions.assertThat(next.isFile())
+          .withFailMessage("isFile")
+          .isEqualTo(fileStatus.isFile());
+      Assertions.assertThat(next.getLen())
+          .withFailMessage("getLen")
+          .isEqualTo(fileStatus.getLen());
+      Assertions.assertThat(next.getOwner())
+          .withFailMessage("getOwner")
+          .isEqualTo(fileStatus.getOwner());
     }
     return count;
   }
@@ -537,13 +559,16 @@ public abstract class AbstractContractGetFileStatusTest extends
 
     MatchesNameFilter file1Filter = new MatchesNameFilter("file-1.txt");
     result = verifyListStatus(1, parent, file1Filter);
-    assertEquals(file1, result[0].getPath());
+    Assertions.assertThat(result[0].getPath())
+        .isEqualTo(file1);
 
     verifyListStatus(0, file1, NO_PATHS);
     result = verifyListStatus(1, file1, ALL_PATHS);
-    assertEquals(file1, result[0].getPath());
+    Assertions.assertThat(result[0].getPath())
+        .isEqualTo(file1);
     result = verifyListStatus(1, file1, file1Filter);
-    assertEquals(file1, result[0].getPath());
+    Assertions.assertThat(result[0].getPath())
+        .isEqualTo(file1);
 
     // empty subdirectory
     Path subdir = path("subdir");
@@ -573,13 +598,16 @@ public abstract class AbstractContractGetFileStatusTest extends
 
     MatchesNameFilter file1Filter = new MatchesNameFilter("file-1.txt");
     result = verifyListLocatedStatus(xfs, 1, parent, file1Filter);
-    assertEquals(file1, result.get(0).getPath());
+    Assertions.assertThat(result.get(0).getPath())
+        .isEqualTo(file1);
 
     verifyListLocatedStatus(xfs, 0, file1, NO_PATHS);
     verifyListLocatedStatus(xfs, 1, file1, ALL_PATHS);
-    assertEquals(file1, result.get(0).getPath());
+    Assertions.assertThat(result.get(0).getPath())
+        .isEqualTo(file1);
     verifyListLocatedStatus(xfs, 1, file1, file1Filter);
-    assertEquals(file1, result.get(0).getPath());
+    Assertions.assertThat(result.get(0).getPath())
+        .isEqualTo(file1);
     verifyListLocatedStatusNextCalls(xfs, 1, file1, file1Filter);
 
     // empty subdirectory
@@ -604,9 +632,9 @@ public abstract class AbstractContractGetFileStatusTest extends
       Path path,
       PathFilter filter) throws IOException {
     FileStatus[] result = getFileSystem().listStatus(path, filter);
-    assertEquals("length of listStatus(" + path + ", " + filter + " ) " +
-        Arrays.toString(result),
-        expected, result.length);
+    Assertions.assertThat(result)
+        .withFailMessage("length of listStatus(" + path + ", " + filter + " ) " + Arrays.toString(result))
+        .hasSize(expected);
     return result;
   }
 
@@ -626,8 +654,9 @@ public abstract class AbstractContractGetFileStatusTest extends
       PathFilter filter) throws IOException {
     RemoteIterator<LocatedFileStatus> it = xfs.listLocatedStatus(path, filter);
     List<LocatedFileStatus> result = toList(it);
-    assertEquals("length of listLocatedStatus(" + path + ", " + filter + " )",
-        expected, result.size());
+    Assertions.assertThat(result)
+        .withFailMessage("length of listLocatedStatus(" + path + ", " + filter + " )")
+        .hasSize(expected);
     return result;
   }
 
@@ -650,8 +679,9 @@ public abstract class AbstractContractGetFileStatusTest extends
       PathFilter filter) throws IOException {
     RemoteIterator<LocatedFileStatus> it = xfs.listLocatedStatus(path, filter);
     List<LocatedFileStatus> result = toListThroughNextCallsAlone(it);
-    assertEquals("length of listLocatedStatus(" + path + ", " + filter + " )",
-        expected, result.size());
+    Assertions.assertThat(result)
+        .withFailMessage("length of listLocatedStatus(" + path + ", " + filter + " )")
+        .hasSize(expected);
     return result;
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractMkdirTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractMkdirTest.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.ParentNotDirectoryException;
 import org.apache.hadoop.fs.Path;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -125,7 +126,7 @@ public abstract class AbstractContractMkdirTest extends AbstractFSContractTestBa
         new Path(getContract().getTestPath() + "/testMkdirSlashHandling/e///")
     };
     for (Path path : paths) {
-      assertTrue(fs.mkdirs(path));
+      Assertions.assertThat(fs.mkdirs(path)).isTrue();
       assertPathExists(path + " does not exist after mkdirs", path);
       assertIsDirectory(path);
       if (path.toString().endsWith("/")) {
@@ -141,11 +142,11 @@ public abstract class AbstractContractMkdirTest extends AbstractFSContractTestBa
     final FileSystem fs = getFileSystem();
 
     final Path parent = path("testMkdirsPopulatingAllNonexistentAncestors");
-    assertTrue(fs.mkdirs(parent));
+    Assertions.assertThat(fs.mkdirs(parent)).isTrue();
     assertPathExists(parent + " should exist before making nested dir", parent);
 
     Path nested = path(parent + "/a/b/c/d/e/f/g/h/i/j/k/L");
-    assertTrue(fs.mkdirs(nested));
+    Assertions.assertThat(fs.mkdirs(nested)).isTrue();
     while (nested != null && !nested.equals(parent) && !nested.isRoot()) {
       assertPathExists(nested + " nested dir should exist", nested);
       nested = nested.getParent();
@@ -158,11 +159,11 @@ public abstract class AbstractContractMkdirTest extends AbstractFSContractTestBa
     final FileSystem fs = getFileSystem();
 
     final Path parent = path("testMkdirsDoesNotRemoveParentDirectories");
-    assertTrue(fs.mkdirs(parent));
+    Assertions.assertThat(fs.mkdirs(parent)).isTrue();
 
     Path p = parent;
     for (int i = 0; i < 10; i++) {
-      assertTrue(fs.mkdirs(p));
+      Assertions.assertThat(fs.mkdirs(p)).isTrue();
       assertPathExists(p + " should exist after mkdir(" + p + ")", p);
       p = path(p + "/dir-" + i);
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractMultipartUploaderTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractMultipartUploaderTest.java
@@ -264,8 +264,9 @@ public abstract class AbstractContractMultipartUploaderTest extends
     } else {
       // otherwise, the same or other uploader can try again.
       PathHandle fd2 = complete(completer, uploadHandle, file, partHandles);
-      assertArrayEquals("Path handles differ", fd.toByteArray(),
-          fd2.toByteArray());
+      Assertions.assertThat(fd2.toByteArray())
+          .withFailMessage("Path handles differ")
+          .isEqualTo(fd.toByteArray());
     }
   }
 
@@ -799,7 +800,9 @@ public abstract class AbstractContractMultipartUploaderTest extends
     }
     Map<Integer, PartHandle> partHandles2 = new HashMap<>();
 
-    assertNotEquals("Upload handles match", upload1, upload2);
+    Assertions.assertThat(upload2)
+        .withFailMessage("Upload handles match")
+        .isNotEqualTo(upload1);
 
     // put part 1
     partHandles1.put(partId1, putPart(file, upload1, partId1, payload1));

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractMultipartUploaderTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractMultipartUploaderTest.java
@@ -30,7 +30,6 @@ import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Assume;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +54,7 @@ import static org.apache.hadoop.io.IOUtils.cleanupWithLogger;
 import static org.apache.hadoop.test.LambdaTestUtils.eventually;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.apache.hadoop.util.functional.FutureIO.awaitFuture;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * Tests of multipart uploads.
@@ -89,9 +89,9 @@ public abstract class AbstractContractMultipartUploaderTest extends
 
     final FileSystem fs = getFileSystem();
     Path testPath = getContract().getTestPath();
-    Assume.assumeTrue("Multipart uploader is not supported",
-        fs.hasPathCapability(testPath,
-            CommonPathCapabilities.FS_MULTIPART_UPLOADER));
+    assumeThat(fs.hasPathCapability(testPath, CommonPathCapabilities.FS_MULTIPART_UPLOADER))
+        .withFailMessage("Multipart uploader is not supported")
+        .isTrue();
     uploader0 = fs.createMultipartUploader(testPath).build();
     uploader1 = fs.createMultipartUploader(testPath).build();
   }
@@ -786,9 +786,9 @@ public abstract class AbstractContractMultipartUploaderTest extends
     UploadHandle upload2;
     try {
       upload2 = startUpload(file);
-      Assume.assumeTrue(
-          "The Filesystem is unexpectedly supporting concurrent uploads",
-          concurrent);
+      assumeThat(concurrent)
+          .withFailMessage("The Filesystem is unexpectedly supporting concurrent uploads")
+          .isTrue();
     } catch (IOException e) {
       if (!concurrent) {
         // this is expected, so end the test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractOpenTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractOpenTest.java
@@ -74,7 +74,8 @@ public abstract class AbstractContractOpenTest
     Path path = path("zero.txt");
     touch(getFileSystem(), path);
     instream = getFileSystem().open(path);
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos())
+        .isEqualTo(0);
     //expect initial read to fail
     assertMinusOne("initial byte read", instream.read());
   }
@@ -85,9 +86,9 @@ public abstract class AbstractContractOpenTest
       final Path path = path("file");
       createFile(getFileSystem(), path, false, new byte[0]);
       final FileStatus stat = getFileSystem().getFileStatus(path);
-      assertEquals("Result wrong for for isEncrypted() in " + stat,
-          areZeroByteFilesEncrypted(),
-          stat.isEncrypted());
+      Assertions.assertThat(stat.isEncrypted())
+        .withFailMessage("Result wrong for for isEncrypted() in " + stat)
+        .isEqualTo(areZeroByteFilesEncrypted());
   }
 
   /**
@@ -150,12 +151,18 @@ public abstract class AbstractContractOpenTest
     FSDataInputStream instream2 = null;
     try {
       int c = instream1.read();
-      assertEquals(0,c);
+      Assertions.assertThat(c).isEqualTo(0);
       instream2 = getFileSystem().open(path);
-      assertEquals("first read of instream 2", 0, instream2.read());
-      assertEquals("second read of instream 1", 1, instream1.read());
+      Assertions.assertThat(instream2.read())
+        .withFailMessage("first read of instream 2")
+        .isEqualTo(0);
+      Assertions.assertThat(instream1.read())
+        .withFailMessage("second read of instream 1")
+        .isEqualTo(1);
       instream1.close();
-      assertEquals("second read of instream 2", 1, instream2.read());
+      Assertions.assertThat(instream2.read())
+        .withFailMessage("second read of instream 2")
+        .isEqualTo(1);
       //close instream1 again
       instream1.close();
     } finally {
@@ -175,13 +182,19 @@ public abstract class AbstractContractOpenTest
     createFile(getFileSystem(), path, true, block);
     //open first
     instream = getFileSystem().open(path);
-    assertEquals(base, instream.read());
-    assertEquals(base + 1, instream.read());
-    assertEquals(base + 2, instream.read());
-    assertEquals(base + 3, instream.read());
+    Assertions.assertThat(instream.read())
+        .isEqualTo(base);
+    Assertions.assertThat(instream.read())
+        .isEqualTo(base + 1);
+    Assertions.assertThat(instream.read())
+        .isEqualTo(base + 2);
+    Assertions.assertThat(instream.read())
+        .isEqualTo(base + 3);
     // and now, failures
-    assertEquals(-1, instream.read());
-    assertEquals(-1, instream.read());
+    Assertions.assertThat(instream.read())
+        .isEqualTo(-1);
+    Assertions.assertThat(instream.read())
+        .isEqualTo(-1);
     instream.close();
   }
 
@@ -238,8 +251,9 @@ public abstract class AbstractContractOpenTest
     FutureDataInputStreamBuilder builder =
         getFileSystem().openFile(path("testOpenFileFailExceptionally"))
             .opt("fs.test.something", true);
-    assertNull("exceptional uprating",
-        builder.build().exceptionally(ex -> null).get());
+    Assertions.assertThat(builder.build().exceptionally(ex -> null).get())
+        .withFailMessage("exceptional uprating")
+        .isNull();
   }
 
   @Test
@@ -303,9 +317,9 @@ public abstract class AbstractContractOpenTest
         .withFileStatus(st)
         .build()
         .thenApply(ContractTestUtils::readStream);
-    assertEquals("Wrong number of bytes read value",
-        len,
-        (long) readAllBytes.get());
+    Assertions.assertThat((long) readAllBytes.get())
+        .withFailMessage("Wrong number of bytes read value")
+        .isEqualTo(len);
     // now reattempt with a new FileStatus and a different path
     // other than the final name element
     // implementations MUST use path in openFile() call
@@ -319,13 +333,13 @@ public abstract class AbstractContractOpenTest
         st.getOwner(),
         st.getGroup(),
         new Path("gopher:///localhost:/" + path.getName()));
-    assertEquals("Wrong number of bytes read value",
-        len,
-        (long) fs.openFile(path)
+    Assertions.assertThat((long) fs.openFile(path)
             .withFileStatus(st2)
             .build()
             .thenApply(ContractTestUtils::readStream)
-            .get());
+            .get())
+        .withFailMessage("Wrong number of bytes read value")
+        .isEqualTo(len);
   }
 
   @Test
@@ -344,8 +358,9 @@ public abstract class AbstractContractOpenTest
       accepted.set(true);
       return ContractTestUtils.readStream(stream);
     }).get();
-    assertTrue("async accept operation not invoked",
-        accepted.get());
+    Assertions.assertThat(accepted.get())
+        .withFailMessage("async accept operation not invoked")
+        .isTrue();
     Assertions.assertThat(bytes)
         .describedAs("bytes read from stream")
         .isEqualTo(len);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractPathHandleTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractPathHandleTest.java
@@ -44,6 +44,7 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IO_FILE_BUFFER_
 import static org.apache.hadoop.test.LambdaTestUtils.interceptFuture;
 
 import org.apache.hadoop.fs.RawPathHandle;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -143,10 +144,10 @@ public abstract class AbstractContractPathHandleTest
     PathHandle fd = getHandleOrSkip(stat);
 
     try (FSDataInputStream in = getFileSystem().open(fd)) {
-      assertTrue("Failed to detect content change", data.allowChange());
+      Assertions.assertThat(data.allowChange()).withFailMessage("Failed to detect content change").isTrue();
       verifyRead(in, b12, 0, b12.length);
     } catch (InvalidPathHandleException e) {
-      assertFalse("Failed to allow content change", data.allowChange());
+      Assertions.assertThat(data.allowChange()).withFailMessage("Failed to allow content change").isFalse();
     }
   }
 
@@ -164,10 +165,10 @@ public abstract class AbstractContractPathHandleTest
     PathHandle fd = getHandleOrSkip(stat);
 
     try (FSDataInputStream in = getFileSystem().open(fd)) {
-      assertTrue("Failed to detect location change", loc.allowChange());
+      Assertions.assertThat(loc.allowChange()).withFailMessage("Failed to detect location change").isTrue();
       verifyRead(in, B1, 0, B1.length);
     } catch (InvalidPathHandleException e) {
-      assertFalse("Failed to allow location change", loc.allowChange());
+      Assertions.assertThat(loc.allowChange()).withFailMessage("Failed to allow location change").isFalse();
     }
   }
 
@@ -189,15 +190,15 @@ public abstract class AbstractContractPathHandleTest
     byte[] b12 = Arrays.copyOf(B1, B1.length + B2.length);
     System.arraycopy(B2, 0, b12, B1.length, B2.length);
     try (FSDataInputStream in = getFileSystem().open(fd)) {
-      assertTrue("Failed to detect location change", loc.allowChange());
-      assertTrue("Failed to detect content change", data.allowChange());
+      Assertions.assertThat(loc.allowChange()).withFailMessage("Failed to detect location change").isTrue();
+      Assertions.assertThat(data.allowChange()).withFailMessage("Failed to detect content change").isTrue();
       verifyRead(in, b12, 0, b12.length);
     } catch (InvalidPathHandleException e) {
       if (data.allowChange()) {
-        assertFalse("Failed to allow location change", loc.allowChange());
+        Assertions.assertThat(loc.allowChange()).withFailMessage("Failed to allow location change").isFalse();
       }
       if (loc.allowChange()) {
-        assertFalse("Failed to allow content change", data.allowChange());
+        Assertions.assertThat(data.allowChange()).withFailMessage("Failed to allow content change").isFalse();
       }
     }
   }
@@ -206,8 +207,8 @@ public abstract class AbstractContractPathHandleTest
     Path path = path(methodName.getMethodName());
     createFile(getFileSystem(), path, false, content);
     FileStatus stat = getFileSystem().getFileStatus(path);
-    assertNotNull(stat);
-    assertEquals(path, stat.getPath());
+    Assertions.assertThat(stat).isNotNull();
+    Assertions.assertThat(stat.getPath()).isEqualTo(path);
     return stat;
   }
 
@@ -264,9 +265,9 @@ public abstract class AbstractContractPathHandleTest
                 testFile(B1)))
         .build()
         .thenApply(ContractTestUtils::readStream);
-    assertEquals("Wrong number of bytes read value",
-        TEST_FILE_LEN,
-        (long) readAllBytes.get());
+    Assertions.assertThat((long) readAllBytes.get())
+        .withFailMessage("Wrong number of bytes read value")
+        .isEqualTo(TEST_FILE_LEN);
   }
 
   @Test
@@ -305,9 +306,9 @@ public abstract class AbstractContractPathHandleTest
                 stat))
         .build()
         .thenApply(ContractTestUtils::readStream);
-    assertEquals("Wrong number of bytes read value",
-        TEST_FILE_LEN,
-        (long) readAllBytes.get());
+    Assertions.assertThat((long) readAllBytes.get())
+        .withFailMessage("Wrong number of bytes read value")
+        .isEqualTo(TEST_FILE_LEN);
   }
 
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.contract;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.io.FileNotFoundException;
@@ -43,8 +44,9 @@ public abstract class AbstractContractRenameTest extends
     writeDataset(getFileSystem(), renameSrc,
         data, data.length, 1024 * 1024, false);
     boolean rename = rename(renameSrc, renameTarget);
-    assertTrue("rename("+renameSrc+", "+ renameTarget+") returned false",
-        rename);
+    Assertions.assertThat(rename)
+        .withFailMessage("rename("+renameSrc+", "+ renameTarget+") returned false")
+        .isTrue();
     assertListStatusFinds(getFileSystem(),
         renameTarget.getParent(), renameTarget);
     verifyFileContents(getFileSystem(), renameTarget, data);
@@ -70,7 +72,9 @@ public abstract class AbstractContractRenameTest extends
         // at least one FS only returns false here, if that is the case
         // warn but continue
         getLogger().warn("Rename returned {} renaming a nonexistent file", renamed);
-        assertFalse("Renaming a missing file returned true", renamed);
+        Assertions.assertThat(renamed)
+            .withFailMessage("Renaming a missing file returned true")
+            .isFalse();
       }
     } catch (FileNotFoundException e) {
       if (renameReturnsFalseOnFailure) {
@@ -105,9 +109,9 @@ public abstract class AbstractContractRenameTest extends
     boolean renameOverwritesDest = isSupported(RENAME_OVERWRITES_DEST);
     boolean renameReturnsFalseOnRenameDestExists =
         isSupported(RENAME_RETURNS_FALSE_IF_DEST_EXISTS);
-    assertFalse(RENAME_OVERWRITES_DEST + " and " +
-        RENAME_RETURNS_FALSE_IF_DEST_EXISTS + " cannot be both supported",
-        renameOverwritesDest && renameReturnsFalseOnRenameDestExists);
+    Assertions.assertThat(renameOverwritesDest && renameReturnsFalseOnRenameDestExists)
+        .withFailMessage(RENAME_OVERWRITES_DEST + " and " + RENAME_RETURNS_FALSE_IF_DEST_EXISTS + " cannot be both supported")
+        .isFalse();
     String expectedTo = "expected rename(" + srcFile + ", " + destFile + ") to ";
 
     boolean destUnchanged = true;
@@ -117,11 +121,13 @@ public abstract class AbstractContractRenameTest extends
       destUnchanged = !renamed;
 
       if (renameOverwritesDest) {
-        assertTrue(expectedTo + "overwrite destination, but got false",
-            renamed);
+        Assertions.assertThat(renamed)
+        .withFailMessage(expectedTo + "overwrite destination, but got false")
+        .isTrue();
       } else if (renameReturnsFalseOnRenameDestExists) {
-        assertFalse(expectedTo + "be rejected with false, but destination " +
-            "was overwritten", renamed);
+        Assertions.assertThat(renamed)
+        .withFailMessage(expectedTo + "be rejected with false, but destination " + "was overwritten")
+        .isFalse();
       } else if (renamed) {
         String destDirLS = generateAndLogErrorListing(srcFile, destFile);
         getLogger().error("dest dir {}", destDirLS);
@@ -133,10 +139,12 @@ public abstract class AbstractContractRenameTest extends
     } catch (FileAlreadyExistsException e) {
       // rename(file, file2) should throw exception iff
       // it neither overwrites nor returns false
-      assertFalse(expectedTo + "overwrite destination, but got exception",
-          renameOverwritesDest);
-      assertFalse(expectedTo + "be rejected with false, but got exception",
-          renameReturnsFalseOnRenameDestExists);
+      Assertions.assertThat(renameOverwritesDest)
+        .withFailMessage(expectedTo + "overwrite destination, but got exception")
+        .isFalse();
+      Assertions.assertThat(renameReturnsFalseOnRenameDestExists)
+        .withFailMessage(expectedTo + "be rejected with false, but got exception")
+        .isFalse();
 
       handleExpectedException(e);
     }
@@ -170,7 +178,9 @@ public abstract class AbstractContractRenameTest extends
     assertIsFile(destFilePath);
     assertIsDirectory(renamedSrc);
     verifyFileContents(fs, destFilePath, destData);
-    assertTrue("rename returned false though the contents were copied", rename);
+    Assertions.assertThat(rename)
+        .withFailMessage("rename returned false though the contents were copied")
+        .isTrue();
   }
 
   @Test
@@ -186,15 +196,15 @@ public abstract class AbstractContractRenameTest extends
     try {
       boolean rename = rename(renameSrc, renameTarget);
       if (renameCreatesDestDirs) {
-        assertTrue(rename);
+        Assertions.assertThat(rename).isTrue();
         verifyFileContents(getFileSystem(), renameTarget, data);
       } else {
-        assertFalse(rename);
+        Assertions.assertThat(rename).isFalse();
         verifyFileContents(getFileSystem(), renameSrc, data);
       }
     } catch (FileNotFoundException e) {
        // allowed unless that rename flag is set
-      assertFalse(renameCreatesDestDirs);
+      Assertions.assertThat(renameCreatesDestDirs).isFalse();
     }
   }
 
@@ -348,7 +358,9 @@ public abstract class AbstractContractRenameTest extends
       outcome = "rename raised an exception: " + e;
     }
     assertPathDoesNotExist("after " + outcome, renameTarget);
-    assertFalse(outcome, renamed);
+    Assertions.assertThat(renamed)
+        .withFailMessage(outcome)
+        .isFalse();
     assertPathExists(action, renameSrc);
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
@@ -230,18 +230,19 @@ public abstract class AbstractContractRootDirectoryTest extends AbstractFSContra
         fs.listLocatedStatus(root));
     String locatedStatusResult = join(locatedStatusList, "\n");
 
-    assertEquals("listStatus(/) vs listLocatedStatus(/) with \n"
+    Assertions.assertThat(locatedStatusList)
+        .withFailMessage("listStatus(/) vs listLocatedStatus(/) with \n"
             + "listStatus =" + listStatusResult
-            +" listLocatedStatus = " + locatedStatusResult,
-        statuses.length, locatedStatusList.size());
+            +" listLocatedStatus = " + locatedStatusResult)
+        .hasSize(statuses.length);
     List<LocatedFileStatus> fileList = toList(fs.listFiles(root, false));
     String listFilesResult = join(fileList, "\n");
-    assertTrue("listStatus(/) vs listFiles(/, false) with \n"
+    Assertions.assertThat(fileList)
+        .withFailMessage("listStatus(/) vs listFiles(/, false) with \n"
             + "listStatus = " + listStatusResult
-            + "listFiles = " + listFilesResult,
-        fileList.size() <= statuses.length);
-    List<FileStatus> statusList = (List<FileStatus>) iteratorToList(
-            fs.listStatusIterator(root));
+            + "listFiles = " + listFilesResult)
+        .hasSizeLessThanOrEqualTo(statuses.length);
+    List<FileStatus> statusList = iteratorToList(fs.listStatusIterator(root));
     Assertions.assertThat(statusList)
             .describedAs("Result of listStatus(/) and listStatusIterator(/)"
                     + " must match")

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractSeekTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractSeekTest.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IOUtils;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,7 +99,7 @@ public abstract class AbstractContractSeekTest extends AbstractFSContractTestBas
   public void testSeekZeroByteFile() throws Throwable {
     describe("seek and read a 0 byte file");
     instream = getFileSystem().open(zeroByteFile);
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
     //expect initial read to fai;
     int result = instream.read();
     assertMinusOne("initial byte read", result);
@@ -116,7 +117,7 @@ public abstract class AbstractContractSeekTest extends AbstractFSContractTestBas
   public void testBlockReadZeroByteFile() throws Throwable {
     describe("do a block read on a 0 byte file");
     instream = getFileSystem().open(zeroByteFile);
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
     //expect that seek to 0 works
     byte[] buffer = new byte[1];
     int result = instream.read(buffer, 0, 1);
@@ -179,7 +180,7 @@ public abstract class AbstractContractSeekTest extends AbstractFSContractTestBas
   @Test
   public void testNegativeSeek() throws Throwable {
     instream = getFileSystem().open(smallSeekFile);
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
     try {
       instream.seek(-1);
       long p = instream.getPos();
@@ -194,39 +195,39 @@ public abstract class AbstractContractSeekTest extends AbstractFSContractTestBas
       //bad seek -expected, but not as preferred as an EOFException
       handleRelaxedException("a negative seek", "EOFException", e);
     }
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
   }
 
   @Test
   public void testSeekFile() throws Throwable {
     describe("basic seek operations");
     instream = getFileSystem().open(smallSeekFile);
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
     //expect that seek to 0 works
     instream.seek(0);
     int result = instream.read();
-    assertEquals(0, result);
-    assertEquals(1, instream.read());
-    assertEquals(2, instream.getPos());
-    assertEquals(2, instream.read());
-    assertEquals(3, instream.getPos());
+    Assertions.assertThat(result).isEqualTo(0);
+    Assertions.assertThat(instream.read()).isEqualTo(1);
+    Assertions.assertThat(instream.getPos()).isEqualTo(2);
+    Assertions.assertThat(instream.read()).isEqualTo(2);
+    Assertions.assertThat(instream.getPos()).isEqualTo(3);
     instream.seek(128);
-    assertEquals(128, instream.getPos());
-    assertEquals(128, instream.read());
+    Assertions.assertThat(instream.getPos()).isEqualTo(128);
+    Assertions.assertThat(instream.read()).isEqualTo(128);
     instream.seek(63);
-    assertEquals(63, instream.read());
+    Assertions.assertThat(instream.read()).isEqualTo(63);
   }
 
   @Test
   public void testSeekAndReadPastEndOfFile() throws Throwable {
     describe("verify that reading past the last bytes in the file returns -1");
     instream = getFileSystem().open(smallSeekFile);
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
     //expect that seek to 0 works
     //go just before the end
     instream.seek(TEST_FILE_LEN - 2);
-    assertTrue("Premature EOF", instream.read() != -1);
-    assertTrue("Premature EOF", instream.read() != -1);
+    Assertions.assertThat(instream.read() != -1).withFailMessage("Premature EOF").isTrue();
+    Assertions.assertThat(instream.read() != -1).withFailMessage("Premature EOF").isTrue();
     assertMinusOne("read past end of file", instream.read());
   }
 
@@ -260,7 +261,7 @@ public abstract class AbstractContractSeekTest extends AbstractFSContractTestBas
     }
     //now go back and try to read from a valid point in the file
     instream.seek(1);
-    assertTrue("Premature EOF", instream.read() != -1);
+    Assertions.assertThat(instream.read() != -1).withFailMessage("Premature EOF").isTrue();
   }
 
   /**
@@ -274,32 +275,32 @@ public abstract class AbstractContractSeekTest extends AbstractFSContractTestBas
     byte[] block = dataset(100 * 1024, 0, 255);
     createFile(getFileSystem(), testSeekFile, true, block);
     instream = getFileSystem().open(testSeekFile);
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
     //expect that seek to 0 works
     instream.seek(0);
     int result = instream.read();
-    assertEquals(0, result);
-    assertEquals(1, instream.read());
-    assertEquals(2, instream.read());
+    Assertions.assertThat(result).isEqualTo(0);
+    Assertions.assertThat(instream.read()).isEqualTo(1);
+    Assertions.assertThat(instream.read()).isEqualTo(2);
 
     //do seek 32KB ahead
     instream.seek(32768);
-    assertEquals("@32768", block[32768], (byte) instream.read());
+    Assertions.assertThat((byte) instream.read()).withFailMessage("@32768").isEqualTo(block[32768]);
     instream.seek(40000);
-    assertEquals("@40000", block[40000], (byte) instream.read());
+    Assertions.assertThat((byte) instream.read()).withFailMessage("@40000").isEqualTo(block[40000]);
     instream.seek(8191);
-    assertEquals("@8191", block[8191], (byte) instream.read());
+    Assertions.assertThat((byte) instream.read()).withFailMessage("@8191").isEqualTo(block[8191]);
     instream.seek(0);
-    assertEquals("@0", 0, (byte) instream.read());
+    Assertions.assertThat((byte) instream.read()).withFailMessage("@0").isEqualTo((byte) 0);
 
     // try read & readFully
     instream.seek(0);
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
     instream.read();
-    assertEquals(1, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(1);
     byte[] buf = new byte[80 * 1024];
     instream.readFully(1, buf, 0, buf.length);
-    assertEquals(1, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(1);
   }
 
   @Test
@@ -312,19 +313,19 @@ public abstract class AbstractContractSeekTest extends AbstractFSContractTestBas
     createFile(getFileSystem(), testSeekFile, true, block);
     instream = getFileSystem().open(testSeekFile);
     instream.seek(39999);
-    assertTrue(-1 != instream.read());
-    assertEquals(40000, instream.getPos());
+    Assertions.assertThat(instream.read()).isNotEqualTo(-1);
+    Assertions.assertThat(instream.getPos()).isEqualTo(40000);
 
     int v = 256;
     byte[] readBuffer = new byte[v];
     instream.readFully(128, readBuffer, 0, v);
     //have gone back
-    assertEquals(40000, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(40000);
     //content is the same too
-    assertEquals("@40000", block[40000], (byte) instream.read());
+    Assertions.assertThat((byte) instream.read()).withFailMessage("@40000").isEqualTo(block[40000]);
     //now verify the picked up data
     for (int i = 0; i < 256; i++) {
-      assertEquals("@" + i, block[i + 128], readBuffer[i]);
+      Assertions.assertThat(readBuffer[i]).withFailMessage("@" + i).isEqualTo(block[i + 128]);
     }
   }
 
@@ -373,13 +374,13 @@ public abstract class AbstractContractSeekTest extends AbstractFSContractTestBas
     describe("readFully against a 0 byte file");
     assumeSupportsPositionedReadable();
     instream = getFileSystem().open(zeroByteFile);
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
     byte[] buffer = new byte[1];
     instream.readFully(0, buffer, 0, 0);
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
     // seek to 0 read 0 bytes from it
     instream.seek(0);
-    assertEquals(0, instream.read(buffer, 0, 0));
+    Assertions.assertThat(instream.read(buffer, 0, 0)).isEqualTo(0);
   }
 
   @Test
@@ -439,14 +440,14 @@ public abstract class AbstractContractSeekTest extends AbstractFSContractTestBas
     }
 
     // read properly
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
     instream.readFully(0, buffer);
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
 
     // now read the entire file in one go
     byte[] fullFile = new byte[TEST_FILE_LEN];
     instream.readFully(0, fullFile);
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
 
     try {
       instream.readFully(16, fullFile);
@@ -566,18 +567,18 @@ public abstract class AbstractContractSeekTest extends AbstractFSContractTestBas
     }
 
     // read properly
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
     instream.readFully(0, buffer);
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
 
     // now read the entire file in one go
     byte[] fullFile = new byte[TEST_FILE_LEN];
     instream.readFully(0, fullFile, 0, fullFile.length);
-    assertEquals(0, instream.getPos());
+    Assertions.assertThat(instream.getPos()).isEqualTo(0);
 
     // now read past the end of the file
-    assertEquals(-1,
-        instream.read(TEST_FILE_LEN + 16, buffer, 0, 1));
+    Assertions.assertThat(instream.read(TEST_FILE_LEN + 16, buffer, 0, 1))
+        .isEqualTo(-1);
   }
 
   @Test
@@ -585,7 +586,7 @@ public abstract class AbstractContractSeekTest extends AbstractFSContractTestBas
     describe("read at the end of the file");
     instream = getFileSystem().open(smallSeekFile);
     instream.seek(TEST_FILE_LEN -1);
-    assertTrue("read at last byte", instream.read() > 0);
-    assertEquals("read just past EOF", -1, instream.read());
+    Assertions.assertThat(instream.read() > 0).withFailMessage("read at last byte").isTrue();
+    Assertions.assertThat(instream.read()).withFailMessage("read just past EOF").isEqualTo(-1);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractUnbufferTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractUnbufferTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.contract;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -115,16 +116,18 @@ public abstract class AbstractContractUnbufferTest extends AbstractFSContractTes
       unbuffer(stream);
       validateFileContents(stream, TEST_FILE_LEN / 2, TEST_FILE_LEN / 2);
       unbuffer(stream);
-      assertEquals("stream should be at end of file", TEST_FILE_LEN,
-              stream.getPos());
+      Assertions.assertThat(stream.getPos())
+          .withFailMessage("stream should be at end of file")
+          .isEqualTo(TEST_FILE_LEN);
     }
   }
 
   private void unbuffer(FSDataInputStream stream) throws IOException {
     long pos = stream.getPos();
     stream.unbuffer();
-    assertEquals("unbuffer unexpectedly changed the stream position", pos,
-            stream.getPos());
+    Assertions.assertThat(stream.getPos())
+        .withFailMessage("unbuffer unexpectedly changed the stream position")
+        .isEqualTo(pos);
   }
 
   protected void validateFullFileContents(FSDataInputStream stream)
@@ -136,9 +139,9 @@ public abstract class AbstractContractUnbufferTest extends AbstractFSContractTes
                                       int startIndex)
           throws IOException {
     byte[] streamData = new byte[length];
-    assertEquals("failed to read expected number of bytes from "
-            + "stream. This may be transient",
-        length, stream.read(streamData));
+    Assertions.assertThat(stream.read(streamData))
+        .withFailMessage("failed to read expected number of bytes from stream. This may be transient")
+        .isEqualTo(length);
     byte[] validateFileBytes;
     if (startIndex == 0 && length == fileBytes.length) {
       validateFileBytes = fileBytes;
@@ -146,7 +149,9 @@ public abstract class AbstractContractUnbufferTest extends AbstractFSContractTes
       validateFileBytes = Arrays.copyOfRange(fileBytes, startIndex,
               startIndex + length);
     }
-    assertArrayEquals("invalid file contents", validateFileBytes, streamData);
+    Assertions.assertThat(streamData)
+        .withFailMessage("invalid file contents")
+        .isEqualTo(validateFileBytes);
   }
 
   protected Path getFile() {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractFSContract.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractFSContract.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.Assert;
+import org.assertj.core.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,7 +84,9 @@ public abstract class AbstractFSContract extends Configured {
    */
   protected void addConfResource(String resource) {
     boolean found = maybeAddConfResource(resource);
-    Assert.assertTrue("Resource not found " + resource, found);
+    Assertions.assertThat(found)
+        .withFailMessage("Resource not found " + resource)
+        .isTrue();
   }
 
   /**
@@ -195,7 +197,7 @@ public abstract class AbstractFSContract extends Configured {
     try {
       return new URI(getScheme(),path, null);
     } catch (URISyntaxException e) {
-      throw new IOException(e.toString() + " with " + path, e);
+      throw new IOException(e + " with " + path, e);
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractFSContractTestBase.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractFSContractTestBase.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -191,15 +192,18 @@ public abstract class AbstractFSContractTestBase extends Assert
     assumeEnabled();
     //extract the test FS
     fileSystem = contract.getTestFileSystem();
-    assertNotNull("null filesystem", fileSystem);
+    Assertions.assertThat(fileSystem)
+        .withFailMessage("null filesystem")
+        .isNotNull();
     URI fsURI = fileSystem.getUri();
     LOG.info("Test filesystem = {} implemented by {}",
         fsURI, fileSystem);
     //sanity check to make sure that the test FS picked up really matches
     //the scheme chosen. This is to avoid defaulting back to the localFS
     //which would be drastic for root FS tests
-    assertEquals("wrong filesystem of " + fsURI,
-                 contract.getScheme(), fsURI.getScheme());
+    Assertions.assertThat(fsURI.getScheme())
+        .withFailMessage("wrong filesystem of " + fsURI)
+        .isEqualTo(contract.getScheme());
     //create the test path
     testPath = getContract().getTestPath();
     mkdirs(testPath);
@@ -360,7 +364,9 @@ public abstract class AbstractFSContractTestBase extends Assert
    * @throws IOException IO problems during file operations
    */
   protected void mkdirs(Path path) throws IOException {
-    assertTrue("Failed to mkdir " + path, fileSystem.mkdirs(path));
+    Assertions.assertThat(fileSystem.mkdirs(path))
+        .withFailMessage("Failed to mkdir " + path)
+        .isTrue();
   }
 
   /**
@@ -381,7 +387,9 @@ public abstract class AbstractFSContractTestBase extends Assert
    * @param result read result to validate
    */
   protected void assertMinusOne(String text, int result) {
-    assertEquals(text + " wrong read result " + result, -1, result);
+    Assertions.assertThat(result)
+        .withFailMessage(text + " wrong read result " + result)
+        .isEqualTo(-1);
   }
 
   protected boolean rename(Path src, Path dst) throws IOException {
@@ -400,4 +408,5 @@ public abstract class AbstractFSContractTestBase extends Assert
     }
     return destDirLS;
   }
+
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractFSContractTestBase.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractFSContractTestBase.java
@@ -28,7 +28,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
-import org.junit.AssumptionViolatedException;
 import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
 import org.slf4j.Logger;
@@ -40,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.cleanup;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * This is the base class for all the contract tests.
@@ -150,8 +150,9 @@ public abstract class AbstractFSContractTestBase extends Assert
    * Include at the start of tests to skip them if the FS is not enabled.
    */
   protected void assumeEnabled() {
-    if (!contract.isEnabled())
-      throw new AssumptionViolatedException("test cases disabled for " + contract);
+    assumeThat(contract.isEnabled())
+        .withFailMessage("test cases disabled for " + contract)
+        .isTrue();
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
@@ -98,11 +98,13 @@ public class ContractTestUtils extends Assert {
                                           String expected) {
     String val = props.getProperty(key);
     if (expected == null) {
-      assertNull("Non null property " + key + " = " + val, val);
+      Assertions.assertThat(val)
+          .withFailMessage("Non null property " + key + " = " + val)
+          .isNull();
     } else {
-      assertEquals("property " + key + " = " + val,
-                          expected,
-                          val);
+      Assertions.assertThat(val)
+          .withFailMessage("property " + key + " = " + val)
+          .isEqualTo(expected);
     }
   }
 
@@ -146,7 +148,9 @@ public class ContractTestUtils extends Assert {
     if (delete) {
       rejectRootOperation(path);
       boolean deleted = fs.delete(path, false);
-      assertTrue("Deleted", deleted);
+      Assertions.assertThat(deleted)
+          .withFailMessage("Deleted")
+          .isTrue();
       assertPathDoesNotExist(fs, "Cleanup failed", path);
     }
   }
@@ -186,9 +190,9 @@ public class ContractTestUtils extends Assert {
   public static void writeDataset(FileSystem fs, Path path, byte[] src,
       int len, int buffersize, boolean overwrite, boolean useBuilder)
       throws IOException {
-    assertTrue(
-      "Not enough data in source array to write " + len + " bytes",
-      src.length >= len);
+    Assertions.assertThat(src)
+        .withFailMessage("Not enough data in source array to write " + len + " bytes")
+        .hasSizeGreaterThanOrEqualTo(len);
     FSDataOutputStream out;
     if (useBuilder) {
       out = fs.createFile(path)
@@ -254,7 +258,9 @@ public class ContractTestUtils extends Assert {
     FileStatus stat = fs.getFileStatus(path);
     assertIsFile(path, stat);
     String statText = stat.toString();
-    assertEquals("wrong length " + statText, original.length, stat.getLen());
+    Assertions.assertThat(stat.getLen())
+        .withFailMessage("wrong length " + statText)
+        .isEqualTo(original.length);
     byte[] bytes = readDataset(fs, path, original.length);
     compareByteArrays(original, bytes, original.length);
   }
@@ -289,8 +295,9 @@ public class ContractTestUtils extends Assert {
   public static void compareByteArrays(byte[] original,
                                        byte[] received,
                                        int len) {
-    assertEquals("Number of bytes read != number written",
-                        len, received.length);
+    Assertions.assertThat(received)
+        .withFailMessage("Number of bytes read != number written")
+        .hasSize(len);
     int errors = 0;
     int firstErrorByte = -1;
     for (int i = 0; i < len; i++) {
@@ -326,7 +333,7 @@ public class ContractTestUtils extends Assert {
         }
         LOG.warn(line);
       }
-      fail(message);
+      Assertions.fail(message);
     }
   }
 
@@ -434,8 +441,9 @@ public class ContractTestUtils extends Assert {
   public static void rename(FileSystem fileSystem, Path src, Path dst)
       throws IOException {
     rejectRootOperation(src, false);
-    assertTrue("rename(" + src + ", " + dst + ") failed",
-        fileSystem.rename(src, dst));
+    Assertions.assertThat(fileSystem.rename(src, dst))
+        .withFailMessage("rename(" + src + ", " + dst + ") failed")
+        .isTrue();
     assertPathDoesNotExist(fileSystem, "renamed source dir", src);
   }
 
@@ -519,7 +527,7 @@ public class ContractTestUtils extends Assert {
   public static void downgrade(String message, Throwable failure) {
     LOG.warn("Downgrading test " + message, failure);
     AssumptionViolatedException ave =
-        new AssumptionViolatedException(failure, null);
+        new AssumptionViolatedException(message, failure);
     throw ave;
   }
 
@@ -562,10 +570,9 @@ public class ContractTestUtils extends Assert {
   public static void assertFileHasLength(FileSystem fs, Path path,
                                          int expected) throws IOException {
     FileStatus status = fs.getFileStatus(path);
-    assertEquals(
-        "Wrong file length of file " + path + " status: " + status,
-        expected,
-        status.getLen());
+    Assertions.assertThat(status.getLen())
+        .withFailMessage("Wrong file length of file " + path + " status: " + status)
+        .isEqualTo(expected);
   }
 
   /**
@@ -586,8 +593,9 @@ public class ContractTestUtils extends Assert {
    * @param fileStatus stats to check
    */
   public static void assertIsDirectory(FileStatus fileStatus) {
-    assertTrue("Should be a directory -but isn't: " + fileStatus,
-               fileStatus.isDirectory());
+    Assertions.assertThat(fileStatus.isDirectory())
+        .withFailMessage("Should be a directory -but isn't: " + fileStatus)
+        .isTrue();
   }
 
   /**
@@ -600,7 +608,9 @@ public class ContractTestUtils extends Assert {
   public static void assertErasureCoded(final FileSystem fs, final Path path)
       throws IOException {
     FileStatus fileStatus = fs.getFileStatus(path);
-    assertTrue(path + " must be erasure coded!", fileStatus.isErasureCoded());
+    Assertions.assertThat(fileStatus.isErasureCoded())
+        .withFailMessage(path + " must be erasure coded!")
+        .isTrue();
   }
 
   /**
@@ -613,8 +623,9 @@ public class ContractTestUtils extends Assert {
   public static void assertNotErasureCoded(final FileSystem fs,
       final Path path) throws IOException {
     FileStatus fileStatus = fs.getFileStatus(path);
-    assertFalse(path + " should not be erasure coded!",
-        fileStatus.isErasureCoded());
+    Assertions.assertThat(fileStatus.isErasureCoded())
+        .withFailMessage(path + " should not be erasure coded!")
+        .isFalse();
   }
 
   /**
@@ -746,7 +757,7 @@ public class ContractTestUtils extends Assert {
     boolean deleted = fs.delete(file, recursive);
     if (!deleted) {
       String dir = ls(fs, file.getParent());
-      assertTrue("Delete failed on " + file + ": " + dir, deleted);
+      Assertions.fail("Delete failed on " + file + ": " + dir);
     }
     assertPathDoesNotExist(fs, "Deleted file", file);
   }
@@ -766,10 +777,10 @@ public class ContractTestUtils extends Assert {
       Path dest,
       boolean expectedResult) throws IOException {
     boolean result = fs.rename(source, dest);
-    if (expectedResult != result) {
-      fail(String.format("Expected rename(%s, %s) to return %b,"
-              + " but result was %b", source, dest, expectedResult, result));
-    }
+    Assertions.assertThat(result)
+        .withFailMessage(String.format("Expected rename(%s, %s) to return %b,"
+            + " but result was %b", source, dest, expectedResult, result))
+        .isEqualTo(expectedResult);
   }
 
   /**
@@ -896,10 +907,12 @@ public class ContractTestUtils extends Assert {
    */
   public static void assertIsFile(Path filename, FileStatus status) {
     String fileInfo = filename + "  " + status;
-    assertFalse("File claims to be a directory " + fileInfo,
-                status.isDirectory());
-    assertFalse("File claims to be a symlink " + fileInfo,
-                       status.isSymlink());
+    Assertions.assertThat(status.isDirectory())
+        .withFailMessage("File claims to be a directory " + fileInfo)
+        .isFalse();
+    Assertions.assertThat(status.isSymlink())
+        .withFailMessage("File claims to be a symlink " + fileInfo)
+        .isFalse();
   }
 
   /**
@@ -1019,7 +1032,7 @@ public class ContractTestUtils extends Assert {
                                             Path path) throws IOException {
     try {
       FileStatus status = fileSystem.getFileStatus(path);
-      fail(message + ": unexpectedly found " + path + " as  " + status);
+      Assertions.fail(message + ": unexpectedly found " + path + " as  " + status);
     } catch (FileNotFoundException expected) {
       //this is expected
 
@@ -1038,7 +1051,7 @@ public class ContractTestUtils extends Assert {
       String message, Path path) throws IOException {
     try {
       FileStatus status = fileContext.getFileStatus(path);
-      fail(message + ": unexpectedly found " + path + " as  " + status);
+      Assertions.fail(message + ": unexpectedly found " + path + " as  " + status);
     } catch (FileNotFoundException expected) {
       //this is expected
 
@@ -1064,9 +1077,10 @@ public class ContractTestUtils extends Assert {
         found = true;
       }
     }
-    assertTrue("Path " + subdir
-                      + " not found in directory " + dir + ":" + builder,
-                      found);
+    Assertions.assertThat(found)
+        .withFailMessage("Path " + subdir
+            + " not found in directory " + dir + ":" + builder)
+        .isTrue();
   }
 
   /**
@@ -1078,7 +1092,9 @@ public class ContractTestUtils extends Assert {
    * @throws IOException IO Problem
    */
   public static void assertMkdirs(FileSystem fs, Path dir) throws IOException {
-    assertTrue("mkdirs(" + dir + ") returned false", fs.mkdirs(dir));
+    Assertions.assertThat(fs.mkdirs(dir))
+        .withFailMessage("mkdirs(" + dir + ") returned false")
+        .isTrue();
   }
 
   /**
@@ -1109,8 +1125,9 @@ public class ContractTestUtils extends Assert {
         break;
       }
     }
-    assertFalse("File content of file is not as expected at offset " + idx,
-                mismatch);
+    Assertions.assertThat(mismatch)
+        .withFailMessage("File content of file is not as expected at offset " + idx)
+        .isFalse();
   }
 
   /**
@@ -1179,9 +1196,10 @@ public class ContractTestUtils extends Assert {
           int length, byte[] originalData) {
     for (int i = 0; i < length; i++) {
       int o = readOffset + i;
-      assertEquals(operation + " with read offset " + readOffset
-                      + ": data[" + i + "] != DATASET[" + o + "]",
-              originalData[o], data.get());
+      Assertions.assertThat(data.get())
+          .withFailMessage(operation + " with read offset " + readOffset
+              + ": data[" + i + "] != DATASET[" + o + "]")
+          .isEqualTo(originalData[o]);
     }
   }
 
@@ -1303,8 +1321,8 @@ public class ContractTestUtils extends Assert {
 
     // Write test file in a specific pattern
     NanoTimer timer = new NanoTimer();
-    assertEquals(fileSize,
-        generateTestFile(fs, objectPath, fileSize, testBufferSize, modulus));
+    Assertions.assertThat(generateTestFile(fs, objectPath, fileSize, testBufferSize, modulus))
+        .isEqualTo(fileSize);
     assertPathExists(fs, "not created successful", objectPath);
     timer.end("Time to write %d bytes", fileSize);
     bandwidth(timer, fileSize);
@@ -1638,23 +1656,26 @@ public class ContractTestUtils extends Assert {
   public static void assertCapabilities(
       Object stream, String[] shouldHaveCapabilities,
       String[] shouldNotHaveCapabilities) {
-    assertTrue("Stream should be instanceof StreamCapabilities",
-        stream instanceof StreamCapabilities);
+    Assertions.assertThat(stream)
+        .withFailMessage("Stream should be instanceof StreamCapabilities")
+        .isInstanceOf(StreamCapabilities.class);
 
     StreamCapabilities source = (StreamCapabilities) stream;
     if (shouldHaveCapabilities != null) {
       for (String shouldHaveCapability : shouldHaveCapabilities) {
-        assertTrue("Should have capability: " + shouldHaveCapability
-                + " in " + source,
-            source.hasCapability(shouldHaveCapability));
+        Assertions.assertThat(source.hasCapability(shouldHaveCapability))
+            .withFailMessage("Should have capability: " + shouldHaveCapability
+                + " in " + source)
+            .isTrue();
       }
     }
 
     if (shouldNotHaveCapabilities != null) {
       for (String shouldNotHaveCapability : shouldNotHaveCapabilities) {
-        assertFalse("Should not have capability: " + shouldNotHaveCapability
-                + " in " + source,
-            source.hasCapability(shouldNotHaveCapability));
+        Assertions.assertThat(source.hasCapability(shouldNotHaveCapability))
+            .withFailMessage("Should not have capability: " + shouldNotHaveCapability
+                + " in " + source)
+            .isFalse();
       }
     }
   }
@@ -1700,10 +1721,10 @@ public class ContractTestUtils extends Assert {
       final String...capabilities) throws IOException {
 
     for (String shouldHaveCapability: capabilities) {
-      assertTrue("Should have capability: " + shouldHaveCapability
-              + " under " + path
-              + " in " + source,
-          source.hasPathCapability(path, shouldHaveCapability));
+      Assertions.assertThat(source.hasPathCapability(path, shouldHaveCapability))
+          .withFailMessage("Should have capability: " + shouldHaveCapability
+              + " under " + path + " in " + source)
+              .isTrue();
     }
   }
 
@@ -1721,9 +1742,10 @@ public class ContractTestUtils extends Assert {
       final String...capabilities) throws IOException {
 
     for (String shouldHaveCapability: capabilities) {
-      assertFalse("Path  must not support capability: " + shouldHaveCapability
-              + " under " + path,
-          source.hasPathCapability(path, shouldHaveCapability));
+      Assertions.assertThat(source.hasPathCapability(path, shouldHaveCapability))
+          .withFailMessage("Path must not support capability: "
+              + shouldHaveCapability + " under " + path)
+          .isFalse();
     }
   }
 
@@ -1798,7 +1820,9 @@ public class ContractTestUtils extends Assert {
      * @param stats statistics array. Must not be null.
      */
     public TreeScanResults(FileStatus[] stats) {
-      assertNotNull("Null file status array", stats);
+      Assertions.assertThat(stats)
+          .withFailMessage("Null file status array")
+          .isNotNull();
       for (FileStatus stat : stats) {
         add(stat);
       }
@@ -1910,12 +1934,15 @@ public class ContractTestUtils extends Assert {
      */
     public void assertSizeEquals(String text, long f, long d, long o) {
       String self = dump();
-      Assert.assertEquals(text + ": file count in " + self,
-          f, getFileCount());
-      Assert.assertEquals(text + ": directory count in " + self,
-          d, getDirCount());
-      Assert.assertEquals(text + ": 'other' count in " + self,
-          o, getOtherCount());
+      Assertions.assertThat(getFileCount())
+          .withFailMessage(text + ": file count in " + self)
+          .isEqualTo(f);
+      Assertions.assertThat(getDirCount())
+          .withFailMessage(text + ": directory count in " + self)
+          .isEqualTo(d);
+      Assertions.assertThat(getOtherCount())
+          .withFailMessage(text + ": 'other' count in " + self)
+          .isEqualTo(o);
     }
 
     /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.util.functional.FutureIO;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.AssumptionViolatedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +64,7 @@ import java.util.concurrent.TimeoutException;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_KEY;
 import static org.apache.hadoop.util.functional.RemoteIterators.foreach;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * Utilities used across test cases.
@@ -522,19 +522,19 @@ public class ContractTestUtils extends Assert {
    * exception for the Junit test runner to mark as failed.
    * @param message text message
    * @param failure what failed
-   * @throws AssumptionViolatedException always
+   * @throws AssumptionViolatedException or similar always
    */
   public static void downgrade(String message, Throwable failure) {
     LOG.warn("Downgrading test " + message, failure);
-    AssumptionViolatedException ave =
-        new AssumptionViolatedException(message, failure);
-    throw ave;
+    assumeThat(false)
+        .withFailMessage(message)
+        .isTrue();
   }
 
   /**
    * report an overridden test as unsupported.
    * @param message message to use in the text
-   * @throws AssumptionViolatedException always
+   * @throws AssumptionViolatedException or similar always
    */
   public static void unsupported(String message) {
     skip(message);
@@ -543,11 +543,13 @@ public class ContractTestUtils extends Assert {
   /**
    * report a test has been skipped for some reason.
    * @param message message to use in the text
-   * @throws AssumptionViolatedException always
+   * @throws AssumptionViolatedException or similar always
    */
   public static void skip(String message) {
     LOG.info("Skipping: {}", message);
-    throw new AssumptionViolatedException(message);
+    assumeThat(false)
+        .withFailMessage(message)
+        .isTrue();
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ftp/FTPContract.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ftp/FTPContract.java
@@ -22,10 +22,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractBondedFSContract;
+import org.assertj.core.api.Assertions;
 
 import java.net.URI;
-
-import static org.junit.Assert.assertNotNull;
 
 /**
  * The contract of FTP; requires the option "test.testdir" to be set
@@ -55,8 +54,9 @@ public class FTPContract extends AbstractBondedFSContract {
   @Override
   public Path getTestPath() {
     String pathString = getOption(TEST_FS_TESTDIR, null);
-    assertNotNull("Undefined test option " + TEST_FS_TESTDIR, pathString);
-    Path path = new Path(pathString);
-    return path;
+    Assertions.assertThat(pathString)
+        .withFailMessage("Undefined test option " + TEST_FS_TESTDIR)
+        .isNotNull();
+    return new Path(pathString);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/rawlocal/TestRawLocalContractUnderlyingFileBehavior.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/rawlocal/TestRawLocalContractUnderlyingFileBehavior.java
@@ -20,13 +20,13 @@ package org.apache.hadoop.fs.contract.rawlocal;
 
 import org.apache.hadoop.conf.Configuration;
 
-import org.junit.Assert;
+import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
 
-public class TestRawLocalContractUnderlyingFileBehavior extends Assert {
+public class TestRawLocalContractUnderlyingFileBehavior {
 
   private static File testDirectory;
 
@@ -36,14 +36,16 @@ public class TestRawLocalContractUnderlyingFileBehavior extends Assert {
       new RawlocalFSContract(new Configuration());
     testDirectory = contract.getTestDirectory();
     testDirectory.mkdirs();
-    assertTrue(testDirectory.isDirectory());
+    Assertions.assertThat(testDirectory).isDirectory();
 
   }
 
   @Test
   public void testDeleteEmptyPath() throws Throwable {
     File nonexistent = new File(testDirectory, "testDeleteEmptyPath");
-    assertFalse(nonexistent.exists());
-    assertFalse("nonexistent.delete() returned true", nonexistent.delete());
+    Assertions.assertThat(nonexistent).doesNotExist();
+    Assertions.assertThat(nonexistent.delete())
+        .withFailMessage("nonexistent.delete() returned true")
+        .isFalse();
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace assertions in `ContractTestUtils` and abstract contract tests with `assertThat` from AssertJ, to reduce dependency on JUnit4.

Kept `extends Assert` for compatibility, but I'd like to get rid of that in the long run.
 
https://issues.apache.org/jira/browse/HADOOP-19025

## How was this patch tested?

```
mvn -DskipShade -am -pl :hadoop-hdfs -Dtest='TestLocalFSContract*,TestHDFSContract*,TestRawLocal*' clean test
```