### PR TITLE
HDFS-17352. Add configuration to control whether DN delete this replica from disk when client requests a missing block

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -188,6 +188,10 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final long DFS_DN_CACHED_DFSUSED_CHECK_INTERVAL_DEFAULT_MS =
       600000;
 
+  public static final String DFS_DATANODE_DELETE_CORRUPT_REPLICA_FROM_DISK_ENABLE =
+      "dfs.datanode.delete.corrupt.replica.from.disk.enable";
+  public static final boolean DFS_DATANODE_DELETE_CORRUPT_REPLICA_FROM_DISK_DEFAULT = true;
+
   public static final String  DFS_NAMENODE_PATH_BASED_CACHE_BLOCK_MAP_ALLOCATION_PERCENT =
       "dfs.namenode.path.based.cache.block.map.allocation.percent";
   public static final float    DFS_NAMENODE_PATH_BASED_CACHE_BLOCK_MAP_ALLOCATION_PERCENT_DEFAULT = 0.25f;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/FsDatasetSpi.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/FsDatasetSpi.java
@@ -698,4 +698,19 @@ public interface FsDatasetSpi<V extends FsVolumeSpi> extends FSDatasetMBean {
    * @param time the last time in milliseconds when the directory scanner successfully ran.
    */
   default void setLastDirScannerFinishTime(long time) {}
+
+  /**
+   * Set to enable or disable the deletion of corrupt replicas from disk
+   * when client requests a missing block.
+   * @param deleteCorruptReplicaFromDisk
+   *        true will delete the actual on-disk block and meta file,
+   *        otherwise false will only remove block from volume map.
+   */
+  void setDeleteCorruptReplicaFromDisk(boolean deleteCorruptReplicaFromDisk);
+
+  /**
+   * Check whether the datanode delete replica from disk when a client requests a missing block.
+   * @return boolean.
+   */
+  boolean isDeleteCorruptReplicaFromDisk();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -2419,9 +2419,9 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
 
     // The replica seems is on its volume map but not on disk.
     // We can't confirm here is block file lost or disk failed.
-    // If checkFiles as true will check block or meta file existence again.
-    // If deleteCorruptReplicaFromDisk as true will delete the actual on-disk block and meta file,
-    // otherwise will remove it from volume map and notify namenode.
+    // If checkFiles is true, the existence of the block and metafile will be checked again.
+    // If deleteCorruptReplicaFromDisk is true, delete the existing block or metafile directly,
+    // otherwise just remove them from the memory volumeMap.
     try (AutoCloseableLock lock = lockManager.writeLock(LockLevel.BLOCK_POOl,
         bpid)) {
       // Check if this block is on the volume map.
@@ -2435,6 +2435,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
               .notifyNamenodeDeletedBlock(extendedBlock, replica.getStorageUuid());
           invalidate(bpid, new Block[] {extendedBlock.getLocalBlock()});
         } else {
+          // For detailed info, please refer to HDFS-16985.
           volumeMap.remove(bpid, block);
           invalidate(bpid, replica);
         }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -290,7 +290,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
   private long curDirScannerNotifyCount;
   private long lastDirScannerNotifyTime;
   private volatile long lastDirScannerFinishTime;
-  private boolean deleteCorruptReplicaFromDisk;
+  private volatile boolean deleteCorruptReplicaFromDisk;
 
   /**
    * An FSDataset has a directory where it loads its data files.
@@ -3859,9 +3859,14 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
     return asyncDiskService.countPendingDeletions();
   }
 
-  @VisibleForTesting
+  @Override
   public void setDeleteCorruptReplicaFromDisk(boolean deleteCorruptReplicaFromDisk) {
     this.deleteCorruptReplicaFromDisk = deleteCorruptReplicaFromDisk;
+  }
+
+  @Override
+  public boolean isDeleteCorruptReplicaFromDisk() {
+    return deleteCorruptReplicaFromDisk;
   }
 }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -129,6 +129,9 @@ import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_DELETE_CORRUPT_REPLICA_FROM_DISK_DEFAULT;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_DELETE_CORRUPT_REPLICA_FROM_DISK_ENABLE;
+
 /**************************************************
  * FSDataset manages a set of data blocks.  Each block
  * has a unique name and an extent on disk.
@@ -287,6 +290,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
   private long curDirScannerNotifyCount;
   private long lastDirScannerNotifyTime;
   private volatile long lastDirScannerFinishTime;
+  private boolean deleteCorruptReplicaFromDisk;
 
   /**
    * An FSDataset has a directory where it loads its data files.
@@ -392,6 +396,9 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
         DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_MAX_NOTIFY_COUNT_KEY,
         DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_MAX_NOTIFY_COUNT_DEFAULT);
     lastDirScannerNotifyTime = System.currentTimeMillis();
+    deleteCorruptReplicaFromDisk = conf.getBoolean(
+        DFS_DATANODE_DELETE_CORRUPT_REPLICA_FROM_DISK_ENABLE,
+        DFS_DATANODE_DELETE_CORRUPT_REPLICA_FROM_DISK_DEFAULT);
   }
 
   /**
@@ -2400,23 +2407,21 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
   }
   /**
    * Invalidate a block which is not found on disk. We should remove it from
-   * memory and notify namenode, but unnecessary  to delete the actual on-disk
-   * block file again.
+   * memory and notify namenode, will decide whether to delete the actual on-disk block and meta
+   * file based on {@link DFSConfigKeys#DFS_DATANODE_DELETE_CORRUPT_REPLICA_FROM_DISK_ENABLE}.
    *
    * @param bpid the block pool ID.
    * @param block The block to be invalidated.
    * @param checkFiles Whether to check data and meta files.
    */
-  public void invalidateMissingBlock(String bpid, Block block, boolean checkFiles) {
+  public void invalidateMissingBlock(String bpid, Block block, boolean checkFiles)
+      throws IOException {
 
     // The replica seems is on its volume map but not on disk.
     // We can't confirm here is block file lost or disk failed.
-    // If block lost:
-    //    deleted local block file is completely unnecessary
-    // If disk failed:
-    //    deleted local block file here may lead to missing-block
-    //    when it with only 1 replication left now.
-    // So remove if from volume map notify namenode is ok.
+    // If checkFiles as true will check block or meta file existence again.
+    // If deleteCorruptReplicaFromDisk as true will delete the actual on-disk block and meta file,
+    // otherwise will remove it from volume map and notify namenode.
     try (AutoCloseableLock lock = lockManager.writeLock(LockLevel.BLOCK_POOl,
         bpid)) {
       // Check if this block is on the volume map.
@@ -2424,13 +2429,20 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
       // Double-check block or meta file existence when checkFiles as true.
       if (replica != null && (!checkFiles ||
           (!replica.blockDataExists() || !replica.metadataExists()))) {
-        volumeMap.remove(bpid, block);
-        invalidate(bpid, replica);
+        if (deleteCorruptReplicaFromDisk) {
+          ExtendedBlock extendedBlock = new ExtendedBlock(bpid, block);
+          datanode
+              .notifyNamenodeDeletedBlock(extendedBlock, replica.getStorageUuid());
+          invalidate(bpid, new Block[] {extendedBlock.getLocalBlock()});
+        } else {
+          volumeMap.remove(bpid, block);
+          invalidate(bpid, replica);
+        }
       }
     }
   }
 
-  public void invalidateMissingBlock(String bpid, Block block) {
+  public void invalidateMissingBlock(String bpid, Block block) throws IOException {
     invalidateMissingBlock(bpid, block, true);
   }
 
@@ -3844,6 +3856,11 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
   @Override
   public long getPendingAsyncDeletions() {
     return asyncDiskService.countPendingDeletions();
+  }
+
+  @VisibleForTesting
+  public void setDeleteCorruptReplicaFromDisk(boolean deleteCorruptReplicaFromDisk) {
+    this.deleteCorruptReplicaFromDisk = deleteCorruptReplicaFromDisk;
   }
 }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -3983,6 +3983,17 @@
 </property>
 
 <property>
+  <name>dfs.datanode.delete.corrupt.replica.from.disk.enable</name>
+  <value>true</value>
+  <description>
+    Whether the datanode delete replica from disk when client requests a missing block,
+    If true will delete the actual on-disk block and meta file,
+    otherwise will only remove it from volume map and notify namenode.
+    The default value is true.
+  </description>
+</property>
+
+<property>
   <name>dfs.webhdfs.rest-csrf.enabled</name>
   <value>false</value>
   <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
@@ -1647,5 +1647,15 @@ public class SimulatedFSDataset implements FsDatasetSpi<FsVolumeSpi> {
   public void setLastDirScannerFinishTime(long time) {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public void setDeleteCorruptReplicaFromDisk(boolean deleteCorruptReplicaFromDisk) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isDeleteCorruptReplicaFromDisk() {
+    throw new UnsupportedOperationException();
+  }
 }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
@@ -487,4 +487,14 @@ public class ExternalDatasetImpl implements FsDatasetSpi<ExternalVolumeImpl> {
   public long getPendingAsyncDeletions() {
     return 0;
   }
+
+  @Override
+  public void setDeleteCorruptReplicaFromDisk(boolean deleteCorruptReplicaFromDisk) {
+
+  }
+
+  @Override
+  public boolean isDeleteCorruptReplicaFromDisk() {
+    return false;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -347,7 +347,7 @@ public class TestDFSAdmin {
     final List<String> outs = Lists.newArrayList();
     final List<String> errs = Lists.newArrayList();
     getReconfigurableProperties("datanode", address, outs, errs);
-    assertEquals(26, outs.size());
+    assertEquals(27, outs.size());
     assertEquals(DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY, outs.get(1));
   }
 


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17352

As discussed at https://github.com/apache/hadoop/pull/6464#issuecomment-1902959898
we should add configuration to control whether DN delete this replica from disk when client requests a missing block.


