### PR TITLE
HDFS-17343. Revert "HDFS-16016. BPServiceActor to provide new thread to handle IBR (#2998)"

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeReport.java
@@ -172,19 +172,8 @@ public class TestDatanodeReport {
         // all bad datanodes
       }
       cluster.triggerHeartbeats(); // IBR delete ack
-      int retries = 0;
-      while (true) {
-        lb = fs.getClient().getLocatedBlocks(p.toString(), 0).get(0);
-        if (0 != lb.getLocations().length) {
-          retries++;
-          if (retries > 7) {
-            Assert.fail("getLocatedBlocks failed after 7 retries");
-          }
-          Thread.sleep(2000);
-        } else {
-          break;
-        }
-      }
+      lb = fs.getClient().getLocatedBlocks(p.toString(), 0).get(0);
+      assertEquals(0, lb.getLocations().length);
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.times;
 
 import java.io.IOException;
 
-import org.mockito.exceptions.base.MockitoAssertionError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -157,7 +156,7 @@ public class TestIncrementalBlockReports {
 
       // Sleep for a very short time since IBR is generated
       // asynchronously.
-      Thread.sleep(1000);
+      Thread.sleep(2000);
 
       // Ensure that no block report was generated immediately.
       // Deleted blocks are reported when the IBR timer elapses.
@@ -168,24 +167,13 @@ public class TestIncrementalBlockReports {
 
       // Trigger a heartbeat, this also triggers an IBR.
       DataNodeTestUtils.triggerHeartbeat(singletonDn);
+      Thread.sleep(2000);
 
       // Ensure that the deleted block is reported.
-      int retries = 0;
-      while (true) {
-        try {
-          Mockito.verify(nnSpy, atLeastOnce()).blockReceivedAndDeleted(
-              any(DatanodeRegistration.class),
-              anyString(),
-              any(StorageReceivedDeletedBlocks[].class));
-          break;
-        } catch (MockitoAssertionError e) {
-          if (retries > 7) {
-            throw e;
-          }
-          retries++;
-          Thread.sleep(2000);
-        }
-      }
+      Mockito.verify(nnSpy, times(1)).blockReceivedAndDeleted(
+          any(DatanodeRegistration.class),
+          anyString(),
+          any(StorageReceivedDeletedBlocks[].class));
 
     } finally {
       cluster.shutdown();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HDFS-17343. Revert HDFS-16016. BPServiceActor to provide new thread to handle IBR.

Revert "HDFS-16016. BPServiceActor to provide new thread to handle IBR (#2998)"
This reverts commit c1bf3cb0

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

