### PR TITLE
Revert "HADOOP-19071. Update maven-surefire-plugin from 3.0.0 to 3.2.5."

### DIFF
--- a/dev-support/bin/hadoop.sh
+++ b/dev-support/bin/hadoop.sh
@@ -577,7 +577,6 @@ function shadedclient_rebuild
 
   extra=(
     "-Dtest=NoUnitTests"
-    "-Dsurefire.failIfNoSpecifiedTests=false"
     "-Dmaven.javadoc.skip=true"
     "-Dcheckstyle.skip=true"
     "-Dspotbugs.skip=true"
@@ -615,7 +614,7 @@ function shadedclient_rebuild
   echo_and_redirect "${logfile}" \
     "${MAVEN}" "${MAVEN_ARGS[@]}" verify -fae --batch-mode -am \
       "${modules[@]}" \
-      -DskipShade -Dtest=NoUnitTests -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true \
+      -DskipShade -Dtest=NoUnitTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true \
       -Dspotbugs.skip=true ${extra[*]}
 
   count=$("${GREP}" -c '\[ERROR\]' "${logfile}")

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -169,7 +169,7 @@
 
     <!-- Plugin versions and config -->
     <maven-surefire-plugin.argLine>-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError</maven-surefire-plugin.argLine>
-    <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire-plugin.version}</maven-failsafe-plugin.version>
 


### PR DESCRIPTION
Reverts apache/hadoop#6537

The upgrade of maven-surefire-plugin is currently found to cause some unit tests not to be executed. Currently, some pr reports oom problems. I will roll back this change first and continue to follow up.