### PR TITLE
HDFS-17412. [FGL] Client RPCs involving maintenance supports fine-grained lock

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -856,7 +856,7 @@ public class BlockManager implements BlockStatsMXBean {
 
   /** Dump meta data to out. */
   public void metaSave(PrintWriter out) {
-    assert namesystem.hasReadLock(); // TODO: block manager read lock and NS write lock
+    assert namesystem.hasReadLock(FSNamesystemLockMode.BM);
     final List<DatanodeDescriptor> live = new ArrayList<DatanodeDescriptor>();
     final List<DatanodeDescriptor> dead = new ArrayList<DatanodeDescriptor>();
     datanodeManager.fetchDatanodes(live, dead, false);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -2010,6 +2010,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   }
 
   private void metaSave(PrintWriter out) {
+    // TODO: Change to hasReadLock(FSNamesystemLockMode.BM)
     assert hasReadLock(FSNamesystemLockMode.GLOBAL);
     // Normally FSReadLock is needed here, but I think thread-safe is unnecessary here.
     long totalInodes = this.dir.totalInodes();
@@ -5119,12 +5120,12 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     checkSuperuserPrivilege(operationName);
     checkOperation(OperationCategory.UNCHECKED);
     cpLock();  // Block if a checkpointing is in progress on standby.
-    writeLock(FSNamesystemLockMode.GLOBAL);
+    writeLock(FSNamesystemLockMode.FS);
     try {
       checkOperation(OperationCategory.UNCHECKED);
       getFSImage().finalizeUpgrade(this.isHaEnabled() && inActiveState());
     } finally {
-      writeUnlock(FSNamesystemLockMode.GLOBAL, operationName, getLockReportInfoSupplier(null));
+      writeUnlock(FSNamesystemLockMode.FS, operationName, getLockReportInfoSupplier(null));
       cpUnlock();
     }
     logAuditEvent(true, operationName, null);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -1991,7 +1991,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     String operationName = "metaSave";
     checkSuperuserPrivilege(operationName);
     checkOperation(OperationCategory.READ);
-    readLock();
+    readLock(FSNamesystemLockMode.GLOBAL);
     try {
       checkOperation(OperationCategory.READ);
       synchronized(metaSaveLock) {
@@ -2004,13 +2004,14 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
         out.close();
       }
     } finally {
-      readUnlock(operationName, getLockReportInfoSupplier(null));
+      readUnlock(FSNamesystemLockMode.GLOBAL, operationName, getLockReportInfoSupplier(null));
     }
     logAuditEvent(true, operationName, null);
   }
 
   private void metaSave(PrintWriter out) {
-    assert hasReadLock();
+    assert hasReadLock(FSNamesystemLockMode.GLOBAL);
+    // Normally FSReadLock is needed here, but I think thread-safe is unnecessary here.
     long totalInodes = this.dir.totalInodes();
     long totalBlocks = this.getBlocksTotal();
     out.println(totalInodes + " files and directories, " + totalBlocks
@@ -4984,14 +4985,14 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     String operationName = "slowDataNodesReport";
     DatanodeInfo[] datanodeInfos;
     checkOperation(OperationCategory.UNCHECKED);
-    readLock();
+    readLock(FSNamesystemLockMode.BM);
     try {
       checkOperation(OperationCategory.UNCHECKED);
       final DatanodeManager dm = getBlockManager().getDatanodeManager();
       final List<DatanodeDescriptor> results = dm.getAllSlowDataNodes();
       datanodeInfos = getDatanodeInfoFromDescriptors(results);
     } finally {
-      readUnlock(operationName, getLockReportInfoSupplier(null));
+      readUnlock(FSNamesystemLockMode.BM, operationName, getLockReportInfoSupplier(null));
     }
     logAuditEvent(true, operationName, null);
     return datanodeInfos;
@@ -5012,14 +5013,14 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     DatanodeInfo[] arr;
     checkSuperuserPrivilege(operationName);
     checkOperation(OperationCategory.UNCHECKED);
-    readLock();
+    readLock(FSNamesystemLockMode.BM);
     try {
       checkOperation(OperationCategory.UNCHECKED);
       final DatanodeManager dm = getBlockManager().getDatanodeManager();      
       final List<DatanodeDescriptor> results = dm.getDatanodeListForReport(type);
       arr = getDatanodeInfoFromDescriptors(results);
     } finally {
-      readUnlock(operationName, getLockReportInfoSupplier(null));
+      readUnlock(FSNamesystemLockMode.BM, operationName, getLockReportInfoSupplier(null));
     }
     logAuditEvent(true, operationName, null);
     return arr;
@@ -5031,13 +5032,13 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     DatanodeStorageReport[] reports;
     checkSuperuserPrivilege(operationName);
     checkOperation(OperationCategory.UNCHECKED);
-    readLock();
+    readLock(FSNamesystemLockMode.BM);
     try {
       checkOperation(OperationCategory.UNCHECKED);
       final DatanodeManager dm = getBlockManager().getDatanodeManager();      
       reports = dm.getDatanodeStorageReport(type);
     } finally {
-      readUnlock(operationName, getLockReportInfoSupplier(null));
+      readUnlock(FSNamesystemLockMode.BM, operationName, getLockReportInfoSupplier(null));
     }
     logAuditEvent(true, operationName, null);
     return reports;
@@ -5056,7 +5057,9 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
 
     boolean saved = false;
     cpLock();  // Block if a checkpointing is in progress on standby.
-    readLock();
+    // TODO: MileStone2 should change this readLock() to writeLock(FSNamesystemLockMode.FS)
+    //  since all directory-tree modification operations will just hold the FSReadLock.
+    readLock(FSNamesystemLockMode.FS);
     try {
       checkOperation(OperationCategory.UNCHECKED);
 
@@ -5066,7 +5069,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       }
       saved = getFSImage().saveNamespace(timeWindow, txGap, this);
     } finally {
-      readUnlock(operationName, getLockReportInfoSupplier(null));
+      readUnlock(FSNamesystemLockMode.FS, operationName, getLockReportInfoSupplier(null));
       cpUnlock();
     }
     if (saved) {
@@ -5088,7 +5091,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     checkSuperuserPrivilege(operationName);
     checkOperation(OperationCategory.UNCHECKED);
     cpLock();  // Block if a checkpointing is in progress on standby.
-    writeLock();
+    writeLock(FSNamesystemLockMode.FS);
     try {
       checkOperation(OperationCategory.UNCHECKED);
       
@@ -5100,7 +5103,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
         getNNStorage().setRestoreFailedStorage(val);
       }
     } finally {
-      writeUnlock(operationName, getLockReportInfoSupplier(null));
+      writeUnlock(FSNamesystemLockMode.FS, operationName, getLockReportInfoSupplier(null));
       cpUnlock();
     }
     logAuditEvent(true, operationName, null);
@@ -5116,12 +5119,12 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     checkSuperuserPrivilege(operationName);
     checkOperation(OperationCategory.UNCHECKED);
     cpLock();  // Block if a checkpointing is in progress on standby.
-    writeLock();
+    writeLock(FSNamesystemLockMode.GLOBAL);
     try {
       checkOperation(OperationCategory.UNCHECKED);
       getFSImage().finalizeUpgrade(this.isHaEnabled() && inActiveState());
     } finally {
-      writeUnlock(operationName, getLockReportInfoSupplier(null));
+      writeUnlock(FSNamesystemLockMode.GLOBAL, operationName, getLockReportInfoSupplier(null));
       cpUnlock();
     }
     logAuditEvent(true, operationName, null);
@@ -7518,7 +7521,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     final String operationName = "queryRollingUpgrade";
     checkSuperuserPrivilege(operationName);
     checkOperation(OperationCategory.READ);
-    readLock();
+    readLock(FSNamesystemLockMode.FS);
     try {
       checkOperation(OperationCategory.READ);
       if (!isRollingUpgrade()) {
@@ -7528,7 +7531,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       boolean hasRollbackImage = this.getFSImage().hasRollbackFSImage();
       rollingUpgradeInfo.setCreatedRollbackImages(hasRollbackImage);
     } finally {
-      readUnlock(operationName, getLockReportInfoSupplier(null));
+      readUnlock(FSNamesystemLockMode.FS, operationName, getLockReportInfoSupplier(null));
     }
     logAuditEvent(true, operationName, null, null, null);
     return rollingUpgradeInfo;
@@ -7538,7 +7541,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     final String operationName = "startRollingUpgrade";
     checkSuperuserPrivilege(operationName);
     checkOperation(OperationCategory.WRITE);
-    writeLock();
+    writeLock(FSNamesystemLockMode.FS);
     try {
       checkOperation(OperationCategory.WRITE);
       if (isRollingUpgrade()) {
@@ -7558,7 +7561,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
         getFSImage().rollEditLog(getEffectiveLayoutVersion());
       }
     } finally {
-      writeUnlock(operationName, getLockReportInfoSupplier(null));
+      writeUnlock(FSNamesystemLockMode.FS, operationName, getLockReportInfoSupplier(null));
     }
 
     getEditLog().logSync();


### PR DESCRIPTION
HDFS-17412. [FGL] Client RPCs involving maintenance supports fine-grained lock.

- getDatanodeReport: BMLock
- getDatanodeStorageReport: BMLock
- saveNamespace: FSLock
- metaSave: GlobalLock
- rollEdits: FSLock
- restoreFailedStorage:  FSLock
- finalizeUpgrade: FSLock
- rollingUpgrade: FSLock
- getSlowDatanodeReport: BMLock