### PR TITLE
HDFS-17394. [FGL] Remove unused WriteHoldCount of FSNamesystemLock

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ContentSummaryComputationContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ContentSummaryComputationContext.java
@@ -123,8 +123,7 @@ public class ContentSummaryComputationContext {
 
     // sanity check.
     if (!hadDirReadLock || !hadFsnReadLock || hadDirWriteLock ||
-        hadFsnWriteLock || dir.getReadHoldCount() != 1 ||
-        fsn.getReadHoldCount() != 1) {
+        hadFsnWriteLock || fsn.getReadHoldCount() != 1) {
       // cannot relinquish
       return false;
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -284,16 +284,6 @@ public class FSDirectory implements Closeable {
     return namesystem.hasReadLock();
   }
 
-  @Deprecated // dirLock is obsolete, use namesystem.fsLock instead
-  public int getReadHoldCount() {
-    return namesystem.getReadHoldCount();
-  }
-
-  @Deprecated // dirLock is obsolete, use namesystem.fsLock instead
-  public int getWriteHoldCount() {
-    return namesystem.getWriteHoldCount();
-  }
-
   public int getListLimit() {
     return lsLimit;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -1849,10 +1849,6 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     return this.fsLock.getReadHoldCount();
   }
 
-  public int getWriteHoldCount() {
-    return this.fsLock.getWriteHoldCount();
-  }
-
   /** Lock the checkpoint lock */
   public void cpLock() {
     this.cpLock.lock();


### PR DESCRIPTION
```
public int getWriteHoldCount() {
  return this.fsLock.getWriteHoldCount(FSNamesystemLockMode.GLOBAL);
}

@Deprecated // dirLock is obsolete, use namesystem.fsLock instead
public int getWriteHoldCount() {
  return namesystem.getWriteHoldCount();
}

// sanity check.
if (!hadDirReadLock || !hadFsnReadLock || hadDirWriteLock ||
    hadFsnWriteLock || dir.getReadHoldCount() != 1 ||
    fsn.getReadHoldCount() != 1) {
  // cannot relinquish
  return false;
} 
```

`getWriteHoldCount` in FSNamesystem.java and FSDirectory.java is unused.
`dir.getReadHoldCount()` is useless as it's same as `fsn.getReadHoldCount()`.