### PR TITLE
YARN-11668. Fix RM crash for potential concurrent modification exception when updating node attributes

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/nodelabels/NodeAttributesManagerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/nodelabels/NodeAttributesManagerImpl.java
@@ -613,7 +613,7 @@ public class NodeAttributesManagerImpl extends NodeAttributesManager {
     }
 
     public Host(String hostName) {
-      this(hostName, new HashMap<NodeAttribute, AttributeValue>());
+      this(hostName, new ConcurrentHashMap<NodeAttribute, AttributeValue>());
     }
 
     public Host(String hostName,


### PR DESCRIPTION
### Description of PR

JIRA: YARN-11668. Fix RM crash for potential concurrent modification exception when updating node attributes.

![img_v3_029c_55ac6b50-64aa-4cbe-81a0-5f8d22c623fg](https://github.com/apache/hadoop/assets/8609142/3bcb0f02-267b-4e28-b7a2-c732a37796cf)

This PR is to fix concurrent modification exception that will make RM crash due to the concurrent node attributes update for one node manager.

### How was this patch tested?

Existing tests.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

