### PR TITLE
HDFS-17448. Enhance the stability of the unit test TestDiskBalancerCommand

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/command/TestDiskBalancerCommand.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/command/TestDiskBalancerCommand.java
@@ -834,8 +834,10 @@ public class TestDiskBalancerCommand {
           .getIpcPort(), dataNode2.getIpcPort());
       final String cmdLine = String.format("hdfs diskbalancer %s", queryArg);
       List<String> outputs = runCommand(cmdLine);
-      assertThat(outputs.get(1), containsString("localhost:" + dataNode1.getIpcPort()));
-      assertThat(outputs.get(6), containsString("localhost:" + dataNode2.getIpcPort()));
+      assertTrue(outputs.get(1).contains("localhost:" + dataNode1.getIpcPort())
+          || outputs.get(6).contains("localhost:" + dataNode1.getIpcPort()));
+      assertTrue(outputs.get(1).contains("localhost:" + dataNode2.getIpcPort())
+          || outputs.get(6).contains("localhost:" + dataNode2.getIpcPort()));
     } finally {
       miniDFSCluster.shutdown();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/command/TestDiskBalancerCommand.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/command/TestDiskBalancerCommand.java
@@ -834,10 +834,13 @@ public class TestDiskBalancerCommand {
           .getIpcPort(), dataNode2.getIpcPort());
       final String cmdLine = String.format("hdfs diskbalancer %s", queryArg);
       List<String> outputs = runCommand(cmdLine);
-      assertTrue(outputs.get(1).contains("localhost:" + dataNode1.getIpcPort())
-          || outputs.get(6).contains("localhost:" + dataNode1.getIpcPort()));
-      assertTrue(outputs.get(1).contains("localhost:" + dataNode2.getIpcPort())
-          || outputs.get(6).contains("localhost:" + dataNode2.getIpcPort()));
+      assertEquals(12,  outputs.size());
+      assertTrue("Expected outputs: " + outputs,
+          outputs.get(1).contains("localhost:" + dataNode1.getIpcPort()) ||
+              outputs.get(6).contains("localhost:" + dataNode1.getIpcPort()));
+      assertTrue("Expected outputs: " + outputs,
+          outputs.get(1).contains("localhost:" + dataNode2.getIpcPort()) ||
+              outputs.get(6).contains("localhost:" + dataNode2.getIpcPort()));
     } finally {
       miniDFSCluster.shutdown();
     }


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17448

TestDiskBalancerCommand#testDiskBalancerQueryWithoutSubmitAndMultipleNodes frequently fails tests, such as:

https://ci-hadoop.apache.org/view/Hadoop/job/hadoop-qbt-trunk-java8-linux-x86_64/1540/testReport/junit/org.apache.hadoop.hdfs.server.diskbalancer.command/TestDiskBalancerCommand/testDiskBalancerQueryWithoutSubmitAndMultipleNodes/

https://ci-hadoop.apache.org/job/hadoop-multibranch/job/PR-6637/1/testReport/org.apache.hadoop.hdfs.server.diskbalancer.command/TestDiskBalancerCommand/testDiskBalancerQueryWithoutSubmitAndMultipleNodes/

I will fix it enhance the stability of the unit test.

