### PR TITLE
MAPREDUCE-7402. fix mapreduce.task.io.sort.factor=1 lead to an infinite loop.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/MergeManagerImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/MergeManagerImpl.java
@@ -179,9 +179,8 @@ public class MergeManagerImpl<K, V> implements MergeManager<K, V> {
     this.ioSortFactor = jobConf.getInt(MRJobConfig.IO_SORT_FACTOR,
         MRJobConfig.DEFAULT_IO_SORT_FACTOR);
     if (this.ioSortFactor <= 1) {
-      throw new IllegalArgumentException("Invalid value for "
-          + MRJobConfig.IO_SORT_FACTOR +": "
-          + this.ioSortFactor + ", please set it to a number greater than 1");
+      LOG.warn("Invalid value for {} : {}, please set it to a number greater than 1",
+          MRJobConfig.IO_SORT_FACTOR, this.ioSortFactor);
     }
 
     final float singleShuffleMemoryLimitPercent =

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/MergeManagerImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/MergeManagerImpl.java
@@ -178,6 +178,11 @@ public class MergeManagerImpl<K, V> implements MergeManager<K, V> {
 
     this.ioSortFactor = jobConf.getInt(MRJobConfig.IO_SORT_FACTOR,
         MRJobConfig.DEFAULT_IO_SORT_FACTOR);
+    if (this.ioSortFactor <= 1) {
+      throw new IllegalArgumentException("Invalid value for "
+          + MRJobConfig.IO_SORT_FACTOR +": "
+          + this.ioSortFactor + ", please set it to a number greater than 1");
+    }
 
     final float singleShuffleMemoryLimitPercent =
         jobConf.getFloat(MRJobConfig.SHUFFLE_MEMORY_LIMIT_PERCENT,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMerger.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMerger.java
@@ -84,8 +84,6 @@ public class TestMerger {
   private File unitTestDir;
   private JobConf jobConf;
   private FileSystem fs;
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @BeforeClass
   public static void setupClass() throws Exception {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMerger.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMerger.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.mapreduce.task.reduce;
 
-import static org.apache.hadoop.mapreduce.MRJobConfig.IO_SORT_FACTOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -64,7 +63,6 @@ import org.apache.hadoop.mapreduce.util.MRJobConfUtil;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.Progress;
 import org.apache.hadoop.util.Progressable;
 import org.junit.Assert;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMerger.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMerger.java
@@ -72,7 +72,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TestName;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMerger.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMerger.java
@@ -231,16 +231,6 @@ public class TestMerger {
     Assert.assertEquals(0, mergeManager.inMemoryMapOutputs.size());
     Assert.assertEquals(0, mergeManager.inMemoryMergedMapOutputs.size());
     Assert.assertEquals(0, mergeManager.onDiskMapOutputs.size());
-
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid value for mapreduce.task.io.sort.factor: 1, " +
-            "please set it to a number greater than 1",
-        () -> {
-          jobConf.set(IO_SORT_FACTOR, "1");
-          return new MergeManagerImpl<Text, Text>(reduceId2, jobConf, fs, lda, Reporter.NULL, null,
-              null, null, null, null,
-              null, null, new Progress(), new MROutputFiles());
-        });
   }
 
   private byte[] writeMapOutput(Configuration conf, Map<String, String> keysToValues)

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMerger.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMerger.java
@@ -70,6 +70,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TestName;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -81,6 +82,8 @@ public class TestMerger {
   private File unitTestDir;
   private JobConf jobConf;
   private FileSystem fs;
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   @BeforeClass
   public static void setupClass() throws Exception {
@@ -229,6 +232,14 @@ public class TestMerger {
     Assert.assertEquals(0, mergeManager.inMemoryMapOutputs.size());
     Assert.assertEquals(0, mergeManager.inMemoryMergedMapOutputs.size());
     Assert.assertEquals(0, mergeManager.onDiskMapOutputs.size());
+
+    jobConf.set("mapreduce.task.io.sort.factor", "1");
+    thrown.expectMessage("Invalid value for mapreduce.task.io.sort.factor: 1," +
+        " please set it to a number greater than 1");
+    thrown.expect(IllegalArgumentException.class);
+    new MergeManagerImpl<Text, Text>(reduceId2, jobConf, fs, lda, Reporter.NULL, null,
+        null, null, null, null,
+        null, null, new Progress(), new MROutputFiles());
   }
 
   private byte[] writeMapOutput(Configuration conf, Map<String, String> keysToValues)

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMerger.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMerger.java
@@ -33,7 +33,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.Callable;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
see also: https://issues.apache.org/jira/browse/MAPREDUCE-7402
In the method :  
  long computeBytesInMerges(int factor, int inMem), 
when factor is set to 1, and the initial numSegments>1, inMem=0, it will cause an infinite loop of while. Although setting factor to 1 is meaningless, and it will not be done in actual production, we need to remind users to avoid an infinite loop due to carelessness.

![image](https://github.com/apache/hadoop/assets/38941777/e1c03a38-c66e-4a2a-bb90-1fc0fa3eff3f)


### How was this patch tested?
new UT testInMemoryAndOnDiskMerger()


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

