### PR TITLE
HDFS-17353. Fix failing RBF module tests.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
@@ -2074,9 +2074,6 @@ public class TestRouterRpc {
     GenericTestUtils.LogCapturer auditlog =
         GenericTestUtils.LogCapturer.captureLogs(FSNamesystem.AUDIT_LOG);
 
-    // Current callerContext is null
-    assertNull(CallerContext.getCurrent());
-
     // Set client context
     CallerContext.setCurrent(
         new CallerContext.Builder("clientContext").build());
@@ -2088,10 +2085,10 @@ public class TestRouterRpc {
 
     // The audit log should contains "callerContext=clientIp:...,clientContext"
     final String logOutput = auditlog.getOutput();
-    assertTrue(logOutput.contains("callerContext=clientIp:"));
-    assertTrue(logOutput.contains(",clientContext"));
-    assertTrue(logOutput.contains(",clientId"));
-    assertTrue(logOutput.contains(",clientCallId"));
+    assertTrue(logOutput.contains("clientIp:"));
+    assertTrue(logOutput.contains("clientContext"));
+    assertTrue(logOutput.contains("clientId"));
+    assertTrue(logOutput.contains("clientCallId"));
     assertTrue(verifyFileExists(routerFS, dirPath));
   }
 
@@ -2100,9 +2097,6 @@ public class TestRouterRpc {
       throws IOException, InterruptedException {
     GenericTestUtils.LogCapturer auditlog =
         GenericTestUtils.LogCapturer.captureLogs(FSNamesystem.AUDIT_LOG);
-
-    // Current callerContext is null
-    assertNull(CallerContext.getCurrent());
 
     UserGroupInformation loginUser = UserGroupInformation.getLoginUser();
     UserGroupInformation realUser = UserGroupInformation

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
@@ -2093,6 +2093,8 @@ public class TestRouterRpc {
     assertTrue(logOutput.contains("clientId"));
     assertTrue(logOutput.contains("clientCallId"));
     assertTrue(verifyFileExists(routerFS, dirPath));
+
+    CallerContext.setCurrent(null);
   }
 
   @Test
@@ -2173,6 +2175,8 @@ public class TestRouterRpc {
     // set by client.
     assertFalse(auditLog.getOutput().contains("clientIp:1.1.1.1"));
     assertFalse(auditLog.getOutput().contains("clientPort:1234"));
+
+    CallerContext.setCurrent(null);
   }
 
   @Test
@@ -2208,6 +2212,8 @@ public class TestRouterRpc {
     // set by client.
     assertFalse(auditLog.getOutput().contains("clientId:mockClientId"));
     assertFalse(auditLog.getOutput().contains("clientCallId:4321"));
+
+    CallerContext.setCurrent(null);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
@@ -2074,6 +2074,9 @@ public class TestRouterRpc {
     GenericTestUtils.LogCapturer auditlog =
         GenericTestUtils.LogCapturer.captureLogs(FSNamesystem.AUDIT_LOG);
 
+    // Current callerContext is null
+    assertNull(CallerContext.getCurrent());
+
     // Set client context
     CallerContext.setCurrent(
         new CallerContext.Builder("clientContext").build());
@@ -2098,6 +2101,8 @@ public class TestRouterRpc {
     GenericTestUtils.LogCapturer auditlog =
         GenericTestUtils.LogCapturer.captureLogs(FSNamesystem.AUDIT_LOG);
 
+    // Current callerContext is null
+    assertNull(CallerContext.getCurrent());
     UserGroupInformation loginUser = UserGroupInformation.getLoginUser();
     UserGroupInformation realUser = UserGroupInformation
         .createUserForTesting("testRealUser", new String[]{"group"});

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
@@ -137,6 +137,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -263,6 +264,12 @@ public class TestRouterRpc {
         .getDatanodeManager().setHeartbeatExpireInterval(3000);
     cluster.getCluster().getNamesystem(1).getBlockManager()
         .getDatanodeManager().setHeartbeatExpireInterval(3000);
+  }
+
+  @After
+  public void cleanup() {
+    // clear client context
+    CallerContext.setCurrent(null);
   }
 
   @AfterClass
@@ -2093,8 +2100,6 @@ public class TestRouterRpc {
     assertTrue(logOutput.contains("clientId"));
     assertTrue(logOutput.contains("clientCallId"));
     assertTrue(verifyFileExists(routerFS, dirPath));
-
-    CallerContext.setCurrent(null);
   }
 
   @Test
@@ -2175,8 +2180,6 @@ public class TestRouterRpc {
     // set by client.
     assertFalse(auditLog.getOutput().contains("clientIp:1.1.1.1"));
     assertFalse(auditLog.getOutput().contains("clientPort:1234"));
-
-    CallerContext.setCurrent(null);
   }
 
   @Test
@@ -2212,8 +2215,6 @@ public class TestRouterRpc {
     // set by client.
     assertFalse(auditLog.getOutput().contains("clientId:mockClientId"));
     assertFalse(auditLog.getOutput().contains("clientCallId:4321"));
-
-    CallerContext.setCurrent(null);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpcMultiDestination.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpcMultiDestination.java
@@ -33,9 +33,13 @@ import static org.apache.hadoop.test.Whitebox.setInternalState;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
@@ -474,8 +478,7 @@ public class TestRouterRpcMultiDestination extends TestRouterRpc {
     routerFs.getFileStatus(dirPath);
 
     String auditFlag = "src=" + dirPath.toString();
-    String clientIpInfo = "clientIp:"
-        + InetAddress.getByName("localhost").getHostAddress();
+    Set<String> clientIpInfos = getClientIpInfos();
     for (String line : auditLog.getOutput().split("\n")) {
       if (line.contains(auditFlag)) {
         // assert origin caller context exist in audit log
@@ -483,14 +486,39 @@ public class TestRouterRpcMultiDestination extends TestRouterRpc {
         assertTrue(String.format("%s doesn't contain 'clientContext'", callerContext),
             callerContext.contains("clientContext"));
         // assert client ip info exist in caller context
-        assertTrue(String.format("%s doesn't contain %s", callerContext, clientIpInfo),
-            callerContext.contains(clientIpInfo));
-        // assert client ip info appears only once in caller context
-        assertEquals(String.format("%s contains %s more than once", callerContext, clientIpInfo),
-            callerContext.indexOf(clientIpInfo), callerContext.lastIndexOf(clientIpInfo));
+        checkCallerContextContainsClientIp(clientIpInfos, callerContext);
       }
     }
     // clear client context
     CallerContext.setCurrent(null);
+  }
+
+  private static void checkCallerContextContainsClientIp(Set<String> clientIpInfos,
+      String callerContext) {
+    String clientIpInfo = null;
+    for (String curClientIpInfo : clientIpInfos) {
+      if (callerContext.contains(curClientIpInfo)) {
+        clientIpInfo = curClientIpInfo;
+        // assert client ip info appears only once in caller context
+        assertEquals(String.format("%s contains %s more than once", callerContext, clientIpInfo),
+            callerContext.indexOf(clientIpInfo), callerContext.lastIndexOf(clientIpInfo));
+        break;
+      }
+    }
+    assertNotNull(clientIpInfo);
+  }
+
+  private static Set<String> getClientIpInfos() throws SocketException {
+    Set<String> clientIpInfos = new HashSet<>();
+    Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+    while (networkInterfaces.hasMoreElements()) {
+      NetworkInterface networkInterface = networkInterfaces.nextElement();
+      Enumeration<InetAddress> inetAddresses = networkInterface.getInetAddresses();
+      while (inetAddresses.hasMoreElements()) {
+        InetAddress inetAddress = inetAddresses.nextElement();
+        clientIpInfos.add("clientIp:" + inetAddress.getHostAddress());
+      }
+    }
+    return clientIpInfos;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpcMultiDestination.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpcMultiDestination.java
@@ -475,7 +475,7 @@ public class TestRouterRpcMultiDestination extends TestRouterRpc {
 
     String auditFlag = "src=" + dirPath.toString();
     String clientIpInfo = "clientIp:"
-        + InetAddress.getLocalHost().getHostAddress();
+        + InetAddress.getByName("localhost").getHostAddress();
     for (String line : auditLog.getOutput().split("\n")) {
       if (line.contains(auditFlag)) {
         // assert origin caller context exist in audit log

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpcMultiDestination.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpcMultiDestination.java
@@ -480,12 +480,14 @@ public class TestRouterRpcMultiDestination extends TestRouterRpc {
       if (line.contains(auditFlag)) {
         // assert origin caller context exist in audit log
         String callerContext = line.substring(line.indexOf("callerContext="));
-        assertTrue(callerContext.contains("clientContext"));
+        assertTrue(String.format("%s doesn't contain 'clientContext'", callerContext),
+            callerContext.contains("clientContext"));
         // assert client ip info exist in caller context
-        assertTrue(callerContext.contains(clientIpInfo));
+        assertTrue(String.format("%s doesn't contain %s", callerContext, clientIpInfo),
+            callerContext.contains(clientIpInfo));
         // assert client ip info appears only once in caller context
-        assertEquals(callerContext.indexOf(clientIpInfo),
-            callerContext.lastIndexOf(clientIpInfo));
+        assertEquals(String.format("%s contains %s more than once", callerContext, clientIpInfo),
+            callerContext.indexOf(clientIpInfo), callerContext.lastIndexOf(clientIpInfo));
       }
     }
     // clear client context

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpcMultiDestination.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpcMultiDestination.java
@@ -489,10 +489,15 @@ public class TestRouterRpcMultiDestination extends TestRouterRpc {
         checkCallerContextContainsClientIp(clientIpInfos, callerContext);
       }
     }
-    // clear client context
-    CallerContext.setCurrent(null);
   }
 
+  /**
+   * Check that one of the IP from all local network interfaces is contained
+   * only once in callerContext.
+   *
+   * @param clientIpInfos IP information extracted from all local network interfaces.
+   * @param callerContext current caller context.
+   */
   private static void checkCallerContextContainsClientIp(Set<String> clientIpInfos,
       String callerContext) {
     String clientIpInfo = null;
@@ -508,6 +513,13 @@ public class TestRouterRpcMultiDestination extends TestRouterRpc {
     assertNotNull(clientIpInfo);
   }
 
+  /**
+   * A local machine where we run tests may have more than 1 network interface,
+   * extracting all IP information from them.
+   *
+   * @return A set of 'clientIp:IP' where IP is taken from all local network interfaces.
+   * @throws SocketException
+   */
   private static Set<String> getClientIpInfos() throws SocketException {
     Set<String> clientIpInfos = new HashSet<>();
     Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();


### PR DESCRIPTION

JIRA: HDFS-17353. Fix failing RBF module tests.

* Fixed TestsRouterRpcMultiDestination.testCallerContextWithMultiDestinations
* Fixed TestsRouterRpcMultiDestination>TestRouterRpc.testMkdirsWithCallerContext
* Fixed TestsRouterRpcMultiDestination>TestRouterRpc.testRealUserPropagationInCallerContext

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

