### PR TITLE
HDFS-17334. FSEditLogAsync#enqueueEdit does not synchronized this before invoke wait method.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogAsync.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogAsync.java
@@ -215,7 +215,9 @@ class FSEditLogAsync extends FSEditLog implements Runnable {
           int permits = overflowMutex.drainPermits();
           try {
             do {
-              this.wait(1000); // will be notified by next logSync.
+              synchronized (this) {
+                this.wait(1000); // will be notified by next logSync.
+              }
             } while (!editPendingQ.offer(edit));
           } finally {
             overflowMutex.release(permits);


### PR DESCRIPTION
### Description of PR
HDFS-17334.

In method FSEditLogAsync#enqueueEdit , there exist the below codes:
```java
        if (Thread.holdsLock(this)) {
          // if queue is full, synchronized caller must immediately relinquish
          // the monitor before re-offering to avoid deadlock with sync thread
          // which needs the monitor to write transactions.
          int permits = overflowMutex.drainPermits();
          try {
            do {
              this.wait(1000); // will be notified by next logSync.
            } while (!editPendingQ.offer(edit));
          } finally {
            overflowMutex.release(permits);
          }
        }  
```
It maybe invoke this.wait(1000) without having object this's monitor.

 