### PR TITLE
HDFS-17358. EC: infinite lease recovery caused by the length of RWR equals to zero or datanode does not have the replica.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockRecoveryWorker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockRecoveryWorker.java
@@ -449,7 +449,7 @@ public class BlockRecoveryWorker {
         safeLength = getSafeLength(syncBlocks);
       } else {
         safeLength = 0;
-        LOG.warn("Block recovery: More than {} datanodes do not have the replica of block {}." +
+        LOG.warn("Block recovery: {} datanodes do not have the replica of block {}." +
             " {} datanodes have zero-length replica. Will remove this block.",
             dnNotHaveReplicaCnt, block, zeroLenReplicaCnt);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockRecoveryWorker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockRecoveryWorker.java
@@ -386,6 +386,8 @@ public class BlockRecoveryWorker {
       Map<Long, BlockRecord> syncBlocks = new HashMap<>(locs.length);
       final int dataBlkNum = ecPolicy.getNumDataUnits();
       final int totalBlkNum = dataBlkNum + ecPolicy.getNumParityUnits();
+      int zeroLenReplicaCnt = 0;
+      int dnNotHaveReplicaCnt = 0;
       //check generation stamps
       for (int i = 0; i < locs.length; i++) {
         DatanodeID id = locs[i];
@@ -419,10 +421,14 @@ public class BlockRecoveryWorker {
             if (info == null) {
               LOG.debug("Block recovery: DataNode: {} does not have " +
                   "replica for block: (block={}, internalBlk={})", id, block, internalBlk);
+              dnNotHaveReplicaCnt++;
             } else {
               LOG.debug("Block recovery: Ignored replica with invalid "
                   + "generation stamp or length: {} from DataNode: {} by block: {}",
                   info, id, block);
+              if (info.getNumBytes() == 0) {
+                zeroLenReplicaCnt++;
+              }
             }
           }
         } catch (RecoveryInProgressException ripE) {
@@ -436,9 +442,17 @@ public class BlockRecoveryWorker {
                   "datanode={})", block, internalBlk, id, e);
         }
       }
-      checkLocations(syncBlocks.size());
 
-      final long safeLength = getSafeLength(syncBlocks);
+      final long safeLength;
+      if (dnNotHaveReplicaCnt + zeroLenReplicaCnt <= locs.length - ecPolicy.getNumDataUnits()) {
+        checkLocations(syncBlocks.size());
+        safeLength = getSafeLength(syncBlocks);
+      } else {
+        safeLength = 0;
+        LOG.warn("Block recovery: More than {} datanodes do not have the replica of block {}." +
+            " Will remove this block.", dnNotHaveReplicaCnt, block);
+      }
+
       LOG.debug("Recovering block {}, length={}, safeLength={}, syncList={}", block,
           block.getNumBytes(), safeLength, syncBlocks);
 
@@ -452,11 +466,13 @@ public class BlockRecoveryWorker {
           rurList.add(r);
         }
       }
-      assert rurList.size() >= dataBlkNum : "incorrect safe length";
 
-      // Recovery the striped block by truncating internal blocks to the safe
-      // length. Abort if there is any failure in this step.
-      truncatePartialBlock(rurList, safeLength);
+      if (safeLength > 0) {
+        Preconditions.checkArgument(rurList.size() >= dataBlkNum, "incorrect safe length");
+        // Recovery the striped block by truncating internal blocks to the safe
+        // length. Abort if there is any failure in this step.
+        truncatePartialBlock(rurList, safeLength);
+      }
 
       // notify Namenode the new size and locations
       final DatanodeID[] newLocs = new DatanodeID[totalBlkNum];
@@ -469,11 +485,20 @@ public class BlockRecoveryWorker {
         int index = (int) (r.rInfo.getBlockId() &
             HdfsServerConstants.BLOCK_GROUP_INDEX_MASK);
         newLocs[index] = r.id;
-        newStorages[index] = r.storageID;
+        if (r.storageID != null) {
+          newStorages[index] = r.storageID;
+        }
       }
       ExtendedBlock newBlock = new ExtendedBlock(bpid, block.getBlockId(),
           safeLength, recoveryId);
       DatanodeProtocolClientSideTranslatorPB nn = getActiveNamenodeForBP(bpid);
+      if (safeLength == 0) {
+        nn.commitBlockSynchronization(block, newBlock.getGenerationStamp(),
+            newBlock.getNumBytes(), true, true, newLocs, newStorages);
+        LOG.info("After block recovery, the length of new block is 0. " +
+            "Will remove this block: {} from file.", newBlock);
+        return;
+      }
       nn.commitBlockSynchronization(block, newBlock.getGenerationStamp(),
           newBlock.getNumBytes(), true, false, newLocs, newStorages);
     }
@@ -527,8 +552,8 @@ public class BlockRecoveryWorker {
     private void checkLocations(int locationCount)
         throws IOException {
       if (locationCount < ecPolicy.getNumDataUnits()) {
-        throw new IOException(block + " has no enough internal blocks" +
-            ", unable to start recovery. Locations=" + Arrays.asList(locs));
+        throw new IOException(block + " has no enough internal blocks(current:" + locationCount +
+            "), unable to start recovery. Locations=" + Arrays.asList(locs));
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockRecoveryWorker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockRecoveryWorker.java
@@ -450,7 +450,8 @@ public class BlockRecoveryWorker {
       } else {
         safeLength = 0;
         LOG.warn("Block recovery: More than {} datanodes do not have the replica of block {}." +
-            " Will remove this block.", dnNotHaveReplicaCnt, block);
+            " {} datanodes have zero-length replica. Will remove this block.",
+            dnNotHaveReplicaCnt, block, zeroLenReplicaCnt);
       }
 
       LOG.debug("Recovering block {}, length={}, safeLength={}, syncList={}", block,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockRecoveryWorker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockRecoveryWorker.java
@@ -553,7 +553,7 @@ public class BlockRecoveryWorker {
     private void checkLocations(int locationCount)
         throws IOException {
       if (locationCount < ecPolicy.getNumDataUnits()) {
-        throw new IOException(block + " has no enough internal blocks(current:" + locationCount +
+        throw new IOException(block + " has no enough internal blocks(current: " + locationCount +
             "), unable to start recovery. Locations=" + Arrays.asList(locs));
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockReader.java
@@ -133,8 +133,8 @@ class StripedBlockReader {
           block.getNumBytes() - offsetInBlock, true, "", peer, source,
           null, stripedReader.getCachingStrategy(), -1, conf);
     } catch (IOException e) {
-      LOG.info("Exception while creating remote block reader, datanode {}",
-          source, e);
+      LOG.info("Exception while creating remote block reader for {}, datanode {}",
+          block, source, e);
       IOUtils.closeStream(peer);
       return null;
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestLeaseRecoveryStriped.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestLeaseRecoveryStriped.java
@@ -275,10 +275,7 @@ public class TestLeaseRecoveryStriped {
       for (int pos = 0; pos < cellSize; pos++) {
         out.write(StripedFileTestUtil.getByte(pos));
       }
-      StripedDataStreamer first = stripedOut.getStripedDataStreamer(0);
-      waitStreamerAllAcked(first);
-      stopBlockStream(first);
-      for (int i = 1; i < dataBlocks + parityBlocks; i++) {
+      for (int i = 0; i < dataBlocks + parityBlocks; i++) {
         StripedDataStreamer s = stripedOut.getStripedDataStreamer(i);
         waitStreamerAllAcked(s);
         stopBlockStream(s);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestLeaseRecoveryStriped.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestLeaseRecoveryStriped.java
@@ -267,12 +267,12 @@ public class TestLeaseRecoveryStriped {
    */
   @Test
   public void testLeaseRecoveryWithManyZeroLengthReplica() {
-    int cellSize = (int)1024 * 1024;
+    int curCellSize = (int)1024 * 1024;
     try {
       final FSDataOutputStream out = dfs.create(p);
       final DFSStripedOutputStream stripedOut = (DFSStripedOutputStream) out
           .getWrappedStream();
-      for (int pos = 0; pos < cellSize; pos++) {
+      for (int pos = 0; pos < curCellSize; pos++) {
         out.write(StripedFileTestUtil.getByte(pos));
       }
       for (int i = 0; i < dataBlocks + parityBlocks; i++) {


### PR DESCRIPTION
### Description of PR
Refer to HDFS-17358.

Recently, there is a strange case happened on our ec production cluster.

The phenomenon is as below described: NameNode does infinite recovery lease of some ec files(~80K+) and those files could never be closed.

After digging into logs and releated code, we found the root cause is below codes in method `BlockRecoveryWorker$RecoveryTaskStriped#recover`:

```java
          // we met info.getNumBytes==0 here! 
          if (info != null &&
              info.getGenerationStamp() >= block.getGenerationStamp() &&
              info.getNumBytes() > 0) {
            final BlockRecord existing = syncBlocks.get(blockId);
            if (existing == null ||
                info.getNumBytes() > existing.rInfo.getNumBytes()) {
              // if we have >1 replicas for the same internal block, we
              // simply choose the one with larger length.
              // TODO: better usage of redundant replicas
              syncBlocks.put(blockId, new BlockRecord(id, proxyDN, info));
            }
          }

          // throw exception here!
          checkLocations(syncBlocks.size());

```

The related logs are as below:

>java.io.IOException: BP-1157541496-10.104.10.198-1702548776421:blk_-9223372036808032688_2938828 has no enough internal blocks, unable to start recovery. Locations=[...] 

>2024-01-23 12:48:16,171 INFO org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsDatasetImpl: initReplicaRecovery: blk_-9223372036808032686_2938828, recoveryId=27615365, replica=ReplicaUnderRecovery, blk_-9223372036808032686_2938828, RUR getNumBytes() = 0 getBytesOnDisk() = 0 getVisibleLength()= -1 getVolume() = /data25/hadoop/hdfs/datanode getBlockURI() = file:/data25/hadoop/hdfs/datanode/current/BP-1157541496-x.x.x.x-1702548776421/current/rbw/blk_-9223372036808032686 recoveryId=27529675 original=ReplicaWaitingToBeRecovered, blk_-9223372036808032686_2938828, RWR getNumBytes() = 0 getBytesOnDisk() = 0 getVisibleLength()= -1 getVolume() = /data25/hadoop/hdfs/datanode getBlockURI() = file:/data25/hadoop/hdfs/datanode/current/BP-1157541496-10.104.10.198-1702548776421/current/rbw/blk_-9223372036808032686

because the length of RWR is zero,  the length of the returned object in below codes is zero. We can't put it into syncBlocks.
So throw exception in checkLocations method.

>ReplicaRecoveryInfo info = callInitReplicaRecovery(proxyDN,new RecoveringBlock(internalBlk, null, recoveryId)); 