### PR TITLE
 HDFS-17337. RPC RESPONSE time seems not exactly accurate when using FSEditLogAsync.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -1089,7 +1089,10 @@ public abstract class Server {
       int count = responseWaitCount.decrementAndGet();
       assert count >= 0 : "response has already been sent";
       if (count == 0) {
+        long startNanos = Time.monotonicNowNanos();
         doResponse(null);
+        getProcessingDetails().set(Timing.RESPONSE,
+            Time.monotonicNowNanos() - startNanos, TimeUnit.NANOSECONDS);
       }
     }
 
@@ -1257,14 +1260,10 @@ public abstract class Server {
         deltaNanos -= details.get(Timing.LOCKSHARED, TimeUnit.NANOSECONDS);
         deltaNanos -= details.get(Timing.LOCKEXCLUSIVE, TimeUnit.NANOSECONDS);
         details.set(Timing.LOCKFREE, deltaNanos, TimeUnit.NANOSECONDS);
-        startNanos = Time.monotonicNowNanos();
 
         setResponseFields(value, responseParams);
         sendResponse();
-
         details.setReturnStatus(responseParams.returnStatus);
-        deltaNanos = Time.monotonicNowNanos() - startNanos;
-        details.set(Timing.RESPONSE, deltaNanos, TimeUnit.NANOSECONDS);
       } else {
         LOG.debug("Deferring response for callId: {}", this.callId);
       }


### PR DESCRIPTION
### Description of PR
Refer to HDFS-17337.
Currently, FSEditLogAsync is enabled by default. 

We have below codes in method Server$RpcCall#run:

```java
      if (!isResponseDeferred()) {
        long deltaNanos = Time.monotonicNowNanos() - startNanos;
        ProcessingDetails details = getProcessingDetails();        
        details.set(Timing.PROCESSING, deltaNanos, TimeUnit.NANOSECONDS);
        deltaNanos -= details.get(Timing.LOCKWAIT, TimeUnit.NANOSECONDS);
        deltaNanos -= details.get(Timing.LOCKSHARED, TimeUnit.NANOSECONDS);
        deltaNanos -= details.get(Timing.LOCKEXCLUSIVE, TimeUnit.NANOSECONDS);
        details.set(Timing.LOCKFREE, deltaNanos, TimeUnit.NANOSECONDS);
        startNanos = Time.monotonicNowNanos();
        setResponseFields(value, responseParams);
        sendResponse();        
        deltaNanos = Time.monotonicNowNanos() - startNanos;
        details.set(Timing.RESPONSE, deltaNanos, TimeUnit.NANOSECONDS);
      } else {
        if (LOG.isDebugEnabled()) {
          LOG.debug("Deferring response for callId: " + this.callId);
        }
      }
```
It computes Timing.RESPONSE of a RpcCall using Time.monotonicNowNanos() - startNanos;

However, if we use async editlogging,  we will not send response here but in FSEditLogAsync.RpcEdit#logSyncNotify.

This causes the Timing.RESPONSE of a RpcCall not be exactly accurate.
```java
    @Override
    public void logSyncNotify(RuntimeException syncEx) {
      try {
        if (syncEx == null) {
          call.sendResponse();
        } else {
          call.abortResponse(syncEx);
        }
      } catch (Exception e) {} // don't care if not sent.
    }
``` 

flame graph like below:
![image](https://github.com/apache/hadoop/assets/25115709/aa3e8415-aca6-479d-93fc-bc05fd97071c)

