### PR TITLE
HADOOP-19049. Fix StatisticsDataReferenceCleaner classloader leak

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4077,6 +4077,7 @@ public abstract class FileSystem extends Configured
       STATS_DATA_CLEANER.
           setName(StatisticsDataReferenceCleaner.class.getName());
       STATS_DATA_CLEANER.setDaemon(true);
+      STATS_DATA_CLEANER.setContextClassLoader(null);
       STATS_DATA_CLEANER.start();
     }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileSystemContractBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileSystemContractBaseTest.java
@@ -527,16 +527,6 @@ public abstract class FileSystemContractBaseTest {
   }
 
   @Test
-  public void testStatisticsDataReferenceCleanerClassLoader() {
-    // initialize the static thread
-    new FileSystem.Statistics("test");
-    Thread thread = Thread.getAllStackTraces().keySet().stream()
-        .filter(t -> t.getName().contains("StatisticsDataReferenceCleaner")).findFirst().get();
-    ClassLoader classLoader = thread.getContextClassLoader();
-    assertNull(classLoader);
-  }
-
-  @Test
   public void testRenameDirectoryAsExistingFile() throws Exception {
     assumeTrue(renameSupported());
     

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileSystemContractBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileSystemContractBaseTest.java
@@ -527,6 +527,18 @@ public abstract class FileSystemContractBaseTest {
   }
 
   @Test
+  public void testStatisticsDataReferenceCleanerClassLoader() {
+    // initialize the static thread
+    new FileSystem.Statistics("test");
+    Thread.getAllStackTraces().keySet().stream()
+        .filter(t -> t.getName().contains("StatisticsDataReferenceCleaner")).findFirst()
+        .ifPresent(t -> {
+          ClassLoader classLoader = t.getContextClassLoader();
+          assertNull(classLoader);
+        });
+  }
+
+  @Test
   public void testRenameDirectoryAsExistingFile() throws Exception {
     assumeTrue(renameSupported());
     

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileSystemContractBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileSystemContractBaseTest.java
@@ -530,12 +530,10 @@ public abstract class FileSystemContractBaseTest {
   public void testStatisticsDataReferenceCleanerClassLoader() {
     // initialize the static thread
     new FileSystem.Statistics("test");
-    Thread.getAllStackTraces().keySet().stream()
-        .filter(t -> t.getName().contains("StatisticsDataReferenceCleaner")).findFirst()
-        .ifPresent(t -> {
-          ClassLoader classLoader = t.getContextClassLoader();
-          assertNull(classLoader);
-        });
+    Thread thread = Thread.getAllStackTraces().keySet().stream()
+        .filter(t -> t.getName().contains("StatisticsDataReferenceCleaner")).findFirst().get();
+    ClassLoader classLoader = thread.getContextClassLoader();
+    assertNull(classLoader);
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileSystemStorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileSystemStorageStatistics.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * This tests basic operations of {@link FileSystemStorageStatistics} class.
@@ -100,6 +101,14 @@ public class TestFileSystemStorageStatistics {
           key, expectedStat, storageStat);
       assertEquals(expectedStat, storageStat);
     }
+  }
+
+  @Test
+  public void testStatisticsDataReferenceCleanerClassLoader() {
+    Thread thread = Thread.getAllStackTraces().keySet().stream()
+        .filter(t -> t.getName().contains("StatisticsDataReferenceCleaner")).findFirst().get();
+    ClassLoader classLoader = thread.getContextClassLoader();
+    assertNull(classLoader);
   }
 
   /**


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
This PR fix StatisticsDataReferenceCleaner thread class loader leak problem. Before start it we should make sure it can not reference class loader.

### How was this patch tested?
Add new test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

