### PR TITLE
YARN-11643. Skip unnecessary pre-check in Multi Node Placement

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/allocator/RegularContainerAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/allocator/RegularContainerAllocator.java
@@ -873,11 +873,12 @@ public class RegularContainerAllocator extends AbstractContainerAllocator {
       if (reservedContainer == null) {
         result = preCheckForNodeCandidateSet(node,
             schedulingMode, resourceLimits, schedulerKey);
-        if (result.getAllocationState() == AllocationState.PRIORITY_SKIPPED
-            || result.getAllocationState() == AllocationState.APP_SKIPPED
-            || result.getAllocationState() == AllocationState.QUEUE_SKIPPED) {
-          break;
-        } else {
+        if (result != null) {
+          if (result.getAllocationState() == AllocationState.PRIORITY_SKIPPED
+              || result.getAllocationState() == AllocationState.APP_SKIPPED
+              || result.getAllocationState() == AllocationState.QUEUE_SKIPPED) {
+            break;
+          }
           continue;
         }
       } else {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/allocator/RegularContainerAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/allocator/RegularContainerAllocator.java
@@ -873,7 +873,11 @@ public class RegularContainerAllocator extends AbstractContainerAllocator {
       if (reservedContainer == null) {
         result = preCheckForNodeCandidateSet(node,
             schedulingMode, resourceLimits, schedulerKey);
-        if (null != result) {
+        if (result.getAllocationState() == AllocationState.PRIORITY_SKIPPED
+            || result.getAllocationState() == AllocationState.APP_SKIPPED
+            || result.getAllocationState() == AllocationState.QUEUE_SKIPPED) {
+          break;
+        } else {
           continue;
         }
       } else {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: [YARN-11643](https://issues.apache.org/jira/browse/YARN-11643). Skip unnecessary pre-check in Multi Node Placement.
Scheduler may do useless while loop when Multi Node Placement enable. This lead to poor schedule performance in worst-case scenario.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

