### PR TITLE
YARN-11646. Do not ignore zero memory capacity config in QueueCapacityConfigParser.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/QueueCapacityConfigParser.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/QueueCapacityConfigParser.java
@@ -148,11 +148,6 @@ public class QueueCapacityConfigParser {
       }
     }
 
-    // Memory always have to be defined
-    if (capacityVector.getMemory() == 0L) {
-      return new QueueCapacityVector();
-    }
-
     return capacityVector;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/TestQueueCapacityConfigParser.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/TestQueueCapacityConfigParser.java
@@ -217,7 +217,8 @@ public class TestQueueCapacityConfigParser {
 
   @Test
   public void testZeroAbsoluteCapacityConfig() {
-    QueueCapacityVector weightCapacityVector = capacityConfigParser.parse(String.format(MEMORY_VCORE_TEMPLATE, 0, 0), QUEUE);
+    QueueCapacityVector weightCapacityVector =
+        capacityConfigParser.parse(String.format(MEMORY_VCORE_TEMPLATE, 0, 0), QUEUE);
 
     QueueCapacityVectorEntry memory = weightCapacityVector.getResource(MEMORY_URI);
     QueueCapacityVectorEntry vcore = weightCapacityVector.getResource(VCORES_URI);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/TestQueueCapacityConfigParser.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/TestQueueCapacityConfigParser.java
@@ -214,4 +214,18 @@ public class TestQueueCapacityConfigParser {
         Lists.newArrayList(nonSetCapacity.iterator());
     Assert.assertEquals(nonSetResources.size(), 0);
   }
+
+  @Test
+  public void testZeroAbsoluteCapacityConfig() {
+    QueueCapacityVector weightCapacityVector = capacityConfigParser.parse(String.format(MEMORY_VCORE_TEMPLATE, 0, 0), QUEUE);
+
+    QueueCapacityVectorEntry memory = weightCapacityVector.getResource(MEMORY_URI);
+    QueueCapacityVectorEntry vcore = weightCapacityVector.getResource(VCORES_URI);
+
+    Assert.assertEquals(ResourceUnitCapacityType.ABSOLUTE, memory.getVectorResourceType());
+    Assert.assertEquals(0, memory.getResourceValue(), EPSILON);
+
+    Assert.assertEquals(ResourceUnitCapacityType.ABSOLUTE, vcore.getVectorResourceType());
+    Assert.assertEquals(0, vcore.getResourceValue(), EPSILON);
+  }
 }


### PR DESCRIPTION
Change-Id: Id00a5382d982dcf33ec8a3769fc33419b660968b

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

There is no reason to ignore the configured capacity if the memory is 0 in the configuration.

It makes it impossible to configure a zero absolute resource capacity.

Example:
```
root.default.capacity=[memory=0, vcores=0]
root.default.maximum-capacity=[memory=2048, vcores=2]
```

### How was this patch tested?

Ran the unit tests.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'YARN-11646. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

