### PR TITLE
HADOOP-19099. Add Protobuf Compatibility Notes

### DIFF
--- a/hadoop-project/src/site/markdown/index.md.vm
+++ b/hadoop-project/src/site/markdown/index.md.vm
@@ -242,6 +242,16 @@ you want to remain exclusively *your cluster*.
 Finally, if you are using Hadoop as a service deployed/managed by someone else,
 do determine what security their products offer and make sure it meets your requirements.
 
+Protobuf Compatibility
+===============
+
+In HADOOP-18197, we upgraded the Protobuf in hadoop-thirdparty to version 3.21.12.
+This version may have compatibility issues with certain versions of JDK8,
+and you may encounter some errors (please refer to the discussion in HADOOP-18197 for specific details).
+
+To address this issue, we recommend upgrading the JDK version in your production environment to a higher version (> JDK8).
+We will resolve this issue by upgrading hadoop-thirdparty's Protobuf to a higher version in a future release of 3.4.x.
+Please note that we will discontinue support for JDK8 in future releases of 3.4.x.
 
 Getting Started
 ===============


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19099. Add Protobuf Compatibility Notes.

In [HADOOP-18197](https://issues.apache.org/jira/browse/HADOOP-18197), we upgraded the Protobuf in hadoop-thirdparty to version 3.21.12. This version may have compatibility issues with certain versions of JDK8. We will document this situation in the index.md file of hadoop 3.4.0 and inform users that we will discontinue support for JDK8 in the future.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

