### PR TITLE
HDFS-17339:Skip cacheReport when one blockPool does not have CacheBlock on this DataNode

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -514,6 +514,10 @@ class BPServiceActor implements Runnable {
 
       String bpid = bpos.getBlockPoolId();
       List<Long> blockIds = dn.getFSDataset().getCacheReport(bpid);
+      // Skip cache report
+      if (blockIds.isEmpty()) {
+        return null;
+      }
       long createTime = monotonicNow();
 
       cmd = bpNamenode.cacheReport(bpRegistration, bpid, blockIds);


### PR DESCRIPTION
Now, DataNode will cacheReport to all NameNode when CacheCapacitySize is not zero. But sometimes, not all NameNodes have CacheBlock on this DataNode. So BPServiceActor should skip cacheReport when one blockPool does not have CacheBlock on this DataNode. If so, the NameNode will reduce unnecessary lock contention