### PR TITLE
HDFS-17397. Choose another DN as soon as possible, when encountering network issues

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -1183,10 +1183,12 @@ class DataStreamer extends Daemon {
             if (begin != null) {
               long duration = Time.monotonicNowNanos() - begin;
               if (TimeUnit.NANOSECONDS.toMillis(duration) > dfsclientSlowLogThresholdMs) {
-                LOG.info("Slow ReadProcessor read fields for block " + block
+                final String msg = "Slow ReadProcessor read fields for block " + block
                     + " took " + TimeUnit.NANOSECONDS.toMillis(duration) + "ms (threshold="
                     + dfsclientSlowLogThresholdMs + "ms); ack: " + ack
-                    + ", targets: " + Arrays.asList(targets));
+                    + ", targets: " + Arrays.asList(targets);
+                LOG.warn(msg);
+                throw new IOException(msg);
               }
             }
           }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

When there is a network issue between the client and DN, the write process will enter hang state. We hope to choose another DN as soon as possible when encountering network problems.

![image](https://github.com/apache/hadoop/assets/95013770/ea573949-ceea-45ce-9166-db5790154fd4)


![image](https://github.com/apache/hadoop/assets/95013770/f5b6877f-a58a-4a05-bc52-1cd32805f096)



### How was this patch tested?

Local tested.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

