### PR TITLE
HADOOP-19013. Adding x-amz-server-side-encryption-aws-kms-key-id in the get file attributes for S3A.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSHeaders.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSHeaders.java
@@ -55,6 +55,9 @@ public interface AWSHeaders {
   /** Header for optional server-side encryption algorithm. */
   String SERVER_SIDE_ENCRYPTION = "x-amz-server-side-encryption";
 
+  /** Header for optional server-side encryption algorithm. */
+  String SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID = "x-amz-server-side-encryption-aws-kms-key-id";
+
   /** Range header for the get object request. */
   String RANGE = "Range";
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/HeaderProcessing.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/HeaderProcessing.java
@@ -47,6 +47,7 @@ import static org.apache.hadoop.fs.s3a.Statistic.INVOCATION_XATTR_GET_MAP;
 import static org.apache.hadoop.fs.s3a.Statistic.INVOCATION_XATTR_GET_NAMED;
 import static org.apache.hadoop.fs.s3a.Statistic.INVOCATION_XATTR_GET_NAMED_MAP;
 import static org.apache.hadoop.fs.s3a.commit.CommitConstants.X_HEADER_MAGIC_MARKER;
+import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.trackDuration;
 
 /**
@@ -184,6 +185,9 @@ public class HeaderProcessing extends AbstractStoreOperation {
    */
   public static final String XA_SERVER_SIDE_ENCRYPTION =
       XA_HEADER_PREFIX + AWSHeaders.SERVER_SIDE_ENCRYPTION;
+
+  public static final String XA_ENCRYPTION_KEY_ID =
+      XA_HEADER_PREFIX + SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID;
 
   /**
    * Storage Class XAttr: {@value}.
@@ -363,6 +367,8 @@ public class HeaderProcessing extends AbstractStoreOperation {
         md.versionId());
     maybeSetHeader(headers, XA_SERVER_SIDE_ENCRYPTION,
         md.serverSideEncryptionAsString());
+    maybeSetHeader(headers, XA_ENCRYPTION_KEY_ID,
+            md.ssekmsKeyId());
     maybeSetHeader(headers, XA_STORAGE_CLASS,
         md.storageClassAsString());
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/EncryptionTestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/EncryptionTestUtils.java
@@ -139,7 +139,8 @@ public final class EncryptionTestUtils {
     Assertions.assertThat(xAttrs)
             .describedAs("Encryption key id should be present")
             .containsKey(XA_ENCRYPTION_KEY_ID);
-    kmsKey.ifPresent(s -> Assertions.assertThat(HeaderProcessing.decodeBytes(xAttrs.get(XA_ENCRYPTION_KEY_ID)))
+    kmsKey.ifPresent(s -> Assertions
+            .assertThat(HeaderProcessing.decodeBytes(xAttrs.get(XA_ENCRYPTION_KEY_ID)))
               .describedAs("Encryption key id should match with the kms key")
               .isEqualTo(s));
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/EncryptionTestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/EncryptionTestUtils.java
@@ -19,7 +19,13 @@
 package org.apache.hadoop.fs.s3a;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
 
+import org.apache.hadoop.fs.s3a.impl.HeaderProcessing;
+import org.apache.hadoop.io.IOUtils;
+import org.assertj.core.api.Assertions;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 import org.apache.commons.codec.digest.DigestUtils;
@@ -28,6 +34,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 import static org.apache.hadoop.fs.s3a.Constants.S3_ENCRYPTION_KEY;
+import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.XA_ENCRYPTION_KEY_ID;
+import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.XA_SERVER_SIDE_ENCRYPTION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public final class EncryptionTestUtils {
@@ -111,4 +119,27 @@ public final class EncryptionTestUtils {
     }
   }
 
+  /**
+   * Assert that a path is encrypted with right encryption settings.
+   * @param fs filesystem.
+   * @param path path
+   * @param algorithm encryption algorithm.
+   * @param kmsKey full kms key if present.
+   * @throws IOException any IOE.
+   */
+  public static void validateEncryptionFileAttributes(S3AFileSystem fs,
+                                                Path path,
+                                                String algorithm,
+                                                Optional<String> kmsKey) throws IOException {
+    Map<String, byte[]> xAttrs = fs.getXAttrs(path);
+    Assertions.assertThat(HeaderProcessing.decodeBytes(xAttrs.get(XA_SERVER_SIDE_ENCRYPTION)))
+                    .describedAs("Server side encryption algorithm must match")
+                    .isEqualTo(algorithm);
+    Assertions.assertThat(xAttrs.containsKey(XA_ENCRYPTION_KEY_ID))
+            .describedAs("Encryption key id should be present")
+            .isTrue();
+    kmsKey.ifPresent(s -> Assertions.assertThat(HeaderProcessing.decodeBytes(xAttrs.get(XA_ENCRYPTION_KEY_ID)))
+              .describedAs("Encryption key id should match with the kms key")
+              .isEqualTo(s));
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/EncryptionTestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/EncryptionTestUtils.java
@@ -19,12 +19,10 @@
 package org.apache.hadoop.fs.s3a;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 
 import org.apache.hadoop.fs.s3a.impl.HeaderProcessing;
-import org.apache.hadoop.io.IOUtils;
 import org.assertj.core.api.Assertions;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/EncryptionTestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/EncryptionTestUtils.java
@@ -132,12 +132,15 @@ public final class EncryptionTestUtils {
                                                 String algorithm,
                                                 Optional<String> kmsKey) throws IOException {
     Map<String, byte[]> xAttrs = fs.getXAttrs(path);
+    Assertions.assertThat(xAttrs.get(XA_SERVER_SIDE_ENCRYPTION))
+            .describedAs("Server side encryption must not be null")
+            .isNotNull();
     Assertions.assertThat(HeaderProcessing.decodeBytes(xAttrs.get(XA_SERVER_SIDE_ENCRYPTION)))
                     .describedAs("Server side encryption algorithm must match")
                     .isEqualTo(algorithm);
-    Assertions.assertThat(xAttrs.containsKey(XA_ENCRYPTION_KEY_ID))
+    Assertions.assertThat(xAttrs)
             .describedAs("Encryption key id should be present")
-            .isTrue();
+            .containsKey(XA_ENCRYPTION_KEY_ID);
     kmsKey.ifPresent(s -> Assertions.assertThat(HeaderProcessing.decodeBytes(xAttrs.get(XA_ENCRYPTION_KEY_ID)))
               .describedAs("Encryption key id should match with the kms key")
               .isEqualTo(s));

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEKMSDefaultKey.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEKMSDefaultKey.java
@@ -21,18 +21,16 @@ package org.apache.hadoop.fs.s3a;
 import java.io.IOException;
 import java.util.Optional;
 
-import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.junit.Test;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
 import static org.apache.hadoop.fs.s3a.EncryptionTestUtils.validateEncryptionFileAttributes;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestBucketName;
-import static org.apache.hadoop.fs.s3a.S3AUtils.getS3EncryptionKey;
 import static org.hamcrest.CoreMatchers.containsString;
 
 /**
@@ -67,6 +65,7 @@ public class ITestS3AEncryptionSSEKMSDefaultKey
 
   @Test
   public void testEncryptionFileAttributes() throws Exception {
+    describe("Test for correct encryption file attributes for SSE-KMS with server default key.");
     Path path = path(createFilename(1024));
     byte[] data = dataset(1024, 'a', 'z');
     S3AFileSystem fs = getFileSystem();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEKMSDefaultKey.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEKMSDefaultKey.java
@@ -72,6 +72,9 @@ public class ITestS3AEncryptionSSEKMSDefaultKey
     writeDataset(fs, path, data, data.length, 1024 * 1024, true);
     ContractTestUtils.verifyFileContents(fs, path, data);
     // we don't know the KMS key in case of server default option.
-    validateEncryptionFileAttributes(fs, path, EncryptionTestUtils.AWS_KMS_SSE_ALGORITHM,  Optional.empty());
+    validateEncryptionFileAttributes(fs,
+            path,
+            EncryptionTestUtils.AWS_KMS_SSE_ALGORITHM,
+            Optional.empty());
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
@@ -46,8 +46,6 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestBucketName;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfEncryptionNotSet;
 import static org.apache.hadoop.fs.s3a.S3AUtils.getS3EncryptionKey;
-import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.XA_ENCRYPTION_KEY_ID;
-import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.XA_SERVER_SIDE_ENCRYPTION;
 
 /**
  * Concrete class that extends {@link AbstractTestS3AEncryption}
@@ -106,6 +104,7 @@ public class ITestS3AEncryptionWithDefaultS3Settings extends
 
   @Test
   public void testEncryptionFileAttributes() throws Exception {
+    describe("Test for correct encryption file attributes for SSE-KMS with user default setting.");
     Path path = path(createFilename(1024));
     byte[] data = dataset(1024, 'a', 'z');
     S3AFileSystem fs = getFileSystem();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
@@ -19,11 +19,8 @@
 package org.apache.hadoop.fs.s3a;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
 import java.util.Optional;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Ignore;
 import org.junit.Test;
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?
Ran all integration tests using us-west-1 bucket.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

