### PR TITLE
HDFS-17335. Add metrics for syncWaitQ in FSEditLogAsync

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
@@ -257,6 +257,7 @@ Each metrics record contains tags such as ProcessName, SessionId, and Hostname a
 | `EditLogTailIntervalAvgTime` | Average time of intervals between edit log tailings by standby NameNode in milliseconds |
 | `EditLogTailInterval`*num*`s(50/75/90/95/99)thPercentileLatency` | The 50/75/90/95/99th percentile of time between edit log tailings by standby NameNode in milliseconds (*num* seconds granularity). Percentile measurement is off by default, by watching no intervals. The intervals are specified by `dfs.metrics.percentiles.intervals`. |
 | `PendingEditsCount` | Current number of pending edits |
+| `PendingSyncEditsCount` | Current number of pending sync edits |
 
 FSNamesystem
 ------------

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogAsync.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogAsync.java
@@ -244,8 +244,8 @@ class FSEditLogAsync extends FSEditLog implements Runnable {
   @Override
   public void run() {
     try {
+      NameNodeMetrics metrics = NameNode.getNameNodeMetrics();
       while (true) {
-        NameNodeMetrics metrics = NameNode.getNameNodeMetrics();
         boolean doSync;
         Edit edit = dequeueEdit();
         if (edit != null) {
@@ -258,6 +258,7 @@ class FSEditLogAsync extends FSEditLog implements Runnable {
           doSync = !syncWaitQ.isEmpty();
           metrics.setPendingEditsCount(0);
         }
+        metrics.setPendingSyncEditsCount(syncWaitQ.size());
         if (doSync) {
           // normally edit log exceptions cause the NN to terminate, but tests
           // relying on ExitUtil.terminate need to see the exception.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/NameNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/NameNodeMetrics.java
@@ -89,6 +89,8 @@ public class NameNodeMetrics {
   MutableCounterLong blockOpsBatched;
   @Metric("Number of pending edits")
   MutableGaugeInt pendingEditsCount;
+  @Metric("Number of pending sync edits")
+  MutableGaugeInt pendingSyncEditsCount;
   @Metric("Number of delete blocks Queued")
   MutableGaugeInt deleteBlocksQueued;
   @Metric("Number of pending deletion blocks")
@@ -363,6 +365,10 @@ public class NameNodeMetrics {
 
   public void setPendingEditsCount(int size) {
     pendingEditsCount.set(size);
+  }
+
+  public void setPendingSyncEditsCount(int size) {
+    pendingSyncEditsCount.set(size);
   }
 
   public void addTransaction(long latency) {


### PR DESCRIPTION

### Description of PR
See HDFS-17335.

To monitor syncWaitQ in FSEditLogAsync, we add a metric syncPendingCount.

The reason we add this metrics is that when dequeueEdit() return null,  the boolean variable doSync is set to !syncWaitQ.isEmpty()    After adding this metrics we can better monitor sync performance and codes.

