### PR TITLE
HDFS-17422. Enhance the stability of the unit test TestDFSAdmin.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -1353,8 +1353,14 @@ public class TestDFSAdmin {
           decommissioningNode1.getIpcPort();
       String node2Addr = decommissioningNode2.getIpAddr() + ":" +
           decommissioningNode2.getIpcPort();
-      assertTrue(outsForFinishReconf.get(0).contains(node1Addr)
-          && outsForFinishReconf.get(0).contains(node2Addr));
+      int finishedReconfCount = 0;
+      for (String outMessage : outsForFinishReconf) {
+        finishedReconfCount = outMessage.contains(node1Addr) ?
+            finishedReconfCount + 1 : finishedReconfCount + 0;
+        finishedReconfCount = outMessage.contains(node2Addr) ?
+            finishedReconfCount + 1 : finishedReconfCount + 0;
+      }
+      assertTrue(finishedReconfCount == 2);
     }
   }
 


### PR DESCRIPTION

It has been observed that TestDFSAdmin frequently fails tests, such as [PR-6620](https://github.com/apache/hadoop/pull/6620). The failure occurs when the test method testDecommissionDataNodesReconfig asserts the first line of the standard output. The issue arises when the content being checked does not appear on a single line. I believe we should change the method of testing. The standard output content, which was printed in [PR-6620](https://github.com/apache/hadoop/pull/6620).