### PR TITLE
YARN-11667. Federation: ResourceRequestComparator occurs NPE when using low version of hadoop submit application

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/ResourceRequest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/ResourceRequest.java
@@ -306,9 +306,10 @@ public abstract class ResourceRequest implements Comparable<ResourceRequest> {
         String h2 = r2.getResourceName();
         ret = h1.compareTo(h2);
       }
-      if (ret == 0) {
-        ret = r1.getExecutionTypeRequest()
-            .compareTo(r2.getExecutionTypeRequest());
+      ExecutionTypeRequest e1 = r1.getExecutionTypeRequest();
+      ExecutionTypeRequest e2 = r2.getExecutionTypeRequest();
+      if (ret == 0 && e1 != null && e2 != null) {
+        ret = e1.compareTo(e2);
       }
       if (ret == 0) {
         ret = r1.getCapability().compareTo(r2.getCapability());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestYarnApiClasses.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestYarnApiClasses.java
@@ -30,6 +30,9 @@ import org.apache.hadoop.yarn.api.records.Token;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.junit.Test;
 
+import java.util.Set;
+import java.util.TreeSet;
+
 import static org.junit.Assert.*;
 
 
@@ -61,6 +64,30 @@ public class TestYarnApiClasses {
     assertNotSame(0, original.compareTo(copy));
     assertFalse(original.hashCode() == copy.hashCode());
 
+  }
+
+  /**
+   * Simple test Resource request comparator.
+   * Test ExecutionTypeRequest is null
+   */
+  @Test
+  public void testResourceRequestComparator() {
+
+    Resource resource = recordFactory.newRecordInstance(Resource.class);
+    Priority priority = recordFactory.newRecordInstance(Priority.class);
+
+    ResourceRequest r1 = ResourceRequest.newInstance(priority, "localhost", resource, 1);
+    r1.setExecutionTypeRequest(null);
+    r1.setCapability(Resource.newInstance(1024, 1));
+
+    ResourceRequest r2 = ResourceRequest.newInstance(priority, "localhost", resource, 1);
+    r2.setExecutionTypeRequest(null);
+    r2.setCapability(Resource.newInstance(2048, 1));
+
+    Set<ResourceRequest> ask =
+            new TreeSet<>(new ResourceRequest.ResourceRequestComparator());
+    assertTrue(ask.add(r1));
+    assertTrue(ask.add(r2));
   }
 
   /**


### PR DESCRIPTION
### Description of PR
When a application is submitted using a lower version of hadoop and the Resource Request built by AM has no ExecutionTypeRequest. After the Resource Request is submitted to AMRMProxy, the NPE occurs when AMRMProxy reconstructs the Allocate Request to add Resource Request to its ask

### How was this patch tested?
Manual Verification and UT

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

