### PR TITLE
HDFS-17435. Fix TestRouterRpc failed

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
@@ -23,12 +23,10 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_REDUNDANCY_CONSI
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.addDirectory;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.countContents;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.createFile;
-import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.createNamenodeReport;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.deleteFile;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.getFileStatus;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.verifyFileExists;
 import static org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.TEST_STRING;
-import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.FEDERATION_STORE_MEMBERSHIP_EXPIRATION_MS;
 import static org.apache.hadoop.ipc.CallerContext.PROXY_USER_PORT;
 import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -74,7 +72,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.SafeModeAction;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.ha.HAServiceProtocol;
 import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSTestUtil;
@@ -118,7 +115,6 @@ import org.apache.hadoop.hdfs.server.federation.RouterConfigBuilder;
 import org.apache.hadoop.hdfs.server.federation.metrics.FederationRPCMetrics;
 import org.apache.hadoop.hdfs.server.federation.metrics.NamenodeBeanMetrics;
 import org.apache.hadoop.hdfs.server.federation.metrics.RBFMetrics;
-import org.apache.hadoop.hdfs.server.federation.resolver.ActiveNamenodeResolver;
 import org.apache.hadoop.hdfs.server.federation.resolver.FileSubclusterResolver;
 import org.apache.hadoop.hdfs.server.namenode.FSDirectory;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
@@ -2330,47 +2326,5 @@ public class TestRouterRpc {
       fileSystem1.delete(new Path(testPath1), true);
       fileSystem1.delete(new Path(testPath2), true);
     }
-  }
-
-  @Test
-  public void testClearStaleNamespacesInRouterStateIdContext() throws Exception {
-    Router testRouter = new Router();
-    Configuration routerConfig = DFSRouter.getConfiguration();
-    routerConfig.set(FEDERATION_STORE_MEMBERSHIP_EXPIRATION_MS, "2000");
-    routerConfig.set(RBFConfigKeys.DFS_ROUTER_SAFEMODE_ENABLE, "false");
-    // Mock resolver classes
-    routerConfig.setClass(RBFConfigKeys.FEDERATION_NAMENODE_RESOLVER_CLIENT_CLASS,
-        MockResolver.class, ActiveNamenodeResolver.class);
-    routerConfig.setClass(RBFConfigKeys.FEDERATION_FILE_RESOLVER_CLIENT_CLASS,
-        MockResolver.class, FileSubclusterResolver.class);
-
-    testRouter.init(routerConfig);
-    String nsID1 = cluster.getNameservices().get(0);
-    String nsID2 = cluster.getNameservices().get(1);
-    MockResolver resolver = (MockResolver)testRouter.getNamenodeResolver();
-    resolver.registerNamenode(createNamenodeReport(nsID1, "nn1",
-        HAServiceProtocol.HAServiceState.ACTIVE));
-    resolver.registerNamenode(createNamenodeReport(nsID2, "nn1",
-        HAServiceProtocol.HAServiceState.ACTIVE));
-
-    RouterRpcServer rpcServer = testRouter.getRpcServer();
-
-    rpcServer.getRouterStateIdContext().getNamespaceStateId(nsID1);
-    rpcServer.getRouterStateIdContext().getNamespaceStateId(nsID2);
-
-    resolver.disableNamespace(nsID1);
-    Thread.sleep(3000);
-    RouterStateIdContext context = rpcServer.getRouterStateIdContext();
-    assertEquals(2, context.getNamespaceIdMap().size());
-
-    testRouter.start();
-    Thread.sleep(3000);
-    // wait clear stale namespaces
-    RouterStateIdContext routerStateIdContext = rpcServer.getRouterStateIdContext();
-    int size = routerStateIdContext.getNamespaceIdMap().size();
-    assertEquals(1, size);
-    rpcServer.stop();
-    rpcServer.close();
-    testRouter.close();
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

TestRouterRpc and TestRouterRpcMultiDestination are failing with the following error.

```
[ERROR] testProxyGetBlockKeys  Time elapsed: 0.573 s  <<< ERROR!
org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security.authorize.AuthorizationException): User: jenkins is not allowed to impersonate jenkins
```

This is caused by `testClearStaleNamespacesInRouterStateIdContext()` which is implemented by HDFS-17354.

`TestRouterRpc#testClearStaleNamespacesInRouterStateIdContext()` affects the global router, causing other unit tests in `TestRouterRpc` to fail.
`testClearStaleNamespacesInRouterStateIdContext()` doesn't need to utilize the global router.
This PR moves `testClearStaleNamespacesInRouterStateIdContext()` from `TestRouterRpc` to `TestDFSRouter`.

### How was this patch tested?

The tests with this PR passed  in my local laptop

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
