### PR TITLE
HADOOP-19079. Check class is an exception class before constructing an instance

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/HttpExceptionUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/HttpExceptionUtils.java
@@ -156,10 +156,8 @@ public class HttpExceptionUtils {
           try {
             ClassLoader cl = HttpExceptionUtils.class.getClassLoader();
             Class klass = cl.loadClass(exClass);
-            if (!Exception.class.isAssignableFrom(klass)) {
-              // no need to fill in details because the catch below will create a good exception
-              throw new IllegalStateException();
-            }
+            Preconditions.checkState(Exception.class.isAssignableFrom(klass),
+                "Class [%s] is not a subclass of Exception", klass);
             MethodHandle methodHandle = PUBLIC_LOOKUP.findConstructor(
                     klass, EXCEPTION_CONSTRUCTOR_TYPE);
             toThrow = (Exception) methodHandle.invoke(exMsg);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/HttpExceptionUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/HttpExceptionUtils.java
@@ -150,6 +150,10 @@ public class HttpExceptionUtils {
           try {
             ClassLoader cl = HttpExceptionUtils.class.getClassLoader();
             Class klass = cl.loadClass(exClass);
+            if (!klass.isAssignableFrom(Exception.class)) {
+              // no need to fill in details because the catch below will create a good exception
+              throw new IllegalStateException();
+            }
             Constructor constr = klass.getConstructor(String.class);
             toThrow = (Exception) constr.newInstance(exMsg);
           } catch (Exception ex) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/HttpExceptionUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/HttpExceptionUtils.java
@@ -150,7 +150,7 @@ public class HttpExceptionUtils {
           try {
             ClassLoader cl = HttpExceptionUtils.class.getClassLoader();
             Class klass = cl.loadClass(exClass);
-            if (!klass.isAssignableFrom(Exception.class)) {
+            if (!Exception.class.isAssignableFrom(klass)) {
               // no need to fill in details because the catch below will create a good exception
               throw new IllegalStateException();
             }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/HttpExceptionUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/HttpExceptionUtils.java
@@ -57,7 +57,8 @@ public class HttpExceptionUtils {
   private static final String ENTER = System.getProperty("line.separator");
 
   private static final MethodHandles.Lookup PUBLIC_LOOKUP = MethodHandles.publicLookup();
-  private static final MethodType EXCEPTION_CONSTRUCTOR_TYPE = MethodType.methodType(void.class, String.class);
+  private static final MethodType EXCEPTION_CONSTRUCTOR_TYPE =
+          MethodType.methodType(void.class, String.class);
 
   /**
    * Creates a HTTP servlet response serializing the exception in it as JSON.
@@ -159,7 +160,8 @@ public class HttpExceptionUtils {
               // no need to fill in details because the catch below will create a good exception
               throw new IllegalStateException();
             }
-            MethodHandle methodHandle = PUBLIC_LOOKUP.findConstructor(klass, EXCEPTION_CONSTRUCTOR_TYPE);
+            MethodHandle methodHandle = PUBLIC_LOOKUP.findConstructor(
+                    klass, EXCEPTION_CONSTRUCTOR_TYPE);
             toThrow = (Exception) methodHandle.invoke(exMsg);
           } catch (Throwable t) {
             toThrow = new IOException(String.format(

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/HttpExceptionUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/HttpExceptionUtils.java
@@ -155,6 +155,10 @@ public class HttpExceptionUtils {
           try {
             ClassLoader cl = HttpExceptionUtils.class.getClassLoader();
             Class klass = cl.loadClass(exClass);
+            if (!Exception.class.isAssignableFrom(klass)) {
+              // no need to fill in details because the catch below will create a good exception
+              throw new IllegalStateException();
+            }
             MethodHandle methodHandle = PUBLIC_LOOKUP.findConstructor(klass, EXCEPTION_CONSTRUCTOR_TYPE);
             toThrow = (Exception) methodHandle.invoke(exMsg);
           } catch (Throwable t) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/impl/prefetch/TestBlockCache.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/impl/prefetch/TestBlockCache.java
@@ -54,7 +54,7 @@ public class TestBlockCache extends AbstractHadoopTestBase {
         () -> cache.put(42, null, null, null));
 
 
-    intercept(NullPointerException.class, null,
+    intercept(NullPointerException.class,
         () -> new SingleFilePerBlockCache(null, 2, null));
 
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/LambdaTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/LambdaTestUtils.java
@@ -927,8 +927,9 @@ public final class LambdaTestUtils {
     sb.append('[');
     int pos = 0;
     for (String s : strings) {
-      if (pos++ > 0)
+      if (pos++ > 0) {
         sb.append(", ");
+      }
       sb.append(s);
     }
     sb.append(']');

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/LambdaTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/LambdaTestUtils.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.util.Time;
 
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
-import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
@@ -383,7 +382,7 @@ public final class LambdaTestUtils {
       Callable<T> eval)
       throws Exception {
     return intercept(clazz,
-        (String) null,
+        null,
         "Expected a " + clazz.getName() + " to be thrown," +
             " but got the result: ",
         eval);
@@ -510,61 +509,6 @@ public final class LambdaTestUtils {
   }
 
   /**
-   * Intercept an exception; throw an {@code AssertionError} if one not raised.
-   * The caught exception is rethrown if it is of the wrong class or
-   * does not contain the text defined in {@code contained}.
-   * <p>
-   * Example: expect deleting a nonexistent file to raise a
-   * {@code FileNotFoundException} with the {@code toString()} value
-   * containing the text {@code "missing"}.
-   * <pre>
-   * FileNotFoundException ioe = intercept(FileNotFoundException.class,
-   *   "missing",
-   *   "path should not be found",
-   *   () -> {
-   *     filesystem.delete(new Path("/missing"), false);
-   *   });
-   * </pre>
-   *
-   * @param clazz class of exception; the raised exception must be this class
-   * <i>or a subclass</i>.
-   * @param contains strings which must be in the {@code toString()} value
-   * of the exception (order does not matter)
-   * @param message any message tho include in exception/log messages
-   * @param eval expression to eval
-   * @param <T> return type of expression
-   * @param <E> exception class
-   * @return the caught exception if it was of the expected type and contents
-   * @throws Exception any other exception raised
-   * @throws AssertionError if the evaluation call didn't raise an exception.
-   * The error includes the {@code toString()} value of the result, if this
-   * can be determined.
-   * @see GenericTestUtils#assertExceptionContains(String, Throwable)
-   */
-  public static <T, E extends Throwable> E intercept(
-          Class<E> clazz,
-          Collection<String> contains,
-          String message,
-          Callable<T> eval)
-          throws Exception {
-    E ex;
-    try {
-      T result = eval.call();
-      throw new AssertionError(message + ": " + robustToString(result));
-    } catch (Throwable e) {
-      if (!clazz.isAssignableFrom(e.getClass())) {
-        throw e;
-      } else {
-        ex = (E) e;
-      }
-    }
-    for (String contained : contains) {
-      GenericTestUtils.assertExceptionContains(contained, ex, message);
-    }
-    return ex;
-  }
-
-  /**
    * Variant of {@link #intercept(Class, Callable)} to simplify void
    * invocations.
    * @param clazz class of exception; the raised exception must be this class
@@ -584,40 +528,12 @@ public final class LambdaTestUtils {
       throws Exception {
     return intercept(clazz, contained,
         "Expecting " + clazz.getName()
-        + (contained != null ? (" with text " + contained) : "")
+        + (contained != null? (" with text " + contained) : "")
         + " but got ",
         () -> {
           eval.call();
           return "void";
         });
-  }
-
-  /**
-   * Variant of {@link #intercept(Class, Callable)} to simplify void
-   * invocations.
-   * @param clazz class of exception; the raised exception must be this class
-   * <i>or a subclass</i>.
-   * @param contains string which must be in the {@code toString()} value
-   * of the exception (order does not matter)
-   * @param eval expression to eval
-   * @param <E> exception class
-   * @return the caught exception if it was of the expected type
-   * @throws Exception any other exception raised
-   * @throws AssertionError if the evaluation call didn't raise an exception.
-   */
-  public static <E extends Throwable> E intercept(
-          Class<E> clazz,
-          Collection<String> contains,
-          VoidCallable eval)
-          throws Exception {
-    return intercept(clazz, contains,
-            "Expecting " + clazz.getName()
-                    + (contains.isEmpty() ? "" : (" with text values " + toString(contains)))
-                    + " but got ",
-            () -> {
-              eval.call();
-              return "void";
-            });
   }
 
   /**
@@ -691,6 +607,7 @@ public final class LambdaTestUtils {
    * Assert that an optional value matches an expected one;
    * checks include null and empty on the actual value.
    * @param message message text
+   * @param expected expected value
    * @param actual actual optional value
    * @param <T> type
    */
@@ -724,6 +641,7 @@ public final class LambdaTestUtils {
    * Invoke a callable; wrap all checked exceptions with an
    * AssertionError.
    * @param closure closure to execute
+   * @return the value of the closure
    * @throws AssertionError if the operation raised an IOE or
    * other checked exception.
    */
@@ -886,19 +804,6 @@ public final class LambdaTestUtils {
           }
         });
    }
-
-  private static String toString(Collection<String> strings) {
-    StringBuilder sb = new StringBuilder();
-    sb.append('[');
-    int pos = 0;
-    for (String s : strings) {
-      if (pos++ > 0)
-        sb.append(", ");
-      sb.append(s);
-    }
-    sb.append(']');
-    return sb.toString();
-  }
 
   /**
    * Verify that the cause of an exception is of the given type.
@@ -1132,3 +1037,4 @@ public final class LambdaTestUtils {
     }
   }
 }
+

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/LambdaTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/LambdaTestUtils.java
@@ -383,6 +383,7 @@ public final class LambdaTestUtils {
       Callable<T> eval)
       throws Exception {
     return intercept(clazz,
+        (String) null,
         "Expected a " + clazz.getName() + " to be thrown," +
             " but got the result: ",
         eval);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/LambdaTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/LambdaTestUtils.java
@@ -18,12 +18,12 @@
 
 package org.apache.hadoop.test;
 
-import org.apache.hadoop.util.Preconditions;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.util.Time;
 
 import java.io.IOException;
@@ -36,6 +36,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 /**
  * Class containing methods and associated classes to make the most of Lambda
@@ -740,7 +741,6 @@ public final class LambdaTestUtils {
    * Invoke a callable; wrap all checked exceptions with an
    * AssertionError.
    * @param closure closure to execute
-   * @return the value of the closure
    * @throws AssertionError if the operation raised an IOE or
    * other checked exception.
    */
@@ -923,17 +923,8 @@ public final class LambdaTestUtils {
   }
 
   private static String toString(Collection<String> strings) {
-    StringBuilder sb = new StringBuilder();
-    sb.append('[');
-    int pos = 0;
-    for (String s : strings) {
-      if (pos++ > 0) {
-        sb.append(", ");
-      }
-      sb.append(s);
-    }
-    sb.append(']');
-    return sb.toString();
+    return strings.stream()
+        .collect(Collectors.joining(",", "[", "]"));
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/LambdaTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/LambdaTestUtils.java
@@ -528,7 +528,7 @@ public final class LambdaTestUtils {
       throws Exception {
     return intercept(clazz, contained,
         "Expecting " + clazz.getName()
-        + (contained != null? (" with text " + contained) : "")
+        + (contained != null ? (" with text " + contained) : "")
         + " but got ",
         () -> {
           eval.call();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
@@ -34,8 +34,11 @@ import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class TestHttpExceptionUtils {
 
@@ -107,8 +110,11 @@ public class TestHttpExceptionUtils {
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
     Mockito.when(conn.getResponseCode()).thenReturn(
         HttpURLConnection.HTTP_BAD_REQUEST);
+    Collection<String> expectedValues =
+            Stream.of(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), "msg", "com.fasterxml.jackson.core.JsonParseException")
+                    .collect(Collectors.toList());
     LambdaTestUtils.intercept(IOException.class,
-            "HTTP status [400], message [msg], URL [null], exception [com.fasterxml.jackson.core.JsonParseException",
+            expectedValues,
             () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
   }
 
@@ -150,8 +156,11 @@ public class TestHttpExceptionUtils {
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
     Mockito.when(conn.getResponseCode()).thenReturn(
         HttpURLConnection.HTTP_BAD_REQUEST);
+    Collection<String> expectedValues =
+            Stream.of(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), "foo.FooException", "EX")
+                    .collect(Collectors.toList());
     LambdaTestUtils.intercept(IOException.class,
-            "HTTP status [400], exception [foo.FooException], message [EX], URL [null]",
+            expectedValues,
             () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
   }
 
@@ -172,8 +181,11 @@ public class TestHttpExceptionUtils {
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
     Mockito.when(conn.getResponseCode()).thenReturn(
             HttpURLConnection.HTTP_BAD_REQUEST);
+    Collection<String> expectedValues =
+            Stream.of(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), "java.lang.String", "EX")
+                    .collect(Collectors.toList());
     LambdaTestUtils.intercept(IOException.class,
-            "HTTP status [400], exception [java.lang.String], message [EX], URL [null]",
+            expectedValues,
             () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
@@ -164,4 +164,30 @@ public class TestHttpExceptionUtils {
     }
   }
 
+  @Test
+  public void testValidateResponseJsonErrorNonException() throws IOException {
+    Map<String, Object> json = new HashMap<String, Object>();
+    json.put(HttpExceptionUtils.ERROR_EXCEPTION_JSON, "invalid");
+    // test case where the exception classname is not a valid exception class
+    json.put(HttpExceptionUtils.ERROR_CLASSNAME_JSON, String.class.getName());
+    json.put(HttpExceptionUtils.ERROR_MESSAGE_JSON, "EX");
+    Map<String, Object> response = new HashMap<String, Object>();
+    response.put(HttpExceptionUtils.ERROR_JSON, json);
+    ObjectMapper jsonMapper = new ObjectMapper();
+    String msg = jsonMapper.writeValueAsString(response);
+    InputStream is = new ByteArrayInputStream(msg.getBytes());
+    HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
+    Mockito.when(conn.getErrorStream()).thenReturn(is);
+    Mockito.when(conn.getResponseMessage()).thenReturn("msg");
+    Mockito.when(conn.getResponseCode()).thenReturn(
+            HttpURLConnection.HTTP_BAD_REQUEST);
+    try {
+      HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED);
+      Assert.fail();
+    } catch (IOException ex) {
+      Assert.assertEquals("HTTP status [400], exception [java.lang.String], message [EX], URL [null]",
+              ex.getMessage());
+    }
+  }
+
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
@@ -185,7 +185,8 @@ public class TestHttpExceptionUtils {
       HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED);
       Assert.fail();
     } catch (IOException ex) {
-      Assert.assertEquals("HTTP status [400], exception [java.lang.String], message [EX], URL [null]",
+      Assert.assertEquals(
+              "HTTP status [400], exception [java.lang.String], message [EX], URL [null]",
               ex.getMessage());
     }
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
@@ -110,12 +110,11 @@ public class TestHttpExceptionUtils {
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
     Mockito.when(conn.getResponseCode()).thenReturn(
         HttpURLConnection.HTTP_BAD_REQUEST);
-    Collection<String> expectedValues =
-            Stream.of(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), "msg", "com.fasterxml.jackson.core.JsonParseException")
-                    .collect(Collectors.toList());
-    LambdaTestUtils.intercept(IOException.class,
-            expectedValues,
+    IOException ex = LambdaTestUtils.intercept(IOException.class,
             () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
+    assertContains(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), ex.getMessage());
+    assertContains("msg", ex.getMessage());
+    assertContains("com.fasterxml.jackson.core.JsonParseException", ex.getMessage());
   }
 
   @Test
@@ -156,12 +155,11 @@ public class TestHttpExceptionUtils {
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
     Mockito.when(conn.getResponseCode()).thenReturn(
         HttpURLConnection.HTTP_BAD_REQUEST);
-    Collection<String> expectedValues =
-            Stream.of(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), "foo.FooException", "EX")
-                    .collect(Collectors.toList());
-    LambdaTestUtils.intercept(IOException.class,
-            expectedValues,
+    IOException ex = LambdaTestUtils.intercept(IOException.class,
             () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
+    assertContains(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), ex.getMessage());
+    assertContains("foo.FooException", ex.getMessage());
+    assertContains("EX", ex.getMessage());
   }
 
   @Test
@@ -181,12 +179,16 @@ public class TestHttpExceptionUtils {
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
     Mockito.when(conn.getResponseCode()).thenReturn(
             HttpURLConnection.HTTP_BAD_REQUEST);
-    Collection<String> expectedValues =
-            Stream.of(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), "java.lang.String", "EX")
-                    .collect(Collectors.toList());
-    LambdaTestUtils.intercept(IOException.class,
-            expectedValues,
+    IOException ex = LambdaTestUtils.intercept(IOException.class,
             () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
+    assertContains(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), ex.getMessage());
+    assertContains("java.lang.String", ex.getMessage());
+    assertContains("EX", ex.getMessage());
+  }
+
+  private static void assertContains(String expected, String actual) {
+    Assert.assertTrue("Expected: " + expected + ", Actual: " + actual,
+        actual.contains(expected));
   }
 
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
@@ -34,11 +34,8 @@ import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class TestHttpExceptionUtils {
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
@@ -84,18 +84,16 @@ public class TestHttpExceptionUtils {
   @Test
   public void testValidateResponseOK() throws IOException {
     HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
-    Mockito.when(conn.getResponseCode()).thenReturn(
-        HttpURLConnection.HTTP_CREATED);
+    Mockito.when(conn.getResponseCode()).thenReturn(HttpURLConnection.HTTP_CREATED);
     HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED);
   }
 
   @Test
   public void testValidateResponseFailNoErrorMessage() throws Exception {
     HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
-    Mockito.when(conn.getResponseCode()).thenReturn(
-        HttpURLConnection.HTTP_BAD_REQUEST);
+    Mockito.when(conn.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
     LambdaTestUtils.intercept(IOException.class,
-            () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
+        () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
   }
 
   @Test
@@ -105,10 +103,9 @@ public class TestHttpExceptionUtils {
     HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
     Mockito.when(conn.getErrorStream()).thenReturn(is);
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
-    Mockito.when(conn.getResponseCode()).thenReturn(
-        HttpURLConnection.HTTP_BAD_REQUEST);
+    Mockito.when(conn.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
     IOException ex = LambdaTestUtils.intercept(IOException.class,
-            () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
+        () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
     assertContains(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), ex.getMessage());
     assertContains("msg", ex.getMessage());
     assertContains("com.fasterxml.jackson.core.JsonParseException", ex.getMessage());
@@ -128,11 +125,10 @@ public class TestHttpExceptionUtils {
     HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
     Mockito.when(conn.getErrorStream()).thenReturn(is);
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
-    Mockito.when(conn.getResponseCode()).thenReturn(
-        HttpURLConnection.HTTP_BAD_REQUEST);
+    Mockito.when(conn.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
     LambdaTestUtils.intercept(IllegalStateException.class,
-            "EX",
-            () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
+        "EX",
+        () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
   }
 
   @Test
@@ -150,10 +146,9 @@ public class TestHttpExceptionUtils {
     HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
     Mockito.when(conn.getErrorStream()).thenReturn(is);
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
-    Mockito.when(conn.getResponseCode()).thenReturn(
-        HttpURLConnection.HTTP_BAD_REQUEST);
+    Mockito.when(conn.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
     IOException ex = LambdaTestUtils.intercept(IOException.class,
-            () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
+        () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
     assertContains(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), ex.getMessage());
     assertContains("foo.FooException", ex.getMessage());
     assertContains("EX", ex.getMessage());
@@ -174,10 +169,9 @@ public class TestHttpExceptionUtils {
     HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
     Mockito.when(conn.getErrorStream()).thenReturn(is);
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
-    Mockito.when(conn.getResponseCode()).thenReturn(
-            HttpURLConnection.HTTP_BAD_REQUEST);
+    Mockito.when(conn.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
     IOException ex = LambdaTestUtils.intercept(IOException.class,
-            () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
+        () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
     assertContains(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), ex.getMessage());
     assertContains("java.lang.String", ex.getMessage());
     assertContains("EX", ex.getMessage());

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -31,6 +32,7 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -87,35 +89,31 @@ public class TestHttpExceptionUtils {
     HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED);
   }
 
-  @Test(expected = IOException.class)
-  public void testValidateResponseFailNoErrorMessage() throws IOException {
+  @Test
+  public void testValidateResponseFailNoErrorMessage() throws Exception {
     HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
     Mockito.when(conn.getResponseCode()).thenReturn(
         HttpURLConnection.HTTP_BAD_REQUEST);
-    HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED);
+    LambdaTestUtils.intercept(IOException.class,
+            () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
   }
 
   @Test
-  public void testValidateResponseNonJsonErrorMessage() throws IOException {
+  public void testValidateResponseNonJsonErrorMessage() throws Exception {
     String msg = "stream";
-    InputStream is = new ByteArrayInputStream(msg.getBytes());
+    InputStream is = new ByteArrayInputStream(msg.getBytes(StandardCharsets.UTF_8));
     HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
     Mockito.when(conn.getErrorStream()).thenReturn(is);
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
     Mockito.when(conn.getResponseCode()).thenReturn(
         HttpURLConnection.HTTP_BAD_REQUEST);
-    try {
-      HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED);
-      Assert.fail();
-    } catch (IOException ex) {
-      Assert.assertTrue(ex.getMessage().contains("msg"));
-      Assert.assertTrue(ex.getMessage().contains("" +
-          HttpURLConnection.HTTP_BAD_REQUEST));
-    }
+    LambdaTestUtils.intercept(IOException.class,
+            "HTTP status [400], message [msg], URL [null], exception [com.fasterxml.jackson.core.JsonParseException",
+            () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
   }
 
   @Test
-  public void testValidateResponseJsonErrorKnownException() throws IOException {
+  public void testValidateResponseJsonErrorKnownException() throws Exception {
     Map<String, Object> json = new HashMap<String, Object>();
     json.put(HttpExceptionUtils.ERROR_EXCEPTION_JSON, IllegalStateException.class.getSimpleName());
     json.put(HttpExceptionUtils.ERROR_CLASSNAME_JSON, IllegalStateException.class.getName());
@@ -124,23 +122,20 @@ public class TestHttpExceptionUtils {
     response.put(HttpExceptionUtils.ERROR_JSON, json);
     ObjectMapper jsonMapper = new ObjectMapper();
     String msg = jsonMapper.writeValueAsString(response);
-    InputStream is = new ByteArrayInputStream(msg.getBytes());
+    InputStream is = new ByteArrayInputStream(msg.getBytes(StandardCharsets.UTF_8));
     HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
     Mockito.when(conn.getErrorStream()).thenReturn(is);
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
     Mockito.when(conn.getResponseCode()).thenReturn(
         HttpURLConnection.HTTP_BAD_REQUEST);
-    try {
-      HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED);
-      Assert.fail();
-    } catch (IllegalStateException ex) {
-      Assert.assertEquals("EX", ex.getMessage());
-    }
+    LambdaTestUtils.intercept(IllegalStateException.class,
+            "EX",
+            () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
   }
 
   @Test
   public void testValidateResponseJsonErrorUnknownException()
-      throws IOException {
+      throws Exception {
     Map<String, Object> json = new HashMap<String, Object>();
     json.put(HttpExceptionUtils.ERROR_EXCEPTION_JSON, "FooException");
     json.put(HttpExceptionUtils.ERROR_CLASSNAME_JSON, "foo.FooException");
@@ -149,23 +144,19 @@ public class TestHttpExceptionUtils {
     response.put(HttpExceptionUtils.ERROR_JSON, json);
     ObjectMapper jsonMapper = new ObjectMapper();
     String msg = jsonMapper.writeValueAsString(response);
-    InputStream is = new ByteArrayInputStream(msg.getBytes());
+    InputStream is = new ByteArrayInputStream(msg.getBytes(StandardCharsets.UTF_8));
     HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
     Mockito.when(conn.getErrorStream()).thenReturn(is);
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
     Mockito.when(conn.getResponseCode()).thenReturn(
         HttpURLConnection.HTTP_BAD_REQUEST);
-    try {
-      HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED);
-      Assert.fail();
-    } catch (IOException ex) {
-      Assert.assertTrue(ex.getMessage().contains("EX"));
-      Assert.assertTrue(ex.getMessage().contains("foo.FooException"));
-    }
+    LambdaTestUtils.intercept(IOException.class,
+            "HTTP status [400], exception [foo.FooException], message [EX], URL [null]",
+            () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
   }
 
   @Test
-  public void testValidateResponseJsonErrorNonException() throws IOException {
+  public void testValidateResponseJsonErrorNonException() throws Exception {
     Map<String, Object> json = new HashMap<String, Object>();
     json.put(HttpExceptionUtils.ERROR_EXCEPTION_JSON, "invalid");
     // test case where the exception classname is not a valid exception class
@@ -175,20 +166,15 @@ public class TestHttpExceptionUtils {
     response.put(HttpExceptionUtils.ERROR_JSON, json);
     ObjectMapper jsonMapper = new ObjectMapper();
     String msg = jsonMapper.writeValueAsString(response);
-    InputStream is = new ByteArrayInputStream(msg.getBytes());
+    InputStream is = new ByteArrayInputStream(msg.getBytes(StandardCharsets.UTF_8));
     HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
     Mockito.when(conn.getErrorStream()).thenReturn(is);
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
     Mockito.when(conn.getResponseCode()).thenReturn(
             HttpURLConnection.HTTP_BAD_REQUEST);
-    try {
-      HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED);
-      Assert.fail();
-    } catch (IOException ex) {
-      Assert.assertEquals(
-              "HTTP status [400], exception [java.lang.String], message [EX], URL [null]",
-              ex.getMessage());
-    }
+    LambdaTestUtils.intercept(IOException.class,
+            "HTTP status [400], exception [java.lang.String], message [EX], URL [null]",
+            () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
   }
 
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHttpExceptionUtils.java
@@ -104,11 +104,10 @@ public class TestHttpExceptionUtils {
     Mockito.when(conn.getErrorStream()).thenReturn(is);
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
     Mockito.when(conn.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
-    IOException ex = LambdaTestUtils.intercept(IOException.class,
+    LambdaTestUtils.interceptAndValidateMessageContains(IOException.class,
+        Arrays.asList(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), "msg",
+          "com.fasterxml.jackson.core.JsonParseException"),
         () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
-    assertContains(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), ex.getMessage());
-    assertContains("msg", ex.getMessage());
-    assertContains("com.fasterxml.jackson.core.JsonParseException", ex.getMessage());
   }
 
   @Test
@@ -147,11 +146,10 @@ public class TestHttpExceptionUtils {
     Mockito.when(conn.getErrorStream()).thenReturn(is);
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
     Mockito.when(conn.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
-    IOException ex = LambdaTestUtils.intercept(IOException.class,
+    LambdaTestUtils.interceptAndValidateMessageContains(IOException.class,
+        Arrays.asList(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST),
+          "foo.FooException", "EX"),
         () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
-    assertContains(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), ex.getMessage());
-    assertContains("foo.FooException", ex.getMessage());
-    assertContains("EX", ex.getMessage());
   }
 
   @Test
@@ -170,16 +168,9 @@ public class TestHttpExceptionUtils {
     Mockito.when(conn.getErrorStream()).thenReturn(is);
     Mockito.when(conn.getResponseMessage()).thenReturn("msg");
     Mockito.when(conn.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
-    IOException ex = LambdaTestUtils.intercept(IOException.class,
+    LambdaTestUtils.interceptAndValidateMessageContains(IOException.class,
+        Arrays.asList(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST),
+          "java.lang.String", "EX"),
         () -> HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_CREATED));
-    assertContains(Integer.toString(HttpURLConnection.HTTP_BAD_REQUEST), ex.getMessage());
-    assertContains("java.lang.String", ex.getMessage());
-    assertContains("EX", ex.getMessage());
   }
-
-  private static void assertContains(String expected, String actual) {
-    Assert.assertTrue("Expected: " + expected + ", Actual: " + actual,
-        actual.contains(expected));
-  }
-
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestPreconditions.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestPreconditions.java
@@ -73,7 +73,6 @@ public class TestPreconditions {
 
     // failure with Null message
     LambdaTestUtils.intercept(NullPointerException.class,
-        null,
         () -> Preconditions.checkNotNull(null, errorMessage));
 
     // failure with message format
@@ -162,7 +161,6 @@ public class TestPreconditions {
     errorMessage = null;
     // failure with Null message
     LambdaTestUtils.intercept(IllegalArgumentException.class,
-        null,
         () -> Preconditions.checkArgument(false, errorMessage));
     // failure with message
     errorMessage = EXPECTED_ERROR_MSG;
@@ -200,7 +198,6 @@ public class TestPreconditions {
     // failure with Null supplier
     final Supplier<String> nullSupplier = null;
     LambdaTestUtils.intercept(IllegalArgumentException.class,
-        null,
         () -> Preconditions.checkArgument(false, nullSupplier));
 
     // ignore illegal format in supplier
@@ -262,7 +259,6 @@ public class TestPreconditions {
     errorMessage = null;
     // failure with Null message
     LambdaTestUtils.intercept(IllegalStateException.class,
-        null,
         () -> Preconditions.checkState(false, errorMessage));
     // failure with message
     errorMessage = EXPECTED_ERROR_MSG;
@@ -300,7 +296,6 @@ public class TestPreconditions {
     // failure with Null supplier
     final Supplier<String> nullSupplier = null;
     LambdaTestUtils.intercept(IllegalStateException.class,
-        null,
         () -> Preconditions.checkState(false, nullSupplier));
 
     // ignore illegal format in supplier


### PR DESCRIPTION
### Description of PR

HADOOP-19079

### How was this patch tested?

New test added

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

