### PR TITLE
HADOOP-19097. S3A: Set fs.s3a.connection.establish.timeout to 30s

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1609,7 +1609,7 @@
 
 <property>
   <name>fs.s3a.connection.establish.timeout</name>
-  <value>5s</value>
+  <value>30s</value>
   <description>Socket connection setup timeout in milliseconds; this will be retried
     more than once.</description>
 </property>


### PR DESCRIPTION

This is consistent with the java value.

I had thought of cutting all the fs.s3a settings from core-default, but think we maybe need to review our public docs before doing that. having to look at Constants.java shouldn't be the default way to learn about an option.

### How was this patch tested?

commented out my timeout from my auth-keys file (so it wasn't stamping on this default) and running the tests. The used ripgrep to look for the "is too low" message; only found in test cases where we explicitly created the problem.

```
2:2024-02-29 10:48:03,153 [JUnit-testMinimumDurationWins] WARN  impl.ConfigurationHelper (LogExactlyOnce.java:warn(39)) - Option fs.s3a.connection.acquisition.timeout is too low (1,000 ms). Setting to 15,000 ms instead
3:2024-02-29 10:48:03,153 [JUnit-testMinimumDurationWins] DEBUG impl.ConfigurationHelper (ConfigurationHelper.java:enforceMinimumDuration(127)) - Option fs.s3a.connection.acquisition.timeout is too low (1,000 ms). Setting to 15,000 ms instead
6:2024-02-29 10:48:03,153 [JUnit-testMinimumDurationWins] DEBUG impl.ConfigurationHelper (ConfigurationHelper.java:enforceMinimumDuration(127)) - Option fs.s3a.connection.establish.timeout is too low (1,000 ms). Setting to 15,000 ms instead
9:2024-02-29 10:48:03,154 [JUnit-testMinimumDurationWins] DEBUG impl.ConfigurationHelper (ConfigurationHelper.java:enforceMinimumDuration(127)) - Option fs.s3a.connection.timeout is too low (1,000 ms). Setting to 15,000 ms instead
22:2024-02-29 10:48:03,310 [JUnit-testEnforceMinDuration] DEBUG impl.ConfigurationHelper (ConfigurationHelper.java:enforceMinimumDuration(127)) - Option key is too low (1,000 ms). Setting to 10,000 ms instead

```


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

