### PR TITLE
HADOOP-19045. CreateSession Timeout - followup

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2098,20 +2098,6 @@
 </property>
 
 <property>
-  <name>fs.s3a.connection.request.timeout</name>
-  <value>0s</value>
-  <description>
-    Time out on HTTP requests to the AWS service; 0 means no timeout.
-
-    Important: this is the maximum duration of any AWS service call,
-    including upload and copy operations. If non-zero, it must be larger
-    than the time to upload multi-megabyte blocks to S3 from the client,
-    and to rename many-GB files. Use with care.
-
-  </description>
-</property>
-
-<property>
   <name>fs.s3a.etag.checksum.enabled</name>
   <value>false</value>
   <description>

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
@@ -231,7 +231,7 @@ The choice is yours. Generally recovery is better, but sometimes fail-fast is mo
 | `fs.s3a.connection.acquisition.timeout` | `60s`   | `*` | Timeout for waiting for a connection from the pool.   |
 | `fs.s3a.connection.establish.timeout`   | `30s`   |     | Time to establish the TCP/TLS connection              |
 | `fs.s3a.connection.idle.time`           | `60s`   | `*` | Maximum time for idle HTTP connections in the pool    |
-| `fs.s3a.connection.request.timeout`     | `0`     |     | If greater than zero, maximum duration of any request |
+| `fs.s3a.connection.request.timeout`     | `60s`   |     | If greater than zero, maximum time for a response     |
 | `fs.s3a.connection.timeout`             | `200s`  |     | Timeout for socket problems on a TCP channel          |
 | `fs.s3a.connection.ttl`                 | `5m`    |     | Lifetime of HTTP connections from the pool            |
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
@@ -1510,7 +1510,7 @@ It is possible to configure a global timeout for AWS service calls using followi
 ```xml
 <property>
   <name>fs.s3a.connection.request.timeout</name>
-  <value>0</value>
+  <value>5m</value>
   <description>
     Time out on HTTP requests to the AWS service; 0 means no timeout.
     Measured in seconds; the usual time suffixes are all supported

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
@@ -40,6 +40,7 @@ import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_KEEPALIVE;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_TTL_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_ESTABLISH_TIMEOUT_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_MAXIMUM_CONNECTIONS;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_REQUEST_TIMEOUT_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_SOCKET_TIMEOUT_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.ESTABLISH_TIMEOUT;
 import static org.apache.hadoop.fs.s3a.Constants.MAXIMUM_CONNECTIONS;
@@ -174,6 +175,21 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
     Assertions.assertThat(settings.getApiCallTimeout())
         .describedAs("%s in %s", REQUEST_TIMEOUT, settings)
         .isEqualTo(Duration.ofHours(1));
+  }
+  /**
+   * Verify that the timeout from {@link org.apache.hadoop.fs.s3a.Constants#DEFAULT_REQUEST_TIMEOUT_DURATION}
+   * makes it all the way through and that nothing in in core-default or core-site is setting it.
+   * This test will fail if someone does set it in core-site.xml
+   */
+  @Test
+  public void testCreateApiConnectionSettingsDefault() {
+    final Configuration conf = new Configuration();
+    Assertions.assertThat(conf.get(REQUEST_TIMEOUT))
+        .describedAs("Request timeout %s", REQUEST_TIMEOUT)
+        .isNull();
+
+    assertDuration(REQUEST_TIMEOUT, DEFAULT_REQUEST_TIMEOUT_DURATION,
+        createApiConnectionSettings(conf).getApiCallTimeout());
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/resources/core-site.xml
+++ b/hadoop-tools/hadoop-aws/src/test/resources/core-site.xml
@@ -202,11 +202,6 @@
   </property>
 
   <property>
-    <name>fs.s3a.connection.request.timeout</name>
-    <value>10s</value>
-  </property>
-
-  <property>
     <name>fs.s3a.attempts.maximum</name>
     <value>1</value>
     <description>How many times should the SDK retry commands on (probably) transient errors.</description>


### PR DESCRIPTION

Remove all declarations of fs.s3a.connection.request.timeout in
- hadoop-common/src/main/resources/core-default.xml
- hadoop-aws/src/test/resources/core-site.xml

New test in TestAwsClientConfig to verify that the value defined in fs.s3a.Constants class is used.

This is brittle to someone overriding it in their test setups, but as this test is intended to verify that the option is not explicitly set, there's no workaround.

Contributed by Steve Loughran


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

