### PR TITLE
HADOOP-19124. Update org.ehcache from 3.3.1 to 3.8.2.

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -356,7 +356,7 @@ org.eclipse.jetty:jetty-webapp:9.4.53.v20231009
 org.eclipse.jetty:jetty-xml:9.4.53.v20231009
 org.eclipse.jetty.websocket:javax-websocket-client-impl:9.4.53.v20231009
 org.eclipse.jetty.websocket:javax-websocket-server-impl:9.4.53.v20231009
-org.ehcache:ehcache:3.3.1
+org.ehcache:ehcache:3.8.2
 org.ini4j:ini4j:0.5.4
 org.lz4:lz4-java:1.7.1
 org.objenesis:objenesis:2.6

--- a/hadoop-client-modules/hadoop-client-check-invariants/src/test/resources/ensure-jars-have-correct-contents.sh
+++ b/hadoop-client-modules/hadoop-client-check-invariants/src/test/resources/ensure-jars-have-correct-contents.sh
@@ -69,6 +69,8 @@ allowed_expr+="|^krb5_udp-template.conf$"
 allowed_expr+="|^jetty-dir.css$"
 # Snappy java is native library. We cannot relocate it to under org/apache/hadoop.
 allowed_expr+="|^org/xerial/"
+allowed_expr+="|^OSGI-INF/"
+allowed_expr+="|^javax/activation/"
 
 allowed_expr+=")"
 declare -i bad_artifacts=0

--- a/hadoop-client-modules/hadoop-client-check-invariants/src/test/resources/ensure-jars-have-correct-contents.sh
+++ b/hadoop-client-modules/hadoop-client-check-invariants/src/test/resources/ensure-jars-have-correct-contents.sh
@@ -69,8 +69,6 @@ allowed_expr+="|^krb5_udp-template.conf$"
 allowed_expr+="|^jetty-dir.css$"
 # Snappy java is native library. We cannot relocate it to under org/apache/hadoop.
 allowed_expr+="|^org/xerial/"
-allowed_expr+="|^OSGI-INF/"
-allowed_expr+="|^javax/activation/"
 
 allowed_expr+=")"
 declare -i bad_artifacts=0

--- a/hadoop-client-modules/hadoop-client-check-test-invariants/pom.xml
+++ b/hadoop-client-modules/hadoop-client-check-test-invariants/pom.xml
@@ -100,6 +100,7 @@
                     <exclude>org.bouncycastle:*</exclude>
                     <!-- Leave snappy that includes native methods which cannot be relocated. -->
                     <exclude>org.xerial.snappy:*</exclude>
+                    <exclude>org.ehcache:*</exclude>
                   </excludes>
                 </banTransitiveDependencies>
                 <banDuplicateClasses>

--- a/hadoop-client-modules/hadoop-client-check-test-invariants/src/test/resources/ensure-jars-have-correct-contents.sh
+++ b/hadoop-client-modules/hadoop-client-check-test-invariants/src/test/resources/ensure-jars-have-correct-contents.sh
@@ -58,6 +58,12 @@ allowed_expr+="|^org.apache.hadoop.application-classloader.properties$"
 allowed_expr+="|^java.policy$"
 #   * Used by javax.annotation
 allowed_expr+="|^jndi.properties$"
+#   * Used by ehcache
+allowed_expr+="|^ehcache-107-ext.xsd$"
+allowed_expr+="|^ehcache-multi.xsd$"
+allowed_expr+="|^.gitkeep$"
+allowed_expr+="|^OSGI-INF.*$"
+allowed_expr+="|^javax.*$"
 
 allowed_expr+=")"
 declare -i bad_artifacts=0

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -133,7 +133,7 @@
 
     <kerby.version>2.0.3</kerby.version>
     <jcache.version>1.0-alpha-1</jcache.version>
-    <ehcache.version>3.3.1</ehcache.version>
+    <ehcache.version>3.8.2</ehcache.version>
     <hikari.version>4.0.3</hikari.version>
     <derby.version>10.14.2.0</derby.version>
     <mssql.version>6.2.1.jre7</mssql.version>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19124. Update org.ehcache from 3.3.1 to 3.8.2.

In YARN-11663, a user pointed out that the memory of the Router increases because the cached data in memory is not cleared in a timely manner. We plan to add cache entry limits for YARN Federation caching.

In FederationJCache, we use Ehcache, which lacks control logic for cache entry limits in lower versions. Therefore, we need to upgrade the version. I have chosen to upgrade from 3.3.1 to 3.8.2 because 3.8.2 version can be successfully compiled locally and pass unit tests.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

