### PR TITLE
YARN-11639. CME and NPE in PriorityUtilizationQueueOrderingPolicy (#6…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/policy/PriorityUtilizationQueueOrderingPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/policy/PriorityUtilizationQueueOrderingPolicy.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity
     .CapacitySchedulerConfiguration;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -254,9 +255,9 @@ public class PriorityUtilizationQueueOrderingPolicy
     // partitionToLookAt is a thread local variable, therefore it is safe to mutate it.
     PriorityUtilizationQueueOrderingPolicy.partitionToLookAt.set(partition);
 
-    // Sort the snapshot of the queues in order to avoid breaking the prerequisites of TimSort.
-    // See YARN-10178 for details.
-    return queues.stream().map(PriorityQueueResourcesForSorting::new).sorted(
+    // Copy (for thread safety) and sort the snapshot of the queues in order to avoid breaking
+    // the prerequisites of TimSort. See YARN-10178 for details.
+    return new ArrayList<>(queues).stream().map(PriorityQueueResourcesForSorting::new).sorted(
         new PriorityQueueComparator()).map(PriorityQueueResourcesForSorting::getQueue).collect(
             Collectors.toList()).iterator();
   }


### PR DESCRIPTION
…455)

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Backporting [YARN-11639](https://issues.apache.org/jira/browse/YARN-11639) from trunk to branch-3.3.

### How was this patch tested?
Run the unit test for the class.

### For code changes:

- [ x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

