### PR TITLE
HADOOP-19073 WASB: Fix connection leak in FolderRenamePending

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
@@ -160,9 +160,12 @@ public class NativeAzureFileSystem extends FileSystem {
 
       // open redo file
       Path f = redoFile;
-      FSDataInputStream input = fs.open(f);
-      byte[] bytes = new byte[MAX_RENAME_PENDING_FILE_SIZE];
-      int l = input.read(bytes);
+	  int l;
+      byte[] bytes;
+      try (FSDataInputStream input = fs.open(f)) {
+        bytes = new byte[MAX_RENAME_PENDING_FILE_SIZE];
+        l = input.read(bytes);
+      }
       if (l <= 0) {
         // Jira HADOOP-12678 -Handle empty rename pending metadata file during
         // atomic rename in redo path. If during renamepending file is created

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
@@ -160,7 +160,7 @@ public class NativeAzureFileSystem extends FileSystem {
 
       // open redo file
       Path f = redoFile;
-	  int l;
+      int l;
       byte[] bytes;
       try (FSDataInputStream input = fs.open(f)) {
         bytes = new byte[MAX_RENAME_PENDING_FILE_SIZE];


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Currently connection leak in FolderRenamePending in getting bytes. the pr aim to fix it


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

