### PR TITLE
HDFS-17444. Add getJournalSyncerStarted jmx metrics, to Indicates whether the JournalSyncer thread has been started.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNode.java
@@ -17,15 +17,8 @@
  */
 package org.apache.hadoop.hdfs.qjournal.server;
 
-import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.util.Preconditions;
-import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
-import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
-import org.apache.hadoop.util.Lists;
-import org.apache.hadoop.util.VersionInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
@@ -40,29 +33,26 @@ import org.apache.hadoop.metrics2.source.JvmMetrics;
 import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.SecurityUtil;
+import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
+import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 import org.apache.hadoop.tracing.TraceUtils;
-import org.apache.hadoop.util.DiskChecker;
-
-import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_JOURNALNODE_HTTP_BIND_HOST_KEY;
-import static org.apache.hadoop.util.ExitUtil.terminate;
-import static org.apache.hadoop.util.Time.now;
-import org.apache.hadoop.util.StringUtils;
-import org.apache.hadoop.util.Tool;
-import org.apache.hadoop.util.ToolRunner;
 import org.apache.hadoop.tracing.Tracer;
+import org.apache.hadoop.util.*;
 import org.eclipse.jetty.util.ajax.JSON;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.management.ObjectName;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
+
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_JOURNALNODE_HTTP_BIND_HOST_KEY;
+import static org.apache.hadoop.util.ExitUtil.terminate;
+import static org.apache.hadoop.util.Time.now;
 
 /**
  * The JournalNode is a daemon which allows namenodes using
@@ -403,6 +393,18 @@ public class JournalNode implements Tool, Configurable, JournalNodeMXBean {
     }
 
     return JSON.toString(status);
+  }
+
+  @Override // JournalNodeMXBean
+  public String getJournalSyncerStatus() {
+    StringBuilder sbuilder = new StringBuilder();
+    journalSyncersById.keySet().forEach((jid) ->
+        sbuilder.append(jid)
+            .append(","));
+    if (sbuilder.length() > 0) {
+      sbuilder.deleteCharAt(sbuilder.length() - 1);
+    }
+    return sbuilder.toString();
   }
 
   @Override // JournalNodeMXBean

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeMXBean.java
@@ -37,6 +37,17 @@ public interface JournalNodeMXBean {
   String getJournalsStatus();
 
   /**
+   * Query JournalSyncer status.
+   *
+   * @return JournalSyncer status.
+   *
+   * example: "ns1,ns3" string means
+   * JournalSyncer thread for ns1 and ns3 has enter working state,
+   * but for ns2 has not enter working state yet.
+   */
+  String getJournalSyncerStatus();
+
+  /**
    * Get host and port of JournalNode.
    *
    * @return colon separated host and port.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeMXBean.java
@@ -80,9 +80,20 @@ public class TestJournalNodeMXBean {
     assertEquals(jn.getJournalsStatus(), journalStatus);
     assertFalse(journalStatus.contains(NAMESERVICE));
 
+    // getJournalSyncerStatus
+    String journalSyncerStarted = (String) mbs.getAttribute(mxbeanName,
+        "JournalSyncerStatus");
+    assertEquals(jn.getJournalSyncerStatus(), journalSyncerStarted);
+    assertFalse(journalSyncerStarted.contains(NAMESERVICE));
+
     // format the journal ns1
     final NamespaceInfo fakeNsInfo = new NamespaceInfo(NS_ID, "mycluster", "my-bp", 0L);
     jn.getOrCreateJournal(NAMESERVICE).format(fakeNsInfo, false);
+
+    // check again after getOrCreateJournal
+    journalSyncerStarted = (String) mbs.getAttribute(mxbeanName,
+        "JournalSyncerStatus");
+    assertTrue(journalSyncerStarted.contains(NAMESERVICE));
 
     // check again after format
     // getJournalsStatus


### PR DESCRIPTION
The JornalNode JVM process is not immediately in a normal state until the JournalSyncer thread is started.
For some management platforms such as Ambari rolling restart JournalNode, we need a jmx metric to determine whether the JournalSyncer thread is started and enter working state for current namespace before restarting the next JournalNode. Otherwise, restart too quickly and more than half of JournalNodes will be out of order, causing the NameNode to die.

When i add it , the effect is as follows:
![image](https://github.com/apache/hadoop/assets/65019264/469883e5-275f-4533-aacd-c1950050e007)
