### PR TITLE
HADOOP-19040. mvn site commands fails due to MetricsSystem And MetricsSystemImpl changes.

### DIFF
--- a/hadoop-common-project/hadoop-common/dev-support/jdiff-workaround.patch
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff-workaround.patch
@@ -14,7 +14,7 @@ index a277abd6e13..1d131d5db6e 100644
 -   *              the annotations of the source object.)
 -   * @param desc  the description of the source (or null. See above.)
 -   * @return the source object
--   * @exception MetricsException
+-   * @exception MetricsException Metrics Exception.
 -   */
 -  public abstract <T> T register(String name, String desc, T source);
 -
@@ -38,7 +38,7 @@ index a277abd6e13..1d131d5db6e 100644
 +   *              the annotations of the source object.)
 +   * @param desc  the description of the source (or null. See above.)
 +   * @return the source object
-    * @exception MetricsException
+    * @exception MetricsException Metrics Exception.
     */
 -  public abstract <T extends MetricsSink>
 -  T register(String name, String desc, T sink);
@@ -65,7 +65,6 @@ index a6edf08e5a7..5b87be1ec67 100644
 -      }
 -      return sink;
 -    }
--    allSinks.put(name, sink);
 -    if (config != null) {
 -      registerSink(name, description, sink);
 -    }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19040. mvn site commands fails due to MetricsSystem And MetricsSystemImpl changes.

When executing the `mvn` site command, an error will appear in the `hadoop-common`  module.

The error message is as follows:

```
[INFO] Executed tasks
[INFO]
[INFO] --- maven-antrun-plugin:1.7:run (post-site) @ hadoop-common ---
[INFO] Executing tasks

main:
     [exec] patching file src/main/java/org/apache/hadoop/metrics2/MetricsSystem.java
     [exec] Hunk #1 succeeded at 42 with fuzz 2.
     [exec] Hunk #2 FAILED at 79.
     [exec] 1 out of 2 hunks FAILED -- saving rejects to file src/main/java/org/apache/hadoop/metrics2/MetricsSystem.java.rej
     [exec] patching file src/main/java/org/apache/hadoop/metrics2/impl/MetricsSystemImpl.java
     [exec] Hunk #1 succeeded at 293 with fuzz 1 (offset 24 lines).
     [exec] patching file src/test/java/org/apache/hadoop/metrics2/impl/TestGangliaMetrics.java
     [exec] Result: 1
```

To solve the `jdiff` bug([HADOOP-13428](https://issues.apache.org/jira/browse/HADOOP-13428)),  we introduced `jdiff-workaround.patch` during the compilation process, but there were some changes in the `MetricsSystem.java` and `MetricsSystemImpl.java` codes, and we need to update workaround.patch.

- MetricsSystem.java
 HADOOP-18229. Fix Hadoop-Common JavaDoc Errors (#4292)

- MetricsSystemImpl.java 
HADOOP-9946. NumAllSinks metrics shows lower value than NumActiveSinks (#5002)


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

