### PR TITLE
YARN-11649. [Federation] Create Override for Maximum Resource Capability in getNewApplication

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -4081,6 +4081,24 @@ public class YarnConfiguration extends Configuration {
   public static final long DEFAULT_FEDERATION_AMRMPROXY_SUBCLUSTER_TIMEOUT =
       60000; // one minute
 
+  public static final String FEDERATION_OVERRIDE_MAX_CLUSTER_CAPABILITY =
+          FEDERATION_PREFIX + "override.maximum.cluster.capability.enabled";
+
+  public static final boolean FEDERATION_DEFAULT_OVERRIDE_MAX_CLUSTER_CAPABILITY =
+          false;
+
+  public static final String FEDERATION_OVERRIDE_MAX_CLUSTER_MEMORY_CAPABILITY_MB =
+          FEDERATION_PREFIX + "override.maximum.cluster.capability.enabled";
+
+  public static final String FEDERATION_OVERRIDE_MAX_CLUSTER_CPU_CAPABILITY_VCORES =
+          FEDERATION_PREFIX + "override.maximum.cluster.capability.enabled";
+
+  public static final long FEDERATION_DEFAULT_OVERRIDE_MAX_CLUSTER_MEMORY_CAPABILITY_MB =
+          8192;
+
+  public static final int FEDERATION_DEFAULT_OVERRIDE_MAX_CLUSTER_CPU_CAPABILITY_VCORES =
+          4;
+
   // Prefix for configs related to selecting SC based on load
   public static final String LOAD_BASED_SC_SELECTOR_PREFIX =
       NM_PREFIX + "least-load-policy-selector.";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
@@ -189,6 +189,10 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
   private final static long DEFAULT_DURATION = 10 * 60 * 1000;
 
+  private final static long FEDERATION_MAX_MEMORY_CAPABILITY = 10000;
+
+  private final static int FEDERATION_MAX_CPU_CAPABILITY = 8;
+
   @Override
   public void setUp() throws IOException {
     super.setUpConfig();
@@ -255,6 +259,10 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     conf.setInt("yarn.scheduler.maximum-allocation-mb", 100 * 1024);
     conf.setInt("yarn.scheduler.maximum-allocation-vcores", 100);
 
+    conf.setBoolean(YarnConfiguration.FEDERATION_OVERRIDE_MAX_CLUSTER_CAPABILITY, true);
+    conf.setLong(YarnConfiguration.FEDERATION_OVERRIDE_MAX_CLUSTER_MEMORY_CAPABILITY_MB, FEDERATION_MAX_MEMORY_CAPABILITY);
+    conf.setInt(YarnConfiguration.FEDERATION_OVERRIDE_MAX_CLUSTER_MEMORY_CAPABILITY_MB, FEDERATION_MAX_CPU_CAPABILITY);
+
     conf.setBoolean("hadoop.security.authentication", true);
     return conf;
   }
@@ -274,6 +282,9 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     Assert.assertNotNull(response.getApplicationId());
     Assert.assertEquals(response.getApplicationId().getClusterTimestamp(),
         ResourceManager.getClusterTimeStamp());
+
+    Assert.assertEquals(response.getMaximumResourceCapability().getMemorySize(), FEDERATION_MAX_MEMORY_CAPABILITY);
+    Assert.assertEquals(response.getMaximumResourceCapability().getVirtualCores(), FEDERATION_MAX_CPU_CAPABILITY);
   }
 
   /**


### PR DESCRIPTION


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: [YARN-11649](https://issues.apache.org/jira/browse/YARN-11649). [Router] Create Override for Maximum Resource Capability in getNewApplication

When getNewApplication is called against YARN Router with Federation on, its possible we get different maxResourceCapabilities on different calls. This is because getNewApplication is called against a random cluster on each call, which may return different maxResourceCapability based on the cluster that the call is executed on.


### How was this patch tested?
Via adding test cases

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

