### PR TITLE
HDFS-17368. HA: Standby should exit safemode when resources are available.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -1582,6 +1582,10 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       standbyCheckpointer = new StandbyCheckpointer(conf, this);
       standbyCheckpointer.start();
     }
+    if (isNoManualAndResourceLowSafeMode()) {
+      LOG.info("Standby should not enter safe mode when resources are low, exiting safe mode.");
+      leaveSafeMode(false);
+    }
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -5261,10 +5261,9 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     String cmd = "Use \"hdfs dfsadmin -safemode leave\" to turn safe mode off.";
     synchronized (this) {
       if (resourceLowSafeMode) {
-        return "Resources are low on NN. Please add or free up more resources"
-            + "then turn off safe mode manually. NOTE:  If you turn off safe "
-            + "mode before adding resources, the NN will immediately return to "
-            + "safe mode. " + cmd;
+        return "Resources are low on NN. Please add or free up more resources. "
+            + "NOTE:  If you turn off safe mode before adding resources, the "
+            + "NN will immediately return to safe mode. ";
       } else if (manualSafeMode) {
         return "It was turned on manually. " + cmd;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHASafeMode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHASafeMode.java
@@ -999,4 +999,11 @@ public class TestHASafeMode {
           () -> miniCluster.transitionToObserver(0));
     }
   }
+
+  @Test
+  public void testTransitionToStandbyWhenSafeModeWithResourcesLow() throws Exception {
+    NameNodeAdapter.enterSafeMode(nn0, true);
+    cluster.transitionToStandby(0);
+    assertFalse("SNN should not enter safe mode when resources low", nn0.isInSafeMode());
+  }
 }


### PR DESCRIPTION
### Description of PR
Refer to HDFS-17368. 

The NameNodeResourceMonitor automatically enters safemode when it detects that the resources are not suffcient. NNRM is only in ANN. If both ANN and SNN enter SM due to low resources, and later SNN's disk space is restored, SNN willl become ANN and ANN will become SNN. However, at this point, SNN will not exit the SM, even if the disk is recovered.

Consider the following scenario:

- Initially, nn-1 is active and nn-2 is standby. The insufficient resources of both nn-1 and nn-2 in dfs.namenode.name.dir, the NameNodeResourceMonitor detects the resource issue and puts nn01 into safemode.
- At this point, nn-1 is in safemode (ON) and active, while nn-2 is in safemode (OFF) and standby.
- After a period of time, the resources in nn-2's dfs.namenode.name.dir recover, triggering failover.
- Now, nn-1 is in safe mode (ON) and standby, while nn-2 is in safe mode (OFF) and active.
- Afterward, the resources in nn-1's dfs.namenode.name.dir recover.
- However, since nn-1 is standby but in safemode (ON), it unable to exit safe mode automatically.

If SNN is detected to be in SM(because low resource), it will exit. 

### How was this patch tested?
Test in a production environment

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

