### PR TITLE
HDFS-17447. Add logging to print the implementation class of AccessControlEnforcer, print ACEnforcer when AccessControlException occurs.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSPermissionChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSPermissionChecker.java
@@ -74,7 +74,8 @@ public class FSPermissionChecker implements AccessControlEnforcer {
       .append(inodeAttrib.getUserName()).append(':')
       .append(inodeAttrib.getGroupName()).append(':')
       .append(inodeAttrib.isDirectory() ? 'd' : '-')
-      .append(inodeAttrib.getFsPermission());
+      .append(inodeAttrib.getFsPermission()).append(", ")
+      .append("ACEnforcer=").append(enforcerName);
     if (deniedFromAcl) {
       sb.append("+");
     }
@@ -93,6 +94,9 @@ public class FSPermissionChecker implements AccessControlEnforcer {
   private final long accessControlEnforcerReportingThresholdMs;
 
   private static ThreadLocal<String> operationType = new ThreadLocal<>();
+
+  // enforcerName, such as RangerAccessControlEnforcer、FSPermissionChecker
+  private String enforcerName;
 
   protected FSPermissionChecker(String fsOwner, String supergroup,
       UserGroupInformation callerUgi,
@@ -124,6 +128,9 @@ public class FSPermissionChecker implements AccessControlEnforcer {
     }
     this.accessControlEnforcerReportingThresholdMs
         = accessControlEnforcerReportingThresholdMs;
+    if (attributeProvider != null) {
+      enforcerName = attributeProvider.getClass().getSimpleName();
+    }
   }
 
   private String checkAccessControlEnforcerSlowness(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSPermissionChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSPermissionChecker.java
@@ -425,6 +425,12 @@ public class TestFSPermissionChecker {
       assertTrue("Permission denied messages must carry the path parent",
               e.getMessage().contains(
                   new Path(path).getParent().toUri().getPath()));
+
+      // in HDFS unit test, AccessControlEnforcer's Implementation class
+      // only be FSPermissionChecker
+      assertTrue("Permission denied messages must carry the ACEnforcer",
+              e.getMessage().contains("ACEnforcer") 
+              && e.getMessage().contains("FSPermissionChecker"));
     }
   }
 


### PR DESCRIPTION
As we know, when Ranger authentication is enabled in the HDFS, if Ranger authentication fails to match, it is degraded to the FSPermissionChecker authentication of the HDFS ACL.

If an ACE occurs, it is not clear whether it comes from Ranger authentication or FSPermissionChecker authentication. So I think we should add a description of AccessControlEnforcer to the ACE exception description to help locate the problem.