### PR TITLE
HDFS-17332 DFSInputStream: avoid logging stacktrace until when we really need to fail a read request with a MissingBlockException

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -1181,13 +1181,13 @@ public class DFSInputStream extends FSInputStream
       final LocatedBlock block, final long start, final long end,
       final ByteBuffer bb,
       final CorruptedBlocks corruptedBlocks,
-      final Map<InetSocketAddress, List<IOException>> ioExceptionMap,
+      final Map<InetSocketAddress, List<IOException>> exceptionMap,
       final int hedgedReadId) {
     return new Callable<ByteBuffer>() {
       @Override
       public ByteBuffer call() throws Exception {
         DFSClientFaultInjector.get().sleepBeforeHedgedGet();
-        actualGetFromOneDataNode(datanode, start, end, bb, corruptedBlocks, ioExceptionMap);
+        actualGetFromOneDataNode(datanode, start, end, bb, corruptedBlocks, exceptionMap);
         return bb;
       }
     };
@@ -1317,7 +1317,7 @@ public class DFSInputStream extends FSInputStream
    */
   private void hedgedFetchBlockByteRange(LocatedBlock block, long start, long end, ByteBuffer buf,
       CorruptedBlocks corruptedBlocks,
-      final Map<InetSocketAddress, List<IOException>> ioExceptionMap) throws IOException {
+      final Map<InetSocketAddress, List<IOException>> exceptionMap) throws IOException {
     final DfsClientConf conf = dfsClient.getConf();
     ArrayList<Future<ByteBuffer>> futures = new ArrayList<>();
     CompletionService<ByteBuffer> hedgedService =
@@ -1340,7 +1340,7 @@ public class DFSInputStream extends FSInputStream
         bb = ByteBuffer.allocate(len);
         Callable<ByteBuffer> getFromDataNodeCallable = getFromOneDataNode(
             chosenNode, block, start, end, bb,
-            corruptedBlocks, ioExceptionMap, hedgedReadId++);
+            corruptedBlocks, exceptionMap, hedgedReadId++);
         Future<ByteBuffer> firstRequest = hedgedService
             .submit(getFromDataNodeCallable);
         futures.add(firstRequest);
@@ -1381,7 +1381,7 @@ public class DFSInputStream extends FSInputStream
             bb = ByteBuffer.allocate(len);
             Callable<ByteBuffer> getFromDataNodeCallable =
                 getFromOneDataNode(chosenNode, block, start, end, bb,
-                    corruptedBlocks, ioExceptionMap, hedgedReadId++);
+                    corruptedBlocks, exceptionMap, hedgedReadId++);
             Future<ByteBuffer> oneMoreRequest =
                 hedgedService.submit(getFromDataNodeCallable);
             futures.add(oneMoreRequest);
@@ -1564,7 +1564,7 @@ public class DFSInputStream extends FSInputStream
             false);
       }
 
-      // Reset ioExceptionMap before fetching the next block.
+      // Reset exceptionMap before fetching the next block.
       exceptionMap.clear();
       remaining -= bytesToRead;
       position += bytesToRead;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -914,7 +914,7 @@ public class DFSInputStream extends FSInputStream
             dfsClient.addNodeToDeadNodeDetector(this, currentNode);
           }
           if (--retries == 0) {
-            // Fail the request
+            // Fail the request and log all exceptions
             logDataNodeExceptionsOnReadError(pos, exceptionMap);
             throw e;
           }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -834,20 +834,20 @@ public class DFSInputStream extends FSInputStream
    * Send IOExceptions happened at each individual datanode to DFSClient.LOG for a failed read
    * request. Used in both readWithStrategy() and pread(), to record the exceptions when a read
    * request failed to be served.
-   * @param pos position in the file where we fail to read
+   * @param position offset in the file where we fail to read
    * @param exceptionMap a map which stores the list of IOExceptions for each datanode
    */
-  private void logDataNodeExceptionsOnReadError(long pos, final Map<InetSocketAddress,
+  private void logDataNodeExceptionsOnReadError(long position, final Map<InetSocketAddress,
       List<IOException>> exceptionMap) {
     String msg = String.format("Failed to read from all available datanodes for file %s "
-        + "at position=%d after retrying.", src, pos);
+        + "at position=%d after retrying.", src, position);
     DFSClient.LOG.error(msg);
     for (Map.Entry<InetSocketAddress, List<IOException>> dataNodeExceptions :
         exceptionMap.entrySet()) {
       List<IOException> exceptions = dataNodeExceptions.getValue();
       for (IOException ex : exceptions) {
         msg = String.format("Exception when fetching file %s at position=%d at datanode %s:", src,
-            pos, dataNodeExceptions.getKey());
+            position, dataNodeExceptions.getKey());
         DFSClient.LOG.error(msg, ex);
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hdfs;
 
+import java.net.InetSocketAddress;
+import java.util.Map;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.fs.ReadOption;
@@ -479,10 +481,14 @@ public class DFSStripedInputStream extends DFSInputStream {
 
   /**
    * Real implementation of pread.
+   * <p>
+   * Note: exceptionMap is not populated with ioExceptions as what we added for DFSInputStream. If
+   * you need this function, please implement it.
    */
   @Override
   protected void fetchBlockByteRange(LocatedBlock block, long start,
-      long end, ByteBuffer buf, CorruptedBlocks corruptedBlocks)
+      long end, ByteBuffer buf, CorruptedBlocks corruptedBlocks,
+      final Map<InetSocketAddress, List<IOException>> exceptionMap)
       throws IOException {
     // Refresh the striped block group
     LocatedStripedBlock blockGroup = getBlockGroupAt(block.getStartOffset());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPread.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPread.java
@@ -17,8 +17,10 @@
  */
 package org.apache.hadoop.hdfs;
 
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_MAX_BLOCK_ACQUIRE_FAILURES_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -35,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ChecksumException;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -52,6 +55,7 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -76,7 +80,12 @@ public class TestPread {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestPread.class.getName());
-
+  private final GenericTestUtils.LogCapturer DFSClientLog =
+      GenericTestUtils.LogCapturer.captureLogs(DFSClient.LOG);
+  @BeforeClass
+  public static void setLogLevel() {
+    GenericTestUtils.setLogLevel(DFSClient.LOG, org.apache.log4j.Level.WARN);
+  }
   @Before
   public void setup() {
     simulatedStorage = false;
@@ -553,6 +562,166 @@ public class TestPread {
       }
     } finally {
       cluster.shutdown();
+    }
+  }
+
+  /**
+   * Test logging in getFromOneDataNode when the number of IOExceptions can be recovered by
+   * retrying on a different datanode or by refreshing data nodes and retrying each data node one
+   * more time.
+   */
+  @Test(timeout=120000)
+  public void testGetFromOneDataNodeExceptionLogging() throws IOException {
+    // With max_block_acquire_failures = 0, we would try on each datanode only once and if
+    // we fail on all three datanodes, we fail the read request.
+    testGetFromOneDataNodeExceptionLogging(0, 0);
+    testGetFromOneDataNodeExceptionLogging(1, 0);
+    testGetFromOneDataNodeExceptionLogging(2, 0);
+
+    // With max_block_acquire_failures = 1, we will re-try each datanode a second time.
+    // So, we can tolerate up to 5 datanode fetch failures.
+    testGetFromOneDataNodeExceptionLogging(3, 1);
+    testGetFromOneDataNodeExceptionLogging(4, 1);
+    testGetFromOneDataNodeExceptionLogging(5, 1);
+  }
+
+  /**
+   * Each failed IOException would result in a WARN log of "Failed to connect to XXX. Continue
+   * with the next available DN". We verify the number of such log lines match the number of
+   * failed DNs.
+   * <p>
+   * @param ioExceptions number of IOExceptions to throw during a test.
+   * @param max_block_acquire_failures number of refreshLocation we would perform once we mark
+   *                                   all current data nodes as dead.
+   */
+  private void testGetFromOneDataNodeExceptionLogging(final int ioExceptions,
+      int max_block_acquire_failures)
+      throws IOException {
+    DFSClientLog.clearOutput();
+
+    if (ioExceptions < 0 || ioExceptions >= 3 * (max_block_acquire_failures+1)) {
+      return;
+    }
+
+    Configuration conf = new Configuration();
+    conf.setInt(DFS_CLIENT_MAX_BLOCK_ACQUIRE_FAILURES_KEY, max_block_acquire_failures);
+    final int[] count = {0};
+    // Set up the InjectionHandler
+    DFSClientFaultInjector.set(Mockito.mock(DFSClientFaultInjector.class));
+    DFSClientFaultInjector injector = DFSClientFaultInjector.get();
+    Mockito.doAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        if (count[0] < ioExceptions) {
+          LOG.info("-------------- throw IOException " + count[0]);
+          count[0]++;
+          throw new IOException("IOException test");
+        }
+        return null;
+      }
+    }).when(injector).fetchFromDatanodeException();
+
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).format(true).build();
+    DistributedFileSystem fileSys = cluster.getFileSystem();
+    DFSClient dfsClient = fileSys.getClient();
+    DFSInputStream input = null;
+    Path file = new Path("/testfile.dat");
+
+    try {
+      DFSTestUtil.createFile(fileSys, file, fileSize, fileSize, blockSize, (short) 3, seed);
+
+      byte[] buffer = new byte[fileSize];
+      input = dfsClient.open(file.toString());
+      input.read(0, buffer, 0, fileSize);
+      assertEquals(ioExceptions, StringUtils.countMatches(DFSClientLog.getOutput(),
+          "Retry with the next available datanode."));
+    } finally {
+      Mockito.reset(injector);
+      IOUtils.cleanupWithLogger(LOG, input);
+      fileSys.close();
+      cluster.shutdown();
+      DFSClientLog.clearOutput();
+    }
+  }
+
+  /**
+   * Test the case where we always hit IOExceptions, causing the read request to fail.
+   */
+  @Test(timeout=60000)
+  public void testFetchFromDataNodeExceptionLoggingFailedRequest()
+      throws IOException {
+    testFetchFromDataNodeExceptionLoggingFailedRequest(0);
+    testFetchFromDataNodeExceptionLoggingFailedRequest(1);
+  }
+
+  /**
+   * We verify that BlockMissingException is threw and there is one ERROR log line of
+   * "Failed to fetch block XXX from all available datanodes."
+   * and 3 * (max_block_acquire_failures+1) ERROR log lines of
+   * "Exception when fetching from datanode XXX".
+   * <p>
+   * max_block_acquire_failures determines how many times we can retry when we fail to read from
+   * all three data nodes.
+   * <ul>
+   *   <li>max_block_acquire_failures = 0: no retry. We will only read from each of the three
+   *   data
+   *   nodes only once. We expect to see 3 ERROR log lines of "Exception when fetching from
+   *   datanode XXX".
+   *   </li>
+   *   <li>max_block_acquire_failures = 1: 1 retry. We will read from each of the three data
+   *   nodes
+   *   twice. We expect to see 6 ERROR log lines of "Exception when fetching from datanode XXX".
+   *   </li>
+   * </ul>
+   */
+  private void testFetchFromDataNodeExceptionLoggingFailedRequest(int max_block_acquire_failures)
+      throws IOException {
+    DFSClientLog.clearOutput();
+
+    Configuration conf = new Configuration();
+    conf.setInt(DFS_CLIENT_MAX_BLOCK_ACQUIRE_FAILURES_KEY, max_block_acquire_failures);
+    // Set up the InjectionHandler
+    DFSClientFaultInjector.set(Mockito.mock(DFSClientFaultInjector.class));
+    DFSClientFaultInjector injector = DFSClientFaultInjector.get();
+    Mockito.doAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        LOG.info("-------------- throw IOException ");
+        throw new IOException("IOException test");
+      }
+    }).when(injector).fetchFromDatanodeException();
+
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).format(true).build();
+    DistributedFileSystem fileSys = cluster.getFileSystem();
+    DFSClient dfsClient = fileSys.getClient();
+    DFSInputStream input = null;
+    Path file = new Path("/testfile.dat");
+
+    try {
+      DFSTestUtil.createFile(fileSys, file, fileSize, fileSize, blockSize, (short) 3, seed);
+
+      byte[] buffer = new byte[fileSize];
+      input = dfsClient.open(file.toString());
+      input.read(0, buffer, 0, fileSize);
+      fail();
+    } catch (BlockMissingException expected) {
+      // Logging from pread
+      assertEquals(1, StringUtils.countMatches(DFSClientLog.getOutput(),
+          "Failed to read from all available datanodes for block"));
+      assertEquals(3 * (max_block_acquire_failures + 1),
+          StringUtils.countMatches(DFSClientLog.getOutput(),
+              "Exception when fetching file /testfile.dat for block"));
+      // Logging from actualGetFromOneDataNode
+      assertEquals(3 * (max_block_acquire_failures + 1),
+          StringUtils.countMatches(DFSClientLog.getOutput(),
+              "Retry with the next available datanode."));
+    }
+    finally {
+      Mockito.reset(injector);
+      IOUtils.cleanupWithLogger(LOG, input);
+      fileSys.close();
+      cluster.shutdown();
+      DFSClientLog.clearOutput();
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPread.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPread.java
@@ -572,13 +572,13 @@ public class TestPread {
    */
   @Test(timeout=120000)
   public void testGetFromOneDataNodeExceptionLogging() throws IOException {
-    // With max_block_acquire_failures = 0, we would try on each datanode only once and if
+    // With maxBlockAcquireFailures = 0, we would try on each datanode only once and if
     // we fail on all three datanodes, we fail the read request.
     testGetFromOneDataNodeExceptionLogging(0, 0);
     testGetFromOneDataNodeExceptionLogging(1, 0);
     testGetFromOneDataNodeExceptionLogging(2, 0);
 
-    // With max_block_acquire_failures = 1, we will re-try each datanode a second time.
+    // With maxBlockAcquireFailures = 1, we will re-try each datanode a second time.
     // So, we can tolerate up to 5 datanode fetch failures.
     testGetFromOneDataNodeExceptionLogging(3, 1);
     testGetFromOneDataNodeExceptionLogging(4, 1);
@@ -657,28 +657,28 @@ public class TestPread {
   /**
    * We verify that BlockMissingException is threw and there is one ERROR log line of
    * "Failed to read from all available datanodes for file"
-   * and 3 * (max_block_acquire_failures+1) ERROR log lines of
+   * and 3 * (maxBlockAcquireFailures+1) ERROR log lines of
    * "Exception when fetching file /testfile.dat at position".
    * <p>
-   * max_block_acquire_failures determines how many times we can retry when we fail to read from
+   * maxBlockAcquireFailures determines how many times we can retry when we fail to read from
    * all three data nodes.
    * <ul>
-   *   <li>max_block_acquire_failures = 0: no retry. We will only read from each of the three
+   *   <li>maxBlockAcquireFailures = 0: no retry. We will only read from each of the three
    *   data nodes only once. We expect to see 3 ERROR log lines of "Exception when fetching file
    *   /testfile.dat at position".
    *   </li>
-   *   <li>max_block_acquire_failures = 1: 1 retry. We will read from each of the three data
+   *   <li>maxBlockAcquireFailures = 1: 1 retry. We will read from each of the three data
    *   nodes twice. We expect to see 6 ERROR log lines of "Exception when fetching file
    *   /testfile.dat at position".
    *   </li>
    * </ul>
    */
-  private void testFetchFromDataNodeExceptionLoggingFailedRequest(int max_block_acquire_failures)
+  private void testFetchFromDataNodeExceptionLoggingFailedRequest(int maxBlockAcquireFailures)
       throws IOException {
     dfsClientLog.clearOutput();
 
     Configuration conf = new Configuration();
-    conf.setInt(DFS_CLIENT_MAX_BLOCK_ACQUIRE_FAILURES_KEY, max_block_acquire_failures);
+    conf.setInt(DFS_CLIENT_MAX_BLOCK_ACQUIRE_FAILURES_KEY, maxBlockAcquireFailures);
     // Set up the InjectionHandler
     DFSClientFaultInjector.set(Mockito.mock(DFSClientFaultInjector.class));
     DFSClientFaultInjector injector = DFSClientFaultInjector.get();
@@ -707,11 +707,11 @@ public class TestPread {
       // Logging from pread
       assertEquals(1, StringUtils.countMatches(dfsClientLog.getOutput(),
           "Failed to read from all available datanodes for file"));
-      assertEquals(3 * (max_block_acquire_failures + 1),
+      assertEquals(3 * (maxBlockAcquireFailures + 1),
           StringUtils.countMatches(dfsClientLog.getOutput(),
               "Exception when fetching file /testfile.dat at position"));
       // Logging from actualGetFromOneDataNode
-      assertEquals(3 * (max_block_acquire_failures + 1),
+      assertEquals(3 * (maxBlockAcquireFailures + 1),
           StringUtils.countMatches(dfsClientLog.getOutput(),
               "Retry with the next available datanode."));
     } finally {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPread.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPread.java
@@ -80,7 +80,7 @@ public class TestPread {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestPread.class.getName());
-  private final GenericTestUtils.LogCapturer DFSClientLog =
+  private final GenericTestUtils.LogCapturer dfsClientLog =
       GenericTestUtils.LogCapturer.captureLogs(DFSClient.LOG);
   @BeforeClass
   public static void setLogLevel() {
@@ -591,20 +591,20 @@ public class TestPread {
    * failed DNs.
    * <p>
    * @param ioExceptions number of IOExceptions to throw during a test.
-   * @param max_block_acquire_failures number of refreshLocation we would perform once we mark
+   * @param maxBlockAcquireFailures number of refreshLocation we would perform once we mark
    *                                   all current data nodes as dead.
    */
   private void testGetFromOneDataNodeExceptionLogging(final int ioExceptions,
-      int max_block_acquire_failures)
+      int maxBlockAcquireFailures)
       throws IOException {
-    DFSClientLog.clearOutput();
+    dfsClientLog.clearOutput();
 
-    if (ioExceptions < 0 || ioExceptions >= 3 * (max_block_acquire_failures+1)) {
+    if (ioExceptions < 0 || ioExceptions >= 3 * (maxBlockAcquireFailures+1)) {
       return;
     }
 
     Configuration conf = new Configuration();
-    conf.setInt(DFS_CLIENT_MAX_BLOCK_ACQUIRE_FAILURES_KEY, max_block_acquire_failures);
+    conf.setInt(DFS_CLIENT_MAX_BLOCK_ACQUIRE_FAILURES_KEY, maxBlockAcquireFailures);
     final int[] count = {0};
     // Set up the InjectionHandler
     DFSClientFaultInjector.set(Mockito.mock(DFSClientFaultInjector.class));
@@ -633,14 +633,14 @@ public class TestPread {
       byte[] buffer = new byte[fileSize];
       input = dfsClient.open(file.toString());
       input.read(0, buffer, 0, fileSize);
-      assertEquals(ioExceptions, StringUtils.countMatches(DFSClientLog.getOutput(),
+      assertEquals(ioExceptions, StringUtils.countMatches(dfsClientLog.getOutput(),
           "Retry with the next available datanode."));
     } finally {
       Mockito.reset(injector);
       IOUtils.cleanupWithLogger(LOG, input);
       fileSys.close();
       cluster.shutdown();
-      DFSClientLog.clearOutput();
+      dfsClientLog.clearOutput();
     }
   }
 
@@ -675,7 +675,7 @@ public class TestPread {
    */
   private void testFetchFromDataNodeExceptionLoggingFailedRequest(int max_block_acquire_failures)
       throws IOException {
-    DFSClientLog.clearOutput();
+    dfsClientLog.clearOutput();
 
     Configuration conf = new Configuration();
     conf.setInt(DFS_CLIENT_MAX_BLOCK_ACQUIRE_FAILURES_KEY, max_block_acquire_failures);
@@ -705,22 +705,21 @@ public class TestPread {
       fail();
     } catch (BlockMissingException expected) {
       // Logging from pread
-      assertEquals(1, StringUtils.countMatches(DFSClientLog.getOutput(),
+      assertEquals(1, StringUtils.countMatches(dfsClientLog.getOutput(),
           "Failed to read from all available datanodes for file"));
       assertEquals(3 * (max_block_acquire_failures + 1),
-          StringUtils.countMatches(DFSClientLog.getOutput(),
+          StringUtils.countMatches(dfsClientLog.getOutput(),
               "Exception when fetching file /testfile.dat at position"));
       // Logging from actualGetFromOneDataNode
       assertEquals(3 * (max_block_acquire_failures + 1),
-          StringUtils.countMatches(DFSClientLog.getOutput(),
+          StringUtils.countMatches(dfsClientLog.getOutput(),
               "Retry with the next available datanode."));
-    }
-    finally {
+    } finally {
       Mockito.reset(injector);
       IOUtils.cleanupWithLogger(LOG, input);
       fileSys.close();
       cluster.shutdown();
-      DFSClientLog.clearOutput();
+      dfsClientLog.clearOutput();
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPread.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPread.java
@@ -656,7 +656,7 @@ public class TestPread {
 
   /**
    * We verify that BlockMissingException is threw and there is one ERROR log line of
-   * "FFailed to read from all available datanodes for block"
+   * "Failed to read from all available datanodes for block"
    * and 3 * (max_block_acquire_failures+1) ERROR log lines of
    * "Exception when fetching file /testfile.dat for block".
    * <p>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPread.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPread.java
@@ -586,8 +586,8 @@ public class TestPread {
   }
 
   /**
-   * Each failed IOException would result in a WARN log of "Failed to connect to XXX. Continue
-   * with the next available DN". We verify the number of such log lines match the number of
+   * Each failed IOException would result in a WARN log of "Failed to connect to XXX. Retry with
+   * the next available datanode.". We verify the number of such log lines match the number of
    * failed DNs.
    * <p>
    * @param ioExceptions number of IOExceptions to throw during a test.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPread.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPread.java
@@ -656,21 +656,20 @@ public class TestPread {
 
   /**
    * We verify that BlockMissingException is threw and there is one ERROR log line of
-   * "Failed to fetch block XXX from all available datanodes."
+   * "FFailed to read from all available datanodes for block"
    * and 3 * (max_block_acquire_failures+1) ERROR log lines of
-   * "Exception when fetching from datanode XXX".
+   * "Exception when fetching file /testfile.dat for block".
    * <p>
    * max_block_acquire_failures determines how many times we can retry when we fail to read from
    * all three data nodes.
    * <ul>
    *   <li>max_block_acquire_failures = 0: no retry. We will only read from each of the three
-   *   data
-   *   nodes only once. We expect to see 3 ERROR log lines of "Exception when fetching from
-   *   datanode XXX".
+   *   data nodes only once. We expect to see 3 ERROR log lines of "Exception when fetching file
+   *   /testfile.dat for block".
    *   </li>
    *   <li>max_block_acquire_failures = 1: 1 retry. We will read from each of the three data
-   *   nodes
-   *   twice. We expect to see 6 ERROR log lines of "Exception when fetching from datanode XXX".
+   *   nodes twice. We expect to see 6 ERROR log lines of "Exception when fetching file
+   *   /testfile.dat for block".
    *   </li>
    * </ul>
    */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPread.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestPread.java
@@ -656,20 +656,20 @@ public class TestPread {
 
   /**
    * We verify that BlockMissingException is threw and there is one ERROR log line of
-   * "Failed to read from all available datanodes for block"
+   * "Failed to read from all available datanodes for file"
    * and 3 * (max_block_acquire_failures+1) ERROR log lines of
-   * "Exception when fetching file /testfile.dat for block".
+   * "Exception when fetching file /testfile.dat at position".
    * <p>
    * max_block_acquire_failures determines how many times we can retry when we fail to read from
    * all three data nodes.
    * <ul>
    *   <li>max_block_acquire_failures = 0: no retry. We will only read from each of the three
    *   data nodes only once. We expect to see 3 ERROR log lines of "Exception when fetching file
-   *   /testfile.dat for block".
+   *   /testfile.dat at position".
    *   </li>
    *   <li>max_block_acquire_failures = 1: 1 retry. We will read from each of the three data
    *   nodes twice. We expect to see 6 ERROR log lines of "Exception when fetching file
-   *   /testfile.dat for block".
+   *   /testfile.dat at position".
    *   </li>
    * </ul>
    */
@@ -706,10 +706,10 @@ public class TestPread {
     } catch (BlockMissingException expected) {
       // Logging from pread
       assertEquals(1, StringUtils.countMatches(DFSClientLog.getOutput(),
-          "Failed to read from all available datanodes for block"));
+          "Failed to read from all available datanodes for file"));
       assertEquals(3 * (max_block_acquire_failures + 1),
           StringUtils.countMatches(DFSClientLog.getOutput(),
-              "Exception when fetching file /testfile.dat for block"));
+              "Exception when fetching file /testfile.dat at position"));
       // Logging from actualGetFromOneDataNode
       assertEquals(3 * (max_block_acquire_failures + 1),
           StringUtils.countMatches(DFSClientLog.getOutput(),

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestRead.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestRead.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedByInterruptException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
@@ -32,6 +33,8 @@ import org.apache.hadoop.hdfs.server.datanode.DataStorage;
 import org.apache.hadoop.hdfs.server.datanode.SimulatedFSDataset;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsDatasetSpi;
 import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.log4j.Level;
 import org.junit.Assert;
 
 import org.apache.hadoop.conf.Configuration;
@@ -39,10 +42,32 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSTestUtil.ShortCircuitTestContext;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_MAX_BLOCK_ACQUIRE_FAILURES_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 
 public class TestRead {
-  final private int BLOCK_SIZE = 512;
+  static final private int BLOCK_SIZE = 512;
+  static final long SEED = 0xDEADBEEFL;
+  static final int FILE_SIZE = BLOCK_SIZE * 10;
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestRead.class.getName());
+  private final GenericTestUtils.LogCapturer DFSClientLog =
+      GenericTestUtils.LogCapturer.captureLogs(DFSClient.LOG);
+
+  @BeforeClass
+  public static void setLogLevel() {
+    GenericTestUtils.setLogLevel(DFSClient.LOG, Level.WARN);
+  }
 
   private void testEOF(MiniDFSCluster cluster, int fileLength) throws IOException {
     FileSystem fs = cluster.getFileSystem();
@@ -188,6 +213,127 @@ public class TestRead {
       public boolean isSimulated() {
         return true;
       }
+    }
+  }
+
+  /**
+   * Test logging in readBuffer() when the number of IOExceptions can be recovered by retrying on
+   * a different datanode or by refreshing data nodes and retrying each data node one more time.
+   */
+  @Test(timeout=120000)
+  public void testReadBufferIOExceptionLogging() throws IOException {
+    testReadBufferIOExceptionLogging(0, 0);
+    testReadBufferIOExceptionLogging(1, 0);
+    testReadBufferIOExceptionLogging(2, 0);
+    testReadBufferIOExceptionLogging(3, 0);
+    testReadBufferIOExceptionLogging(4, 1);
+    testReadBufferIOExceptionLogging(5, 1);
+    testReadBufferIOExceptionLogging(6, 1);
+  }
+
+  /**
+   * @param IOExceptions number of IOExceptions to throw during a test.
+   * @param max_block_acquire_failures number of refreshLocation we would perform once we mark
+   *                                   all current data nodes as dead.
+   */
+  private void testReadBufferIOExceptionLogging(final int IOExceptions,
+      int max_block_acquire_failures) throws IOException {
+    DFSClientLog.clearOutput();
+    Configuration conf = new Configuration();
+    conf.setInt(DFS_CLIENT_MAX_BLOCK_ACQUIRE_FAILURES_KEY, max_block_acquire_failures);
+    final int[] count = {0};
+    // Set up the InjectionHandler
+    DFSClientFaultInjector.set(Mockito.mock(DFSClientFaultInjector.class));
+    DFSClientFaultInjector injector = DFSClientFaultInjector.get();
+    Mockito.doAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        if (count[0] < IOExceptions) {
+          LOG.info("-------------- throw IOException");
+          count[0]++;
+          throw new IOException("IOException test");
+        }
+        return null;
+      }
+    }).when(injector).fetchFromDatanodeException();
+
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).format(true).build();
+    DistributedFileSystem fileSys = cluster.getFileSystem();
+    DFSClient dfsClient = fileSys.getClient();
+    DFSInputStream input = null;
+    Path file = new Path("/testfile.dat");
+
+    try {
+      DFSTestUtil.createFile(fileSys, file, FILE_SIZE, FILE_SIZE, BLOCK_SIZE, (short) 3, SEED);
+
+      byte[] buffer = new byte[FILE_SIZE];
+      input = dfsClient.open(file.toString());
+      input.read(buffer, 0, FILE_SIZE);
+      assertEquals(IOExceptions, StringUtils.countMatches(DFSClientLog.getOutput(),
+          "Retry with the current or next available datanode."));
+    } finally {
+      Mockito.reset(injector);
+      IOUtils.cleanupWithLogger(LOG, input);
+      fileSys.close();
+      cluster.shutdown();
+      DFSClientLog.clearOutput();
+    }
+  }
+
+  /**
+   * Test the case where we always hit IOExceptions, causing the read request to fail.
+   */
+  @Test(timeout=60000)
+  public void testReadBufferIOExceptionLoggingFailedRequest() throws IOException {
+    testReadBufferIOExceptionLoggingFailedRequest(0);
+    testReadBufferIOExceptionLoggingFailedRequest(1);
+  }
+
+  private void testReadBufferIOExceptionLoggingFailedRequest(int max_block_acquire_failures) throws IOException {
+    DFSClientLog.clearOutput();
+    Configuration conf = new Configuration();
+    conf.setInt(DFS_CLIENT_MAX_BLOCK_ACQUIRE_FAILURES_KEY, max_block_acquire_failures);
+    // Set up the InjectionHandler
+    DFSClientFaultInjector.set(Mockito.mock(DFSClientFaultInjector.class));
+    DFSClientFaultInjector injector = DFSClientFaultInjector.get();
+    Mockito.doAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        LOG.info("-------------- throw IOException");
+        throw new IOException("IOException test");
+      }
+    }).when(injector).fetchFromDatanodeException();
+
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).format(true).build();
+    DistributedFileSystem fileSys = cluster.getFileSystem();
+    DFSClient dfsClient = fileSys.getClient();
+    DFSInputStream input = null;
+    Path file = new Path("/testfile.dat");
+
+    try {
+      DFSTestUtil.createFile(fileSys, file, FILE_SIZE, FILE_SIZE, BLOCK_SIZE, (short) 3, SEED);
+
+      byte[] buffer = new byte[FILE_SIZE];
+      input = dfsClient.open(file.toString());
+      input.read(buffer, 0, FILE_SIZE);
+      fail();
+    } catch (BlockMissingException e) {
+      // Logging from readWithStrategy()
+      assertEquals(1, StringUtils.countMatches(DFSClientLog.getOutput(),
+          "Failed to read from all available datanodes for file"));
+      assertEquals(1 + 3L * (max_block_acquire_failures + 1),
+          StringUtils.countMatches(DFSClientLog.getOutput(),
+              "Exception when fetching file /testfile.dat at position="));
+      // Logging from actualGetFromOneDataNode
+      assertEquals(1 + 3L * (max_block_acquire_failures + 1),
+          StringUtils.countMatches(DFSClientLog.getOutput(),
+              "Retry with the current or next available datanode."));
+    } finally {
+      Mockito.reset(injector);
+      IOUtils.cleanupWithLogger(LOG, input);
+      fileSys.close();
+      cluster.shutdown();
+      DFSClientLog.clearOutput();
     }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

In DFSInputStream#actualGetFromOneDataNode() and DFSInputStream#readBuffer(), it would send the exception stacktrace to the dfsClient.LOG whenever we fail on a DN. However, in most cases, the read request will be served successfully by reading from the next available DN. The existence of exception stacktrace in the log has caused multiple hadoop users at Linkedin to consider this WARN message as the RC/fatal error for their jobs.  We would like to improve the log message and avoid sending the stacktrace to dfsClient.LOG when a read succeeds. 

Exceptions happened during a read are stored in a map. If a read request succeeds after retry, we won't print these exception callstacks in log (a warn log line will continue to be printed though). When all retries failed and we need to fail a read request, we will print exceptions stored in the map to the log together with its callstack. So, in a nutshell, when a read succeeds, we won't see callstacks from exceptions in the log. When a read fails, we will continue to see all exception callstacks in the log.

old code uses `LOG.warn(string msg, exception e)`, when we fail on a data node. This will include the callstack from the exception to be printed to the log. In the new code, we create the error msg with `string.format("Exception=%s", ex)` for the exception and this won't include the callstack from the exception. Then, we use LOG.warn(string msg) to print a single line to the log. 


Example: when we failed on the first DN but succeeded on the second. 
* Before
```
[12]<stderr>:23/11/30 23:01:33 WARN hdfs.DFSClient: Connection failure: Failed to connect to 10.150.91.13/10.150.91.13:71 for file /XXXX/part-yyyy-95b9909c-zzz-c000.avro for block BP-364971551-DatanodeIP-1448516588954:blk_zzzz_129864739321:java.net.SocketTimeoutException: 60000 millis timeout while waiting for channel to be ready for read. ch : java.nio.channels.SocketChannel[connected local=/ip:40492 remote=datanodeIP:71] 
[12]<stderr>:java.net.SocketTimeoutException: 60000 millis timeout while waiting for channel to be ready for read. ch : java.nio.channels.SocketChannel[connected local=/localIp:40492 remote=datanodeIP:71] 
[12]<stderr>: at org.apache.hadoop.net.SocketIOWithTimeout.doIO(SocketIOWithTimeout.java:164) 
[12]<stderr>: at org.apache.hadoop.net.SocketInputStream.read(SocketInputStream.java:161) 
[12]<stderr>: at org.apache.hadoop.net.SocketInputStream.read(SocketInputStream.java:131) 
[12]<stderr>: at org.apache.hadoop.net.SocketInputStream.read(SocketInputStream.java:118) 
[12]<stderr>: at java.io.FilterInputStream.read(FilterInputStream.java:83) 
[12]<stderr>: at org.apache.hadoop.hdfs.protocolPB.PBHelperClient.vintPrefixed(PBHelperClient.java:458) 
[12]<stderr>: at org.apache.hadoop.hdfs.client.impl.BlockReaderRemote2.newBlockReader(BlockReaderRemote2.java:412) 
...
```

* After
```
Failed to read block %s for file %s from datanode %s. Exception is SocketTimeOut. Retry with the next available datanode.
```
### How was this patch tested?

```
mvn test -Dtest=TestPread,TestRead
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.hdfs.TestPread
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 72.325 s - in org.apache.hadoop.hdfs.TestPread
[INFO] Running org.apache.hadoop.hdfs.TestRead
[WARNING] Tests run: 6, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 29.558 s - in org.apache.hadoop.hdfs.TestRead
```

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

