### PR TITLE
HDFS-17374. EC: StripedBlockReader#newConnectedPeer should set SO_TIMEOUT and SO_KEEPALIVE

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockReader.java
@@ -150,9 +150,9 @@ class StripedBlockReader {
     final int socketTimeout = datanode.getDnConf().getSocketTimeout();
     try {
       sock = NetUtils.getDefaultSocketFactory(conf).createSocket();
+      NetUtils.connect(sock, addr, socketTimeout);
       sock.setSoTimeout(socketTimeout * 3);
       sock.setKeepAlive(true);
-      NetUtils.connect(sock, addr, socketTimeout);
       peer = DFSUtilClient.peerFromSocketAndKey(datanode.getSaslClient(),
           sock, datanode.getDataEncryptionKeyFactoryForBlock(b),
           blockToken, datanodeId, socketTimeout);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockReader.java
@@ -150,6 +150,8 @@ class StripedBlockReader {
     final int socketTimeout = datanode.getDnConf().getSocketTimeout();
     try {
       sock = NetUtils.getDefaultSocketFactory(conf).createSocket();
+      sock.setSoTimeout(socketTimeout * 3);
+      sock.setKeepAlive(true);
       NetUtils.connect(sock, addr, socketTimeout);
       peer = DFSUtilClient.peerFromSocketAndKey(datanode.getSaslClient(),
           sock, datanode.getDataEncryptionKeyFactoryForBlock(b),


### PR DESCRIPTION
### Description of PR
   Refer to HDFS-17374.
   We met a strange and serious problem on the one of product cluster using EC. 
   The problem can be reproduced every time when writing mass data into this EC cluster along with the network card is full.  After writing, there are many half-open connection and can never release by themselves until we restart datanode.
  After digging into some logs and codes, we suspect that it was caused by StripedBlockReader#newConnectedPeer without setting tcp_keepalive.
  This problem is very serious, because it can use up datanode‘s available port.


![image](https://github.com/apache/hadoop/assets/25115709/991f814c-6dd9-435e-834e-544d62084f28)

![image](https://github.com/apache/hadoop/assets/25115709/bfe1fc63-e281-4ddb-89e1-17452cbd65f1)



