### PR TITLE
HADOOP-19111. Removing redundant debug message about client info

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -1128,8 +1128,7 @@ public class Client implements AutoCloseable {
             synchronized (ipcStreams.out) {
               if (LOG.isDebugEnabled()) {
                 Call call = pair.getLeft();
-                LOG.debug(getName() + "{} sending #{} {}", getName(), call.id,
-                    call.rpcRequest);
+                LOG.debug("{} sending #{} {}", getName(), call.id, call.rpcRequest);
               }
               // RpcRequestHeader + RpcRequest
               ipcStreams.sendRequest(buf.toByteArray());


### PR DESCRIPTION
Description of PR
https://issues.apache.org/jira/browse/HADOOP-19111

Removing redundant debug message about client info

when sending rpc request,the debug message print client name(which is getName()) twice,this is confusing.

like:

2024-03-16 11:58:49,564 DEBUG ipc.Client: :1113 IPC Client (382750013) connection to kdcserver/172.20.10.12:8888 from nn/[bigdata@WUZK.COM](mailto:bigdata@WUZK.COM)IPC Client (382750013) connection to kdcserver/172.20.10.12:8888 from nn/[bigdata@WUZK.COM](mailto:bigdata@WUZK.COM) sending #0 org.apache.hadoop.hdfs.protocol.ClientProtocol.getListing

the debug message above should delete the bold font part
(can't set strikethrough like jira,so use bold fond)

### How was this patch tested?
The code chaning is easy to understand. And I have it tested in Junit with other cases in local

### For code changes:

                LOG.debug(getName() + "{} sending #{} {}", getName(), call.id, call.rpcRequest);

abut the code above,there are two reasons to change:
a: getName() + and the ｛｝placeholder are duplicate
b: To avoid String copy, we should use placehold rather than String +