### PR TITLE
HADOOP-19044: AWS SDK V2 - Update S3A region logic

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -291,15 +291,25 @@ public class DefaultS3ClientFactory extends Configured
     if (endpoint != null) {
       checkArgument(!fipsEnabled,
           "%s : %s", ERROR_ENDPOINT_WITH_FIPS, endpoint);
-      builder.endpointOverride(endpoint);
-      // No region was configured, try to determine it from the endpoint.
-      if (region == null) {
-        region = getS3RegionFromEndpoint(parameters.getEndpoint());
-        if (region != null) {
-          origin = "endpoint";
-        }
+      if(parameters.getEndpoint().equals(CENTRAL_ENDPOINT)){
+        // this will cause some issues, override this and ignore the endpoint setting
+        // this is to make it similar to cross region access.
+        region = Region.of(AWS_S3_DEFAULT_REGION);
+        builder.crossRegionAccessEnabled(true);
+        builder.region(region);
+        origin = "cross region access fallback because of global endpoint";
       }
-      LOG.debug("Setting endpoint to {}", endpoint);
+      else {
+        builder.endpointOverride(endpoint);
+        // No region was configured, try to determine it from the endpoint.
+        if (region == null) {
+          region = getS3RegionFromEndpoint(parameters.getEndpoint());
+          if (region != null) {
+            origin = "endpoint";
+          }
+        }
+        LOG.debug("Setting endpoint to {}", endpoint);
+      }
     }
 
     if (region != null) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEndpointRegion.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEndpointRegion.java
@@ -146,7 +146,7 @@ public class ITestS3AEndpointRegion extends AbstractS3ATestBase {
     describe("Create a client with the central endpoint");
     Configuration conf = getConfiguration();
 
-    S3Client client = createS3Client(conf, CENTRAL_ENDPOINT, null, US_EAST_1, false);
+    S3Client client = createS3Client(conf, CENTRAL_ENDPOINT, null, US_EAST_2, false);
 
     expectInterceptorException(client);
   }
@@ -272,7 +272,7 @@ public class ITestS3AEndpointRegion extends AbstractS3ATestBase {
     public void beforeExecution(Context.BeforeExecution context,
         ExecutionAttributes executionAttributes)  {
 
-      if (endpoint != null) {
+      if (endpoint != null && !endpoint.equals(CENTRAL_ENDPOINT)) {
         Assertions.assertThat(
                 executionAttributes.getAttribute(AwsExecutionAttribute.ENDPOINT_OVERRIDDEN))
             .describedAs("Endpoint not overridden").isTrue();


### PR DESCRIPTION
If both fs.s3a.endpoint & fs.s3a.endpoint.region are empty, Spark will set fs.s3a.endpoint to

s3.amazonaws.com here:https://github.com/apache/spark/blob/9a2f39318e3af8b3817dc5e4baf52e548d82063c/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala#L540

 HADOOP-18908, updated the region logic such that if fs.s3a.endpoint.region is set, or if a region can be parsed from fs.s3a.endpoint (which will happen in this case, region will be US_EAST_1), cross region access is not enabled. This will cause 400 errors if the bucket is not in US_EAST_1.

 Proposed: Updated the logic so that if the endpoint is the global s3.amazonaws.com , cross region access is enabled.

### Description of PR


### How was this patch tested?
Its being currently tested against us-west-2 by explicitly setting the endpoint as s3.amazonaws.com


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

