### PR TITLE
HDFS-17402. StartupSafeMode should not exit when resources are from l…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -4539,7 +4539,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
           } else {
             if (isNoManualAndResourceLowSafeMode()) {
               LOG.info("Namenode has sufficient available resources, exiting safe mode.");
-              leaveSafeMode(false);
+              leaveResourceLowSafeMode();
             }
           }
           try {
@@ -5244,6 +5244,23 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
         setManualAndResourceLowSafeMode(false, false);
         startSecretManagerIfNecessary();
       }
+    } finally {
+      writeUnlock("leaveSafeMode", getLockReportInfoSupplier(null));
+    }
+  }
+
+  /**
+   * Leave resource low safe mode.
+   */
+  void leaveResourceLowSafeMode() {
+    writeLock();
+    try {
+      if (!isInSafeMode()) {
+        NameNode.stateChangeLog.info("STATE* Safe mode is already OFF");
+        return;
+      }
+      setManualAndResourceLowSafeMode(false, false);
+      startSecretManagerIfNecessary();
     } finally {
       writeUnlock("leaveSafeMode", getLockReportInfoSupplier(null));
     }


### PR DESCRIPTION
### Description of PR
Refer to [HDFS-17402](https://issues.apache.org/jira/browse/HDFS-17402).
After [HDFS-17231](https://issues.apache.org/jira/browse/HDFS-17231), NameNode can exit safemode automatically when resources are from low to available. It used org.apache.hadoop.hdfs.server.namenode.FSNamesystem#leaveSafeMode, this function will change BMSafeModeStatus. However, NameNode entering resource low safe mode doesn't change BMSafeModeStatus in org.apache.hadoop.hdfs.server.namenode.FSNamesystem#enterSafeMode. This is not equal
Now:
a. NN enter StartupSafeMode
b. NN enter ResourceLowSafeMode
c. NN resources from low to available
d. NN safemode off
 
Expectations：
a. NN enter StartupSafeMode
b. NN enter ResourceLowSafeMode
c. NN resources from low to available
d. NN exit ResourceLowSafeMode but in StartupSafeMode

### How was this patch tested?
Add UT

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

