### PR TITLE
HDFS-17372. KeyUpdateCommand should be processed at high priority level to avoid access key not update in time when meet huge many commands.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -1501,7 +1501,8 @@ class BPServiceActor implements Runnable {
       }
       ((LinkedBlockingDeque<Runnable>) queue).putFirst(
           () -> processCommand(new DatanodeCommand[]{cmd}));
-      LOG.info("Enque command: {} to the head of queue", cmd);
+
+      LOG.info("Enqueue command: {} to the head of queue", cmd);
       dn.getMetrics().incrActorCmdQueueLength(1);
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -36,7 +36,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -62,6 +62,7 @@ import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
 import org.apache.hadoop.hdfs.server.protocol.DisallowedDatanodeException;
 import org.apache.hadoop.hdfs.server.protocol.HeartbeatResponse;
 import org.apache.hadoop.hdfs.server.protocol.InvalidBlockReportLeaseException;
+import org.apache.hadoop.hdfs.server.protocol.KeyUpdateCommand;
 import org.apache.hadoop.hdfs.server.protocol.NamespaceInfo;
 import org.apache.hadoop.hdfs.server.protocol.SlowDiskReports;
 import org.apache.hadoop.hdfs.server.protocol.SlowPeerReports;
@@ -740,7 +741,18 @@ class BPServiceActor implements Runnable {
             if (state == HAServiceState.ACTIVE) {
               handleRollingUpgradeStatus(resp);
             }
-            commandProcessingThread.enqueue(resp.getCommands());
+            DatanodeCommand[] cmds = resp.getCommands();
+            if (cmds != null && cmds.length != 0) {
+              int length = cmds.length;
+              for (int i = length - 1; i >= 0; i--) {
+                if (cmds[i] instanceof KeyUpdateCommand) {
+                  commandProcessingThread.enqueueFirst(cmds[i]);
+                  cmds[i] = null;
+                  break;
+                }
+              }
+              commandProcessingThread.enqueue(cmds);
+            }
             isSlownode = resp.getIsSlownode();
           }
         }
@@ -1391,7 +1403,7 @@ class BPServiceActor implements Runnable {
     CommandProcessingThread(BPServiceActor actor) {
       super("Command processor");
       this.actor = actor;
-      this.queue = new LinkedBlockingQueue<>();
+      this.queue = new LinkedBlockingDeque<>();
       setDaemon(true);
     }
 
@@ -1492,6 +1504,21 @@ class BPServiceActor implements Runnable {
         queue.put(() -> processCommand(cmds));
         dn.getMetrics().incrActorCmdQueueLength(1);
       }
+    }
+
+    /**
+     * Enqueue DatanodeCommand to the head of queue.
+     * @param cmd
+     * @throws InterruptedException
+     */
+    void enqueueFirst(DatanodeCommand cmd) throws InterruptedException {
+      if (cmd == null) {
+        return;
+      }
+      ((LinkedBlockingDeque<Runnable>) queue).putFirst(
+          () -> processCommand(new DatanodeCommand[]{cmd}));
+      LOG.info("Enque command: {} to the head of queue", cmd);
+      dn.getMetrics().incrActorCmdQueueLength(1);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -1490,6 +1490,21 @@ class BPServiceActor implements Runnable {
       dn.getMetrics().incrActorCmdQueueLength(1);
     }
 
+    /**
+     * Enqueue DatanodeCommand to the head of queue.
+     * @param cmd
+     * @throws InterruptedException
+     */
+    void enqueueFirst(DatanodeCommand cmd) throws InterruptedException {
+      if (cmd == null) {
+        return;
+      }
+      ((LinkedBlockingDeque<Runnable>) queue).putFirst(
+          () -> processCommand(new DatanodeCommand[]{cmd}));
+      LOG.info("Enque command: {} to the head of queue", cmd);
+      dn.getMetrics().incrActorCmdQueueLength(1);
+    }
+
     void enqueue(List<DatanodeCommand> cmds) throws InterruptedException {
       if (cmds == null) {
         return;
@@ -1504,21 +1519,6 @@ class BPServiceActor implements Runnable {
         queue.put(() -> processCommand(cmds));
         dn.getMetrics().incrActorCmdQueueLength(1);
       }
-    }
-
-    /**
-     * Enqueue DatanodeCommand to the head of queue.
-     * @param cmd
-     * @throws InterruptedException
-     */
-    void enqueueFirst(DatanodeCommand cmd) throws InterruptedException {
-      if (cmd == null) {
-        return;
-      }
-      ((LinkedBlockingDeque<Runnable>) queue).putFirst(
-          () -> processCommand(new DatanodeCommand[]{cmd}));
-      LOG.info("Enque command: {} to the head of queue", cmd);
-      dn.getMetrics().incrActorCmdQueueLength(1);
     }
   }
 


### PR DESCRIPTION
### Description of PR
Refer to HDFS-17372.

  Recently, we met a critical problem in our production cluster which have lots of small files. In that cluster, per datanode has almost six million blocks. 
  After deleting large dir or recommision, some datanodes's SumOfActorCommandQueueLength metrics became very high as below picture shows.

![image](https://github.com/apache/hadoop/assets/25115709/a8754f73-7779-400b-835a-4c0044959f8c)

After a while, we found some datanodes's write block ops became zero. That means client can not write to those datanodes. We found some logs on those datanodes:

```
2024-02-05 17:30:11,657 WARN org.apache.hadoop.hdfs.server.datanode.DataNode: Block token verification failed: op=WRITE_BLOCK, remoteAddress=/x.x.x.x:63990, message=Can't re-compute password for block_token_identifier (expiryDate=1707161411033, keyId=596193458, userId=hdfs, blockPoolId=BP-1169917699-x.x.x.x-1678688680604, blockId=11354988786, access modes=[WRITE], storageTypes= [DISK, DISK, DISK, DISK, DISK, DISK, DISK], storageIds= [DS-2664b73d-1cc9-4613-b6e3-cd58ec5ae8d5, DS-8f18621e-46c1-49b3-8bf5-7f5b8e47fe80, DS-527817e1-c5d0-4085-929f-9100a423223f, DS-d3f850c9-18ab-43cc-86d9-779b9d71a79f, DS-e4aa15ce-0c5f-4645-a582-e187e46e7183, DS-3fbbd401-58d2-49ac-a258-da7769417593, DS-d76a51e4-73db-4db6-a4e0-f82a38c1ad82]), since the required block key (keyID=596193458) doesn't exist.
```

That is to say,  DNA_ACCESSKEYUPDATE command was blocked in CommandProcessingThread#queue. This can be deadly.

So, we should guarantee that command with high-priority should be processed in time.


