### PR TITLE
YARN-11642. Fix Flaky Test TestTimelineAuthFilterForV2#testPutTimelineEntities.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/timelineservice/security/TestTimelineAuthFilterForV2.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/timelineservice/security/TestTimelineAuthFilterForV2.java
@@ -211,7 +211,8 @@ public class TestTimelineAuthFilterForV2 {
     }
     UserGroupInformation.setConfiguration(conf);
     collectorManager = new DummyNodeTimelineCollectorManager();
-    auxService = PerNodeTimelineCollectorsAuxService.launchServer(
+    PerNodeTimelineCollectorsAuxService as = new PerNodeTimelineCollectorsAuxService();
+    auxService = as.launchServer(
         new String[0], collectorManager, conf);
     if (withKerberosLogin) {
       SecurityUtil.login(conf, YarnConfiguration.TIMELINE_SERVICE_KEYTAB,


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11642. Fix Flaky Test TestTimelineAuthFilterForV2#testPutTimelineEntities.

We can find the following unit test failure report:

[Report1
](https://ci-hadoop.apache.org/job/hadoop-multibranch/job/PR-6410/1/testReport/org.apache.hadoop.yarn.server.timelineservice.security/TestTimelineAuthFilterForV2/testPutTimelineEntities_boolean__boolean__3_/)

```
org.opentest4j.AssertionFailedError: expected: <2> but was: <1>
...
at org.apache.hadoop.yarn.server.timelineservice.security.TestTimelineAuthFilterForV2.publishAndVerifyEntity(TestTimelineAuthFilterForV2.java:324)
at org.apache.hadoop.yarn.server.timelineservice.security.TestTimelineAuthFilterForV2.publishWithRetries(TestTimelineAuthFilterForV2.java:337)
at org.apache.hadoop.yarn.server.timelineservice.security.TestTimelineAuthFilterForV2.testPutTimelineEntities(TestTimelineAuthFilterForV2.java:383)
```

[Report2
](https://ci-hadoop.apache.org/job/hadoop-multibranch/job/PR-6396/2/testReport/org.apache.hadoop.yarn.server.timelineservice.security/TestTimelineAuthFilterForV2/testPutTimelineEntities_boolean__boolean__3_/)

```
expected: <true> but was: <false>
...
at org.apache.hadoop.yarn.server.timelineservice.security.TestTimelineAuthFilterForV2.verifyEntity(TestTimelineAuthFilterForV2.java:294)
at org.apache.hadoop.yarn.server.timelineservice.security.TestTimelineAuthFilterForV2.testPutTimelineEntities(TestTimelineAuthFilterForV2.java:441)
```

The reason for this error is that `PerNodeTimelineCollectorsAuxService` was not initialized normally.

```
2024-01-05 09:34:21,511 WARN  [main] collector.PerNodeTimelineCollectorsAuxService (StringUtils.java:startupShutdownMessage(755)) - failed to register any UNIX signal loggers: 
java.lang.IllegalStateException: Can't re-install the signal handlers.
at org.apache.hadoop.util.SignalLogger.register(SignalLogger.java:73)
at org.apache.hadoop.util.StringUtils.startupShutdownMessage(StringUtils.java:753)
... 
```

`PerNodeTimelineCollectorsAuxService` is initialized using a static method and is initialized in parallel by multiple threads(because our unit tests are parallel.), resulting in an error. 

```
/usr/bin/mvn --batch-mode -Dmaven.repo.local=/home/jenkins/jenkins-home/workspace/hadoop-multibranch_PR-6396/yetus-m2/hadoop-trunk-patch-0 -Dsurefire.rerunFailingTestsCount=2 -Pparallel-tests -Pshelltest -Pnative -Drequire.fuse -Drequire.openssl -Drequire.snappy -Drequire.valgrind -Drequire.zstd -Drequire.test.libhadoop -Pyarn-ui clean test -fae ...
```

We can change the static `initialization` to `new PerNodeTimelineCollectorsAuxService()` to avoid this problem, which has been verified in the local environment.

### How was this patch tested?

Junit Test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

