### PR TITLE
HADOOP-19031. Enhance access control for RunJar.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/RunJar.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/RunJar.java
@@ -28,10 +28,14 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
@@ -287,20 +291,18 @@ public class RunJar {
 
     final File workDir;
     try {
-      workDir = File.createTempFile("hadoop-unjar", "", tmpDir);
-    } catch (IOException ioe) {
+      FileAttribute<Set<PosixFilePermission>> perms = PosixFilePermissions
+          .asFileAttribute(PosixFilePermissions.fromString("rwx------"));
+      workDir = Files.createTempDirectory(tmpDir.toPath(), "hadoop-unjar", perms).toFile();
+    } catch (IOException | SecurityException e) {
       // If user has insufficient perms to write to tmpDir, default
       // "Permission denied" message doesn't specify a filename.
       System.err.println("Error creating temp dir in java.io.tmpdir "
-                         + tmpDir + " due to " + ioe.getMessage());
+                         + tmpDir + " due to " + e.getMessage());
       System.exit(-1);
       return;
     }
 
-    if (!workDir.delete()) {
-      System.err.println("Delete failed for " + workDir);
-      System.exit(-1);
-    }
     ensureDirectory(workDir);
 
     ShutdownHookManager.get().addShutdownHook(


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Make sure that the work directory of RunJar is only accessible by the current user.

### How was this patch tested?


### For code changes:

- [Y] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [Y] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [Y] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [Y] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?