### PR TITLE
HDFS-17346. Fix DirectoryScanner check mark the normal blocks as corrupt

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeFaultInjector.java
@@ -162,4 +162,9 @@ public class DataNodeFaultInjector {
    * Just delay delete replica a while.
    */
   public void delayDeleteReplica() {}
+
+  /**
+   * Just delay run diff record a while.
+   */
+  public void delayDiffRecord() {}
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DirectoryScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DirectoryScanner.java
@@ -509,6 +509,7 @@ public class DirectoryScanner implements Runnable {
 
     // Pre-sort the reports outside of the lock
     blockPoolReport.sortBlocks();
+    DataNodeFaultInjector.get().delayDiffRecord();
 
     for (final String bpid : blockPoolReport.getBlockPoolIds()) {
       List<ScanInfo> blockpoolReport = blockPoolReport.getScanInfo(bpid);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
@@ -40,7 +40,9 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -56,10 +58,12 @@ import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.protocol.Block;
+import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
@@ -560,6 +564,88 @@ public class TestDirectoryScanner {
         scanner = null;
       }
       cluster.shutdown();
+    }
+  }
+
+  @Test(timeout = 600000)
+  public void testDirectoryScannerDuringUpdateBlockMeta() throws Exception {
+    Configuration conf = getConfiguration();
+    DataNodeFaultInjector oldDnInjector = DataNodeFaultInjector.get();
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+    try {
+      cluster.waitActive();
+      bpid = cluster.getNamesystem().getBlockPoolId();
+      fds = DataNodeTestUtils.getFSDataset(cluster.getDataNodes().get(0));
+      client = cluster.getFileSystem().getClient();
+      DistributedFileSystem fs = cluster.getFileSystem();
+      conf.setInt(DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_THREADS_KEY, 1);
+      GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer.
+          captureLogs(NameNode.stateChangeLog);
+
+      // Add files with 1 blocks.
+      Path path = new Path("/testFile");
+      DFSTestUtil.createFile(fs, path, 50, (short) 1, 0);
+      DFSTestUtil.waitReplication(fs, path, (short) 1);
+      LocatedBlock lb = DFSTestUtil.getAllBlocks(fs, path).get(0);
+      DatanodeInfo[] loc = lb.getLocations();
+      assertEquals(1, loc.length);
+      DataNodeFaultInjector dnFaultInjector = new DataNodeFaultInjector() {
+        @Override
+        public void delayDiffRecord() {
+          try {
+            Thread.sleep(8000);
+          } catch (InterruptedException e) {
+            // Ignore exception.
+          }
+        }
+      };
+
+      DataNodeFaultInjector.set(dnFaultInjector);
+      ExecutorService executorService = Executors.newFixedThreadPool(2);
+      try {
+        Future<?> blockReaderFuture = executorService.submit(() -> {
+          try {
+            // Submit tasks run directory scanner.
+            scanner = new DirectoryScanner(fds, conf);
+            scanner.setRetainDiffs(true);
+            scanner.reconcile();
+          } catch (IOException e) {
+            // Ignore exception.
+          }
+        });
+
+        Future<?> finalizeBlockFuture = executorService.submit(() -> {
+          try {
+            // Submit tasks run append file.
+            DFSTestUtil.appendFile(fs, path, 50);
+          } catch (Exception e) {
+            // Ignore exception.
+          }
+        });
+
+        // Wait for both tasks to complete.
+        blockReaderFuture.get();
+        finalizeBlockFuture.get();
+      } finally {
+        executorService.shutdown();
+      }
+
+      DirectoryScanner.Stats stats = scanner.stats.get(bpid);
+      assertNotNull(stats);
+      assertEquals(1, stats.mismatchBlocks);
+
+      // Check nn log will not reportBadBlocks message.
+      String msg = "*DIR* reportBadBlocks for block: " + bpid + ":" +
+          getBlockFile(lb.getBlock().getBlockId());
+      assertFalse(logCapturer.getOutput().contains(msg));
+    } finally {
+      if (scanner != null) {
+        scanner.shutdown();
+        scanner = null;
+      }
+      DataNodeFaultInjector.set(oldDnInjector);
+      cluster.shutdown();
+      cluster = null;
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
@@ -603,7 +603,7 @@ public class TestDirectoryScanner {
       DataNodeFaultInjector.set(dnFaultInjector);
       ExecutorService executorService = Executors.newFixedThreadPool(2);
       try {
-        Future<?> blockReaderFuture = executorService.submit(() -> {
+        Future<?> directoryScannerFuture = executorService.submit(() -> {
           try {
             // Submit tasks run directory scanner.
             scanner = new DirectoryScanner(fds, conf);
@@ -614,7 +614,7 @@ public class TestDirectoryScanner {
           }
         });
 
-        Future<?> finalizeBlockFuture = executorService.submit(() -> {
+        Future<?> appendBlockFuture = executorService.submit(() -> {
           try {
             // Submit tasks run append file.
             DFSTestUtil.appendFile(fs, path, 50);
@@ -624,8 +624,8 @@ public class TestDirectoryScanner {
         });
 
         // Wait for both tasks to complete.
-        blockReaderFuture.get();
-        finalizeBlockFuture.get();
+        directoryScannerFuture.get();
+        appendBlockFuture.get();
       } finally {
         executorService.shutdown();
       }


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17346

DirectoryScanner check mark the normal blocks as corrupt and report to namenode, it maybe cause some corrupted blocks, actually these are health.

This can happen if Appending and DirectoryScanner are running at the same time, and the probability is very high.

**Root cause:**

- Create a file such as:blk_xxx_1001 and diskFile is "file:/XXX/current/finalized/blk_xxx", diskMetaFile is "file:/XXX/current/finalized/blk_xxx_1001.meta"

- Run DirectoryScanner, first will create BlockPoolReport.ScanInfo and record blockFile is "file:/XXX/current/finalized/blk_xxx" and metaFile is "file:/XXX/current/finalized/blk_xxx_1001.meta"

- Simultaneously other thread to complete append for blk_xxx, then the diskFile "file:/XXX/current/finalized/blk_xxx", diskMetaFile "file:/XXX/current/finalized/blk_xxx_1002.meta", memMetaFile "file:/XXX/current/finalized/blk_xxx", memDataFile "file:/XXX/current/finalized/blk_xxx_1002.meta"

- DirectoryScanner continue to run, due to the different generation stamps of the metadata file in mem and metadata file in scanInfo will add the scanInfo object to the list of differences

- Continue to run FsDatasetImpl#checkAndUpdate will traverse the list of differences, due to current diskMetaFile "/XXX/current/finalized/blk_xxx_1001.meta" is not exists, so isRegular as false
```
 final boolean isRegular = FileUtil.isRegularFile(diskMetaFile, false) && FileUtil.isRegularFile(diskFile, false);
```
- Here will mark the normal blocks as corrupt and report to namenode
```
     } else if (!isRegular) {
         corruptBlock = new Block(memBlockInfo);
        LOG.warn("Block:{} is not a regular file.", corruptBlock.getBlockId());
     }
```

