### PR TITLE
HDFS-17327. Fix ReconfigurableBase class's reconfigureProperty method judgment logic.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/ReconfigurableBase.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/ReconfigurableBase.java
@@ -228,7 +228,7 @@ public abstract class ReconfigurableBase
       synchronized(getConf()) {
         getConf().get(property);
         String effectiveValue = reconfigurePropertyImpl(property, newVal);
-        if (newVal != null) {
+        if (effectiveValue != null) {
           getConf().set(property, effectiveValue);
         } else {
           getConf().unset(property);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/ReconfigurableBase.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/ReconfigurableBase.java
@@ -224,11 +224,11 @@ public abstract class ReconfigurableBase
   public final void reconfigureProperty(String property, String newVal)
     throws ReconfigurationException {
     if (isPropertyReconfigurable(property)) {
-      LOG.info("changing property " + property + " to " + newVal);
       synchronized(getConf()) {
         getConf().get(property);
         String effectiveValue = reconfigurePropertyImpl(property, newVal);
         if (effectiveValue != null) {
+          LOG.info("changing property " + property + " to " + effectiveValue);
           getConf().set(property, effectiveValue);
         } else {
           getConf().unset(property);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -1039,13 +1039,13 @@ public class DataNode extends ReconfigurableBase
         result = Boolean.toString(enable);
       } else if (property.equals(DFS_DISK_BALANCER_PLAN_VALID_INTERVAL)) {
         if (newVal == null) {
-          // set to default
+          // set to the value of the current system or default
           long defaultInterval = getConf().getTimeDuration(
               DFS_DISK_BALANCER_PLAN_VALID_INTERVAL,
               DFS_DISK_BALANCER_PLAN_VALID_INTERVAL_DEFAULT,
               TimeUnit.MILLISECONDS);
           getDiskBalancer().setPlanValidityInterval(defaultInterval);
-          result = DFS_DISK_BALANCER_PLAN_VALID_INTERVAL_DEFAULT;
+          result = Long.toString(defaultInterval);
         } else {
           long newInterval = getConf()
               .getTimeDurationHelper(DFS_DISK_BALANCER_PLAN_VALID_INTERVAL,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeReconfiguration.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeReconfiguration.java
@@ -916,6 +916,17 @@ public class TestDataNodeReconfiguration {
       dn.reconfigureProperty(DFS_DISK_BALANCER_PLAN_VALID_INTERVAL, "1m");
       assertEquals(60000, dn.getDiskBalancer().getPlanValidityInterval());
       assertEquals(60000, dn.getDiskBalancer().getPlanValidityIntervalInConfig());
+
+      // Verify set to the value of the current system
+      long curTimeInterval = dn.getConf().getTimeDuration(DFS_DISK_BALANCER_PLAN_VALID_INTERVAL,
+          DFS_DISK_BALANCER_PLAN_VALID_INTERVAL_DEFAULT, TimeUnit.MILLISECONDS);
+      dn.reconfigureProperty(DFS_DISK_BALANCER_PLAN_VALID_INTERVAL, null);
+      assertEquals(60000, curTimeInterval);
+      assertEquals(curTimeInterval, dn.getDiskBalancer().getPlanValidityInterval());
+      assertEquals(60000, dn.getDiskBalancer().getPlanValidityIntervalInConfig());
+      curTimeInterval = dn.getConf().getTimeDuration(DFS_DISK_BALANCER_PLAN_VALID_INTERVAL,
+          DFS_DISK_BALANCER_PLAN_VALID_INTERVAL_DEFAULT, TimeUnit.MILLISECONDS);
+      assertEquals(60000, curTimeInterval);
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: https://issues.apache.org/jira/browse/HDFS-17327
1. If it is a null value, after reconfig, It may be that the current system value is in effect, not necessarily the default value.
2. `ReconfigurableBase#reconfigureProperty` judges the condition incorrectly, When the effectValue is not null, the system value needs to be changed.
3. In other words, certain variables actually have effected, but the current configuration of the system is refreshed to null.
### How was this patch tested?
Add Unit Test