### PR TITLE
HADOOP-14451. Deadlock in NativeIO

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/nativeio/NativeIO.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/nativeio/NativeIO.java
@@ -220,6 +220,9 @@ public class NativeIO {
       }
     }
 
+    /** Initialize the JNI method ID and class ID cache. */
+    private static native void initNativePosix(boolean doThreadsafeWorkaround);
+
     /**
      * JNI wrapper of persist memory operations.
      */
@@ -331,11 +334,11 @@ public class NativeIO {
       if (NativeCodeLoader.isNativeCodeLoaded()) {
         try {
           Configuration conf = new Configuration();
-          workaroundNonThreadSafePasswdCalls = conf.getBoolean(
-            WORKAROUND_NON_THREADSAFE_CALLS_KEY,
-            WORKAROUND_NON_THREADSAFE_CALLS_DEFAULT);
+          boolean workaroundNonThreadSafePasswdCalls = conf.getBoolean(
+              WORKAROUND_NON_THREADSAFE_CALLS_KEY,
+              WORKAROUND_NON_THREADSAFE_CALLS_DEFAULT);
 
-          initNative();
+          initNativePosix(workaroundNonThreadSafePasswdCalls);
           nativeLoaded = true;
 
           cacheTimeout = conf.getLong(
@@ -679,9 +682,6 @@ public class NativeIO {
         throws IOException;
   }
 
-  private static boolean workaroundNonThreadSafePasswdCalls = false;
-
-
   public static class Windows {
     // Flags for CreateFile() call on Windows
     public static final long GENERIC_READ = 0x80000000L;
@@ -833,7 +833,9 @@ public class NativeIO {
     static {
       if (NativeCodeLoader.isNativeCodeLoaded()) {
         try {
-          initNative();
+          initNativeWindows(false);
+          // As of now there is no change between initNative()
+          // and initNativeWindows() native impls.
           nativeLoaded = true;
         } catch (Throwable t) {
           // This can happen if the user has an older version of libhadoop.so
@@ -843,6 +845,10 @@ public class NativeIO {
         }
       }
     }
+
+    /** Initialize the JNI method ID and class ID cache. */
+    private static native void initNativeWindows(
+        boolean doThreadsafeWorkaround);
   }
 
   private static final Logger LOG = LoggerFactory.getLogger(NativeIO.class);
@@ -852,7 +858,7 @@ public class NativeIO {
   static {
     if (NativeCodeLoader.isNativeCodeLoaded()) {
       try {
-        initNative();
+        initNative(false);
         nativeLoaded = true;
       } catch (Throwable t) {
         // This can happen if the user has an older version of libhadoop.so
@@ -871,7 +877,7 @@ public class NativeIO {
   }
 
   /** Initialize the JNI method ID and class ID cache */
-  private static native void initNative();
+  private static native void initNative(boolean doThreadsafeWorkaround);
 
   /**
    * Get the maximum number of bytes that can be locked into memory at any

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/nativeio/TestNativeIoInit.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/nativeio/TestNativeIoInit.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.io.nativeio;
+
+import static org.junit.Assume.assumeTrue;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+
+/**
+ * Separate class to ensure forked Tests load the static blocks again.
+ */
+public class TestNativeIoInit {
+
+  /**
+   * Refer HADOOP-14451
+   * Scenario:
+   * 1. One thread calls a static method of NativeIO, which loads static block
+   * of NativeIo.
+   * 2. Second thread calls a static method of NativeIo.POSIX, which loads a
+   * static block of NativeIO.POSIX class
+   * <p>
+   * Expected: Loading these two static blocks separately should not result in
+   * deadlock.
+   */
+  @Test(timeout = 10000)
+  public void testDeadlockLinux() throws Exception {
+    Thread one = new Thread() {
+      @Override
+      public void run() {
+        NativeIO.isAvailable();
+      }
+    };
+    Thread two = new Thread() {
+      @Override
+      public void run() {
+        NativeIO.POSIX.isAvailable();
+      }
+    };
+    two.start();
+    one.start();
+    one.join();
+    two.join();
+  }
+
+  @Test(timeout = 10000)
+  public void testDeadlockWindows() throws Exception {
+    assumeTrue("Expected windows", Path.WINDOWS);
+    Thread one = new Thread() {
+      @Override
+      public void run() {
+        NativeIO.isAvailable();
+      }
+    };
+    Thread two = new Thread() {
+      @Override
+      public void run() {
+        try {
+          NativeIO.Windows.extendWorkingSetSize(100);
+        } catch (IOException e) {
+          //igored
+        }
+      }
+    };
+    two.start();
+    one.start();
+    one.join();
+    two.join();
+  }
+}


### PR DESCRIPTION
### Description of PR
* Scenario:
  1. One thread calls a static method of NativeIO, which loads static block of NativeIo.
  2. Second thread calls a static method of NativeIo.POSIX, which loads a static block of NativeIO.POSIX class

Both try to lock on same object inside native code gets into deadlock.

### How was this patch tested?
Reproducible Unit tests.

### For code changes:

- [* ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

