### PR TITLE
HDFS-17299. Adding rack failure tolerance when creating a new file 

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -1242,7 +1242,8 @@ class DataStreamer extends Daemon {
       streamerClosed = true;
       return false;
     }
-    boolean doSleep = setupPipelineForAppendOrRecovery();
+    boolean doSleep = false;
+    setupPipelineForAppendOrRecovery();
 
     if (!streamerClosed && dfsClient.clientRunning) {
       if (stage == BlockConstructionStage.PIPELINE_CLOSE) {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -1671,7 +1671,6 @@ class DataStreamer extends Daemon {
         // Connect to first DataNode in the list.
         success = createBlockOutputStream(nodes, nextStorageTypes, 0L, false)
             || setupPipelineForAppendOrRecovery();
-
       } catch(IOException ie) {
         LOG.warn("Exception in setupPipelineForCreate " + this, ie);
         success = false;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -1242,7 +1242,7 @@ class DataStreamer extends Daemon {
       streamerClosed = true;
       return false;
     }
-    boolean doSleep = false;
+
     setupPipelineForAppendOrRecovery();
 
     if (!streamerClosed && dfsClient.clientRunning) {
@@ -1277,7 +1277,7 @@ class DataStreamer extends Daemon {
       }
     }
 
-    return doSleep;
+    return false;
   }
 
   void setHflush() {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -608,10 +608,6 @@ class DataStreamer extends Daemon {
     this.storageIDs = storageIDs;
   }
 
-  void setAccessToken(Token<BlockTokenIdentifier> t) {
-    this.accessToken = t;
-  }
-
   /**
    * Initialize for data streaming
    */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
@@ -212,7 +212,10 @@ class BlockReceiver implements Closeable {
       } else {
         switch (stage) {
         case PIPELINE_SETUP_CREATE:
-          replicaHandler = datanode.data.createRbw(storageType, block, allowLazyPersist);
+          replicaHandler = datanode.data.createRbw(storageType, block, allowLazyPersist, newGs);
+          if (newGs != 0L) {
+            block.setGenerationStamp(newGs);
+          }
           datanode.notifyNamenodeReceivingBlock(
               block, replicaHandler.getReplica().getStorageUuid());
           break;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/FsDatasetSpi.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/FsDatasetSpi.java
@@ -334,6 +334,16 @@ public interface FsDatasetSpi<V extends FsVolumeSpi> extends FSDatasetMBean {
       ExtendedBlock b, boolean allowLazyPersist) throws IOException;
 
   /**
+   * Creates a RBW replica and returns the meta info of the replica
+   *
+   * @param b block
+   * @return the meta info of the replica which is being written to
+   * @throws IOException if an error occurs
+   */
+  ReplicaHandler createRbw(StorageType storageType,
+      ExtendedBlock b, boolean allowLazyPersist, long newGS) throws IOException;
+
+  /**
    * Recovers a RBW replica and returns the meta info of the replica.
    *
    * @param b block
@@ -466,7 +476,7 @@ public interface FsDatasetSpi<V extends FsVolumeSpi> extends FSDatasetMBean {
   boolean isValidRbw(ExtendedBlock b);
 
   /**
-   * Invalidates the specified blocks
+   * Invalidates the specified blocks.
    * @param bpid Block pool Id
    * @param invalidBlks - the blocks to be invalidated
    * @throws IOException

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -3547,5 +3547,3 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
     }
   }
 }
-
-

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -1472,13 +1472,29 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
   public ReplicaHandler createRbw(
       StorageType storageType, ExtendedBlock b, boolean allowLazyPersist)
       throws IOException {
+    return createRbw(storageType, b, allowLazyPersist, 0L);
+  }
+
+  @Override // FsDatasetSpi
+  public ReplicaHandler createRbw(
+      StorageType storageType, ExtendedBlock b,
+      boolean allowLazyPersist, long newGS) throws IOException {
     try(AutoCloseableLock lock = datasetWriteLock.acquire()) {
       ReplicaInfo replicaInfo = volumeMap.get(b.getBlockPoolId(),
           b.getBlockId());
       if (replicaInfo != null) {
-        throw new ReplicaAlreadyExistsException("Block " + b +
-            " already exists in state " + replicaInfo.getState() +
-            " and thus cannot be created.");
+        // In case of retries with same blockPoolId + blockId as before
+        // with updated GS, cleanup the old replica to avoid
+        // any multiple copies with same blockPoolId + blockId
+        if (newGS != 0L) {
+          cleanupReplica(replicaInfo, replicaInfo.getBlockFile(), replicaInfo.getMetaFile(),
+              replicaInfo.getBlockFile().length(), replicaInfo.getMetaFile().length(),
+              b.getBlockPoolId());
+        } else {
+          throw new ReplicaAlreadyExistsException("Block " + b +
+              " already exists in state " + replicaInfo.getState() +
+              " and thus cannot be created.");
+        }
       }
       // create a new block
       FsVolumeReference ref = null;
@@ -3198,6 +3214,14 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
         newReplicaInfo.isOnTransientStorage());
 
     // Remove the old replicas
+    cleanupReplica(replicaInfo, blockFile, metaFile, blockFileUsed, metaFileUsed, bpid);
+
+    // If deletion failed then the directory scanner will cleanup the blocks
+    // eventually.
+  }
+
+  private void cleanupReplica(ReplicaInfo replicaInfo, File blockFile, File metaFile,
+      long blockFileUsed, long metaFileUsed, final String bpid) {
     if (blockFile.delete() || !blockFile.exists()) {
       FsVolumeImpl volume = (FsVolumeImpl) replicaInfo.getVolume();
       volume.onBlockFileDeletion(bpid, blockFileUsed);
@@ -3205,9 +3229,6 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
         volume.onMetaFileDeletion(bpid, metaFileUsed);
       }
     }
-
-    // If deletion failed then the directory scanner will cleanup the blocks
-    // eventually.
   }
 
   class LazyWriter implements Runnable {
@@ -3526,3 +3547,5 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
     }
   }
 }
+
+

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestCrcCorruption.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestCrcCorruption.java
@@ -86,7 +86,7 @@ public class TestCrcCorruption {
    * create/write. To recover from corruption while writing, at
    * least two replicas are needed.
    */
-  @Test(timeout=50000)
+  @Test(timeout=600000)
   public void testCorruptionDuringWrt() throws Exception {
     Configuration conf = new HdfsConfiguration();
     // Set short retry timeouts so this test runs faster

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestCrcCorruption.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestCrcCorruption.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.datanode.FinalizedReplica;
 import org.apache.hadoop.io.IOUtils;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -86,7 +87,7 @@ public class TestCrcCorruption {
    * create/write. To recover from corruption while writing, at
    * least two replicas are needed.
    */
-  @Test(timeout=600000)
+  @Test(timeout=50000)
   public void testCorruptionDuringWrt() throws Exception {
     Configuration conf = new HdfsConfiguration();
     // Set short retry timeouts so this test runs faster

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestCrcCorruption.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestCrcCorruption.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.datanode.FinalizedReplica;
 import org.apache.hadoop.io.IOUtils;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -1760,7 +1760,8 @@ public class TestDistributedFileSystem {
         DFSTestUtil.createFile(fs, new Path("/testFile"), 1024L, (short) 3, 1024L);
       } catch (IOException e) {
         threw = true;
-      } assertTrue(threw);
+      }
+      assertTrue(threw);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -1721,15 +1721,18 @@ public class TestDistributedFileSystem {
         false);
     conf.setInt(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.
         MIN_REPLICATION, 2);
-    // 3 racks & 3 nodes. 1 per rack
-    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3)
-        .racks(new String[] {"/rack1", "/rack2", "/rack3"}).build()) {
+    // 3 racks & 6 nodes. 1 per rack for 2 racks and 3 nodes in the 3rd rack
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(6)
+        .racks(new String[] {"/rack1", "/rack2", "/rack3", "/rack3", "/rack3", "/rack3"}).build()) {
       cluster.waitClusterUp();
       DistributedFileSystem fs = cluster.getFileSystem();
-      // kill one DN, so only 2 racks stays with active DN
-      cluster.stopDataNode(0);
+      // kill all the DNs in the 3rd rack.
+      cluster.stopDataNode(5);
+      cluster.stopDataNode(4);
+      cluster.stopDataNode(3);
+      cluster.stopDataNode(2);
+
       // create a file with replication 3, for rack fault tolerant BPP,
-      // it should allocate nodes in all 3 racks.
       DFSTestUtil.createFile(fs, new Path("/testFile"), 1024L, (short) 3, 1024L);
     }
   }
@@ -1742,13 +1745,16 @@ public class TestDistributedFileSystem {
         BlockPlacementPolicyRackFaultTolerant.class, BlockPlacementPolicy.class);
     conf.setBoolean(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.ENABLE_KEY, false);
     conf.setInt(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.MIN_REPLICATION, 3);
-    // 3 racks & 3 nodes. 1 per rack
-    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3)
-        .racks(new String[] {"/rack1", "/rack2", "/rack3"}).build()) {
+    // 3 racks & 6 nodes. 1 per rack for 2 racks and 3 nodes in the 3rd rack
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(6)
+        .racks(new String[] {"/rack1", "/rack2", "/rack3", "/rack3", "/rack3", "/rack3"}).build()) {
       cluster.waitClusterUp();
       DistributedFileSystem fs = cluster.getFileSystem();
       // kill one DN, so only 2 racks stays with active DN
-      cluster.stopDataNode(0);
+      cluster.stopDataNode(5);
+      cluster.stopDataNode(4);
+      cluster.stopDataNode(3);
+      cluster.stopDataNode(2);
       boolean threw = false;
       try {
         DFSTestUtil.createFile(fs, new Path("/testFile"), 1024L, (short) 3, 1024L);
@@ -1771,12 +1777,15 @@ public class TestDistributedFileSystem {
     conf.setInt(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.
         MIN_REPLICATION, 1);
     // 3 racks & 3 nodes. 1 per rack
-    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3)
-        .racks(new String[] {"/rack1", "/rack2", "/rack3"}).build()) {
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(6)
+        .racks(new String[] {"/rack1", "/rack2", "/rack3", "/rack3", "/rack3", "/rack3"}).build()) {
       cluster.waitClusterUp();
       DistributedFileSystem fs = cluster.getFileSystem();
-      // kill 2 DN, so only 1 racks stays with active DN
-      cluster.stopDataNode(0);
+      // kill one DN, so only 2 racks stays with active DN
+      cluster.stopDataNode(5);
+      cluster.stopDataNode(4);
+      cluster.stopDataNode(3);
+      cluster.stopDataNode(2);
       cluster.stopDataNode(1);
       // create a file with replication 3, for rack fault tolerant BPP,
       // it should allocate nodes in all 3 racks.
@@ -1797,12 +1806,15 @@ public class TestDistributedFileSystem {
     conf.setInt(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.
         MIN_REPLICATION, 2);
     // 3 racks & 3 nodes. 1 per rack
-    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3)
-        .racks(new String[] {"/rack1", "/rack2", "/rack3"}).build()) {
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(6)
+        .racks(new String[] {"/rack1", "/rack2", "/rack3", "/rack3", "/rack3", "/rack3"}).build()) {
       cluster.waitClusterUp();
       DistributedFileSystem fs = cluster.getFileSystem();
-      // kill 2 DN, so only 1 rack stays with active DN
-      cluster.stopDataNode(0);
+      // kill one DN, so only 2 racks stays with active DN
+      cluster.stopDataNode(5);
+      cluster.stopDataNode(4);
+      cluster.stopDataNode(3);
+      cluster.stopDataNode(2);
       cluster.stopDataNode(1);
       boolean threw = false;
       try {
@@ -1826,8 +1838,8 @@ public class TestDistributedFileSystem {
         HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.ENABLE_KEY,
         false);
     // 3 racks & 3 nodes. 1 per rack
-    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3)
-        .racks(new String[] {"/rack1", "/rack2", "/rack3"}).build()) {
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(6)
+        .racks(new String[] {"/rack1", "/rack2", "/rack3", "/rack3", "/rack3", "/rack3"}).build()) {
       cluster.waitClusterUp();
       DistributedFileSystem fs = cluster.getFileSystem();
       // shutdown all DNs

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -1721,12 +1721,12 @@ public class TestDistributedFileSystem {
         false);
     conf.setInt(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.
         MIN_REPLICATION, 2);
-    // 3 racks & 6 nodes. 1 per rack for 2 racks and 3 nodes in the 3rd rack
+    // 3 racks & 6 nodes. 1 per rack for 2 racks and 4 nodes in the 3rd rack
     try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(6)
         .racks(new String[] {"/rack1", "/rack2", "/rack3", "/rack3", "/rack3", "/rack3"}).build()) {
       cluster.waitClusterUp();
       DistributedFileSystem fs = cluster.getFileSystem();
-      // kill all the DNs in the 3rd rack.
+      // kill all the DNs in the 3rd rack, so only 2 racks stays with 1 active DN each
       cluster.stopDataNode(5);
       cluster.stopDataNode(4);
       cluster.stopDataNode(3);
@@ -1745,12 +1745,12 @@ public class TestDistributedFileSystem {
         BlockPlacementPolicyRackFaultTolerant.class, BlockPlacementPolicy.class);
     conf.setBoolean(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.ENABLE_KEY, false);
     conf.setInt(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.MIN_REPLICATION, 3);
-    // 3 racks & 6 nodes. 1 per rack for 2 racks and 3 nodes in the 3rd rack
+    // 3 racks & 6 nodes. 1 per rack for 2 racks and 4 nodes in the 3rd rack
     try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(6)
         .racks(new String[] {"/rack1", "/rack2", "/rack3", "/rack3", "/rack3", "/rack3"}).build()) {
       cluster.waitClusterUp();
       DistributedFileSystem fs = cluster.getFileSystem();
-      // kill one DN, so only 2 racks stays with active DN
+      // kill all the DNs in the 3rd rack, so only 2 racks stays with 1 active DN each
       cluster.stopDataNode(5);
       cluster.stopDataNode(4);
       cluster.stopDataNode(3);
@@ -1777,12 +1777,12 @@ public class TestDistributedFileSystem {
         false);
     conf.setInt(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.
         MIN_REPLICATION, 1);
-    // 3 racks & 3 nodes. 1 per rack
+    // 3 racks & 6 nodes. 1 per rack for 2 racks and 4 nodes in the 3rd rack
     try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(6)
         .racks(new String[] {"/rack1", "/rack2", "/rack3", "/rack3", "/rack3", "/rack3"}).build()) {
       cluster.waitClusterUp();
       DistributedFileSystem fs = cluster.getFileSystem();
-      // kill one DN, so only 2 racks stays with active DN
+      // kill all DNs except 1, so only rack1 stays with 1 active DN
       cluster.stopDataNode(5);
       cluster.stopDataNode(4);
       cluster.stopDataNode(3);
@@ -1806,12 +1806,12 @@ public class TestDistributedFileSystem {
         false);
     conf.setInt(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.
         MIN_REPLICATION, 2);
-    // 3 racks & 3 nodes. 1 per rack
+    // 3 racks & 6 nodes. 1 per rack for 2 racks and 4 nodes in the 3rd rack
     try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(6)
         .racks(new String[] {"/rack1", "/rack2", "/rack3", "/rack3", "/rack3", "/rack3"}).build()) {
       cluster.waitClusterUp();
       DistributedFileSystem fs = cluster.getFileSystem();
-      // kill one DN, so only 2 racks stays with active DN
+      // kill all DNs except 1, so only rack1 stays with 1 active DN
       cluster.stopDataNode(5);
       cluster.stopDataNode(4);
       cluster.stopDataNode(3);
@@ -1838,7 +1838,7 @@ public class TestDistributedFileSystem {
     conf.setBoolean(
         HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.ENABLE_KEY,
         false);
-    // 3 racks & 3 nodes. 1 per rack
+    // 3 racks & 6 nodes. 1 per rack for 2 racks and 4 nodes in the 3rd rack
     try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(6)
         .racks(new String[] {"/rack1", "/rack2", "/rack3", "/rack3", "/rack3", "/rack3"}).build()) {
       cluster.waitClusterUp();
@@ -1857,5 +1857,4 @@ public class TestDistributedFileSystem {
       assertTrue(threw);
     }
   }
-
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -54,7 +54,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.BlockStorageLocation;
@@ -89,6 +88,8 @@ import org.apache.hadoop.hdfs.client.impl.LeaseRenewer;
 import org.apache.hadoop.hdfs.DFSOpsCountStatistics.OpType;
 import org.apache.hadoop.hdfs.net.Peer;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockPlacementPolicy;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockPlacementPolicyRackFaultTolerant;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.datanode.DataNodeFaultInjector;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsDatasetSpi;
@@ -1707,4 +1708,141 @@ public class TestDistributedFileSystem {
       assertEquals("Number of SSD should be 1 but was : " + numSSD, 1, numSSD);
     }
   }
+
+  @Test
+  public void testSingleRackFailureDuringPipelineSetupMinReplicationPossible() throws Exception {
+    Configuration conf = getTestConfiguration();
+    conf.setClass(
+        DFSConfigKeys.DFS_BLOCK_REPLICATOR_CLASSNAME_KEY,
+        BlockPlacementPolicyRackFaultTolerant.class,
+        BlockPlacementPolicy.class);
+    conf.setBoolean(
+        HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.ENABLE_KEY,
+        false);
+    conf.setInt(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.
+        MIN_REPLICATION, 2);
+    // 3 racks & 3 nodes. 1 per rack
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3)
+        .racks(new String[] {"/rack1", "/rack2", "/rack3"}).build()) {
+      cluster.waitClusterUp();
+      DistributedFileSystem fs = cluster.getFileSystem();
+      // kill one DN, so only 2 racks stays with active DN
+      cluster.stopDataNode(0);
+      // create a file with replication 3, for rack fault tolerant BPP,
+      // it should allocate nodes in all 3 racks.
+      DFSTestUtil.createFile(fs, new Path("/testFile"), 1024L, (short) 3, 1024L);
+    }
+  }
+
+  @Test
+  public void testSingleRackFailureDuringPipelineSetupMinReplicationImpossible()
+      throws Exception {
+    Configuration conf = getTestConfiguration();
+    conf.setClass(DFSConfigKeys.DFS_BLOCK_REPLICATOR_CLASSNAME_KEY,
+        BlockPlacementPolicyRackFaultTolerant.class, BlockPlacementPolicy.class);
+    conf.setBoolean(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.ENABLE_KEY, false);
+    conf.setInt(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.MIN_REPLICATION, 3);
+    // 3 racks & 3 nodes. 1 per rack
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3)
+        .racks(new String[] {"/rack1", "/rack2", "/rack3"}).build()) {
+      cluster.waitClusterUp();
+      DistributedFileSystem fs = cluster.getFileSystem();
+      // kill one DN, so only 2 racks stays with active DN
+      cluster.stopDataNode(0);
+      boolean threw = false;
+      try {
+        DFSTestUtil.createFile(fs, new Path("/testFile"), 1024L, (short) 3, 1024L);
+      } catch (IOException e) {
+        threw = true;
+      } assertTrue(threw);
+    }
+  }
+
+  @Test
+  public void testMultipleRackFailureDuringPipelineSetupMinReplicationPossible() throws Exception {
+    Configuration conf = getTestConfiguration();
+    conf.setClass(
+        DFSConfigKeys.DFS_BLOCK_REPLICATOR_CLASSNAME_KEY,
+        BlockPlacementPolicyRackFaultTolerant.class,
+        BlockPlacementPolicy.class);
+    conf.setBoolean(
+        HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.ENABLE_KEY,
+        false);
+    conf.setInt(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.
+        MIN_REPLICATION, 1);
+    // 3 racks & 3 nodes. 1 per rack
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3)
+        .racks(new String[] {"/rack1", "/rack2", "/rack3"}).build()) {
+      cluster.waitClusterUp();
+      DistributedFileSystem fs = cluster.getFileSystem();
+      // kill 2 DN, so only 1 racks stays with active DN
+      cluster.stopDataNode(0);
+      cluster.stopDataNode(1);
+      // create a file with replication 3, for rack fault tolerant BPP,
+      // it should allocate nodes in all 3 racks.
+      DFSTestUtil.createFile(fs, new Path("/testFile"), 1024L, (short) 3, 1024L);
+    }
+  }
+
+  @Test
+  public void testMultipleRackFailureDuringPipelineSetupMinReplicationImpossible()
+      throws Exception {
+    Configuration conf = getTestConfiguration();
+    conf.setClass(DFSConfigKeys.DFS_BLOCK_REPLICATOR_CLASSNAME_KEY,
+        BlockPlacementPolicyRackFaultTolerant.class,
+        BlockPlacementPolicy.class);
+    conf.setBoolean(
+        HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.ENABLE_KEY,
+        false);
+    conf.setInt(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.
+        MIN_REPLICATION, 2);
+    // 3 racks & 3 nodes. 1 per rack
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3)
+        .racks(new String[] {"/rack1", "/rack2", "/rack3"}).build()) {
+      cluster.waitClusterUp();
+      DistributedFileSystem fs = cluster.getFileSystem();
+      // kill 2 DN, so only 1 rack stays with active DN
+      cluster.stopDataNode(0);
+      cluster.stopDataNode(1);
+      boolean threw = false;
+      try {
+        DFSTestUtil.createFile(fs, new Path("/testFile"),
+            1024L, (short) 3, 1024L);
+      } catch (IOException e) {
+        threw = true;
+      }
+      assertTrue(threw);
+    }
+  }
+
+  @Test
+  public void testAllRackFailureDuringPipelineSetup() throws Exception {
+    Configuration conf = getTestConfiguration();
+    conf.setClass(
+        DFSConfigKeys.DFS_BLOCK_REPLICATOR_CLASSNAME_KEY,
+        BlockPlacementPolicyRackFaultTolerant.class,
+        BlockPlacementPolicy.class);
+    conf.setBoolean(
+        HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.ENABLE_KEY,
+        false);
+    // 3 racks & 3 nodes. 1 per rack
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3)
+        .racks(new String[] {"/rack1", "/rack2", "/rack3"}).build()) {
+      cluster.waitClusterUp();
+      DistributedFileSystem fs = cluster.getFileSystem();
+      // shutdown all DNs
+      cluster.shutdownDataNodes();
+      // create a file with replication 3, for rack fault tolerant BPP,
+      // it should allocate nodes in all 3 rack but fail because no DNs are present.
+      boolean threw = false;
+      try {
+        DFSTestUtil.createFile(fs, new Path("/testFile"),
+            1024L, (short) 3, 1024L);
+      } catch (IOException e) {
+        threw = true;
+      }
+      assertTrue(threw);
+    }
+  }
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
@@ -1103,6 +1103,12 @@ public class SimulatedFSDataset implements FsDatasetSpi<FsVolumeSpi> {
     return createTemporary(storageType, b, false);
   }
 
+  @Override
+  public ReplicaHandler createRbw(StorageType storageType,
+      ExtendedBlock b, boolean allowLazyPersist, long newGS) throws IOException {
+    return createRbw(storageType, b, allowLazyPersist);
+  }
+
   @Override // FsDatasetSpi
   public synchronized ReplicaHandler createTemporary(StorageType storageType,
       ExtendedBlock b, boolean isTransfer) throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
@@ -149,6 +149,12 @@ public class ExternalDatasetImpl implements FsDatasetSpi<ExternalVolumeImpl> {
   }
 
   @Override
+  public ReplicaHandler createRbw(StorageType storageType,
+      ExtendedBlock b, boolean allowLazyPersist, long newGS) throws IOException {
+    return createRbw(storageType, b, allowLazyPersist);
+  }
+
+  @Override
   public ReplicaHandler recoverRbw(ExtendedBlock b, long newGS,
       long minBytesRcvd, long maxBytesRcvd) throws IOException {
     return new ReplicaHandler(new ExternalReplicaInPipeline(), null);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

