### PR TITLE
HDFS-17364. EC: Configurably use WeakReferencedElasticByteBufferPool in DFSStripedInputStream.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -530,6 +530,9 @@ public interface HdfsClientConfigKeys {
      * span 6 DNs, so this default value accommodates 3 read streams
      */
     int     THREADPOOL_SIZE_DEFAULT = 18;
+
+    String WEAK_REF_BUFFER_POOL_KEY = PREFIX + "bufferpool.weak.references.enabled";
+    boolean WEAK_REF_BUFFER_POOL_DEFAULT = false;
   }
 
   /** dfs.http.client configuration properties */

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
@@ -159,6 +159,7 @@ public class DfsClientConf {
       replicaAccessorBuilderClasses;
 
   private final int stripedReadThreadpoolSize;
+  private final boolean stripedReadWeakRefBufferPool;
 
   private final boolean dataTransferTcpNoDelay;
 
@@ -295,6 +296,11 @@ public class DfsClientConf {
     Preconditions.checkArgument(stripedReadThreadpoolSize > 0, "The value of " +
         HdfsClientConfigKeys.StripedRead.THREADPOOL_SIZE_KEY +
         " must be greater than 0.");
+
+    stripedReadWeakRefBufferPool = conf.getBoolean(
+            HdfsClientConfigKeys.StripedRead.WEAK_REF_BUFFER_POOL_KEY,
+            HdfsClientConfigKeys.StripedRead.WEAK_REF_BUFFER_POOL_DEFAULT);
+
     replicaAccessorBuilderClasses = loadReplicaAccessorBuilderClasses(conf);
 
     leaseHardLimitPeriod =
@@ -688,6 +694,10 @@ public class DfsClientConf {
    */
   public int getStripedReadThreadpoolSize() {
     return stripedReadThreadpoolSize;
+  }
+
+  public boolean getStripedReadWeakRefBufferPool() {
+    return stripedReadWeakRefBufferPool;
   }
 
   /**


### PR DESCRIPTION
### Description of PR

Follows the pattern of existing striped and hedged read shared resources. Moves the singleton BUFFER_POOL from DFSStripedInputStream into DFSClient and handles synchronized initialization of that pool.


### How was this patch tested?
I've deployed it to a few of my company's production hbase regionservers. The config works, and the WeakReferencedElasticByteBufferPool helps reduce stable memory usage by 1.5GB (would be load dependent).


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

