### PR TITLE
HADOOP-19060. Support hadoop client authentication through keytab configuration.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeys.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeys.java
@@ -505,4 +505,13 @@ public class CommonConfigurationKeys extends CommonConfigurationKeysPublic {
   public static final String HADOOP_SECURITY_RESOLVER_IMPL =
       "hadoop.security.resolver.impl";
 
+  /**
+   * The hadoop client keytab principal.
+   */
+  public static final String HADOOP_CLIENT_KEYTAB_PRINCIPAL = "hadoop.client.keytab.principal";
+
+  /**
+   * The hadoop client keytab file path.
+   */
+  public static final String HADOOP_CLIENT_KEYTAB_FILE_PATH = "hadoop.client.keytab.file.path";
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestUGILoginFromKeytab.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestUGILoginFromKeytab.java
@@ -593,6 +593,25 @@ public class TestUGILoginFromKeytab {
     clonedRelogin.get();
   }
 
+  @Test
+  public void testUGILoginFromKeytabConfig() throws Exception {
+    String principal = "foo";
+    File keytab = new File(workDir, "foo.keytab");
+    kdc.createPrincipal(keytab, principal);
+
+    Configuration clientConfig = new Configuration();
+    clientConfig.set(CommonConfigurationKeys.HADOOP_SECURITY_AUTHENTICATION, "kerberos");
+    clientConfig.set(CommonConfigurationKeys.HADOOP_CLIENT_KEYTAB_PRINCIPAL, "foo");
+    clientConfig.set(CommonConfigurationKeys.HADOOP_CLIENT_KEYTAB_FILE_PATH, keytab.getPath());
+    UserGroupInformation.setConfiguration(clientConfig);
+    UserGroupInformation ugi = UserGroupInformation.getLoginUser();
+    Assert.assertTrue("UGI should be configured to login from keytab", ugi.isFromKeytab());
+
+    User user = getUser(ugi.getSubject());
+    Assert.assertNotNull(user);
+    Assert.assertNotNull(user.getLogin());
+  }
+
   private User getUser(Subject subject) {
     Iterator<User> iter = subject.getPrincipals(User.class).iterator();
     return iter.hasNext() ? iter.next() : null;


### PR DESCRIPTION
### Description of PR
JIRA: https://issues.apache.org/jira/browse/HADOOP-19060

**Shield references to `UserGroupInformation` Class.**

The current HDFS client keytab authentication code is as follows:
```java
Configuration conf = new Configuration();
conf.addResource(new Path("/usr/local/service/hadoop/etc/hadoop/hdfs-site.xml"));
conf.addResource(new Path("/usr/local/service/hadoop/etc/hadoop/core-site.xml"));
UserGroupInformation.setConfiguration(conf);
UserGroupInformation.loginUserFromKeytab("foo", "/var/krb5kdc/foo.keytab");
FileSystem fileSystem = FileSystem.get(conf);
FileStatus[] fileStatus = fileSystem.listStatus(new Path("/"));
for (FileStatus status : fileStatus) {
    System.out.println(status.getPath());
} 
```

This feature supports configuring keytab information in core-site.xml or hdfs site.xml. The authentication code is as follows:
```java
Configuration conf = new Configuration();
conf.addResource(new Path("/usr/local/service/hadoop/etc/hadoop/hdfs-site.xml"));
conf.addResource(new Path("/usr/local/service/hadoop/etc/hadoop/core-site.xml"));
FileSystem fileSystem = FileSystem.get(conf);
FileStatus[] fileStatus = fileSystem.listStatus(new Path("/"));
for (FileStatus status : fileStatus) {
    System.out.println(status.getPath());
} 
```

The config of core-site.xml related to authentication is as follows:
```xml
<configuration>
    <property>
        <name>hadoop.security.authentication</name>
        <value>kerberos</value>
    </property>
    <property>
        <name>hadoop.client.keytab.principal</name>
        <value>foo</value>
    </property>
    <property>
        <name>hadoop.client.keytab.file.path</name>
        <value>/var/krb5kdc/foo.keytab</value>
    </property>
</configuration>
```


### How was this patch tested?
Add UnitTest.