### PR TITLE
HDFS-17341: Support dedicated user queues in Namenode FairCallQueue

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeys.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeys.java
@@ -118,6 +118,16 @@ public class CommonConfigurationKeys extends CommonConfigurationKeysPublic {
   public static final String IPC_CALLQUEUE_CAPACITY_WEIGHTS_KEY =
       "callqueue.capacity.weights";
 
+  public static final String IPC_CALLQUEUE_RESERVED_USERS_KEY =
+      "faircallqueue.reserved.users";
+  public static final String IPC_CALLQUEUE_RESERVED_USERS_MAX_KEY =
+      "faircallqueue.reserved.users.max";
+  public static final int IPC_CALLQUEUE_RESERVED_USERS_MAX_KEY_DEFAULT = 10;
+  public static final String IPC_CALLQUEUE_RESERVED_USERS_CAPACITIES_KEY =
+      "faircallqueue.reserved.users.capacities";
+  public static final String IPC_CALLQUEUE_WRRMUX_RESERVED_WEIGHTS_KEY =
+      "faircallqueue.multiplexer.reserved.weights";
+
   /**
    * IPC scheduler priority levels.
    */


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
BUG=HDFS-17341

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

