### PR TITLE
HDFS-17436. Supplement log information for AccessControlException

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSPermissionChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSPermissionChecker.java
@@ -467,6 +467,7 @@ public class FSPermissionChecker implements AccessControlEnforcer {
             false);
       }
     } catch (AccessControlException ace) {
+      LOG.debug("Error while checking permission: ", ace);
       throw new AccessControlException(
           toAccessControlString(nodeAttributes, inode.getFullPathName(),
               access));


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
For more information about this PR, please refer to the following issue：
[HDFS-17436](https://issues.apache.org/jira/browse/HDFS-17436) checkPermission should not ignore original AccessControlException

I think we should keep the original AccessControlException information, so that we can understand the real situation of the problem.

### How was this patch tested?
Because this patch has no changes at the logical level of the code, there is no corresponding unit test.
Although there is no specific unit test for this patch, I can see the corresponding information in the log of active namenode when I trigger the exception again.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

