### PR TITLE
YARN-11655. modify default value of Allocated GPUs and Reserved GPUs in yarn scheduler webui from -1 to 0

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/dao/AppInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/dao/AppInfo.java
@@ -121,8 +121,8 @@ public class AppInfo {
             .getReservedResources().getMemorySize();
         Integer gpuIndex = ResourceUtils.getResourceTypeIndex()
             .get(ResourceInformation.GPU_URI);
-        allocatedGpus = -1;
-        reservedGpus = -1;
+        allocatedGpus = 0L;
+        reservedGpus = 0L;
         if (gpuIndex != null) {
           allocatedGpus = usageReport.getUsedResources()
               .getResourceValue(ResourceInformation.GPU_URI);


### PR DESCRIPTION
in yarn scheduler webui,the value of Allocated GPUs and Reserved GPUs be set to 0 by default may be better. when GPUs not used,these values should be 0.
