### PR TITLE
HDFS-17446. The DataNode adds a log to report its progress during addToReplicasMap execution.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
@@ -723,7 +723,7 @@ public class BlockPoolSlice {
     }
   }
 
-
+  private AtomicLong scanBlockCnt = new AtomicLong(0L);
   /**
    * Add replicas under the given directory to the volume map
    * @param volumeMap the replicas map
@@ -749,6 +749,11 @@ public class BlockPoolSlice {
             lazyWriteReplicaMap, isFinalized, exceptions, subTaskQueue);
         subTask.fork();
         subTaskQueue.add(subTask);
+      } else {
+        long num = scanBlockCnt.get();
+        if (num > 0 && num % 10000 == 0) {
+          LOG.info("Scan process: " + num + " blocks have been scanned.");
+        }
       }
 
       if (isFinalized && FsDatasetUtil.isUnlinkTmpFile(file)) {
@@ -768,6 +773,7 @@ public class BlockPoolSlice {
       Block block = new Block(blockId, file.length(), genStamp);
       addReplicaToReplicasMap(block, volumeMap, lazyWriteReplicaMap,
           isFinalized);
+      scanBlockCnt.incrementAndGet();
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -2102,4 +2102,28 @@ public class TestFsDatasetImpl {
       DataNodeFaultInjector.set(oldDnInjector);
     }
   }
+
+  /**
+   * My patch only adds a log print. Therefore, I cannot write assert judgments.
+   * I can only verify the normal function of addVolume.
+   */
+  @Test
+  public void testLog4AddToReplicasMap() throws IOException {
+    List<NamespaceInfo> nsInfos = Lists.newArrayList();
+    for (String bpid : BLOCK_POOL_IDS) {
+      nsInfos.add(new NamespaceInfo(0, CLUSTER_ID, bpid, 1));
+    }
+    String path = BASE_DIR + "/newData0";
+    String pathUri = new Path(path).toUri().toString();
+    StorageLocation loc = StorageLocation.parse(pathUri);
+    Storage.StorageDirectory sd = createStorageDirectory(
+        new File(path), conf);
+    DataStorage.VolumeBuilder builder =
+        new DataStorage.VolumeBuilder(storage, sd);
+    when(storage.prepareVolume(eq(datanode), eq(loc),
+        anyList()))
+        .thenReturn(builder);
+    dataset.addVolume(loc, nsInfos);
+  }
+
 }


### PR DESCRIPTION
Datanodes do not print logs when addToReplicasMap is just started, so we will not be aware of its progress, or even wait up to 4 hours for a large cluster. This is very confusing.

- A cluster is as follows:
![image](https://github.com/apache/hadoop/assets/65019264/b1cc4f8c-0873-48aa-b61f-ac4d181c805c)

- The optimized result is as follows:

(Because Scan thread is ForkJoinPool, so the printing may be repeated, but it will affect the overall progress of the presentation
)
![image](https://github.com/apache/hadoop/assets/65019264/2504fb29-3cd1-4757-ad77-3bceb05872df)
