### PR TITLE
HDFS-17429. Fixing wrong log file name in datatransfer Sender.java

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/Sender.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/Sender.java
@@ -57,11 +57,16 @@ import org.apache.hadoop.tracing.Tracer;
 import org.apache.hadoop.tracing.TraceUtils;
 
 import org.apache.hadoop.thirdparty.protobuf.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /** Sender */
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
 public class Sender implements DataTransferProtocol {
+  private static final Logger LOG = LoggerFactory.getLogger(Sender.class);
+
   private final DataOutputStream out;
 
   /** Create a sender for DataTransferProtocol with a output stream. */


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17429


### How was this patch tested?


### For code changes:

The Sender.java have no LOG variable, just using the interface it impletments, so in the trace log, the file name is wrong:

2024-03-18 16:34:40,274 TRACE **datatransfer.DataTransferProtocol**: :80 Sending DataTransferOp OpReadBlockProto: header {

It's actually printed in Sender.java

