### PR TITLE
HDFS-17383:Datanode current block token should come from active NameNode in HA mode

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -430,6 +430,9 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
    * Clear expired namespace in the shared RouterStateIdContext.
    */
   private void clearStaleNamespacesInRouterStateIdContext() {
+    if (!router.isRouterState(RouterServiceState.RUNNING)) {
+      return;
+    }
     try {
       final Set<String> resolvedNamespaces = namenodeResolver.getNamespaces()
           .stream()

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
@@ -336,7 +336,14 @@ public class MockResolver
   @Override
   public synchronized Set<FederationNamespaceInfo> getNamespaces()
       throws IOException {
-    return Collections.unmodifiableSet(this.namespaces);
+    Set<FederationNamespaceInfo> ret = new TreeSet<>();
+    Set<String> disabled = getDisabledNamespaces();
+    for (FederationNamespaceInfo ns : namespaces) {
+      if (!disabled.contains(ns.getNameserviceId())) {
+        ret.add(ns);
+      }
+    }
+    return Collections.unmodifiableSet(ret);
   }
 
   public void clearDisableNamespaces() {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
@@ -23,10 +23,12 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_REDUNDANCY_CONSI
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.addDirectory;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.countContents;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.createFile;
+import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.createNamenodeReport;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.deleteFile;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.getFileStatus;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.verifyFileExists;
 import static org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.TEST_STRING;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.FEDERATION_STORE_MEMBERSHIP_EXPIRATION_MS;
 import static org.apache.hadoop.ipc.CallerContext.PROXY_USER_PORT;
 import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,6 +74,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.SafeModeAction;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.ha.HAServiceProtocol;
 import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSTestUtil;
@@ -115,6 +118,7 @@ import org.apache.hadoop.hdfs.server.federation.RouterConfigBuilder;
 import org.apache.hadoop.hdfs.server.federation.metrics.FederationRPCMetrics;
 import org.apache.hadoop.hdfs.server.federation.metrics.NamenodeBeanMetrics;
 import org.apache.hadoop.hdfs.server.federation.metrics.RBFMetrics;
+import org.apache.hadoop.hdfs.server.federation.resolver.ActiveNamenodeResolver;
 import org.apache.hadoop.hdfs.server.federation.resolver.FileSubclusterResolver;
 import org.apache.hadoop.hdfs.server.namenode.FSDirectory;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
@@ -2320,5 +2324,47 @@ public class TestRouterRpc {
       fileSystem1.delete(new Path(testPath1), true);
       fileSystem1.delete(new Path(testPath2), true);
     }
+  }
+
+  @Test
+  public void testClearStaleNamespacesInRouterStateIdContext() throws Exception {
+    Router testRouter = new Router();
+    Configuration routerConfig = DFSRouter.getConfiguration();
+    routerConfig.set(FEDERATION_STORE_MEMBERSHIP_EXPIRATION_MS, "2000");
+    routerConfig.set(RBFConfigKeys.DFS_ROUTER_SAFEMODE_ENABLE, "false");
+    // Mock resolver classes
+    routerConfig.setClass(RBFConfigKeys.FEDERATION_NAMENODE_RESOLVER_CLIENT_CLASS,
+        MockResolver.class, ActiveNamenodeResolver.class);
+    routerConfig.setClass(RBFConfigKeys.FEDERATION_FILE_RESOLVER_CLIENT_CLASS,
+        MockResolver.class, FileSubclusterResolver.class);
+
+    testRouter.init(routerConfig);
+    String nsID1 = cluster.getNameservices().get(0);
+    String nsID2 = cluster.getNameservices().get(1);
+    MockResolver resolver = (MockResolver)testRouter.getNamenodeResolver();
+    resolver.registerNamenode(createNamenodeReport(nsID1, "nn1",
+        HAServiceProtocol.HAServiceState.ACTIVE));
+    resolver.registerNamenode(createNamenodeReport(nsID2, "nn1",
+        HAServiceProtocol.HAServiceState.ACTIVE));
+
+    RouterRpcServer rpcServer = testRouter.getRpcServer();
+
+    rpcServer.getRouterStateIdContext().getNamespaceStateId(nsID1);
+    rpcServer.getRouterStateIdContext().getNamespaceStateId(nsID2);
+
+    resolver.disableNamespace(nsID1);
+    Thread.sleep(3000);
+    RouterStateIdContext context = rpcServer.getRouterStateIdContext();
+    assertEquals(2, context.getNamespaceIdMap().size());
+
+    testRouter.start();
+    Thread.sleep(3000);
+    // wait clear stale namespaces
+    RouterStateIdContext routerStateIdContext = rpcServer.getRouterStateIdContext();
+    int size = routerStateIdContext.getNamespaceIdMap().size();
+    assertEquals(1, size);
+    rpcServer.stop();
+    rpcServer.close();
+    testRouter.close();
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/block/BlockPoolTokenSecretManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/block/BlockPoolTokenSecretManager.java
@@ -141,9 +141,9 @@ public class BlockPoolTokenSecretManager extends
   /**
    * See {@link BlockTokenSecretManager#addKeys(ExportedBlockKeys)}.
    */
-  public void addKeys(String bpid, ExportedBlockKeys exportedKeys)
-      throws IOException {
-    get(bpid).addKeys(exportedKeys);
+  public void addKeys(String bpid, ExportedBlockKeys exportedKeys,
+                      boolean updateCurrentKey) throws IOException {
+    get(bpid).addKeys(exportedKeys, updateCurrentKey);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/block/BlockTokenSecretManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/block/BlockTokenSecretManager.java
@@ -218,17 +218,23 @@ public class BlockTokenSecretManager extends
     }
   }
 
+  public synchronized void addKeys(ExportedBlockKeys exportedKeys) throws IOException {
+    addKeys(exportedKeys, true);
+  }
+
   /**
    * Set block keys, only to be used in worker mode
    */
-  public synchronized void addKeys(ExportedBlockKeys exportedKeys)
-      throws IOException {
+  public synchronized void addKeys(ExportedBlockKeys exportedKeys,
+      boolean updateCurrentKey) throws IOException {
     if (isMaster || exportedKeys == null) {
       return;
     }
     LOG.info("Setting block keys. BlockPool = {} .", blockPoolId);
     removeExpiredKeys();
-    this.currentKey = exportedKeys.getCurrentKey();
+    if (updateCurrentKey) {
+      this.currentKey = exportedKeys.getCurrentKey();
+    }
     BlockKey[] receivedKeys = exportedKeys.getAllKeys();
     for (int i = 0; i < receivedKeys.length; i++) {
       if (receivedKeys[i] != null) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -789,7 +789,7 @@ public class BlockManager implements BlockStatsMXBean {
     checkNSRunning = false;
   }
 
-  private boolean isBlockTokenEnabled() {
+  protected boolean isBlockTokenEnabled() {
     return blockTokenSecretManager != null;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -2043,10 +2043,13 @@ public class DatanodeManager {
     }
   }
   
-  public void markAllDatanodesStale() {
+  public void markAllDatanodesStaleAndSetNeedKeyUpdate() {
     LOG.info("Marking all datanodes as stale");
     synchronized (this) {
       for (DatanodeDescriptor dn : datanodeMap.values()) {
+        if (blockManager.isBlockTokenEnabled()) {
+          dn.setNeedKeyUpdate(true);
+        }
         for(DatanodeStorageInfo storage : dn.getStorageInfos()) {
           storage.markStaleAfterFailover();
         }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPOfferService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPOfferService.java
@@ -427,8 +427,10 @@ class BPOfferService {
       dn.bpRegistrationSucceeded(bpRegistration, getBlockPoolId());
       // Add the initial block token secret keys to the DN's secret manager.
       if (dn.isBlockTokenEnabled) {
+        boolean updateCurrentKey = bpServiceActor.state == null
+            || bpServiceActor.state == HAServiceState.ACTIVE;
         dn.blockPoolTokenSecretManager.addKeys(getBlockPoolId(),
-            reg.getExportedKeys());
+            reg.getExportedKeys(), updateCurrentKey);
       }
     } finally {
       writeUnlock();
@@ -781,7 +783,7 @@ class BPOfferService {
       if (dn.isBlockTokenEnabled) {
         dn.blockPoolTokenSecretManager.addKeys(
             getBlockPoolId(), 
-            ((KeyUpdateCommand) cmd).getExportedKeys());
+            ((KeyUpdateCommand) cmd).getExportedKeys(), true);
       }
       break;
     case DatanodeProtocol.DNA_BALANCERBANDWIDTHUPDATE:
@@ -822,7 +824,7 @@ class BPOfferService {
       if (dn.isBlockTokenEnabled) {
         dn.blockPoolTokenSecretManager.addKeys(
             getBlockPoolId(), 
-            ((KeyUpdateCommand) cmd).getExportedKeys());
+            ((KeyUpdateCommand) cmd).getExportedKeys(), false);
       }
       break;
     case DatanodeProtocol.DNA_TRANSFER:

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -313,6 +313,7 @@ class BPServiceActor implements Runnable {
     // This also initializes our block pool in the DN if we are
     // the first NN connection for this BP.
     bpos.verifyAndSetNamespaceInfo(this, nsInfo);
+    state = nsInfo.getState();
 
     /* set thread name again to include NamespaceInfo when it's available. */
     this.bpThread.setName(formatThreadName("heartbeating", nnAddr));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -1850,7 +1850,7 @@ public class DataNode extends ReconfigurableBase
   }
 
   @VisibleForTesting
-  void setIBRDisabledForTest(boolean disabled) {
+  public void setIBRDisabledForTest(boolean disabled) {
     this.ibrDisabledForTests = disabled;
   }
 
@@ -1859,7 +1859,7 @@ public class DataNode extends ReconfigurableBase
     return this.ibrDisabledForTests;
   }
 
-  void setCacheReportsDisabledForTest(boolean disabled) {
+  public void setCacheReportsDisabledForTest(boolean disabled) {
     this.cacheReportsDisabledForTests = disabled;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
@@ -1468,6 +1468,7 @@ class DataXceiver extends Receiver implements Runnable {
           LOG.warn("Block token verification failed: op={}, " +
                   "remoteAddress={}, message={}",
               op, remoteAddress, e.getLocalizedMessage());
+          datanode.getMetrics().incrInvalidTokenCount();
           throw e;
         } finally {
           IOUtils.closeStream(out);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
@@ -102,6 +102,8 @@ public class DataNodeMetrics {
   final MutableQuantiles[]   ramDiskBlocksLazyPersistWindowMsQuantiles;
 
   @Metric MutableCounterLong fsyncCount;
+
+  @Metric MutableCounterLong invalidTokenCount;
   
   @Metric MutableCounterLong volumeFailures;
 
@@ -348,6 +350,10 @@ public class DataNodeMetrics {
     blocksWritten.incr();
   }
 
+  public long getBlocksWrittenCount() {
+    return blocksWritten.value();
+  }
+
   public void incrBlocksRemoved(int delta) {
     blocksRemoved.incr(delta);
   }
@@ -407,6 +413,14 @@ public class DataNodeMetrics {
 
   public void incrFsyncCount() {
     fsyncCount.incr();
+  }
+
+  public void incrInvalidTokenCount() {
+    invalidTokenCount.incr();
+  }
+
+  public long getInvalidTokenCount() {
+    return invalidTokenCount.value();
   }
 
   public void incrTotalWriteTime(long timeTaken) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -1405,7 +1405,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
         editLogTailer.catchupDuringFailover();
         
         blockManager.setPostponeBlocksFromFuture(false);
-        blockManager.getDatanodeManager().markAllDatanodesStale();
+        blockManager.getDatanodeManager().markAllDatanodesStaleAndSetNeedKeyUpdate();
         blockManager.clearQueues();
         blockManager.processAllPendingDNMessages();
         blockManager.getBlockIdManager().applyImpendingGenerationStamp();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestGetBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestGetBlocks.java
@@ -535,7 +535,7 @@ public class TestGetBlocks {
     assertEquals(blockNum - count, blocks.length);
 
     // set all storage stale
-    bm0.getDatanodeManager().markAllDatanodesStale();
+    bm0.getDatanodeManager().markAllDatanodesStaleAndSetNeedKeyUpdate();
     blocks = namenode.getBlocks(
         dataNodes[0], fileLen*2, 0, 0, null).getBlocks();
     assertEquals(0, blocks.length);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/security/token/block/TestBlockToken.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/security/token/block/TestBlockToken.java
@@ -467,7 +467,7 @@ public class TestBlockToken {
       bpMgr.addBlockPool(bpid, slaveHandler);
 
       ExportedBlockKeys keys = masterHandler.exportKeys();
-      bpMgr.addKeys(bpid, keys);
+      bpMgr.addKeys(bpid, keys, true);
       String[] storageIds = new String[] {"DS-9001"};
       tokenGenerationAndVerification(masterHandler, bpMgr.get(bpid),
           new StorageType[]{StorageType.DEFAULT}, storageIds);
@@ -480,7 +480,7 @@ public class TestBlockToken {
       tokenGenerationAndVerification(masterHandler, bpMgr.get(bpid), null,
           null);
       keys = masterHandler.exportKeys();
-      bpMgr.addKeys(bpid, keys);
+      bpMgr.addKeys(bpid, keys, true);
       tokenGenerationAndVerification(masterHandler, bpMgr.get(bpid),
           new StorageType[]{StorageType.DEFAULT}, new String[]{"DS-9001"});
       tokenGenerationAndVerification(masterHandler, bpMgr.get(bpid), null,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/security/token/block/TestUpdateDataNodeCurrentKey.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/security/token/block/TestUpdateDataNodeCurrentKey.java
@@ -1,0 +1,170 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.security.token.block;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdfs.DFSClientAdapter;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.MiniDFSNNTopology;
+import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
+import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockManager;
+import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeDescriptor;
+import org.apache.hadoop.hdfs.server.datanode.DataNode;
+import org.apache.hadoop.hdfs.server.datanode.ReplicaInfo;
+import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsDatasetTestUtil;
+import org.apache.hadoop.hdfs.server.namenode.NameNode;
+import org.apache.hadoop.hdfs.server.protocol.DatanodeRegistration;
+import org.apache.hadoop.security.token.Token;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Random;
+
+public class TestUpdateDataNodeCurrentKey {
+  private static final Random RAN = new Random();
+  private static final short REPLICATION = (short)1;
+  private MiniDFSCluster cluster = null;
+  private Configuration config;
+  private  DistributedFileSystem fileSystem;
+
+  @Before
+  public void setup() throws IOException {
+    config = new Configuration();
+    config.setInt(
+        DFSConfigKeys.DFS_NAMENODE_REPLICATION_MAX_STREAMS_KEY, 8);
+    config.setInt(
+        DFSConfigKeys.DFS_NAMENODE_REPLICATION_STREAMS_HARD_LIMIT_KEY, 10);
+    config.setInt(
+        DFSConfigKeys.DFS_NAMENODE_REPLICATION_WORK_MULTIPLIER_PER_ITERATION,
+        12);
+    config.setInt(
+        DFSConfigKeys.DFS_NAMENODE_RECONSTRUCTION_PENDING_TIMEOUT_SEC_KEY,
+        300);
+    config.setBoolean(DFSConfigKeys.DFS_BLOCK_ACCESS_TOKEN_ENABLE_KEY, true);
+    config.setBoolean(DFSConfigKeys.DFS_BLOCK_ACCESS_TOKEN_ENABLE_KEY, true);
+
+    cluster = new MiniDFSCluster.Builder(config)
+        .nnTopology(MiniDFSNNTopology.simpleHATopology())
+        .numDataNodes(REPLICATION).build();
+    cluster.transitionToActive(0);
+    cluster.waitActive();
+  }
+
+  @After
+  public void shutDownCluster() throws IOException {
+    if (cluster != null) {
+      fileSystem.close();
+      cluster.shutdown();
+      cluster = null;
+    }
+  }
+
+  private void writeBlockToDataNode(DistributedFileSystem fs) throws IOException {
+    final Path p = new Path("/test");
+    final int size = (1 << 16) + RAN.nextInt(1 << 16);
+    final FSDataOutputStream out = fs.create(p, REPLICATION);
+    final byte[] bytes = new byte[1024];
+    for (int remaining = size; remaining > 0; ) {
+      RAN.nextBytes(bytes);
+      final int len = bytes.length < remaining ? bytes.length : remaining;
+      out.write(bytes, 0, len);
+      out.hflush();
+      remaining -= len;
+    }
+    out.close();
+  }
+
+  @Test
+  public void TestUpdateDatanodeCurrentKeyWithHATopology()
+      throws IOException, InterruptedException {
+    //Step1: create a file, write some data.
+    fileSystem = cluster.getFileSystem(0);
+    writeBlockToDataNode(fileSystem);
+    final DataNode oldDataNode = cluster.getDataNodes().get(0);
+
+    //Step2: add a new datanode for copy block
+    cluster.startDataNodes(config, 1, true, null, null);
+    final DataNode newDataNode = cluster.getDataNodes().get(1);
+    final String bpid = cluster.getNamesystem(0).getBlockPoolId();
+
+    final DatanodeInfo[] dataNodeInfos = cluster.getNameNodeRpc(0).
+        getDatanodeReport(HdfsConstants.DatanodeReportType.LIVE);
+    Assert.assertEquals(2, dataNodeInfos.length);
+
+    int i = 0;
+    DatanodeInfo oldNodeInfo = null;
+    DatanodeInfo newNodeInfo = null;
+    for (DatanodeRegistration dnReg = newDataNode.getDNRegistrationForBP(bpid);
+         i < dataNodeInfos.length && !dataNodeInfos[i].equals(dnReg); i++) {
+      Assert.assertTrue(i < dataNodeInfos.length);
+      oldNodeInfo = dataNodeInfos[i];
+      newNodeInfo = dataNodeInfos[1 - i];
+    }
+
+    final Collection<ReplicaInfo> replicas = FsDatasetTestUtil.getReplicas(
+        oldDataNode.getFSDataset(), bpid);
+    Assert.assertTrue(replicas.size() > 0);
+    final ReplicaInfo r = replicas.iterator().next();
+    final ExtendedBlock b = new ExtendedBlock(bpid, r.getBlockId(),
+        r.getVisibleLength(), r.getGenerationStamp());
+
+    //Step3: simulate new datanode losing contact to sbn
+    newDataNode.scheduleAllBlockReport(0);
+    newDataNode.setHeartbeatsDisabledForTests(true);
+    newDataNode.setIBRDisabledForTest(true);
+    newDataNode.setCacheReportsDisabledForTest(true);
+    Thread.sleep(3000);
+    cluster.restartNameNode(1, false);
+
+    //Step4: trigger old datanode heartbeatToStandby to update block token
+    final NameNode standbyNameNode = cluster.getNameNode(1);
+    final BlockManager sbm = standbyNameNode.getNamesystem().getBlockManager();
+    while (sbm.getDatanodeManager().getDatanodes().size() < 1) {
+      Thread.sleep(100);
+    }
+    sbm.getBlockTokenSecretManager().updateKeys();
+    DatanodeDescriptor datanode = sbm.getDatanodeManager().getDatanodeMap()
+        .entrySet().iterator().next().getValue();
+    datanode.setNeedKeyUpdate(true);
+    Thread.sleep(4000);
+
+    //Step4: trigger old datanode to transfer block to new block
+    Token<BlockTokenIdentifier> token = oldDataNode.getBlockPoolTokenSecretManager().
+        generateToken(b, EnumSet.of(BlockTokenIdentifier.AccessMode.COPY),
+            new StorageType[]{StorageType.DEFAULT}, new String[0]);
+    DFSTestUtil.transferFinalizedBlock(b, token, DFSClientAdapter.getDFSClient(fileSystem),
+        oldNodeInfo, newNodeInfo);
+    Thread.sleep(500);
+
+    Assert.assertTrue(newDataNode.getMetrics().getInvalidTokenCount() == 0);
+    Assert.assertTrue(newDataNode.getMetrics().getBlocksWrittenCount() == 1);
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
@@ -522,7 +522,7 @@ public class TestBlockManager {
     try {
       cluster.waitActive();
       BlockManager blockManager = cluster.getNamesystem().getBlockManager();
-      blockManager.getDatanodeManager().markAllDatanodesStale();
+      blockManager.getDatanodeManager().markAllDatanodesStaleAndSetNeedKeyUpdate();
       FileSystem fs = cluster.getFileSystem();
       FSDataOutputStream out = fs.create(file);
       for (int i = 0; i < 1024 * 1024 * 1; i++) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestCorruptionWithFailover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestCorruptionWithFailover.java
@@ -65,8 +65,8 @@ public class TestCorruptionWithFailover {
       BlockManager bm1 = cluster.getNamesystem(1).getBlockManager();
       // Mark datanodes as stale, as are marked if a namenode went through a
       // failover, to prevent replica deletion.
-      bm0.getDatanodeManager().markAllDatanodesStale();
-      bm1.getDatanodeManager().markAllDatanodesStale();
+      bm0.getDatanodeManager().markAllDatanodesStaleAndSetNeedKeyUpdate();
+      bm1.getDatanodeManager().markAllDatanodesStaleAndSetNeedKeyUpdate();
       // Restart the datanode
       cluster.restartDataNode(dn);
       // The replica from the datanode will be having lesser genstamp, so


### PR DESCRIPTION
We found that transfer block failed during the namenode upgrade. The specific error reported was that the block token verification failed. The reason is that during the datanode transfer block process, the source datanode uses its own generated block token, and the keyid comes from ANN or SBN. However, because the newly upgraded NN has just been started, the keyid owned by the source datanode may not be owned by the target datanode, so the write fails. Here's how to reproduce this situation in [HDFS-17383](https://issues.apache.org/jira/browse/HDFS-17383)

