### PR TITLE
HADOOP-18883. [ABFS]: Expect-100 JDK bug resolution: prevent multiple server calls

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
@@ -69,6 +69,7 @@ public final class AbfsHttpConstants {
    * and should qualify for retry.
    */
   public static final int HTTP_CONTINUE = 100;
+  public static final String EXPECT_100_JDK_ERROR = "Server rejected operation";
 
   // Abfs generic constants
   public static final String SINGLE_WHITE_SPACE = " ";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -338,7 +338,7 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
              */
             AppendRequestParameters reqParams = new AppendRequestParameters(
                 offset, 0, bytesLength, mode, false, leaseId, isExpectHeaderEnabled);
-            AbfsRestOperation op = client.append(path,
+            AbfsRestOperation op = getClient().append(path,
                 blockUploadData.toByteArray(), reqParams, cachedSasToken.get(),
                 contextEncryptionAdapter, new TracingContext(tracingContext));
             cachedSasToken.update(op.getSasToken());
@@ -655,7 +655,7 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
     AbfsPerfTracker tracker = client.getAbfsPerfTracker();
     try (AbfsPerfInfo perfInfo = new AbfsPerfInfo(tracker,
             "flushWrittenBytesToServiceInternal", "flush")) {
-      AbfsRestOperation op = client.flush(path, offset, retainUncommitedData,
+      AbfsRestOperation op = getClient().flush(path, offset, retainUncommitedData,
           isClose, cachedSasToken.get(), leaseId, contextEncryptionAdapter,
           new TracingContext(tracingContext));
       cachedSasToken.update(op.getSasToken());
@@ -794,5 +794,10 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
   @VisibleForTesting
   ListeningExecutorService getExecutorService() {
     return executorService;
+  }
+
+  @VisibleForTesting
+  AbfsClient getClient() {
+    return client;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.APPEND_ACTION;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EXPECT_100_JDK_ERROR;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_METHOD_PATCH;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_METHOD_PUT;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HUNDRED_CONTINUE;
@@ -586,7 +587,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
         .getConnResponseMessage();
 
     // Make the getOutputStream throw IOException to see it returns from the sendRequest correctly.
-    Mockito.doThrow(new ProtocolException("Server rejected Operation"))
+    Mockito.doThrow(new ProtocolException(EXPECT_100_JDK_ERROR))
         .when(abfsHttpOperation)
         .getConnOutputStream();
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsOutputStream.java
@@ -18,21 +18,27 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.azurebfs.AbstractAbfsIntegrationTest;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
 import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
 import org.apache.hadoop.test.LambdaTestUtils;
+
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_IS_EXPECT_HEADER_ENABLED;
 
 /**
  * Test create operation.
@@ -146,6 +152,61 @@ public class ITestAbfsOutputStream extends AbstractAbfsIntegrationTest {
       LambdaTestUtils
           .intercept(PathIOException.class, getMethodName(), out::close);
     }
+  }
+
+  @Test
+  public void testExpect100ContinueFailureInAppend() throws Exception {
+    Configuration configuration = new Configuration(getRawConfiguration());
+    configuration.set(FS_AZURE_ACCOUNT_IS_EXPECT_HEADER_ENABLED, "true");
+    AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.newInstance(
+        configuration);
+    Path path = new Path("/testFile");
+    AbfsOutputStream os = Mockito.spy(
+        (AbfsOutputStream) fs.create(path).getWrappedStream());
+    AbfsClient spiedClient = Mockito.spy(os.getClient());
+    AbfsHttpOperation[] httpOpForAppendTest = new AbfsHttpOperation[2];
+    mockSetupForAppend(httpOpForAppendTest, spiedClient);
+    Mockito.doReturn(spiedClient).when(os).getClient();
+    fs.delete(path, true);
+    os.write(1);
+    LambdaTestUtils.intercept(FileNotFoundException.class, () -> {
+      os.close();
+    });
+    Assertions.assertThat(httpOpForAppendTest[0].getConnectionDisconnectedOnError())
+        .describedAs("First try from AbfsClient will have expect-100 "
+            + "header and should fail with expect-100 error.").isTrue();
+    Mockito.verify(httpOpForAppendTest[0], Mockito.times(0))
+        .processConnHeadersAndInputStreams(Mockito.any(byte[].class),
+            Mockito.anyInt(), Mockito.anyInt());
+
+    Assertions.assertThat(httpOpForAppendTest[1].getConnectionDisconnectedOnError())
+        .describedAs("The retried operation from AbfsClient should not "
+            + "fail with expect-100 error. The retried operation does not have"
+            + "expect-100 header.").isFalse();
+    Mockito.verify(httpOpForAppendTest[1], Mockito.times(1))
+        .processConnHeadersAndInputStreams(Mockito.any(byte[].class),
+            Mockito.anyInt(), Mockito.anyInt());
+  }
+
+  private void mockSetupForAppend(final AbfsHttpOperation[] httpOpForAppendTest,
+      final AbfsClient spiedClient) {
+    int[] index = new int[1];
+    index[0] = 0;
+    Mockito.doAnswer(abfsRestOpAppendGetInvocation -> {
+          AbfsRestOperation op = Mockito.spy(
+              (AbfsRestOperation) abfsRestOpAppendGetInvocation.callRealMethod());
+          Mockito.doAnswer(createHttpOpInvocation -> {
+            httpOpForAppendTest[index[0]] = Mockito.spy(
+                (AbfsHttpOperation) createHttpOpInvocation.callRealMethod());
+            return httpOpForAppendTest[index[0]++];
+          }).when(op).createHttpOperation();
+          return op;
+        })
+        .when(spiedClient)
+        .getAbfsRestOperation(Mockito.any(AbfsRestOperationType.class),
+            Mockito.anyString(), Mockito.any(
+                URL.class), Mockito.anyList(), Mockito.any(byte[].class),
+            Mockito.anyInt(), Mockito.anyInt(), Mockito.nullable(String.class));
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsRestOperation.java
@@ -49,6 +49,7 @@ import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.APPEND_ACTION;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EXPECT_100_JDK_ERROR;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_METHOD_PATCH;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_METHOD_PUT;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HUNDRED_CONTINUE;
@@ -232,7 +233,7 @@ public class ITestAbfsRestOperation extends AbstractAbfsIntegrationTest {
       Mockito.doReturn(responseMessage)
           .when(abfsHttpOperation)
           .getConnResponseMessage();
-      Mockito.doThrow(new ProtocolException("Server rejected Operation"))
+      Mockito.doThrow(new ProtocolException(EXPECT_100_JDK_ERROR))
           .when(abfsHttpOperation)
           .getConnOutputStream();
       break;


### PR DESCRIPTION
Backport of https://github.com/apache/hadoop/commit/7dc166ddc7fa524d842c77c0d6e83dde6d13dc54
Trunk PR: https://github.com/apache/hadoop/pull/6022

Description:

Address JDK bug JDK-8314978 related to handling of HTTP 100 responses.

https://bugs.openjdk.org/browse/JDK-8314978

In the AbfsHttpOperation, after sendRequest() we call processResponse() method from AbfsRestOperation.
Even if the conn.getOutputStream() fails due to expect-100 error, we consume the exception and let the code go ahead. This may call getHeaderField() / getHeaderFields() / getHeaderFieldLong() after getOutputStream() has failed. These invocation all lead to server calls.

This commit aims to prevent this.
If connection.getOutputStream() fails due to an Expect-100 error, the ABFS client does not invoke getHeaderField(), getHeaderFields(), getHeaderFieldLong() or getInputStream().

getResponseCode() is safe as on the failure it sets the responseCode variable in HttpUrlConnection object.




------------------------
:::: AGGREGATED TEST RESULT ::::

HNS-OAuth
========================
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAbfsClientThrottlingAnalyzer.testManySuccessAndErrorsAndWaiting:181->fuzzyValidate:64 The actual value 9 is not within the expected range: [5.60, 8.40].
[INFO]
[ERROR] Tests run: 141, Failures: 1, Errors: 0, Skipped: 5
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:336 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 567, Failures: 0, Errors: 1, Skipped: 24
[INFO] Results:
[INFO]
[WARNING] Tests run: 340, Failures: 0, Errors: 0, Skipped: 41

HNS-SharedKey
========================
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAbfsClientThrottlingAnalyzer.testManySuccessAndErrorsAndWaiting:181->fuzzyValidate:64 The actual value 9 is not within the expected range: [5.60, 8.40].
[INFO]
[ERROR] Tests run: 141, Failures: 1, Errors: 0, Skipped: 5
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:329 » TestTimedOut test timed o...
[ERROR]   ITestAzureBlobFileSystemLease.testTwoWritersCreateAppendWithInfiniteLeaseEnabled:186->twoWriters:154 » TestTimedOut
[INFO]
[ERROR] Tests run: 560, Failures: 0, Errors: 2, Skipped: 24
[INFO] Results:
[INFO]
[WARNING] Tests run: 340, Failures: 0, Errors: 0, Skipped: 41

NonHNS-SharedKey
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 141, Failures: 0, Errors: 0, Skipped: 11
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ITestAzureBlobFileSystemRandomRead.testValidateSeekBounds:269->Assert.assertTrue:42->Assert.fail:89 There should not be any network I/O (elapsedTimeMs=42).
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:344->lambda$testAcquireRetry$6:345 » TestTimedOut
[INFO]
[ERROR] Tests run: 551, Failures: 1, Errors: 1, Skipped: 264
[INFO] Results:
[INFO]
[WARNING] Tests run: 340, Failures: 0, Errors: 0, Skipped: 44

AppendBlob-HNS-OAuth
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 141, Failures: 0, Errors: 0, Skipped: 5
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:329 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 564, Failures: 0, Errors: 1, Skipped: 24
[INFO] Results:
[INFO]
[WARNING] Tests run: 340, Failures: 0, Errors: 0, Skipped: 41

Time taken: 49 mins 32 secs.
azureuser@Hadoop-VM-EAST2:~/hadoop/hadoop-tools/hadoop-azure$
azureuser@Hadoop-VM-EAST2:~/hadoop/hadoop-tools/hadoop-azure$
azureuser@Hadoop-VM-EAST2:~/hadoop/hadoop-tools/hadoop-azure$ git log
commit 56109e0e6c8962deca87d004159742584e32c3cb (HEAD -> branch-3.4_expect100resolution, origin/branch-3.4_expect100resolution)
Author: Pranav Saxena <108325433+saxenapranav@users.noreply.github.com>
Date:   Sun Jan 21 11:14:54 2024 -0800

    HADOOP-18883. [ABFS]: Expect-100 JDK bug resolution: prevent multiple server calls (#6022)


