### PR TITLE
HDFS-17365. EC: Add extra redunency configuration in checkStreamerFailures to prevent data loss.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
@@ -332,7 +332,7 @@ public class DFSStripedOutputStream extends DFSOutputStream
     int failedStreamerToleratedTmp = dfsClient.getConfiguration().getInt(
         DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED,
         DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED_DEFAILT);
-    
+
     failedStreamerTolerated = Math.min(failedStreamerToleratedTmp,
         ecPolicy.getNumParityUnits());
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
@@ -73,8 +73,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedunency.DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED;
-import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedunency.DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED_DEFAILT;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedundancy.DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedundancy.DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED_DEFAILT;
 
 /**
  * This class supports writing files in striped layout and erasure coded format.

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
@@ -73,8 +73,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedunency.DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED;
-import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedunency.DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED_DEFAILT;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedunency.DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedunency.DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED_DEFAILT;
 
 /**
  * This class supports writing files in striped layout and erasure coded format.
@@ -286,7 +286,7 @@ public class DFSStripedOutputStream extends DFSOutputStream
   private CompletionService<Void> flushAllExecutorCompletionService;
   private int blockGroupIndex;
   private long datanodeRestartTimeout;
-  private final int failedStreamerTolerated;
+  private final int failedBlocksTolerated;
 
   /** Construct a new output stream for creating a file. */
   DFSStripedOutputStream(DFSClient dfsClient, String src, HdfsFileStatus stat,
@@ -327,11 +327,11 @@ public class DFSStripedOutputStream extends DFSOutputStream
     datanodeRestartTimeout = dfsClient.getConf().getDatanodeRestartTimeout();
     setCurrentStreamer(0);
 
-    int failedStreamerToleratedTmp = dfsClient.getConfiguration().getInt(
-        DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED,
-        DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED_DEFAILT);
+    int failedBlocksToleratedTmp = dfsClient.getConfiguration().getInt(
+        DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED,
+        DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED_DEFAILT);
 
-    failedStreamerTolerated = Math.min(failedStreamerToleratedTmp,
+    failedBlocksTolerated = Math.min(failedBlocksToleratedTmp,
         ecPolicy.getNumParityUnits());
   }
 
@@ -413,11 +413,11 @@ public class DFSStripedOutputStream extends DFSOutputStream
       LOG.debug("original failed streamers: {}", failedStreamers);
       LOG.debug("newly failed streamers: {}", newFailed);
     }
-    if (failCount > (numAllBlocks - numDataBlocks)) {
+    if (failCount > failedBlocksTolerated) {
       closeAllStreamers();
       throw new IOException("Failed: the number of failed blocks = "
-          + failCount + " > the number of parity blocks = "
-          + (numAllBlocks - numDataBlocks));
+          + failCount + " > the number of failed blocks tolerated = "
+          + failedBlocksTolerated);
     }
     return newFailed;
   }
@@ -698,7 +698,7 @@ public class DFSStripedOutputStream extends DFSOutputStream
       // 2) create new block outputstream
       newFailed = waitCreatingStreamers(healthySet);
       if (newFailed.size() + failedStreamers.size() >
-          failedStreamerTolerated) {
+          failedBlocksTolerated) {
         // The write has failed, Close all the streamers.
         closeAllStreamers();
         throw new IOException(

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
@@ -75,8 +75,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedunency.DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedunency.DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED_DEFAILT;
-import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.RECOVER_LEASE_ON_CLOSE_EXCEPTION_DEFAULT;
-import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.RECOVER_LEASE_ON_CLOSE_EXCEPTION_KEY;
 
 /**
  * This class supports writing files in striped layout and erasure coded format.

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
@@ -330,7 +330,9 @@ public class DFSStripedOutputStream extends DFSOutputStream
     int failedBlocksToleratedTmp = dfsClient.getConfiguration().getInt(
         DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED,
         DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED_DEFAILT);
-
+    if (failedBlocksToleratedTmp < 0) {
+      failedBlocksToleratedTmp = ecPolicy.getNumParityUnits();
+    }
     failedBlocksTolerated = Math.min(failedBlocksToleratedTmp,
         ecPolicy.getNumParityUnits());
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
@@ -73,6 +73,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedunency.DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedunency.DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED_DEFAILT;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.RECOVER_LEASE_ON_CLOSE_EXCEPTION_DEFAULT;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.RECOVER_LEASE_ON_CLOSE_EXCEPTION_KEY;
+
 /**
  * This class supports writing files in striped layout and erasure coded format.
  * Each stripe contains a sequence of cells.
@@ -283,6 +288,7 @@ public class DFSStripedOutputStream extends DFSOutputStream
   private CompletionService<Void> flushAllExecutorCompletionService;
   private int blockGroupIndex;
   private long datanodeRestartTimeout;
+  private final int failedStreamerTolerated;
 
   /** Construct a new output stream for creating a file. */
   DFSStripedOutputStream(DFSClient dfsClient, String src, HdfsFileStatus stat,
@@ -322,6 +328,13 @@ public class DFSStripedOutputStream extends DFSOutputStream
     currentPackets = new DFSPacket[streamers.size()];
     datanodeRestartTimeout = dfsClient.getConf().getDatanodeRestartTimeout();
     setCurrentStreamer(0);
+
+    int failedStreamerToleratedTmp = dfsClient.getConfiguration().getInt(
+        DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED,
+        DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED_DEFAILT);
+    
+    failedStreamerTolerated = Math.min(failedStreamerToleratedTmp,
+        ecPolicy.getNumParityUnits());
   }
 
   /** Construct a new output stream for appending to a file. */
@@ -687,7 +700,7 @@ public class DFSStripedOutputStream extends DFSOutputStream
       // 2) create new block outputstream
       newFailed = waitCreatingStreamers(healthySet);
       if (newFailed.size() + failedStreamers.size() >
-          numAllBlocks - numDataBlocks) {
+          failedStreamerTolerated) {
         // The write has failed, Close all the streamers.
         closeAllStreamers();
         throw new IOException(

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -432,7 +432,7 @@ public interface HdfsClientConfigKeys {
     interface ECRedunency {
       String DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED =
           "dfs.client.ec.write.failed.blocks.tolerated";
-      int DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED_DEFAILT = Integer.MAX_VALUE;
+      int DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED_DEFAILT = -1;
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -433,7 +433,6 @@ public interface HdfsClientConfigKeys {
           "dfs.client.ec.failed.write.block.tolerated";
       int DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED_DEFAILT = Integer.MAX_VALUE;
     }
-    
   }
 
   /** dfs.client.block.write configuration properties */

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -427,6 +427,13 @@ public interface HdfsClientConfigKeys {
           PREFIX + "count-reset-time-period-ms";
       long    COUNT_RESET_TIME_PERIOD_MS_DEFAULT = 10 * MS_PER_SECOND;
     }
+    
+    interface ECRedunency {
+      String DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED =
+          "dfs.client.ec.failed.write.block.tolerated";
+      int DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED_DEFAILT = Integer.MAX_VALUE;
+    }
+    
   }
 
   /** dfs.client.block.write configuration properties */

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -429,7 +429,7 @@ public interface HdfsClientConfigKeys {
     }
 
     @SuppressWarnings("checkstyle:InterfaceIsType")
-    interface ECRedunency {
+    interface ECRedundancy {
       String DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED =
           "dfs.client.ec.write.failed.blocks.tolerated";
       int DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED_DEFAILT = -1;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -429,9 +429,9 @@ public interface HdfsClientConfigKeys {
     }
     
     interface ECRedunency {
-      String DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED =
-          "dfs.client.ec.failed.write.block.tolerated";
-      int DFS_CLIENT_EC_FAILED_WRITE_BLOCK_TOLERATED_DEFAILT = Integer.MAX_VALUE;
+      String DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED =
+          "dfs.client.ec.write.failed.blocks.tolerated";
+      int DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED_DEFAILT = Integer.MAX_VALUE;
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -427,7 +427,8 @@ public interface HdfsClientConfigKeys {
           PREFIX + "count-reset-time-period-ms";
       long    COUNT_RESET_TIME_PERIOD_MS_DEFAULT = 10 * MS_PER_SECOND;
     }
-    
+
+    @SuppressWarnings("checkstyle:InterfaceIsType")
     interface ECRedunency {
       String DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED =
           "dfs.client.ec.write.failed.blocks.tolerated";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -3924,6 +3924,19 @@
 </property>
 
 <property>
+  <name>dfs.client.ec.failed.write.block.tolerated</name>
+  <value></value>
+  <description>
+    Provide extra tolerated failed streamer for ec policy to prevent
+    the potential data loss. For example, if we use RS-6-3-1024K ec policy.
+    We can write successfully when there are 3 failure streamers. But if one of the six
+    replicas lost during reconstruction, we may lose the data forever.
+    It should better configured between [0, numParityBlocks], the default value is
+    the parity block number of some ec policy.
+  </description>
+</property>
+
+<property>
   <name>dfs.namenode.quota.init-threads</name>
   <value>12</value>
   <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -3925,14 +3925,14 @@
 
 <property>
   <name>dfs.client.ec.write.failed.blocks.tolerated</name>
-  <value>2147483647</value>
+  <value>-1</value>
   <description>
     Provide extra tolerated failed streamer for ec policy to prevent
     the potential data loss. For example, if we use RS-6-3-1024K ec policy.
     We can write successfully when there are 3 failure streamers. But if one of the six
     replicas lost during reconstruction, we may lose the data forever.
-    It should better configured between [0, numParityBlocks], the default value is
-    the parity block number of the specified ec policy we are using.
+    It should better configured between [0, numParityBlocks], the default value is -1 which
+    means the parity block number of the specified ec policy we are using.
   </description>
 </property>
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -3924,7 +3924,7 @@
 </property>
 
 <property>
-  <name>dfs.client.ec.failed.write.block.tolerated</name>
+  <name>dfs.client.ec.write.failed.blocks.tolerated</name>
   <value>2147483647</value>
   <description>
     Provide extra tolerated failed streamer for ec policy to prevent
@@ -3932,7 +3932,7 @@
     We can write successfully when there are 3 failure streamers. But if one of the six
     replicas lost during reconstruction, we may lose the data forever.
     It should better configured between [0, numParityBlocks], the default value is
-    the parity block number of some ec policy.
+    the parity block number of the specified ec policy we are using.
   </description>
 </property>
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -3925,7 +3925,7 @@
 
 <property>
   <name>dfs.client.ec.failed.write.block.tolerated</name>
-  <value></value>
+  <value>2147483647</value>
   <description>
     Provide extra tolerated failed streamer for ec policy to prevent
     the potential data loss. For example, if we use RS-6-3-1024K ec policy.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/tools/TestHdfsConfigFields.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/tools/TestHdfsConfigFields.java
@@ -47,7 +47,8 @@ public class TestHdfsConfigFields extends TestConfigurationFieldsBase {
         HdfsClientConfigKeys.Read.class, HdfsClientConfigKeys.HedgedRead.class,
         HdfsClientConfigKeys.ShortCircuit.class,
         HdfsClientConfigKeys.Retry.class, HdfsClientConfigKeys.Mmap.class,
-        HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.class };
+        HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.class,
+        HdfsClientConfigKeys.Write.ECRedunency.class};
 
     // Set error modes
     errorIfMissingConfigProps = true;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/tools/TestHdfsConfigFields.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/tools/TestHdfsConfigFields.java
@@ -48,7 +48,7 @@ public class TestHdfsConfigFields extends TestConfigurationFieldsBase {
         HdfsClientConfigKeys.ShortCircuit.class,
         HdfsClientConfigKeys.Retry.class, HdfsClientConfigKeys.Mmap.class,
         HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.class,
-        HdfsClientConfigKeys.Write.ECRedunency.class};
+        HdfsClientConfigKeys.Write.ECRedundancy.class};
 
     // Set error modes
     errorIfMissingConfigProps = true;


### PR DESCRIPTION
### Description of PR
Refer to HDFS-17365.

Currently, when we write ec files. It can tolerate with at most `numAllBlocks - numDataBlocks` failed streamers.
However, this can lead to block missing exception in some case.

For example, When we use RS-6-3-1024K ec policy,  we have written 6 blocks successfully. 
this block is going to be reconstructed, but before that, one of the 6 blocks lost, we may lose the data forerver.
Or if we restart datanode at that time, client will get block missing exception.

So, we should better add some redundancy here.
