### PR TITLE
HADOOP-19038. Improve create-release RUN script.

### DIFF
--- a/dev-support/bin/create-release
+++ b/dev-support/bin/create-release
@@ -504,9 +504,9 @@ function dockermode
     echo "LABEL org.apache.hadoop.create-release=\"cr-${RANDOM}\""
 
     # setup ownerships, etc
-    echo "RUN groupadd --non-unique -g ${group_id} ${user_name}"
-    echo "RUN useradd -g ${group_id} -u ${user_id} -m ${user_name}"
-    echo "RUN chown -R ${user_name} /home/${user_name}"
+    echo "RUN groupadd --non-unique -g ${group_id} ${user_name}; exit 0;"
+    echo "RUN useradd -g ${group_id} -u ${user_id} -m ${user_name}; exit 0;"
+    echo "RUN chown -R ${user_name} /home/${user_name}; exit 0;"
     echo "ENV HOME /home/${user_name}"
     echo "RUN mkdir -p /maven"
     echo "RUN chown -R ${user_name} /maven"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19038. Improve create-release RUN script.

Using `create-release` will create a docker image locally, but three of the RUN scripts may fail to execute.

1. RUN groupadd --non-unique -g 0 root

```
=> ERROR [16/20] RUN groupadd --non-unique -g 0 root                                                            0.2s
------
 > [16/20] RUN groupadd --non-unique -g 0 root:
0.154 groupadd: group 'root' already exists
------
Dockerfile:100
--------------------
  98 |
  99 |     LABEL org.apache.hadoop.create-release="cr-19697"
 100 | >>> RUN groupadd --non-unique -g 0 root
 101 |     RUN useradd -g 0 -u 0 -m root
 102 |     RUN chown -R root /home/root
```

2. RUN useradd -g 0 -u 0 -m root

```
 > [17/20] RUN useradd -g 0 -u 0 -m root:
0.165 useradd: user 'root' already exists
------
Dockerfile:101
--------------------
  99 |     LABEL org.apache.hadoop.create-release="cr-12068"
 100 |     RUN groupadd --non-unique -g 0 root; exit 0;
 101 | >>> RUN useradd -g 0 -u 0 -m root
 102 |     RUN chown -R root /home/root
 103 |     ENV HOME /home/root
```

3. RUN chown -R root /home/root

```
 > [18/20] RUN chown -R root /home/root:
0.168 chown: cannot access '/home/root': No such file or directory
------
Dockerfile:102
--------------------
 100 |     RUN groupadd --non-unique -g 0 root; exit 0;
 101 |     RUN useradd -g 0 -u 0 -m root; exit 0;
 102 | >>> RUN chown -R root /home/root
 103 |     ENV HOME /home/root
 104 |     RUN mkdir -p /maven
--------------------
```

Even if these three scripts fail, subsequent steps can continue to be executed, so I added exit 0 after the script.

- After the modification is completed, the script can be executed normally:

```
> [internal] load .dockerignore                                                                                                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                            0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                       0.0s
 => => transferring dockerfile: 3.26kB                                                                                                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/ubuntu:focal                                                                                                                                                                                                            1.5s
 => [ 1/20] FROM docker.io/library/ubuntu:focal@sha256:f2034e7195f61334e6caff6ecf2e965f92d11e888309065da85ff50c617732b8                                                                                                                                                    0.0s
 => [internal] load build context                                                                                                                                                                                                                                          0.0s
 => => transferring context: 997B                                                                                                                                                                                                                                          0.0s
 => CACHED [ 2/20] WORKDIR /root                                                                                                                                                                                                                                           0.0s
 => CACHED [ 3/20] RUN echo APT::Install-Recommends "0"; > /etc/apt/apt.conf.d/10disableextras                                                                                                                                                                             0.0s
 => CACHED [ 4/20] RUN echo APT::Install-Suggests "0"; >>  /etc/apt/apt.conf.d/10disableextras                                                                                                                                                                             0.0s
 => CACHED [ 5/20] COPY pkg-resolver pkg-resolver                                                                                                                                                                                                                          0.0s
 => CACHED [ 6/20] RUN chmod a+x pkg-resolver/*.sh pkg-resolver/*.py     && chmod a+r pkg-resolver/*.json                                                                                                                                                                  0.0s
 => CACHED [ 7/20] RUN apt-get -q update     && apt-get -q install -y --no-install-recommends python3     && apt-get -q install -y --no-install-recommends $(pkg-resolver/resolve.py ubuntu:focal)     && apt-get clean     && rm -rf /var/lib/apt/lists/*                 0.0s
 => CACHED [ 8/20] RUN locale-gen en_US.UTF-8                                                                                                                                                                                                                              0.0s
 => CACHED [ 9/20] RUN pkg-resolver/install-common-pkgs.sh                                                                                                                                                                                                                 0.0s
 => CACHED [10/20] RUN pkg-resolver/install-maven.sh ubuntu:focal                                                                                                                                                                                                          0.0s
 => CACHED [11/20] RUN pkg-resolver/install-spotbugs.sh ubuntu:focal                                                                                                                                                                                                       0.0s
 => CACHED [12/20] RUN pkg-resolver/install-boost.sh ubuntu:focal                                                                                                                                                                                                          0.0s
 => CACHED [13/20] RUN pkg-resolver/install-protobuf.sh ubuntu:focal                                                                                                                                                                                                       0.0s
 => CACHED [14/20] RUN pkg-resolver/install-hadolint.sh ubuntu:focal                                                                                                                                                                                                       0.0s
 => CACHED [15/20] RUN pkg-resolver/install-intel-isa-l.sh ubuntu:focal                                                                                                                                                                                                    0.0s
 => CACHED [16/20] RUN groupadd --non-unique -g 0 root; exit 0;                                                                                                                                                                                                            0.0s
 => CACHED [17/20] RUN useradd -g 0 -u 0 -m root; exit 0;                                                                                                                                                                                                                  0.0s
 => [18/20] RUN chown -R root /home/root; exit 0;                                                                                                                                                                                                                          0.2s
 => [19/20] RUN mkdir -p /maven                                                                                                                                                                                                                                            0.3s
 => [20/20] RUN chown -R root /maven
```


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

