### PR TITLE
YARN-11660. Fix huge performance regression for SingleConstraintAppPlacementAllocator

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/placement/SingleConstraintAppPlacementAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/placement/SingleConstraintAppPlacementAllocator.java
@@ -309,6 +309,8 @@ public class SingleConstraintAppPlacementAllocator<N extends SchedulerNode>
     // Deduct pending #allocations by 1
     ResourceSizing sizing = schedulingRequest.getResourceSizing();
     sizing.setNumAllocations(sizing.getNumAllocations() - 1);
+
+    appSchedulingInfo.decPendingResource(targetNodePartition, sizing.getResources());
   }
 
   @Override


### PR DESCRIPTION
### Description of PR

JIRA: YARN-11660. Fix huge performance regression for SingleConstraintAppPlacementAllocator.

When using the `SingleConstraintAppPlacementAllocator` with scheduling request in our internal cluster, I found the huge performance regression from the metric of `allocateAvgTime`. 

After digging this bug, I found this dangerous bug will always check the non-pending resource apps due to missing of desc pending resource for one app for the async scheduling threads.

### How was this patch tested?

Has been applied in our internal cluster

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

