### PR TITLE
YARN-11644. LogAggregationService can't upload log in time when application finished

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/AppLogAggregator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/AppLogAggregator.java
@@ -36,5 +36,7 @@ public interface AppLogAggregator extends Runnable {
 
   boolean isAggregationEnabled();
 
+  boolean isDone();
+
   UserGroupInformation updateCredentials(Credentials cred);
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/AppLogAggregatorImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/AppLogAggregatorImpl.java
@@ -476,12 +476,6 @@ public class AppLogAggregatorImpl implements AppLogAggregator {
       // loss of logs
       LOG.error("Error occurred while aggregating the log for the application "
           + appId, e);
-    } catch (Exception e) {
-      // do post clean up of log directories on any other exception
-      LOG.error("Error occurred while aggregating the log for the application "
-          + appId, e);
-      doAppLogAggregationPostCleanUp();
-    } finally {
       if (!this.appAggregationFinished.get() && !this.aborted.get()) {
         LOG.warn("Log aggregation did not complete for application " + appId);
         this.dispatcher.getEventHandler().handle(
@@ -489,6 +483,11 @@ public class AppLogAggregatorImpl implements AppLogAggregator {
                 ApplicationEventType.APPLICATION_LOG_HANDLING_FAILED));
       }
       this.appAggregationFinished.set(true);
+    } catch (Exception e) {
+      // do post clean up of log directories on any other exception
+      LOG.error("Error occurred while aggregating the log for the application "
+          + appId, e);
+      doAppLogAggregationPostCleanUp();
     }
   }
 
@@ -505,6 +504,7 @@ public class AppLogAggregatorImpl implements AppLogAggregator {
             uploadLogsForContainers(false);
           } else {
             wait(THREAD_SLEEP_TIME);
+            return;
           }
         } catch (InterruptedException e) {
           LOG.warn("PendingContainers queue is interrupted");
@@ -612,6 +612,11 @@ public class AppLogAggregatorImpl implements AppLogAggregator {
   @Override
   public boolean isAggregationEnabled() {
     return !logAggregationDisabled;
+  }
+
+  @Override
+  public boolean isDone() {
+    return appAggregationFinished.get() || aborted.get();
   }
 
   @Private

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/LogAggregationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/LogAggregationService.java
@@ -482,7 +482,7 @@ public class LogAggregationService extends AbstractService implements
     return logAggregationFileController;
   }
 
-  class StoreUnexecutedPolicy implements RejectedExecutionHandler {
+  public static class StoreUnexecutedPolicy implements RejectedExecutionHandler {
 
     List<Runnable> unexecutedTasks = new ArrayList<>();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/LogAggregationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/LogAggregationService.java
@@ -19,11 +19,15 @@
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.logaggregation;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.security.token.SecretManager;
@@ -91,7 +95,8 @@ public class LogAggregationService extends AbstractService implements
   private final Set<ApplicationId> invalidTokenApps;
 
   @VisibleForTesting
-  ExecutorService threadPool;
+  ThreadPoolExecutor threadPool;
+  StoreUnexecutedPolicy unexecutedPolicy;
   
   public LogAggregationService(Dispatcher dispatcher, Context context,
       DeletionService deletionService, LocalDirsHandlerService dirsHandler) {
@@ -150,10 +155,12 @@ public class LogAggregationService extends AbstractService implements
 
   protected void serviceInit(Configuration conf) throws Exception {
     int threadPoolSize = getAggregatorThreadPoolSize(conf);
-    this.threadPool = HadoopExecutors.newFixedThreadPool(threadPoolSize,
+    this.threadPool = (ThreadPoolExecutor) HadoopExecutors.newFixedThreadPool(threadPoolSize,
         new ThreadFactoryBuilder()
             .setNameFormat("LogAggregationService #%d")
             .build());
+    this.unexecutedPolicy = new StoreUnexecutedPolicy();
+    this.threadPool.setRejectedExecutionHandler(unexecutedPolicy);
 
     rollingMonitorInterval = calculateRollingMonitorInterval(conf);
     LOG.info("rollingMonitorInterval is set as {}. The logs will be " +
@@ -207,6 +214,9 @@ public class LogAggregationService extends AbstractService implements
         LOG.warn("Aggregation stop interrupted!");
         break;
       }
+    }
+    for (Runnable aggregator : unexecutedPolicy.getUnexecutedTasks()) {
+      aggregator.run();
     }
     for (ApplicationId appId : appLogAggregators.keySet()) {
       LOG.warn("Some logs may not have been aggregated for " + appId);
@@ -294,8 +304,12 @@ public class LogAggregationService extends AbstractService implements
         try {
           appLogAggregator.run();
         } finally {
-          appLogAggregators.remove(appId);
-          closeFileSystems(userUgi);
+          if (appLogAggregator.isDone()) {
+            appLogAggregators.remove(appId);
+            closeFileSystems(userUgi);
+          } else {
+            threadPool.execute(this);
+          }
         }
       }
     };
@@ -466,5 +480,21 @@ public class LogAggregationService extends AbstractService implements
     LogAggregationFileController logAggregationFileController = factory
         .getFileControllerForWrite();
     return logAggregationFileController;
+  }
+
+  class StoreUnexecutedPolicy implements RejectedExecutionHandler {
+
+    List<Runnable> unexecutedTasks = new ArrayList<>();
+
+    @Override
+    public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+      if (executor.isShutdown()) {
+        unexecutedTasks.add(r);
+      }
+    }
+
+    public List<Runnable> getUnexecutedTasks() {
+      return unexecutedTasks;
+    }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: [YARN-11644](https://issues.apache.org/jira/browse/YARN-11644) LogAggregationService can't upload log in time when application finished.
Current implementation of AppLogAggregatorImpl is to do empty while loop until application finish.
If too many applications running, it will block the following applications upload logs.
Make AppLogAggregatorImpl return when application has not finished and resubmit itself to thread pool. It not only fixed the block issue but also shrink the thread pool size (default: 100).

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

