### PR TITLE
HDFS-17433. metrics sumOfActorCommandQueueLength should only record valid commands.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -1487,8 +1487,10 @@ class BPServiceActor implements Runnable {
     }
 
     void enqueue(DatanodeCommand[] cmds) throws InterruptedException {
-      queue.put(() -> processCommand(cmds));
-      dn.getMetrics().incrActorCmdQueueLength(1);
+      if (cmds.length != 0) {
+        queue.put(() -> processCommand(cmds));
+        dn.getMetrics().incrActorCmdQueueLength(1); 
+      }
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -1489,7 +1489,7 @@ class BPServiceActor implements Runnable {
     void enqueue(DatanodeCommand[] cmds) throws InterruptedException {
       if (cmds.length != 0) {
         queue.put(() -> processCommand(cmds));
-        dn.getMetrics().incrActorCmdQueueLength(1); 
+        dn.getMetrics().incrActorCmdQueueLength(1);
       }
     }
   }


### PR DESCRIPTION
### Description of PR
  We add an phone alarm on metrics sumOfActorCommandQueueLength when it beyond 3000.
  Recently, we received the alarm and we found that `DatanodeCommand[] cmds` with array length equals to 0 was 
still put into queue and incrActorCmdQueueLength.
  When processedCommandsOpAvgTime is high, those empty cmds were put into queue every heartbeat intervel.
  sumOfActorCommandQueueLength should better only record valid commands.


