### PR TITLE
HADOOP-19035. CrcUtil/CrcComposer should not throw IOException for non-IO.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/CrcComposer.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/CrcComposer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -46,7 +46,7 @@ public class CrcComposer {
 
   private int curCompositeCrc = 0;
   private long curPositionInStripe = 0;
-  private ByteArrayOutputStream digestOut = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream digestOut = new ByteArrayOutputStream();
 
   /**
    * Returns a CrcComposer which will collapse all ingested CRCs into a single
@@ -54,12 +54,10 @@ public class CrcComposer {
    *
    * @param type type.
    * @param bytesPerCrcHint bytesPerCrcHint.
-   * @throws IOException raised on errors performing I/O.
    * @return a CrcComposer which will collapse all ingested CRCs into a single value.
    */
   public static CrcComposer newCrcComposer(
-      DataChecksum.Type type, long bytesPerCrcHint)
-      throws IOException {
+      DataChecksum.Type type, long bytesPerCrcHint) {
     return newStripedCrcComposer(type, bytesPerCrcHint, Long.MAX_VALUE);
   }
 
@@ -78,11 +76,9 @@ public class CrcComposer {
    * @param stripeLength stripeLength.
    * @return a CrcComposer which will collapse CRCs for every combined.
    * underlying data size which aligns with the specified stripe boundary.
-   * @throws IOException raised on errors performing I/O.
    */
   public static CrcComposer newStripedCrcComposer(
-      DataChecksum.Type type, long bytesPerCrcHint, long stripeLength)
-      throws IOException {
+      DataChecksum.Type type, long bytesPerCrcHint, long stripeLength) {
     int polynomial = DataChecksum.getCrcPolynomialForType(type);
     return new CrcComposer(
         polynomial,
@@ -118,13 +114,10 @@ public class CrcComposer {
    * @param offset offset.
    * @param length must be a multiple of the expected byte-size of a CRC.
    * @param bytesPerCrc bytesPerCrc.
-   * @throws IOException raised on errors performing I/O.
    */
-  public void update(
-      byte[] crcBuffer, int offset, int length, long bytesPerCrc)
-      throws IOException {
+  public void update(byte[] crcBuffer, int offset, int length, long bytesPerCrc) {
     if (length % CRC_SIZE_BYTES != 0) {
-      throw new IOException(String.format(
+      throw new IllegalArgumentException(String.format(
           "Trying to update CRC from byte array with length '%d' at offset "
           + "'%d' which is not a multiple of %d!",
           length, offset, CRC_SIZE_BYTES));
@@ -162,9 +155,8 @@ public class CrcComposer {
    *
    * @param crcB crcB.
    * @param bytesPerCrc bytesPerCrc.
-   * @throws IOException raised on errors performing I/O.
    */
-  public void update(int crcB, long bytesPerCrc) throws IOException {
+  public void update(int crcB, long bytesPerCrc) {
     if (curCompositeCrc == 0) {
       curCompositeCrc = crcB;
     } else if (bytesPerCrc == bytesPerCrcHint) {
@@ -178,7 +170,7 @@ public class CrcComposer {
     curPositionInStripe += bytesPerCrc;
 
     if (curPositionInStripe > stripeLength) {
-      throw new IOException(String.format(
+      throw new IllegalStateException(String.format(
           "Current position in stripe '%d' after advancing by bytesPerCrc '%d' "
           + "exceeds stripeLength '%d' without stripe alignment.",
           curPositionInStripe, bytesPerCrc, stripeLength));

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/CrcUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/CrcUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -21,7 +21,6 @@ package org.apache.hadoop.util;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
-import java.io.IOException;
 import java.util.Arrays;
 
 /**
@@ -112,15 +111,7 @@ public final class CrcUtil {
    */
   public static byte[] intToBytes(int value) {
     byte[] buf = new byte[4];
-    try {
-      writeInt(buf, 0, value);
-    } catch (IOException ioe) {
-      // Since this should only be able to occur from code bugs within this
-      // class rather than user input, we throw as a RuntimeException
-      // rather than requiring this method to declare throwing IOException
-      // for something the caller can't control.
-      throw new RuntimeException(ioe);
-    }
+    writeInt(buf, 0, value);
     return buf;
   }
 
@@ -132,16 +123,14 @@ public final class CrcUtil {
    * @param buf buf size.
    * @param offset offset.
    * @param value value.
-   * @throws IOException raised on errors performing I/O.
    */
-  public static void writeInt(byte[] buf, int offset, int value)
-      throws IOException {
+  public static void writeInt(byte[] buf, int offset, int value) {
     if (offset + 4  > buf.length) {
-      throw new IOException(String.format(
+      throw new ArrayIndexOutOfBoundsException(String.format(
           "writeInt out of bounds: buf.length=%d, offset=%d",
           buf.length, offset));
     }
-    buf[offset + 0] = (byte)((value >>> 24) & 0xff);
+    buf[offset    ] = (byte)((value >>> 24) & 0xff);
     buf[offset + 1] = (byte)((value >>> 16) & 0xff);
     buf[offset + 2] = (byte)((value >>> 8) & 0xff);
     buf[offset + 3] = (byte)(value & 0xff);
@@ -154,20 +143,17 @@ public final class CrcUtil {
    * @param offset offset.
    * @param buf buf.
    * @return int.
-   * @throws IOException raised on errors performing I/O.
    */
-  public static int readInt(byte[] buf, int offset)
-      throws IOException {
+  public static int readInt(byte[] buf, int offset) {
     if (offset + 4  > buf.length) {
-      throw new IOException(String.format(
+      throw new ArrayIndexOutOfBoundsException(String.format(
           "readInt out of bounds: buf.length=%d, offset=%d",
           buf.length, offset));
     }
-    int value = ((buf[offset + 0] & 0xff) << 24) |
+    return      ((buf[offset    ] & 0xff) << 24) |
                 ((buf[offset + 1] & 0xff) << 16) |
                 ((buf[offset + 2] & 0xff) << 8)  |
                 ((buf[offset + 3] & 0xff));
-    return value;
   }
 
   /**
@@ -176,13 +162,11 @@ public final class CrcUtil {
    * formatted value.
    *
    * @param bytes bytes.
-   * @throws IOException raised on errors performing I/O.
    * @return a list of hex formatted values.
    */
-  public static String toSingleCrcString(final byte[] bytes)
-      throws IOException {
+  public static String toSingleCrcString(final byte[] bytes) {
     if (bytes.length != 4) {
-      throw new IOException((String.format(
+      throw new IllegalArgumentException((String.format(
           "Unexpected byte[] length '%d' for single CRC. Contents: %s",
           bytes.length, Arrays.toString(bytes))));
     }
@@ -195,13 +179,11 @@ public final class CrcUtil {
    * hex formatted values.
    *
    * @param bytes bytes.
-   * @throws IOException raised on errors performing I/O.
    * @return a list of hex formatted values.
    */
-  public static String toMultiCrcString(final byte[] bytes)
-      throws IOException {
+  public static String toMultiCrcString(final byte[] bytes) {
     if (bytes.length % 4 != 0) {
-      throw new IOException((String.format(
+      throw new IllegalArgumentException((String.format(
           "Unexpected byte[] length '%d' not divisible by 4. Contents: %s",
           bytes.length, Arrays.toString(bytes))));
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/DataChecksum.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/DataChecksum.java
@@ -120,14 +120,14 @@ public class DataChecksum implements Checksum {
    * @throws IOException if there is no CRC polynomial applicable
    *     to the given {@code type}.
    */
-  public static int getCrcPolynomialForType(Type type) throws IOException {
+  public static int getCrcPolynomialForType(Type type) {
     switch (type) {
     case CRC32:
       return CrcUtil.GZIP_POLYNOMIAL;
     case CRC32C:
       return CrcUtil.CASTAGNOLI_POLYNOMIAL;
     default:
-      throw new IOException(
+      throw new IllegalArgumentException(
           "No CRC polynomial could be associated with type: " + type);
     }
   }
@@ -155,10 +155,9 @@ public class DataChecksum implements Checksum {
    * @param bytes bytes.
    * @param offset offset.
    * @return DataChecksum of the type in the array or null in case of an error.
-   * @throws IOException raised on errors performing I/O.
    */
   public static DataChecksum newDataChecksum(byte[] bytes, int offset)
-      throws IOException {
+      throws InvalidChecksumSizeException {
     if (offset < 0 || bytes.length < offset + getChecksumHeaderSize()) {
       throw new InvalidChecksumSizeException("Could not create DataChecksum "
           + " from the byte array of length " + bytes.length

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/DataChecksum.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/DataChecksum.java
@@ -117,8 +117,6 @@ public class DataChecksum implements Checksum {
    * @param type type.
    * @return the int representation of the polynomial associated with the
    *     CRC {@code type}, suitable for use with further CRC arithmetic.
-   * @throws IOException if there is no CRC polynomial applicable
-   *     to the given {@code type}.
    */
   public static int getCrcPolynomialForType(Type type) {
     switch (type) {
@@ -155,6 +153,7 @@ public class DataChecksum implements Checksum {
    * @param bytes bytes.
    * @param offset offset.
    * @return DataChecksum of the type in the array or null in case of an error.
+   * @throws InvalidChecksumSizeException when the stored checksum is invalid.
    */
   public static DataChecksum newDataChecksum(byte[] bytes, int offset)
       throws InvalidChecksumSizeException {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestCrcComposer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestCrcComposer.java
@@ -225,7 +225,7 @@ public class TestCrcComposer {
     // boundary in a single CRC, which is not allowed, since we'd lack a
     // CRC corresponding to the actual cellSize boundary.
     LambdaTestUtils.intercept(
-        IOException.class,
+        IllegalStateException.class,
         "stripe",
         () -> digester.update(crcsByChunk[1], cellSize));
   }
@@ -236,7 +236,7 @@ public class TestCrcComposer {
     CrcComposer digester = CrcComposer.newCrcComposer(type, chunkSize);
 
     LambdaTestUtils.intercept(
-        IOException.class,
+        IllegalArgumentException.class,
         "length",
         () -> digester.update(crcBytesByChunk, 0, 6, chunkSize));
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestCrcComposer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestCrcComposer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,6 +20,7 @@ package org.apache.hadoop.util;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -38,19 +39,18 @@ public class TestCrcComposer {
   @Rule
   public Timeout globalTimeout = new Timeout(10000, TimeUnit.MILLISECONDS);
 
-  private Random rand = new Random(1234);
+  private final Random rand = new Random(1234);
 
-  private DataChecksum.Type type = DataChecksum.Type.CRC32C;
-  private DataChecksum checksum = DataChecksum.newDataChecksum(
-      type, Integer.MAX_VALUE);
-  private int dataSize = 75;
-  private byte[] data = new byte[dataSize];
-  private int chunkSize = 10;
-  private int cellSize = 20;
+  private final DataChecksum.Type type = DataChecksum.Type.CRC32C;
+  private final DataChecksum checksum = Objects.requireNonNull(
+      DataChecksum.newDataChecksum(type, Integer.MAX_VALUE));
+  private final int dataSize = 75;
+  private final byte[] data = new byte[dataSize];
+  private final int chunkSize = 10;
+  private final int cellSize = 20;
 
   private int fullCrc;
   private int[] crcsByChunk;
-  private int[] crcsByCell;
 
   private byte[] crcBytesByChunk;
   private byte[] crcBytesByCell;
@@ -69,7 +69,7 @@ public class TestCrcComposer {
         data, (crcsByChunk.length - 1) * chunkSize, dataSize % chunkSize);
 
     // 3 cells of size cellSize, 1 cell of size (dataSize % cellSize).
-    crcsByCell = new int[4];
+    int[] crcsByCell = new int[4];
     for (int i = 0; i < 3; ++i) {
       crcsByCell[i] = getRangeChecksum(data, i * cellSize, cellSize);
     }
@@ -86,7 +86,7 @@ public class TestCrcComposer {
     return (int) checksum.getValue();
   }
 
-  private byte[] intArrayToByteArray(int[] values) throws IOException {
+  private byte[] intArrayToByteArray(int[] values) {
     byte[] bytes = new byte[values.length * 4];
     for (int i = 0; i < values.length; ++i) {
       CrcUtil.writeInt(bytes, i * 4, values[i]);
@@ -95,7 +95,7 @@ public class TestCrcComposer {
   }
 
   @Test
-  public void testUnstripedIncorrectChunkSize() throws IOException {
+  public void testUnstripedIncorrectChunkSize() {
     CrcComposer digester = CrcComposer.newCrcComposer(type, chunkSize);
 
     // If we incorrectly specify that all CRCs ingested correspond to chunkSize
@@ -110,7 +110,7 @@ public class TestCrcComposer {
   }
 
   @Test
-  public void testUnstripedByteArray() throws IOException {
+  public void testUnstripedByteArray() {
     CrcComposer digester = CrcComposer.newCrcComposer(type, chunkSize);
     digester.update(crcBytesByChunk, 0, crcBytesByChunk.length - 4, chunkSize);
     digester.update(
@@ -137,7 +137,7 @@ public class TestCrcComposer {
   }
 
   @Test
-  public void testUnstripedSingleCrcs() throws IOException {
+  public void testUnstripedSingleCrcs() {
     CrcComposer digester = CrcComposer.newCrcComposer(type, chunkSize);
     for (int i = 0; i < crcsByChunk.length - 1; ++i) {
       digester.update(crcsByChunk[i], chunkSize);
@@ -151,7 +151,7 @@ public class TestCrcComposer {
   }
 
   @Test
-  public void testStripedByteArray() throws IOException {
+  public void testStripedByteArray() {
     CrcComposer digester =
         CrcComposer.newStripedCrcComposer(type, chunkSize, cellSize);
     digester.update(crcBytesByChunk, 0, crcBytesByChunk.length - 4, chunkSize);
@@ -176,7 +176,7 @@ public class TestCrcComposer {
   }
 
   @Test
-  public void testStripedSingleCrcs() throws IOException {
+  public void testStripedSingleCrcs() {
     CrcComposer digester =
         CrcComposer.newStripedCrcComposer(type, chunkSize, cellSize);
     for (int i = 0; i < crcsByChunk.length - 1; ++i) {


### PR DESCRIPTION
### Description of PR

https://issues.apache.org/jira/browse/HADOOP-19035

CrcUtil and CrcComposer should throw specific exceptions for non-IO cases
- IllegalArgumentException: invalid arguments
- ArrayIndexOutOfBoundsException: index exceeds array size
- IllegalStateException: unexpected computation state

### How was this patch tested?

By updating existing tests.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

