### PR TITLE
HADOOP-19037. AWS SDK v2: ITestS3AConfiguration failing with region problems

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
@@ -78,6 +78,10 @@ public class ITestS3AConfiguration {
   private static final String AP_ILLEGAL_ACCESS =
       "ARN of type accesspoint cannot be passed as a bucket";
 
+  private static final String US_EAST_1 = "us-east-1";
+
+  private static final String STS_ENDPOINT = "sts.us-east-1.amazonaws.com";
+
   private Configuration conf;
   private S3AFileSystem fs;
 
@@ -565,8 +569,9 @@ public class ITestS3AConfiguration {
 
     final String bucket = fs.getBucket();
     StsClient stsClient =
-        STSClientFactory.builder(config, bucket, new AnonymousAWSCredentialsProvider(), "",
-            "").build();
+        STSClientFactory.builder(config, bucket, new AnonymousAWSCredentialsProvider(),
+                STS_ENDPOINT, US_EAST_1).build();
+
 
     intercept(StsException.class, "", () ->
         stsClient.getSessionToken());


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Jira: https://issues.apache.org/jira/browse/HADOOP-19037

Currently ITestS3AConfiguration.testS3SpecificSignerOverride failing when `~/.aws/config` profile region is not set. This is because if a region is not provided to STS client it will fall back to using the SDK DefaultAwsRegionProviderChain: env var, profile, EC2 Metadata(IMDS) to get the client signing region. If none of these providers are successful, this test will fail. This PR sets this test STS client region to not rely on the SDK region provider chain.

We will continue to have test coverage of configuring STS client builder in ITestS3ATemporaryCredentials.

### How was this patch tested?
Tested with a bucket in eu-west-1 with `mvn clean verify -Dparallel-tests -DtestsThreadCount=16`
- With a no region `~/.aws/config `

All tests passing other than 2 failures:
```
ITestS3ACommitterFactory.testEverything (testInvalidFileBinding())
ITestS3AConfiguration.testRequestTimeout (Expected: https://issues.apache.org/jira/browse/HADOOP-19022)
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

