### PR TITLE
HDFS-17426. Remove Invalid FileSystemECReadStats logic in DFSInputStream

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -63,7 +63,6 @@ import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.hdfs.DFSUtilClient.CorruptedBlocks;
 import org.apache.hadoop.hdfs.client.impl.BlockReaderFactory;
 import org.apache.hadoop.hdfs.client.impl.DfsClientConf;
-import org.apache.hadoop.hdfs.protocol.BlockType;
 import org.apache.hadoop.hdfs.protocol.ClientDatanodeProtocol;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfoWithStorage;
@@ -897,9 +896,6 @@ public class DFSInputStream extends FSInputStream
           updateReadStatistics(readStatistics, result, blockReader);
           dfsClient.updateFileSystemReadStats(blockReader.getNetworkDistance(),
               result, readTimeMS);
-          if (readStatistics.getBlockType() == BlockType.STRIPED) {
-            dfsClient.updateFileSystemECReadStats(result);
-          }
           return result;
         } catch (ChecksumException ce) {
           throw ce;
@@ -1238,9 +1234,6 @@ public class DFSInputStream extends FSInputStream
         IOUtilsClient.updateReadStatistics(readStatistics, nread, reader);
         dfsClient.updateFileSystemReadStats(
             reader.getNetworkDistance(), nread, readTimeMS);
-        if (readStatistics.getBlockType() == BlockType.STRIPED) {
-          dfsClient.updateFileSystemECReadStats(nread);
-        }
         if (nread != len) {
           throw new IOException("truncated return from reader.read(): " +
               "excpected " + len + ", got " + nread);


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17426

When read the replication file, the following logic will be called when `readingWithStrategy` and `actualGetFromOneDataNode` logic in `DFSInputStream.java`

```
 if (readStatistics.getBlockType() == BlockType.STRIPED) {
          dfsClient.updateFileSystemECReadStats(nread);
  }
```
This is invalid call, can remove it.

