### PR TITLE
HDFS-17357. NioInetPeer.close() should close socket connection.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/net/NioInetPeer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/net/NioInetPeer.java
@@ -91,7 +91,11 @@ public class NioInetPeer implements Peer {
     try {
       in.close();
     } finally {
-      out.close();
+      try {
+        out.close();
+      } finally {
+        socket.close();
+      }
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: [HDFS-17357](https://issues.apache.org/jira/browse/HDFS-17357)


NioInetPeer.close()  now do not close socket connection.  

And I found 3w+ connections leakage in datanode . And I found many warn message as blew.

```
2024-01-22 15:27:57,500 WARN org.apache.hadoop.hdfs.server.datanode.DataNode: hostname:50010:DataXceiverServer
java.io.IOException: Xceiver count 8198 exceeds the limit of concurrent xcievers: 8192
        at org.apache.hadoop.hdfs.server.datanode.DataXceiverServer.run(DataXceiverServer.java:234)
        at java.lang.Thread.run(Thread.java:748)
```

When any Exception is found in DataXceiverServer, it will execute clostStream.

IOUtils.closeStream(peer)    -> Peer.close() -> NioInetPeer.close() 

But NioInetPeer.close()  is not invoked with  close socket connection. And this will lead to connection leakage.

And Other subClass of Peer's close() is implemented with socket.close().  See EncryptedPeer, DomainPeer, BasicInetPeer


This solution can be reporduced as following:
(1) Client write data to HDFS , and datanode has heavy load in IO. 
(2) datanode Xceiver count max to DFS_DATANODE_MAX_RECEIVER_THREADS_KEY ， the new Xceiver will fail and throw IOException . And the socket will not release.
(3) Client crash for that no new data will be added or client.close is executed.
(4) There will be socket connection leakage between datanodes.


The connection leakage like this
dn1
dn1:57042      dn2:50010      ESTABLISHED 

dn2
dn2:50010      dn1:57042      ESTABLISHED 
