### PR TITLE
HDFS-17370. Fix junit dependency for running parameterized tests in hadoop-hdfs-rbf

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
@@ -177,6 +177,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

We need to add junit-jupiter-engine dependency for running parameterized tests in hadoop-hdfs-rbf.

### How was this patch tested?

All parameterized tests in TestObserverWithRouter didn't run by `mvn test` command before this change. They worked correctly after making the change. I verified this on my local machine.

before
```
[INFO] Results:
[INFO]
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
```

after
```
[INFO] Running org.apache.hadoop.hdfs.server.federation.router.TestObserverWithRouter
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 420.454 s - in org.apache.hadoop.hdfs.server.federation.router.TestObserverWithRouter
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
