### PR TITLE
YARN-11657. Remove protobuf-2.5 from hadoop-yarn-api module (#6575)

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -315,12 +315,12 @@ Controlling the redistribution of the protobuf-2.5 dependency
 
     The protobuf 2.5.0 library is used at compile time to compile the class
     org.apache.hadoop.ipc.ProtobufHelper; this class known to have been used by
-    external projects in the past. Protobuf 2.5 is not used elsewhere in
+    external projects in the past. Protobuf 2.5 is not used directly in
     the Hadoop codebase; alongside the move to Protobuf 3.x a private successor
     class, org.apache.hadoop.ipc.internal.ShadedProtobufHelper is now used.
 
     The hadoop-common module no longer exports its compile-time dependency on
-    protobuf-2.5. Hadoop distributions no longer include it.
+    protobuf-java-2.5.
     Any application declaring a dependency on hadoop-commmon will no longer get
     the artifact added to their classpath.
     If is still required, then they must explicitly declare it:
@@ -337,9 +337,13 @@ Controlling the redistribution of the protobuf-2.5 dependency
 
            -Dcommon.protobuf2.scope=compile
 
-    If this is done then protobuf-2.5.0.jar will again be exported as a
+    If this is done then protobuf-java-2.5.0.jar will again be exported as a
     hadoop-common dependency, and included in the share/hadoop/common/lib/
     directory of any Hadoop distribution built.
+
+    Note that protobuf-java-2.5.0.jar is still placed in
+    share/hadoop/yarn/timelineservice/lib; this is needed by the hbase client
+    library.
 
 ----------------------------------------------------------------------------------
 Building components separately

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -395,9 +395,10 @@ hadoop-tools/hadoop-sls/src/main/html/js/thirdparty/d3.v3.js
 hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/static/d3-3.5.17.min.js
 leveldb v1.13
 
-com.google.protobuf:protobuf-java:3.6.1
+com.google.protobuf:protobuf-java:2.5.0
+com.google.protobuf:protobuf-java:3.21.12
 com.google.re2j:re2j:1.1
-com.jcraft:jsch:0.1.54
+com.jcraft:jsch:0.1.55
 com.thoughtworks.paranamer:paranamer:2.3
 jakarta.activation:jakarta.activation-api:1.2.1
 org.fusesource.leveldbjni:leveldbjni-all:1.8

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/pom.xml
@@ -63,11 +63,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.hadoop.thirdparty</groupId>
       <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
     </dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
@@ -72,6 +72,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+      <scope>${transient.protobuf2.scope}</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
@@ -112,10 +112,6 @@
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-servlet</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION

The import of protobuf-java-2.5 in the hadoop-yarn-api module is downgraded from "compile" to "provided"

This removes it from share/hadoop/yarn/lib/protobuf-java-2.5.0.jar

It is still found under
share/hadoop/yarn/timelineservice/lib/protobuf-java-2.5.0.jar


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

