### PR TITLE
HDFS-17432. Fix junit dependency to enable JUnit4 tests to run in hadoop-hdfs-rbf

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
@@ -182,6 +182,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

After HDFS-17370, JUnit4 tests stopped running in hadoop-hdfs-rbf. To enable both JUnit4 and JUnit5 tests to run, we need to add junit-vintage-engine to the hadoop-hdfs-rbf/pom.xml.

### How was this patch tested?

I confirmed that all unit tests in hadoop-hdfs-rbf ran with this change with `cd hadoop-hdfs-project/hadoop-hdfs-rbf && mvn clean test -fae` in my local laptop.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
