### PR TITLE
HDFS-17443. add null check for fileSys and cluster in TestNameEditsConfigs#testNameEditsConfigsFailure before shutting down

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameEditsConfigs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameEditsConfigs.java
@@ -447,8 +447,12 @@ public class TestNameEditsConfigs {
           replication, SEED);
       checkFile(fileSys, file1, replication);
     } finally  {
-      fileSys.close();
-      cluster.shutdown();
+      if (fileSys != null) {
+        fileSys.close();
+      }
+      if (cluster != null) {
+        cluster.shutdown();
+      }
     }
 
     // 2


### PR DESCRIPTION
### Description of PR
This PR provides a fix for HDFS-17443 by adding null checking for fileSys and cluster before stopping them in the `finally` in `TestNameEditsConfigs#testNameEditsConfigsFailure`.

### How was this patch tested?
The patch is tested via setting dfs.namenode.edits.dir.minimum to 251625215 and running org.apache.hadoop.hdfs.server.namenode.TestNameEditsConfigs#testNameEditsConfigsFailure, which would throw the correct exception.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

