### PR TITLE
HDFS-17449. catch the IndexOutOfBounds and throw IllegalArgument instead

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/HostsFileWriter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/HostsFileWriter.java
@@ -106,14 +106,13 @@ public class HostsFileWriter {
         for (String hostNameAndPort : decommissionHostNameAndPorts) {
           DatanodeAdminProperties dn = new DatanodeAdminProperties();
           String[] hostAndPort = hostNameAndPort.split(":");
-          try {
-            dn.setHostName(hostAndPort[0]);
-            dn.setPort(Integer.parseInt(hostAndPort[1]));
-            dn.setAdminState(AdminStates.DECOMMISSIONED);
-          } catch (Exception e) {
+          if (hostAndPort.length != 2) {
             throw new IllegalArgumentException("The decommision host name and port format is "
-                + "invalid. The format should be in <host>:<port>, not " + hostNameAndPort, e);
+                + "invalid. The format should be in <host>:<port>, not " + hostNameAndPort);
           }
+          dn.setHostName(hostAndPort[0]);
+          dn.setPort(Integer.parseInt(hostAndPort[1]));
+          dn.setAdminState(AdminStates.DECOMMISSIONED);
           allDNs.add(dn);
         }
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/HostsFileWriter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/HostsFileWriter.java
@@ -106,9 +106,14 @@ public class HostsFileWriter {
         for (String hostNameAndPort : decommissionHostNameAndPorts) {
           DatanodeAdminProperties dn = new DatanodeAdminProperties();
           String[] hostAndPort = hostNameAndPort.split(":");
-          dn.setHostName(hostAndPort[0]);
-          dn.setPort(Integer.parseInt(hostAndPort[1]));
-          dn.setAdminState(AdminStates.DECOMMISSIONED);
+          try {
+            dn.setHostName(hostAndPort[0]);
+            dn.setPort(Integer.parseInt(hostAndPort[1]));
+            dn.setAdminState(AdminStates.DECOMMISSIONED);
+          } catch (Exception e) {
+            throw new IllegalArgumentException("The decommision host name and port format is "
+                + "invalid. The format should be in <host>:<port>, not " + hostNameAndPort, e);
+          }
           allDNs.add(dn);
         }
       }


### PR DESCRIPTION
### Description of PR
This PR catches the IndexOutOfBounds encountered during parsing of decommission host name and port string, and throws a more informative IllegalArgument instead.

### How was this patch tested?
Running org.apache.hadoop.hdfs.server.namenode.TestDecommissioningStatusWithBackoffMonitor#testDecommissionStatusAfterDNRestart with namenode host provider set to org.apache.hadoop.hdfs.server.blockmanagement.CombinedHostFileManager now throws IllegalArgument.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

