### PR TITLE
MAPREDUCE-7469. NNBench createControlFiles should use thread pool to improve performance.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/hdfs/NNBench.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/hdfs/NNBench.java
@@ -143,7 +143,7 @@ public class NNBench extends Configured implements Tool {
    * 
    * @throws IOException on error
    */
-  private void createControlFiles() throws ExecutionException, InterruptedException {
+  private void createControlFiles() {
     LOG.info("Creating " + numberOfMaps + " control files");
 
     List<Future<Void>> list = new ArrayList<>();
@@ -160,8 +160,7 @@ public class NNBench extends Configured implements Tool {
       try {
         list.get(i).get();
       } catch (InterruptedException | ExecutionException e) {
-        LOG.error("Creating control files Error.");
-        throw e;
+        LOG.error("Creating control files Error.", e);
       }
     }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/hdfs/NNBench.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/hdfs/NNBench.java
@@ -112,8 +112,6 @@ public class NNBench extends Configured implements Tool {
   private static final String OP_RENAME = "rename";
   private static final String OP_DELETE = "delete";
   private static final int MAX_OPERATION_EXCEPTIONS = 1000;
-  private ExecutorService executorService =
-      HadoopExecutors.newFixedThreadPool(2 * Runtime.getRuntime().availableProcessors());
   
   // To display in the format that matches the NN and DN log format
   // Example: 2007-10-26 00:01:19,853
@@ -146,6 +144,8 @@ public class NNBench extends Configured implements Tool {
   private void createControlFiles() {
     LOG.info("Creating " + numberOfMaps + " control files");
 
+    ExecutorService executorService =
+        HadoopExecutors.newFixedThreadPool(2 * Runtime.getRuntime().availableProcessors());
     List<Future<Void>> list = new ArrayList<>();
     for (int i = 0; i < numberOfMaps; i++) {
       String strFileName = "NNBench_Controlfile_" + i;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/hdfs/NNBench.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/hdfs/NNBench.java
@@ -26,9 +26,15 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.List;
 import java.util.StringTokenizer;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.conf.Configuration;
@@ -55,6 +61,7 @@ import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapred.SequenceFileInputFormat;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
+import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,6 +112,8 @@ public class NNBench extends Configured implements Tool {
   private static final String OP_RENAME = "rename";
   private static final String OP_DELETE = "delete";
   private static final int MAX_OPERATION_EXCEPTIONS = 1000;
+  private ExecutorService executorService =
+      HadoopExecutors.newFixedThreadPool(2 * Runtime.getRuntime().availableProcessors());
   
   // To display in the format that matches the NN and DN log format
   // Example: 2007-10-26 00:01:19,853
@@ -134,27 +143,60 @@ public class NNBench extends Configured implements Tool {
    * 
    * @throws IOException on error
    */
-  private void createControlFiles() throws IOException {
+  private void createControlFiles() throws ExecutionException, InterruptedException {
     LOG.info("Creating " + numberOfMaps + " control files");
 
+    List<Future<Void>> list = new ArrayList<>();
     for (int i = 0; i < numberOfMaps; i++) {
       String strFileName = "NNBench_Controlfile_" + i;
       Path filePath = new Path(new Path(baseDir, CONTROL_DIR_NAME),
               strFileName);
 
+      Future<Void> future = executorService.submit(new CreateControlFile(strFileName, filePath, i));
+      list.add(future);
+    }
+
+    for (int i = 0; i < list.size(); i++) {
+      try {
+        list.get(i).get();
+      } catch (InterruptedException | ExecutionException e) {
+        LOG.error("Creating control files Error.");
+        throw e;
+      }
+    }
+
+    executorService.shutdown();
+  }
+
+  private class CreateControlFile implements Callable<Void> {
+    private String strFileName;
+    private Path filePath;
+    private int order;
+
+    CreateControlFile(String strFileName, Path filePath, int order) {
+      this.strFileName = strFileName;
+      this.filePath = filePath;
+      this.order = order;
+    }
+
+    @Override
+    public Void call() throws Exception {
       SequenceFile.Writer writer = null;
       try {
         writer = SequenceFile.createWriter(getConf(), Writer.file(filePath),
             Writer.keyClass(Text.class), Writer.valueClass(LongWritable.class),
             Writer.compression(CompressionType.NONE));
-        writer.append(new Text(strFileName), new LongWritable(i));
+        writer.append(new Text(strFileName), new LongWritable(order));
       } finally {
         if (writer != null) {
           writer.close();
         }
       }
+      return null;
     }
+
   }
+
   /**
    * Display version
    */


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: [MAPREDUCE-7469](https://issues.apache.org/jira/browse/MAPREDUCE-7469) NNBench createControlFiles should use thread pool to improve performance.


### How was this patch tested?

Add test case for this.
