### PR TITLE
HDFS-17360. Record the number of times a block is read during a certain time period.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1603,6 +1603,9 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final boolean DFS_PIPELINE_SLOWNODE_ENABLED_DEFAULT = false;
   public static final String DFS_PIPELINE_CONGESTION_RATIO = "dfs.pipeline.congestion.ratio";
   public static final double DFS_PIPELINE_CONGESTION_RATIO_DEFAULT = 1.5;
+  public static final String DFS_DATANODE_READ_BLOCKID_COUNTS_METRIC_ENABLED_KEY =
+      "dfs.datanode.read.blockid.counts.metric.enabled";
+  public static final boolean DFS_DATANODE_READ_BLOCKID_COUNTS_METRIC_ENABLED_DEFAULT = false;
 
   // Key Provider Cache Expiry
   public static final String DFS_DATANODE_BLOCK_PINNING_ENABLED =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -271,6 +271,7 @@ import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.com.google.common.cache.CacheBuilder;
 import org.apache.hadoop.thirdparty.com.google.common.cache.CacheLoader;
 import org.apache.hadoop.thirdparty.com.google.common.cache.LoadingCache;
+import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.AtomicLongMap;
 import org.apache.hadoop.thirdparty.protobuf.BlockingService;
 
 import org.slf4j.Logger;
@@ -466,6 +467,7 @@ public class DataNode extends ReconfigurableBase
   private static final int NUM_CORES = Runtime.getRuntime()
       .availableProcessors();
   private final double congestionRatio;
+  private final boolean readBlockIdCountsEnabled;
   private DiskBalancer diskBalancer;
   private DataSetLockManager dataSetLockManager;
 
@@ -492,6 +494,8 @@ public class DataNode extends ReconfigurableBase
 
   private DataTransferThrottler ecReconstuctReadThrottler;
   private DataTransferThrottler ecReconstuctWriteThrottler;
+
+  private final AtomicLongMap<String> readBlockIdCounts;
 
   /**
    * Creates a dummy DataNode for testing purpose.
@@ -522,6 +526,10 @@ public class DataNode extends ReconfigurableBase
         DFSConfigKeys.DFS_PIPELINE_CONGESTION_RATIO_DEFAULT);
     this.congestionRatio = congestionRationTmp > 0 ?
         congestionRationTmp : DFSConfigKeys.DFS_PIPELINE_CONGESTION_RATIO_DEFAULT;
+    this.readBlockIdCountsEnabled =
+        conf.getBoolean(DFSConfigKeys.DFS_DATANODE_READ_BLOCKID_COUNTS_METRIC_ENABLED_KEY,
+            DFSConfigKeys.DFS_DATANODE_READ_BLOCKID_COUNTS_METRIC_ENABLED_DEFAULT);
+    readBlockIdCounts = readBlockIdCountsEnabled ? AtomicLongMap.create() : null;
   }
 
   /**
@@ -625,6 +633,10 @@ public class DataNode extends ReconfigurableBase
         DFSConfigKeys.DFS_PIPELINE_CONGESTION_RATIO_DEFAULT);
     this.congestionRatio = congestionRationTmp > 0 ?
         congestionRationTmp : DFSConfigKeys.DFS_PIPELINE_CONGESTION_RATIO_DEFAULT;
+    this.readBlockIdCountsEnabled =
+        conf.getBoolean(DFSConfigKeys.DFS_DATANODE_READ_BLOCKID_COUNTS_METRIC_ENABLED_KEY,
+            DFSConfigKeys.DFS_DATANODE_READ_BLOCKID_COUNTS_METRIC_ENABLED_DEFAULT);
+    this.readBlockIdCounts = readBlockIdCountsEnabled ? AtomicLongMap.create() : null;
   }
 
   @Override  // ReconfigurableBase
@@ -4386,5 +4398,23 @@ public class DataNode extends ReconfigurableBase
   @VisibleForTesting
   public BlockPoolManager getBlockPoolManager() {
     return blockPoolManager;
+  }
+
+  public void incrReadBlockIdCounts(String blockId) {
+    if (readBlockIdCountsEnabled) {
+      readBlockIdCounts.incrementAndGet(blockId);
+    }
+  }
+
+  public void decrReadBlockIdCounts(String blockId) {
+    if (readBlockIdCountsEnabled) {
+      readBlockIdCounts.decrementAndGet(blockId);
+      readBlockIdCounts.removeIfZero(blockId);
+    }
+  }
+
+  @Override // DataNodeMXBean
+  public Map<String, Long> getReadBlockIdCounts() {
+    return readBlockIdCountsEnabled ? readBlockIdCounts.asMap() : null;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeMXBean.java
@@ -164,4 +164,11 @@ public interface DataNodeMXBean {
    * @return Start time of the DataNode.
    */
   long getDNStartedTimeInMillis();
+
+  /**
+   * Gets the read BlockId counts on a per-Datanode basis.
+   *
+   * @return Map of read BlockId counts, e.g. {"1073741825":390,"1073741889":555}
+   */
+  Map<String, Long> getReadBlockIdCounts();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
@@ -587,6 +587,7 @@ class DataXceiver extends Receiver implements Runnable {
     previousOpClientName = clientName;
     long read = 0;
     updateCurrentThreadName("Sending block " + block);
+    String blockId = Long.toString(block.getBlockId());
     OutputStream baseStream = getOutputStream();
     DataOutputStream out = getBufferedOutputStream();
     checkAccess(out, true, block, blockToken, Op.READ_BLOCK,
@@ -602,6 +603,7 @@ class DataXceiver extends Receiver implements Runnable {
         dnR + " Served block " + block + " to " + remoteAddress;
 
     try {
+      datanode.incrReadBlockIdCounts(blockId);
       try {
         blockSender = new BlockSender(block, blockOffset, length,
             true, false, sendChecksum, datanode, clientTraceFmt,
@@ -668,6 +670,7 @@ class DataXceiver extends Receiver implements Runnable {
       throw ioe;
     } finally {
       IOUtils.closeStream(blockSender);
+      datanode.decrReadBlockIdCounts(blockId);
     }
 
     //update metrics

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6582,4 +6582,11 @@
       Enables observer reads for clients. This should only be enabled when clients are using routers.
     </description>
   </property>
+  <property>
+    <name>dfs.datanode.read.blockid.counts.metric.enabled</name>
+    <value>false</value>
+    <description>
+      The datanode records the frequency switch for reading a certain block, defaults to false.
+    </description>
+  </property>
 </configuration>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIAR: https://issues.apache.org/jira/browse/HDFS-17360

1. In prod env, it is common for high concurrency to read a certain block, leading to an increase in machine load, affect other tasks.
2. Now, record the number of requests for blockId during a specific time period on the jmx page, and promptly locate abnormal tasks.
3. And combined with the `fsck` tool to obtain blockId specific paths.


### How was this patch tested?
Add `TestDataNodeMetrics#testReadBlockIdCounts` UT.