### PR TITLE
HDFS-17344. Last packet will be splited into two parts when write block.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
@@ -539,6 +539,10 @@ public class DFSOutputStream extends FSOutputSummer
       int psize = 0;
       if (blockSize == getStreamer().getBytesCurBlock()) {
         psize = writePacketSize;
+      } else if (blockSize - getStreamer().getBytesCurBlock() + PacketHeader.PKT_MAX_HEADER_LEN
+          < writePacketSize) { 
+        psize = (int)(blockSize - getStreamer().getBytesCurBlock()) +
+            PacketHeader.PKT_MAX_HEADER_LEN;
       } else {
         psize = (int) Math
             .min(blockSize - getStreamer().getBytesCurBlock(), writePacketSize);

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
@@ -540,7 +540,7 @@ public class DFSOutputStream extends FSOutputSummer
       if (blockSize == getStreamer().getBytesCurBlock()) {
         psize = writePacketSize;
       } else if (blockSize - getStreamer().getBytesCurBlock() + PacketHeader.PKT_MAX_HEADER_LEN
-          < writePacketSize) { 
+          < writePacketSize) {
         psize = (int)(blockSize - getStreamer().getBytesCurBlock()) +
             PacketHeader.PKT_MAX_HEADER_LEN;
       } else {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
@@ -539,13 +539,14 @@ public class DFSOutputStream extends FSOutputSummer
       int psize = 0;
       if (blockSize == getStreamer().getBytesCurBlock()) {
         psize = writePacketSize;
-      } else if (blockSize - getStreamer().getBytesCurBlock() + PacketHeader.PKT_MAX_HEADER_LEN
-          < writePacketSize) {
-        psize = (int)(blockSize - getStreamer().getBytesCurBlock()) +
-            PacketHeader.PKT_MAX_HEADER_LEN;
       } else {
         psize = (int) Math
             .min(blockSize - getStreamer().getBytesCurBlock(), writePacketSize);
+        if (psize < writePacketSize) {
+          final int chunkSize = bytesPerChecksum + getChecksumSize();
+          int numPackets = (psize + bytesPerChecksum - 1) / bytesPerChecksum;
+          psize = PacketHeader.PKT_MAX_HEADER_LEN + numPackets * chunkSize;
+        }
       }
       computePacketChunkSize(psize, bytesPerChecksum);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSOutputStream.java
@@ -549,6 +549,45 @@ public class TestDFSOutputStream {
     fs.delete(new Path("/testfile.dat"), true);
   }
 
+  @Test(timeout = 60000)
+  public void testLastPacketSizeInBlocks() throws IOException {
+    final long blockSize = (long) 1024 * 1024;
+    MiniDFSCluster dfsCluster = cluster;
+    DistributedFileSystem fs = dfsCluster.getFileSystem();
+    Configuration dfsConf = fs.getConf();
+
+    EnumSet<CreateFlag> flags = EnumSet.of(CreateFlag.CREATE);
+    try(FSDataOutputStream fos = fs.create(new Path("/testfile.dat"),
+        FsPermission.getDefault(),
+        flags, 512, (short)3, blockSize, null)) {
+
+      DataChecksum crc32c = DataChecksum.newDataChecksum(
+          DataChecksum.Type.CRC32C, 512);
+
+      long loop = 0;
+      Random r = new Random();
+      byte[] buf = new byte[(int) blockSize];
+      r.nextBytes(buf);
+      fos.write(buf);
+      fos.hflush();
+
+      int chunkSize = crc32c.getBytesPerChecksum() + crc32c.getChecksumSize();
+      int packetContentSize = (dfsConf.getInt(DFS_CLIENT_WRITE_PACKET_SIZE_KEY,
+          DFS_CLIENT_WRITE_PACKET_SIZE_DEFAULT) -
+          PacketHeader.PKT_MAX_HEADER_LEN) / chunkSize * chunkSize;
+
+      while (loop < 20) {
+        r.nextBytes(buf);
+        fos.write(buf);
+        fos.hflush();
+        loop++;
+        Assert.assertEquals(((DFSOutputStream) fos.getWrappedStream()).packetSize,
+            packetContentSize);
+      }
+    }
+    fs.delete(new Path("/testfile.dat"), true);
+  }
+
   @AfterClass
   public static void tearDown() {
     if (cluster != null) {


### PR DESCRIPTION
### Description of PR
Refer to HDFS-17344.

As mentioned in https://github.com/apache/hadoop/pull/6368#issuecomment-1899635293
This PR is trying to solve this problem.
The root problem is that we pass inaccurate packet size(parameter psize) to computePacketChunkSize method within method adjustChunkBoundary.

### How To Test
The existed unit test case testFirstPacketSizeInNewBlocks() can cover this PR's change.

