### PR TITLE
HDFS-17438. RBF: The newest STANDBY and UNAVAILABLE nn should be the lowest priority.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
@@ -405,6 +405,28 @@ public abstract class GenericTestUtils {
   }
 
   /**
+   * Wait at least {@code atLeastWaitForMillis} from start to end of the test.
+   *
+   * @param check the test to perform.
+   * @param atLeastWaitForMillis the minimum waiting time from the beginning
+   * to the end of the test.
+   * @throws InterruptedException if the method is interrupted while waiting.
+   */
+  public static <T> T atLeastWaitFor(final Supplier<T> check,
+      long atLeastWaitForMillis) throws InterruptedException {
+    if (atLeastWaitForMillis < 0) {
+      atLeastWaitForMillis = 0;
+    }
+    long st = Time.monotonicNow();
+    T result = check.get();
+    long runTime = Time.monotonicNow() - st;
+    if (runTime < atLeastWaitForMillis) {
+      Thread.sleep(atLeastWaitForMillis - runTime);
+    }
+    return result;
+  }
+
+  /**
    * Prints output to one {@link PrintStream} while copying to the other.
    * <p>
    * Closing the main {@link PrintStream} will NOT close the other.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
@@ -405,24 +405,19 @@ public abstract class GenericTestUtils {
   }
 
   /**
-   * Wait at least {@code atLeastWaitForMillis} from start to end of the test.
+   * Execute check and wait for {@code executeAndWaitForMillis}.
    *
    * @param check the test to perform.
-   * @param atLeastWaitForMillis the minimum waiting time from the beginning
-   * to the end of the test.
+   * @param executeAndWaitForMillis Waiting time after executing check.
    * @throws InterruptedException if the method is interrupted while waiting.
    */
-  public static <T> T atLeastWaitFor(final Supplier<T> check,
-      long atLeastWaitForMillis) throws InterruptedException {
-    if (atLeastWaitForMillis < 0) {
-      atLeastWaitForMillis = 0;
+  public static <T> T executeAndWait(final Supplier<T> check,
+      long executeAndWaitForMillis) throws InterruptedException {
+    if (executeAndWaitForMillis < 0) {
+      executeAndWaitForMillis = 0;
     }
-    long st = Time.monotonicNow();
     T result = check.get();
-    long runTime = Time.monotonicNow() - st;
-    if (runTime < atLeastWaitForMillis) {
-      Thread.sleep(atLeastWaitForMillis - runTime);
-    }
+    Thread.sleep(executeAndWaitForMillis);
     return result;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/NamenodePriorityComparator.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/NamenodePriorityComparator.java
@@ -59,8 +59,8 @@ public class NamenodePriorityComparator
    * @param o2 Context 2.
    * @return Comparison between dates.
    */
-  private int compareModDates(FederationNamenodeServiceState state, FederationNamenodeContext o1,
-      FederationNamenodeContext o2) {
+  private int compareModDates(FederationNamenodeServiceState state,
+      FederationNamenodeContext o1, FederationNamenodeContext o2) {
     // Reverse sort, lowest position is highest priority.
     if (state == FederationNamenodeServiceState.ACTIVE
         || state == FederationNamenodeServiceState.OBSERVER) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/NamenodePriorityComparator.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/NamenodePriorityComparator.java
@@ -25,6 +25,7 @@ import java.util.Comparator;
  * priorities are:
  * <ul>
  * <li>ACTIVE
+ * <li>OBSERVER
  * <li>STANDBY
  * <li>UNAVAILABLE
  * </ul>
@@ -44,7 +45,7 @@ public class NamenodePriorityComparator
 
     if (state1 == state2) {
       // Both have the same state, use mode dates
-      return compareModDates(o1, o2);
+      return compareModDates(state1, o1, o2);
     } else {
       // Enum is ordered by priority
       return state1.compareTo(state2);
@@ -58,9 +59,13 @@ public class NamenodePriorityComparator
    * @param o2 Context 2.
    * @return Comparison between dates.
    */
-  private int compareModDates(FederationNamenodeContext o1,
+  private int compareModDates(FederationNamenodeServiceState state, FederationNamenodeContext o1,
       FederationNamenodeContext o2) {
     // Reverse sort, lowest position is highest priority.
-    return (int) (o2.getDateModified() - o1.getDateModified());
+    if (state == FederationNamenodeServiceState.ACTIVE
+        || state == FederationNamenodeServiceState.OBSERVER) {
+      return (int) (o2.getDateModified() - o1.getDateModified());
+    }
+    return (int) (o1.getDateModified() - o2.getDateModified());
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestNamenodeResolver.java
@@ -26,6 +26,7 @@ import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStor
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.getStateStoreConfiguration;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.newStateStore;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.waitStateStore;
+import static org.apache.hadoop.test.GenericTestUtils.atLeastWaitFor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -282,13 +283,13 @@ public class TestNamenodeResolver {
     // 1) ns0:nn0 - Active
     // 2) ns0:nn1 - Standby (newest)
     // Verify the selected entry is the active entry
-    assertTrue(namenodeResolver.registerNamenode(
-        createNamenodeReport(
-            NAMESERVICES[0], NAMENODES[0], HAServiceState.ACTIVE)));
-    Thread.sleep(100);
-    assertTrue(namenodeResolver.registerNamenode(
-        createNamenodeReport(
-            NAMESERVICES[0], NAMENODES[1], HAServiceState.STANDBY)));
+    assertTrue(atLeastWaitFor(
+        () -> registerNamenode(
+            NAMESERVICES[0], NAMENODES[0], HAServiceState.ACTIVE),
+        100));
+
+    assertTrue(registerNamenode(
+            NAMESERVICES[0], NAMENODES[1], HAServiceState.STANDBY));
 
     stateStore.refreshCaches(true);
 
@@ -300,16 +301,15 @@ public class TestNamenodeResolver {
     // 2) ns0:nn1 - Standby (newest)
     // Verify the selected entry is the standby entry as the active entry is
     // stale
-    assertTrue(namenodeResolver.registerNamenode(
-        createNamenodeReport(
-            NAMESERVICES[0], NAMENODES[0], HAServiceState.ACTIVE)));
-
     // Expire active registration
-    Thread.sleep(6000);
+    assertTrue(atLeastWaitFor(
+        () -> registerNamenode(
+            NAMESERVICES[0], NAMENODES[0], HAServiceState.ACTIVE),
+        6000));
 
     // Refresh standby registration
-    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
-        NAMESERVICES[0], NAMENODES[1], HAServiceState.STANDBY)));
+    assertTrue(registerNamenode(
+        NAMESERVICES[0], NAMENODES[1], HAServiceState.STANDBY));
 
     // Verify that standby is selected (active is now expired)
     stateStore.refreshCaches(true);
@@ -319,11 +319,12 @@ public class TestNamenodeResolver {
     // 1) ns0:nn0 - Active
     // 2) ns0:nn1 - Unavailable (newest)
     // Verify the selected entry is the active entry
-    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
-        NAMESERVICES[0], NAMENODES[0], HAServiceState.ACTIVE)));
-    Thread.sleep(100);
-    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
-        NAMESERVICES[0], NAMENODES[1], null)));
+    assertTrue(atLeastWaitFor(
+        () -> registerNamenode(
+            NAMESERVICES[0], NAMENODES[0], HAServiceState.ACTIVE),
+        100));
+    assertTrue(registerNamenode(
+        NAMESERVICES[0], NAMENODES[1], null));
     stateStore.refreshCaches(true);
     verifyFirstRegistration(NAMESERVICES[0], NAMENODES[0], 2,
         FederationNamenodeServiceState.ACTIVE);
@@ -331,11 +332,12 @@ public class TestNamenodeResolver {
     // 1) ns0:nn0 - Unavailable (newest)
     // 2) ns0:nn1 - Standby
     // Verify the selected entry is the standby entry
-    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
-        NAMESERVICES[0], NAMENODES[1], HAServiceState.STANDBY)));
-    Thread.sleep(1000);
-    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
-        NAMESERVICES[0], NAMENODES[0], null)));
+    assertTrue(atLeastWaitFor(
+        () -> registerNamenode(
+            NAMESERVICES[0], NAMENODES[1], HAServiceState.STANDBY),
+        1000));
+    assertTrue(registerNamenode(
+        NAMESERVICES[0], NAMENODES[0], null));
 
     stateStore.refreshCaches(true);
     verifyFirstRegistration(NAMESERVICES[0], NAMENODES[1], 2,
@@ -345,14 +347,16 @@ public class TestNamenodeResolver {
     // 2) ns0:nn1 - Standby
     // 3) ns0:nn2 - Active (newest)
     // Verify the selected entry is the newest active entry
-    assertTrue(namenodeResolver.registerNamenode(
-        createNamenodeReport(NAMESERVICES[0], NAMENODES[0], null)));
-    Thread.sleep(100);
-    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
-        NAMESERVICES[0], NAMENODES[1], HAServiceState.STANDBY)));
-    Thread.sleep(100);
-    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
-        NAMESERVICES[0], NAMENODES[2], HAServiceState.ACTIVE)));
+    assertTrue(atLeastWaitFor(
+        () -> registerNamenode(
+            NAMESERVICES[0], NAMENODES[0], null),
+        100));
+    assertTrue(atLeastWaitFor(
+        () -> registerNamenode(
+            NAMESERVICES[0], NAMENODES[1], HAServiceState.STANDBY),
+        100));
+    assertTrue(registerNamenode(
+        NAMESERVICES[0], NAMENODES[2], HAServiceState.ACTIVE));
 
     stateStore.refreshCaches(true);
     verifyFirstRegistration(NAMESERVICES[0], NAMENODES[2], 3,
@@ -362,14 +366,16 @@ public class TestNamenodeResolver {
     // 2) ns0:nn1 - Standby
     // 3) ns0:nn2 - Standby (newest)
     // Verify the selected entry is the oldest standby entry
-    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
-        NAMESERVICES[0], NAMENODES[0], HAServiceState.STANDBY)));
-    Thread.sleep(1500);
-    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
-        NAMESERVICES[0], NAMENODES[2], HAServiceState.STANDBY)));
-    Thread.sleep(1500);
-    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
-        NAMESERVICES[0], NAMENODES[1], HAServiceState.STANDBY)));
+    assertTrue(atLeastWaitFor(
+        () -> registerNamenode(
+            NAMESERVICES[0], NAMENODES[0], HAServiceState.STANDBY),
+        1500));
+    assertTrue(atLeastWaitFor(
+        () -> registerNamenode(
+            NAMESERVICES[0], NAMENODES[2], HAServiceState.STANDBY),
+        1500));
+    assertTrue(registerNamenode(
+        NAMESERVICES[0], NAMENODES[1], HAServiceState.STANDBY));
 
     stateStore.refreshCaches(true);
     verifyFirstRegistration(NAMESERVICES[0], NAMENODES[0], 3,
@@ -378,11 +384,12 @@ public class TestNamenodeResolver {
     // 1) ns0:nn0 - Observer (oldest)
     // 2) ns0:nn1 - Observer (newest)
     // Verify the selected entry is the newest Observer entry
-    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
-        NAMESERVICES[0], NAMENODES[0], HAServiceState.OBSERVER)));
-    Thread.sleep(1500);
-    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
-        NAMESERVICES[0], NAMENODES[1], HAServiceState.OBSERVER)));
+    assertTrue(atLeastWaitFor(
+        () -> registerNamenode(
+            NAMESERVICES[0], NAMENODES[0], HAServiceState.OBSERVER),
+        1500));
+    assertTrue(registerNamenode(
+        NAMESERVICES[0], NAMENODES[1], HAServiceState.OBSERVER));
 
     stateStore.refreshCaches(true);
     verifyFirstRegistration(NAMESERVICES[0], NAMENODES[1], 3,
@@ -392,14 +399,16 @@ public class TestNamenodeResolver {
     // 2) ns0:nn1 - Unavailable
     // 3) ns0:nn2 - Unavailable (newest)
     // Verify the selected entry is the oldest Unavailable entry
-    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
-        NAMESERVICES[0], NAMENODES[0], null)));
-    Thread.sleep(1500);
-    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
-        NAMESERVICES[0], NAMENODES[1], null)));
-    Thread.sleep(1500);
-    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
-        NAMESERVICES[0], NAMENODES[2], null)));
+    assertTrue(atLeastWaitFor(
+        () -> registerNamenode(
+            NAMESERVICES[0], NAMENODES[0], null),
+        1500));
+    assertTrue(atLeastWaitFor(
+        () -> registerNamenode(
+            NAMESERVICES[0], NAMENODES[1], null),
+        1500));
+    assertTrue(registerNamenode(
+        NAMESERVICES[0], NAMENODES[2], null));
     stateStore.refreshCaches(true);
     verifyFirstRegistration(NAMESERVICES[0], NAMENODES[0], 3,
         FederationNamenodeServiceState.UNAVAILABLE);
@@ -456,5 +465,15 @@ public class TestNamenodeResolver {
     int port = Integer.parseInt(rpcAddrArr[1]);
     String hostname = rpcAddrArr[0];
     return new InetSocketAddress(hostname, port);
+  }
+
+  private boolean registerNamenode(String nsId,
+      String nnId, HAServiceState haServiceState) {
+    try {
+      return namenodeResolver.registerNamenode(
+          createNamenodeReport(nsId, nnId, haServiceState));
+    }catch (IOException e) {
+      return false;
+    }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestNamenodeResolver.java
@@ -371,7 +371,7 @@ public class TestNamenodeResolver {
         NAMESERVICES[0], NAMENODES[1], HAServiceState.STANDBY)));
 
     stateStore.refreshCaches(true);
-    verifyFirstRegistration(NAMESERVICES[0], NAMENODES[1], 3,
+    verifyFirstRegistration(NAMESERVICES[0], NAMENODES[0], 3,
         FederationNamenodeServiceState.STANDBY);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestNamenodeResolver.java
@@ -359,11 +359,12 @@ public class TestNamenodeResolver {
         FederationNamenodeServiceState.ACTIVE);
 
     // 1) ns0:nn0 - Standby (oldest)
-    // 2) ns0:nn1 - Standby (newest)
-    // 3) ns0:nn2 - Standby
-    // Verify the selected entry is the newest standby entry
+    // 2) ns0:nn1 - Standby
+    // 3) ns0:nn2 - Standby (newest)
+    // Verify the selected entry is the oldest standby entry
     assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
         NAMESERVICES[0], NAMENODES[0], HAServiceState.STANDBY)));
+    Thread.sleep(1500);
     assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
         NAMESERVICES[0], NAMENODES[2], HAServiceState.STANDBY)));
     Thread.sleep(1500);
@@ -373,6 +374,35 @@ public class TestNamenodeResolver {
     stateStore.refreshCaches(true);
     verifyFirstRegistration(NAMESERVICES[0], NAMENODES[0], 3,
         FederationNamenodeServiceState.STANDBY);
+
+    // 1) ns0:nn0 - Observer (oldest)
+    // 2) ns0:nn1 - Observer (newest)
+    // Verify the selected entry is the newest Observer entry
+    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
+        NAMESERVICES[0], NAMENODES[0], HAServiceState.OBSERVER)));
+    Thread.sleep(1500);
+    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
+        NAMESERVICES[0], NAMENODES[1], HAServiceState.OBSERVER)));
+
+    stateStore.refreshCaches(true);
+    verifyFirstRegistration(NAMESERVICES[0], NAMENODES[1], 3,
+        FederationNamenodeServiceState.OBSERVER);
+
+    // 1) ns0:nn0 - Unavailable (oldest)
+    // 2) ns0:nn1 - Unavailable
+    // 3) ns0:nn2 - Unavailable (newest)
+    // Verify the selected entry is the oldest Unavailable entry
+    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
+        NAMESERVICES[0], NAMENODES[0], null)));
+    Thread.sleep(1500);
+    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
+        NAMESERVICES[0], NAMENODES[1], null)));
+    Thread.sleep(1500);
+    assertTrue(namenodeResolver.registerNamenode(createNamenodeReport(
+        NAMESERVICES[0], NAMENODES[2], null)));
+    stateStore.refreshCaches(true);
+    verifyFirstRegistration(NAMESERVICES[0], NAMENODES[0], 3,
+        FederationNamenodeServiceState.UNAVAILABLE);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestNamenodeResolver.java
@@ -472,7 +472,7 @@ public class TestNamenodeResolver {
     try {
       return namenodeResolver.registerNamenode(
           createNamenodeReport(nsId, nnId, haServiceState));
-    }catch (IOException e) {
+    } catch (IOException e) {
       return false;
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestNamenodeResolver.java
@@ -26,7 +26,7 @@ import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStor
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.getStateStoreConfiguration;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.newStateStore;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.waitStateStore;
-import static org.apache.hadoop.test.GenericTestUtils.atLeastWaitFor;
+import static org.apache.hadoop.test.GenericTestUtils.executeAndWait;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -283,7 +283,7 @@ public class TestNamenodeResolver {
     // 1) ns0:nn0 - Active
     // 2) ns0:nn1 - Standby (newest)
     // Verify the selected entry is the active entry
-    assertTrue(atLeastWaitFor(
+    assertTrue(executeAndWait(
         () -> registerNamenode(
             NAMESERVICES[0], NAMENODES[0], HAServiceState.ACTIVE),
         100));
@@ -302,7 +302,7 @@ public class TestNamenodeResolver {
     // Verify the selected entry is the standby entry as the active entry is
     // stale
     // Expire active registration
-    assertTrue(atLeastWaitFor(
+    assertTrue(executeAndWait(
         () -> registerNamenode(
             NAMESERVICES[0], NAMENODES[0], HAServiceState.ACTIVE),
         6000));
@@ -319,7 +319,7 @@ public class TestNamenodeResolver {
     // 1) ns0:nn0 - Active
     // 2) ns0:nn1 - Unavailable (newest)
     // Verify the selected entry is the active entry
-    assertTrue(atLeastWaitFor(
+    assertTrue(executeAndWait(
         () -> registerNamenode(
             NAMESERVICES[0], NAMENODES[0], HAServiceState.ACTIVE),
         100));
@@ -332,7 +332,7 @@ public class TestNamenodeResolver {
     // 1) ns0:nn0 - Unavailable (newest)
     // 2) ns0:nn1 - Standby
     // Verify the selected entry is the standby entry
-    assertTrue(atLeastWaitFor(
+    assertTrue(executeAndWait(
         () -> registerNamenode(
             NAMESERVICES[0], NAMENODES[1], HAServiceState.STANDBY),
         1000));
@@ -347,11 +347,11 @@ public class TestNamenodeResolver {
     // 2) ns0:nn1 - Standby
     // 3) ns0:nn2 - Active (newest)
     // Verify the selected entry is the newest active entry
-    assertTrue(atLeastWaitFor(
+    assertTrue(executeAndWait(
         () -> registerNamenode(
             NAMESERVICES[0], NAMENODES[0], null),
         100));
-    assertTrue(atLeastWaitFor(
+    assertTrue(executeAndWait(
         () -> registerNamenode(
             NAMESERVICES[0], NAMENODES[1], HAServiceState.STANDBY),
         100));
@@ -366,11 +366,11 @@ public class TestNamenodeResolver {
     // 2) ns0:nn1 - Standby
     // 3) ns0:nn2 - Standby (newest)
     // Verify the selected entry is the oldest standby entry
-    assertTrue(atLeastWaitFor(
+    assertTrue(executeAndWait(
         () -> registerNamenode(
             NAMESERVICES[0], NAMENODES[0], HAServiceState.STANDBY),
         1500));
-    assertTrue(atLeastWaitFor(
+    assertTrue(executeAndWait(
         () -> registerNamenode(
             NAMESERVICES[0], NAMENODES[2], HAServiceState.STANDBY),
         1500));
@@ -384,7 +384,7 @@ public class TestNamenodeResolver {
     // 1) ns0:nn0 - Observer (oldest)
     // 2) ns0:nn1 - Observer (newest)
     // Verify the selected entry is the newest Observer entry
-    assertTrue(atLeastWaitFor(
+    assertTrue(executeAndWait(
         () -> registerNamenode(
             NAMESERVICES[0], NAMENODES[0], HAServiceState.OBSERVER),
         1500));
@@ -399,11 +399,11 @@ public class TestNamenodeResolver {
     // 2) ns0:nn1 - Unavailable
     // 3) ns0:nn2 - Unavailable (newest)
     // Verify the selected entry is the oldest Unavailable entry
-    assertTrue(atLeastWaitFor(
+    assertTrue(executeAndWait(
         () -> registerNamenode(
             NAMESERVICES[0], NAMENODES[0], null),
         1500));
-    assertTrue(atLeastWaitFor(
+    assertTrue(executeAndWait(
         () -> registerNamenode(
             NAMESERVICES[0], NAMENODES[1], null),
         1500));


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
seeAlso: https://issues.apache.org/jira/browse/HDFS-17438

At present, when the status of all namenodes in an ns in the router is the same, the namenode which is the newest reported will be placed at the top of the cache. when the client accesses the ns through the router, it will first access the namenode.

If multiple namenodes in this route are in an active state, or if there are namenodes with multiple observer states, the existing logic is not a problem, because the newest reported active or observer state namenode have a higher probability of being true active or observer compared to the namenode that reported active or observer state a long time ago.

Similarly, the newest reported namenode with a status of standby or unavailable has a higher probability of being a standby or unavailable namenode compared to the namenode reported with a status of standby or unavailable a long time ago. Therefore, the newest nn reported as standby or unavailable status should have a lower priority for access, the oldest nn reported as standby or unavailable status should have a higher priority for access.


### How was this patch tested?

use TestNamenodeResolver#testRegistrationNamenodeSelection().
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

