### PR TITLE
HDFS-17391:Adjust the checkpoint io buffer size to the chunk size

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/TransferFsImage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/TransferFsImage.java
@@ -311,7 +311,7 @@ public class TransferFsImage {
       ImageServlet.setVerificationHeadersForPut(connection, imageFile);
 
       // Write the file to output stream.
-      writeFileToPutRequest(conf, connection, imageFile, canceler);
+      writeFileToPutRequest(conf, connection, imageFile, canceler, chunkSize);
 
       int responseCode = connection.getResponseCode();
       if (responseCode != HttpURLConnection.HTTP_OK) {
@@ -330,7 +330,8 @@ public class TransferFsImage {
   }
 
   private static void writeFileToPutRequest(Configuration conf,
-      HttpURLConnection connection, File imageFile, Canceler canceler)
+      HttpURLConnection connection, File imageFile, Canceler canceler,
+      int bufferSize)
       throws IOException {
     connection.setRequestProperty(Util.CONTENT_TYPE, "application/octet-stream");
     connection.setRequestProperty(Util.CONTENT_TRANSFER_ENCODING, "binary");
@@ -338,7 +339,7 @@ public class TransferFsImage {
     FileInputStream input = new FileInputStream(imageFile);
     try {
       copyFileToStream(output, imageFile, input,
-          ImageServlet.getThrottler(conf), canceler);
+          ImageServlet.getThrottler(conf), canceler, bufferSize);
     } finally {
       IOUtils.closeStream(input);
       IOUtils.closeStream(output);
@@ -352,13 +353,14 @@ public class TransferFsImage {
   public static void copyFileToStream(OutputStream out, File localfile,
       FileInputStream infile, DataTransferThrottler throttler)
     throws IOException {
-    copyFileToStream(out, localfile, infile, throttler, null);
+    copyFileToStream(out, localfile, infile, throttler, null, -1);
   }
 
   private static void copyFileToStream(OutputStream out, File localfile,
       FileInputStream infile, DataTransferThrottler throttler,
-      Canceler canceler) throws IOException {
-    byte buf[] = new byte[IO_FILE_BUFFER_SIZE];
+      Canceler canceler, int bufferSize) throws IOException {
+    int bufSize = bufferSize > 0 ? bufferSize : IO_FILE_BUFFER_SIZE;
+    byte buf[] = new byte[bufSize];
     long total = 0;
     int num = 1;
     IOException ioe = null;
@@ -372,7 +374,7 @@ public class TransferFsImage {
             shouldSendShortFile(localfile)) {
           // Test sending image shorter than localfile
           long len = localfile.length();
-          buf = new byte[(int)Math.min(len/2, IO_FILE_BUFFER_SIZE)];
+          buf = new byte[(int)Math.min(len/2, bufSize)];
           // This will read at most half of the image
           // and the rest of the image will be sent over the wire
           infile.read(buf);


### PR DESCRIPTION

Adjust the checkpoint io buffer size to the chunk size to reduce checkpoint time.
Before change：
2022-07-11 07:10:50,900 INFO org.apache.hadoop.hdfs.server.namenode.TransferFsImage: Uploaded image with txid 374700896827 to namenode at http://xxxx:50070/ in 1729.465 seconds
After change:
2022-07-12 08:15:55,068 INFO org.apache.hadoop.hdfs.server.namenode.TransferFsImage: Uploaded image with txid 375717629244 to namenode at http://xxxx:50070/ in 858.668 seconds

