### PR TITLE
HDFS-17328. DiskBalancer should not computeNodeDensity every time when addVolume.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/diskbalancer/connectors/DBNameNodeConnector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/diskbalancer/connectors/DBNameNodeConnector.java
@@ -133,7 +133,10 @@ class DBNameNodeConnector implements ClusterConnector {
       throws Exception {
     Preconditions.checkNotNull(node);
     Preconditions.checkNotNull(reports);
-    for (StorageReport report : reports) {
+    int len = reports.length;
+    boolean needComputeDensity = false;
+    for (int i = 0; i < len; i++) {
+      StorageReport report = reports[i];
       DatanodeStorage storage = report.getStorage();
       DiskBalancerVolume volume = new DiskBalancerVolume();
       volume.setCapacity(report.getCapacity());
@@ -153,8 +156,10 @@ class DBNameNodeConnector implements ClusterConnector {
           .READ_ONLY_SHARED) || report.isFailed());
       volume.setStorageType(storage.getStorageType().name());
       volume.setIsTransient(storage.getStorageType().isTransient());
-      node.addVolume(volume);
+      if (i == len - 1) {
+        needComputeDensity = true;
+      }
+      node.addVolume(volume, needComputeDensity);
     }
-
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/diskbalancer/datamodel/DiskBalancerDataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/diskbalancer/datamodel/DiskBalancerDataNode.java
@@ -238,6 +238,10 @@ public class DiskBalancerDataNode implements Comparable<DiskBalancerDataNode> {
    * @param volume - volume
    */
   public void addVolume(DiskBalancerVolume volume) throws Exception {
+    addVolume(volume, false);
+  }
+
+  public void addVolume(DiskBalancerVolume volume, boolean computeDensity) throws Exception {
     Preconditions.checkNotNull(volume, "volume cannot be null");
     Preconditions.checkNotNull(volumeSets, "volume sets cannot be null");
     Preconditions
@@ -254,7 +258,9 @@ public class DiskBalancerDataNode implements Comparable<DiskBalancerDataNode> {
     }
 
     vSet.addVolume(volume);
-    computeNodeDensity();
+    if (computeDensity) {
+      computeNodeDensity();
+    }
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/diskbalancer/datamodel/DiskBalancerDataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/diskbalancer/datamodel/DiskBalancerDataNode.java
@@ -238,7 +238,7 @@ public class DiskBalancerDataNode implements Comparable<DiskBalancerDataNode> {
    * @param volume - volume
    */
   public void addVolume(DiskBalancerVolume volume) throws Exception {
-    addVolume(volume, false);
+    addVolume(volume, true);
   }
 
   public void addVolume(DiskBalancerVolume volume, boolean computeDensity) throws Exception {


### PR DESCRIPTION
### Description of PR
When we call DiskBalancerDataNode#addVolume method, it will computeNodeDensity every time. That is unnecessary. We only need to compute NodeDensity when all volumes were added. This can improve the speed of report command.