### PR TITLE
HADOOP-19134. Use StringBuilder instead of StringBuffer.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyShell.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyShell.java
@@ -169,7 +169,7 @@ public class KeyShell extends CommandShell {
 
   @Override
   public String getCommandUsage() {
-    StringBuffer sbuf = new StringBuffer(USAGE_PREFIX + COMMANDS);
+    StringBuilder sbuf = new StringBuilder(USAGE_PREFIX + COMMANDS);
     String banner = StringUtils.repeat("=", 66);
     sbuf.append(banner + "\n");
     sbuf.append(CreateCommand.USAGE + ":\n\n" + CreateCommand.DESC + "\n");

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/DF.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/DF.java
@@ -163,7 +163,7 @@ public class DF extends Shell {
   @VisibleForTesting
   protected void parseOutput() throws IOException {
     if (output.size() < 2) {
-      StringBuffer sb = new StringBuffer("Fewer lines of output than expected");
+      StringBuilder sb = new StringBuilder("Fewer lines of output than expected");
       if (output.size() > 0) {
         sb.append(": " + output.get(0));
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
@@ -1052,7 +1052,7 @@ public class FileUtil {
 
   private static void unTarUsingTar(File inFile, File untarDir,
       boolean gzipped) throws IOException {
-    StringBuffer untarCommand = new StringBuffer();
+    StringBuilder untarCommand = new StringBuilder();
     // not using canonical path here; this postpones relative path
     // resolution until bash is executed.
     final String source = "'" + FileUtil.makeSecureShellPath(inFile) + "'";

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/oncrpc/RpcDeniedReply.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/oncrpc/RpcDeniedReply.java
@@ -58,7 +58,7 @@ public class RpcDeniedReply extends RpcReply {
 
   @Override
   public String toString() {
-    return new StringBuffer().append("xid:").append(xid)
+    return new StringBuilder().append("xid:").append(xid)
         .append(",messageType:").append(messageType).append("verifier_flavor:")
         .append(verifier.getFlavor()).append("rejectState:")
         .append(rejectState).toString();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ProviderUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ProviderUtils.java
@@ -148,7 +148,7 @@ public final class ProviderUtils {
     if (providerPath == null) {
       return config;
     }
-    StringBuffer newProviderPath = new StringBuffer();
+    StringBuilder newProviderPath = new StringBuilder();
     String[] providers = providerPath.split(",");
     Path path = null;
     for (String provider: providers) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/CredentialShell.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/CredentialShell.java
@@ -127,7 +127,7 @@ public class CredentialShell extends CommandShell {
 
   @Override
   public String getCommandUsage() {
-    StringBuffer sbuf = new StringBuffer(USAGE_PREFIX + COMMANDS);
+    StringBuilder sbuf = new StringBuilder(USAGE_PREFIX + COMMANDS);
     String banner = StringUtils.repeat("=", 66);
     sbuf.append(banner + "\n")
         .append(CreateCommand.USAGE + ":\n\n" + CreateCommand.DESC + "\n")

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/SSLHostnameVerifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/SSLHostnameVerifier.java
@@ -416,10 +416,10 @@ public interface SSLHostnameVerifier extends javax.net.ssl.HostnameVerifier {
             for (Iterator<String> it = names.iterator(); it.hasNext();) {
                 // Don't trim the CN, though!
                 final String cn = StringUtils.toLowerCase(it.next());
-                // Store CN in StringBuffer in case we need to report an error.
-            buf.append(" <")
-            .append(cn)
-            .append('>');
+                // Store CN in StringBuilder in case we need to report an error.
+                buf.append(" <")
+                    .append(cn)
+                    .append('>');
                 if (it.hasNext()) {
                     buf.append(" OR");
                 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/SSLHostnameVerifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/SSLHostnameVerifier.java
@@ -370,7 +370,7 @@ public interface SSLHostnameVerifier extends javax.net.ssl.HostnameVerifier {
                     strictWithSubDomains);
             }
             // Build up lists of allowed hosts For logging/debugging purposes.
-            StringBuffer buf = new StringBuffer(32);
+            StringBuilder buf = new StringBuilder(32);
             buf.append('<');
             for (int i = 0; i < hosts.length; i++) {
                 String h = hosts[i];
@@ -408,8 +408,8 @@ public interface SSLHostnameVerifier extends javax.net.ssl.HostnameVerifier {
                 throw new SSLException(msg);
             }
 
-            // StringBuffer for building the error message.
-            buf = new StringBuffer();
+            // StringBuilder for building the error message.
+            buf = new StringBuilder();
 
             boolean match = false;
             out:

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/SSLHostnameVerifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/SSLHostnameVerifier.java
@@ -74,235 +74,235 @@ import org.slf4j.LoggerFactory;
 @InterfaceStability.Evolving
 public interface SSLHostnameVerifier extends javax.net.ssl.HostnameVerifier {
 
-    @Override
-    boolean verify(String host, SSLSession session);
+  @Override
+  boolean verify(String host, SSLSession session);
 
-    void check(String host, SSLSocket ssl) throws IOException;
+  void check(String host, SSLSocket ssl) throws IOException;
 
-    void check(String host, X509Certificate cert) throws SSLException;
+  void check(String host, X509Certificate cert) throws SSLException;
 
-    void check(String host, String[] cns, String[] subjectAlts)
-        throws SSLException;
+  void check(String host, String[] cns, String[] subjectAlts)
+      throws SSLException;
 
-    void check(String[] hosts, SSLSocket ssl) throws IOException;
+  void check(String[] hosts, SSLSocket ssl) throws IOException;
 
-    void check(String[] hosts, X509Certificate cert) throws SSLException;
+  void check(String[] hosts, X509Certificate cert) throws SSLException;
 
+
+  /**
+   * Checks to see if the supplied hostname matches any of the supplied CNs
+   * or "DNS" Subject-Alts.  Most implementations only look at the first CN,
+   * and ignore any additional CNs.  Most implementations do look at all of
+   * the "DNS" Subject-Alts. The CNs or Subject-Alts may contain wildcards
+   * according to RFC 2818.
+   *
+   * @param cns         CN fields, in order, as extracted from the X.509
+   *                    certificate.
+   * @param subjectAlts Subject-Alt fields of type 2 ("DNS"), as extracted
+   *                    from the X.509 certificate.
+   * @param hosts       The array of hostnames to verify.
+   * @throws SSLException If verification failed.
+   */
+  void check(String[] hosts, String[] cns, String[] subjectAlts)
+      throws SSLException;
+
+
+  /**
+   * The DEFAULT HostnameVerifier works the same way as Curl and Firefox.
+   * <p>
+   * The hostname must match either the first CN, or any of the subject-alts.
+   * A wildcard can occur in the CN, and in any of the subject-alts.
+   * <p>
+   * The only difference between DEFAULT and STRICT is that a wildcard (such
+   * as "*.foo.com") with DEFAULT matches all subdomains, including
+   * "a.b.foo.com".
+   */
+  public final static SSLHostnameVerifier DEFAULT =
+      new AbstractVerifier() {
+        @Override
+        public final void check(final String[] hosts, final String[] cns,
+                                final String[] subjectAlts)
+            throws SSLException {
+          check(hosts, cns, subjectAlts, false, false);
+        }
+
+        @Override
+        public final String toString() { return "DEFAULT"; }
+      };
+
+
+  /**
+   * The DEFAULT_AND_LOCALHOST HostnameVerifier works like the DEFAULT
+   * one with one additional relaxation:  a host of "localhost",
+   * "localhost.localdomain", "127.0.0.1", "::1" will always pass, no matter
+   * what is in the server's certificate.
+   */
+  public final static SSLHostnameVerifier DEFAULT_AND_LOCALHOST =
+      new AbstractVerifier() {
+        @Override
+        public final void check(final String[] hosts, final String[] cns,
+                                final String[] subjectAlts)
+            throws SSLException {
+          if (isLocalhost(hosts[0])) {
+            return;
+          }
+          check(hosts, cns, subjectAlts, false, false);
+        }
+
+        @Override
+        public final String toString() { return "DEFAULT_AND_LOCALHOST"; }
+      };
+
+  /**
+   * The STRICT HostnameVerifier works the same way as java.net.URL in Sun
+   * Java 1.4, Sun Java 5, Sun Java 6.  It's also pretty close to IE6.
+   * This implementation appears to be compliant with RFC 2818 for dealing
+   * with wildcards.
+   * <p>
+   * The hostname must match either the first CN, or any of the subject-alts.
+   * A wildcard can occur in the CN, and in any of the subject-alts.  The
+   * one divergence from IE6 is how we only check the first CN.  IE6 allows
+   * a match against any of the CNs present.  We decided to follow in
+   * Sun Java 1.4's footsteps and only check the first CN.
+   * <p>
+   * A wildcard such as "*.foo.com" matches only subdomains in the same
+   * level, for example "a.foo.com".  It does not match deeper subdomains
+   * such as "a.b.foo.com".
+   */
+  public final static SSLHostnameVerifier STRICT =
+      new AbstractVerifier() {
+        @Override
+        public final void check(final String[] host, final String[] cns,
+                                final String[] subjectAlts)
+            throws SSLException {
+          check(host, cns, subjectAlts, false, true);
+        }
+
+        @Override
+        public final String toString() { return "STRICT"; }
+      };
+
+  /**
+   * The STRICT_IE6 HostnameVerifier works just like the STRICT one with one
+   * minor variation:  the hostname can match against any of the CN's in the
+   * server's certificate, not just the first one.  This behaviour is
+   * identical to IE6's behaviour.
+   */
+  public final static SSLHostnameVerifier STRICT_IE6 =
+      new AbstractVerifier() {
+        @Override
+        public final void check(final String[] host, final String[] cns,
+                                final String[] subjectAlts)
+            throws SSLException {
+          check(host, cns, subjectAlts, true, true);
+        }
+
+        @Override
+        public final String toString() { return "STRICT_IE6"; }
+      };
+
+  /**
+   * The ALLOW_ALL HostnameVerifier essentially turns hostname verification
+   * off.  This implementation is a no-op, and never throws the SSLException.
+   */
+  public final static SSLHostnameVerifier ALLOW_ALL =
+      new AbstractVerifier() {
+        @Override
+        public final void check(final String[] host, final String[] cns,
+                                final String[] subjectAlts) {
+          // Allow everything - so never blowup.
+        }
+
+        @Override
+        public final String toString() { return "ALLOW_ALL"; }
+      };
+
+  abstract class AbstractVerifier implements SSLHostnameVerifier {
 
     /**
-     * Checks to see if the supplied hostname matches any of the supplied CNs
-     * or "DNS" Subject-Alts.  Most implementations only look at the first CN,
-     * and ignore any additional CNs.  Most implementations do look at all of
-     * the "DNS" Subject-Alts. The CNs or Subject-Alts may contain wildcards
-     * according to RFC 2818.
+     * Writes as SSLFactory logs as it is the only consumer of this verifier
+     * class.
+     */
+    static final Logger LOG = LoggerFactory.getLogger(SSLFactory.class);
+
+    /**
+     * This contains a list of 2nd-level domains that aren't allowed to
+     * have wildcards when combined with country-codes.
+     * For example: [*.co.uk].
+     * <p>
+     * The [*.co.uk] problem is an interesting one.  Should we just hope
+     * that CA's would never foolishly allow such a certificate to happen?
+     * Looks like we're the only implementation guarding against this.
+     * Firefox, Curl, Sun Java 1.4, 5, 6 don't bother with this check.
+     */
+    private final static String[] BAD_COUNTRY_2LDS =
+        {"ac", "co", "com", "ed", "edu", "go", "gouv", "gov", "info",
+            "lg", "ne", "net", "or", "org"};
+
+    private final static String[] LOCALHOSTS = {"::1", "127.0.0.1",
+        "localhost",
+        "localhost.localdomain"};
+
+
+    static {
+      // Just in case developer forgot to manually sort the array.  :-)
+      Arrays.sort(BAD_COUNTRY_2LDS);
+      Arrays.sort(LOCALHOSTS);
+    }
+
+    protected AbstractVerifier() {}
+
+    /**
+     * The javax.net.ssl.HostnameVerifier contract.
      *
-     * @param cns         CN fields, in order, as extracted from the X.509
-     *                    certificate.
-     * @param subjectAlts Subject-Alt fields of type 2 ("DNS"), as extracted
-     *                    from the X.509 certificate.
-     * @param hosts       The array of hostnames to verify.
-     * @throws SSLException If verification failed.
+     * @param host    'hostname' we used to create our socket
+     * @param session SSLSession with the remote server
+     * @return true if the host matched the one in the certificate.
      */
-    void check(String[] hosts, String[] cns, String[] subjectAlts)
-        throws SSLException;
+    @Override
+    public boolean verify(String host, SSLSession session) {
+      try {
+        Certificate[] certs = session.getPeerCertificates();
+        X509Certificate x509 = (X509Certificate) certs[0];
+        check(new String[]{host}, x509);
+        return true;
+      }
+      catch (SSLException e) {
+        return false;
+      }
+    }
 
+    @Override
+    public void check(String host, SSLSocket ssl) throws IOException {
+      check(new String[]{host}, ssl);
+    }
 
-    /**
-     * The DEFAULT HostnameVerifier works the same way as Curl and Firefox.
-     * <p>
-     * The hostname must match either the first CN, or any of the subject-alts.
-     * A wildcard can occur in the CN, and in any of the subject-alts.
-     * <p>
-     * The only difference between DEFAULT and STRICT is that a wildcard (such
-     * as "*.foo.com") with DEFAULT matches all subdomains, including
-     * "a.b.foo.com".
-     */
-    public final static SSLHostnameVerifier DEFAULT =
-        new AbstractVerifier() {
-            @Override
-            public final void check(final String[] hosts, final String[] cns,
-                                    final String[] subjectAlts)
-                throws SSLException {
-                check(hosts, cns, subjectAlts, false, false);
-            }
+    @Override
+    public void check(String host, X509Certificate cert)
+        throws SSLException {
+      check(new String[]{host}, cert);
+    }
 
-            @Override
-            public final String toString() { return "DEFAULT"; }
-        };
+    @Override
+    public void check(String host, String[] cns, String[] subjectAlts)
+        throws SSLException {
+      check(new String[]{host}, cns, subjectAlts);
+    }
 
+    @Override
+    public void check(String host[], SSLSocket ssl)
+        throws IOException {
+      if (host == null) {
+        throw new NullPointerException("host to verify is null");
+      }
 
-    /**
-     * The DEFAULT_AND_LOCALHOST HostnameVerifier works like the DEFAULT
-     * one with one additional relaxation:  a host of "localhost",
-     * "localhost.localdomain", "127.0.0.1", "::1" will always pass, no matter
-     * what is in the server's certificate.
-     */
-    public final static SSLHostnameVerifier DEFAULT_AND_LOCALHOST =
-        new AbstractVerifier() {
-            @Override
-            public final void check(final String[] hosts, final String[] cns,
-                                    final String[] subjectAlts)
-                throws SSLException {
-                if (isLocalhost(hosts[0])) {
-                    return;
-                }
-                check(hosts, cns, subjectAlts, false, false);
-            }
-
-            @Override
-            public final String toString() { return "DEFAULT_AND_LOCALHOST"; }
-        };
-
-    /**
-     * The STRICT HostnameVerifier works the same way as java.net.URL in Sun
-     * Java 1.4, Sun Java 5, Sun Java 6.  It's also pretty close to IE6.
-     * This implementation appears to be compliant with RFC 2818 for dealing
-     * with wildcards.
-     * <p>
-     * The hostname must match either the first CN, or any of the subject-alts.
-     * A wildcard can occur in the CN, and in any of the subject-alts.  The
-     * one divergence from IE6 is how we only check the first CN.  IE6 allows
-     * a match against any of the CNs present.  We decided to follow in
-     * Sun Java 1.4's footsteps and only check the first CN.
-     * <p>
-     * A wildcard such as "*.foo.com" matches only subdomains in the same
-     * level, for example "a.foo.com".  It does not match deeper subdomains
-     * such as "a.b.foo.com".
-     */
-    public final static SSLHostnameVerifier STRICT =
-        new AbstractVerifier() {
-            @Override
-            public final void check(final String[] host, final String[] cns,
-                                    final String[] subjectAlts)
-                throws SSLException {
-                check(host, cns, subjectAlts, false, true);
-            }
-
-            @Override
-            public final String toString() { return "STRICT"; }
-        };
-
-    /**
-     * The STRICT_IE6 HostnameVerifier works just like the STRICT one with one
-     * minor variation:  the hostname can match against any of the CN's in the
-     * server's certificate, not just the first one.  This behaviour is
-     * identical to IE6's behaviour.
-     */
-    public final static SSLHostnameVerifier STRICT_IE6 =
-        new AbstractVerifier() {
-            @Override
-            public final void check(final String[] host, final String[] cns,
-                                    final String[] subjectAlts)
-                throws SSLException {
-                check(host, cns, subjectAlts, true, true);
-            }
-
-            @Override
-            public final String toString() { return "STRICT_IE6"; }
-        };
-
-    /**
-     * The ALLOW_ALL HostnameVerifier essentially turns hostname verification
-     * off.  This implementation is a no-op, and never throws the SSLException.
-     */
-    public final static SSLHostnameVerifier ALLOW_ALL =
-        new AbstractVerifier() {
-            @Override
-            public final void check(final String[] host, final String[] cns,
-                                    final String[] subjectAlts) {
-                // Allow everything - so never blowup.
-            }
-
-            @Override
-            public final String toString() { return "ALLOW_ALL"; }
-        };
-
-    abstract class AbstractVerifier implements SSLHostnameVerifier {
-
-        /**
-         * Writes as SSLFactory logs as it is the only consumer of this verifier
-         * class.
-         */
-        static final Logger LOG = LoggerFactory.getLogger(SSLFactory.class);
-
-        /**
-         * This contains a list of 2nd-level domains that aren't allowed to
-         * have wildcards when combined with country-codes.
-         * For example: [*.co.uk].
-         * <p>
-         * The [*.co.uk] problem is an interesting one.  Should we just hope
-         * that CA's would never foolishly allow such a certificate to happen?
-         * Looks like we're the only implementation guarding against this.
-         * Firefox, Curl, Sun Java 1.4, 5, 6 don't bother with this check.
-         */
-        private final static String[] BAD_COUNTRY_2LDS =
-            {"ac", "co", "com", "ed", "edu", "go", "gouv", "gov", "info",
-                "lg", "ne", "net", "or", "org"};
-
-        private final static String[] LOCALHOSTS = {"::1", "127.0.0.1",
-            "localhost",
-            "localhost.localdomain"};
-
-
-        static {
-            // Just in case developer forgot to manually sort the array.  :-)
-            Arrays.sort(BAD_COUNTRY_2LDS);
-            Arrays.sort(LOCALHOSTS);
-        }
-
-        protected AbstractVerifier() {}
-
-        /**
-         * The javax.net.ssl.HostnameVerifier contract.
-         *
-         * @param host    'hostname' we used to create our socket
-         * @param session SSLSession with the remote server
-         * @return true if the host matched the one in the certificate.
-         */
-        @Override
-        public boolean verify(String host, SSLSession session) {
-            try {
-                Certificate[] certs = session.getPeerCertificates();
-                X509Certificate x509 = (X509Certificate) certs[0];
-                check(new String[]{host}, x509);
-                return true;
-            }
-            catch (SSLException e) {
-                return false;
-            }
-        }
-
-        @Override
-        public void check(String host, SSLSocket ssl) throws IOException {
-            check(new String[]{host}, ssl);
-        }
-
-        @Override
-        public void check(String host, X509Certificate cert)
-            throws SSLException {
-            check(new String[]{host}, cert);
-        }
-
-        @Override
-        public void check(String host, String[] cns, String[] subjectAlts)
-            throws SSLException {
-            check(new String[]{host}, cns, subjectAlts);
-        }
-
-        @Override
-        public void check(String host[], SSLSocket ssl)
-            throws IOException {
-            if (host == null) {
-                throw new NullPointerException("host to verify is null");
-            }
-
-            SSLSession session = ssl.getSession();
-            if (session == null) {
-                // In our experience this only happens under IBM 1.4.x when
-                // spurious (unrelated) certificates show up in the server'
-                // chain.  Hopefully this will unearth the real problem:
-                InputStream in = ssl.getInputStream();
-                in.available();
+      SSLSession session = ssl.getSession();
+      if (session == null) {
+        // In our experience this only happens under IBM 1.4.x when
+        // spurious (unrelated) certificates show up in the server'
+        // chain.  Hopefully this will unearth the real problem:
+        InputStream in = ssl.getInputStream();
+        in.available();
                 /*
                   If you're looking at the 2 lines of code above because
                   you're running into a problem, you probably have two
@@ -319,207 +319,207 @@ public interface SSLHostnameVerifier extends javax.net.ssl.HostnameVerifier {
                           to a non-IBM JVM.
                 */
 
-                // If ssl.getInputStream().available() didn't cause an
-                // exception, maybe at least now the session is available?
-                session = ssl.getSession();
-                if (session == null) {
-                    // If it's still null, probably a startHandshake() will
-                    // unearth the real problem.
-                    ssl.startHandshake();
+        // If ssl.getInputStream().available() didn't cause an
+        // exception, maybe at least now the session is available?
+        session = ssl.getSession();
+        if (session == null) {
+          // If it's still null, probably a startHandshake() will
+          // unearth the real problem.
+          ssl.startHandshake();
 
-                    // Okay, if we still haven't managed to cause an exception,
-                    // might as well go for the NPE.  Or maybe we're okay now?
-                    session = ssl.getSession();
-                }
-            }
-            Certificate[] certs;
-            try {
-                certs = session.getPeerCertificates();
-            } catch (SSLPeerUnverifiedException spue) {
-                InputStream in = ssl.getInputStream();
-                in.available();
-                // Didn't trigger anything interesting?  Okay, just throw
-                // original.
-                throw spue;
-            }
-            X509Certificate x509 = (X509Certificate) certs[0];
-            check(host, x509);
+          // Okay, if we still haven't managed to cause an exception,
+          // might as well go for the NPE.  Or maybe we're okay now?
+          session = ssl.getSession();
         }
-
-        @Override
-        public void check(String[] host, X509Certificate cert)
-            throws SSLException {
-            String[] cns = Certificates.getCNs(cert);
-            String[] subjectAlts = Certificates.getDNSSubjectAlts(cert);
-            try {
-                check(host, cns, subjectAlts);
-            } catch (SSLException e) {
-                LOG.error("Host check error {}", e);
-                throw e;
-            }
-        }
-
-        public void check(final String[] hosts, final String[] cns,
-                          final String[] subjectAlts, final boolean ie6,
-                          final boolean strictWithSubDomains)
-            throws SSLException {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("Hosts:{}, CNs:{} subjectAlts:{}, ie6:{}, " +
-                    "strictWithSubDomains{}", Arrays.toString(hosts),
-                    Arrays.toString(cns), Arrays.toString(subjectAlts), ie6,
-                    strictWithSubDomains);
-            }
-            // Build up lists of allowed hosts For logging/debugging purposes.
-            StringBuilder buf = new StringBuilder(32);
-            buf.append('<');
-            for (int i = 0; i < hosts.length; i++) {
-                String h = hosts[i];
-                h = h != null ? StringUtils.toLowerCase(h.trim()) : "";
-                hosts[i] = h;
-                if (i > 0) {
-                    buf.append('/');
-                }
-                buf.append(h);
-            }
-            buf.append('>');
-            String hostnames = buf.toString();
-            // Build the list of names we're going to check.  Our DEFAULT and
-            // STRICT implementations of the HostnameVerifier only use the
-            // first CN provided.  All other CNs are ignored.
-            // (Firefox, wget, curl, Sun Java 1.4, 5, 6 all work this way).
-            final Set<String> names = new TreeSet<String>();
-            if (cns != null && cns.length > 0 && cns[0] != null) {
-                names.add(cns[0]);
-                if (ie6) {
-                    for (int i = 1; i < cns.length; i++) {
-                        names.add(cns[i]);
-                    }
-                }
-            }
-            if (subjectAlts != null) {
-                for (int i = 0; i < subjectAlts.length; i++) {
-                    if (subjectAlts[i] != null) {
-                        names.add(subjectAlts[i]);
-                    }
-                }
-            }
-            if (names.isEmpty()) {
-                String msg = "Certificate for " + hosts[0] + " doesn't contain CN or DNS subjectAlt";
-                throw new SSLException(msg);
-            }
-
-            // StringBuilder for building the error message.
-            buf = new StringBuilder();
-
-            boolean match = false;
-            out:
-            for (Iterator<String> it = names.iterator(); it.hasNext();) {
-                // Don't trim the CN, though!
-                final String cn = StringUtils.toLowerCase(it.next());
-                // Store CN in StringBuilder in case we need to report an error.
-                buf.append(" <")
-                    .append(cn)
-                    .append('>');
-                if (it.hasNext()) {
-                    buf.append(" OR");
-                }
-
-                // The CN better have at least two dots if it wants wildcard
-                // action.  It also can't be [*.co.uk] or [*.co.jp] or
-                // [*.org.uk], etc...
-                boolean doWildcard = cn.startsWith("*.") &&
-                                     cn.lastIndexOf('.') >= 0 &&
-                                     !isIP4Address(cn) &&
-                                     acceptableCountryWildcard(cn);
-
-                for (int i = 0; i < hosts.length; i++) {
-                    final String hostName =
-                        StringUtils.toLowerCase(hosts[i].trim());
-                    if (doWildcard) {
-                        match = hostName.endsWith(cn.substring(1));
-                        if (match && strictWithSubDomains) {
-                            // If we're in strict mode, then [*.foo.com] is not
-                            // allowed to match [a.b.foo.com]
-                            match = countDots(hostName) == countDots(cn);
-                        }
-                    } else {
-                        match = hostName.equals(cn);
-                    }
-                    if (match) {
-                        break out;
-                    }
-                }
-            }
-            if (!match) {
-                throw new SSLException("hostname in certificate didn't match: " + hostnames + " !=" + buf);
-            }
-        }
-
-        public static boolean isIP4Address(final String cn) {
-            boolean isIP4 = true;
-            String tld = cn;
-            int x = cn.lastIndexOf('.');
-            // We only bother analyzing the characters after the final dot
-            // in the name.
-            if (x >= 0 && x + 1 < cn.length()) {
-                tld = cn.substring(x + 1);
-            }
-            for (int i = 0; i < tld.length(); i++) {
-                if (!Character.isDigit(tld.charAt(0))) {
-                    isIP4 = false;
-                    break;
-                }
-            }
-            return isIP4;
-        }
-
-        public static boolean acceptableCountryWildcard(final String cn) {
-            int cnLen = cn.length();
-            if (cnLen >= 7 && cnLen <= 9) {
-                // Look for the '.' in the 3rd-last position:
-                if (cn.charAt(cnLen - 3) == '.') {
-                    // Trim off the [*.] and the [.XX].
-                    String s = cn.substring(2, cnLen - 3);
-                    // And test against the sorted array of bad 2lds:
-                    int x = Arrays.binarySearch(BAD_COUNTRY_2LDS, s);
-                    return x < 0;
-                }
-            }
-            return true;
-        }
-
-        public static boolean isLocalhost(String host) {
-            host = host != null ? StringUtils.toLowerCase(host.trim()) : "";
-            if (host.startsWith("::1")) {
-                int x = host.lastIndexOf('%');
-                if (x >= 0) {
-                    host = host.substring(0, x);
-                }
-            }
-            int x = Arrays.binarySearch(LOCALHOSTS, host);
-            return x >= 0;
-        }
-
-        /**
-         * Counts the number of dots "." in a string.
-         *
-         * @param s string to count dots from
-         * @return number of dots
-         */
-        public static int countDots(final String s) {
-            int count = 0;
-            for (int i = 0; i < s.length(); i++) {
-                if (s.charAt(i) == '.') {
-                    count++;
-                }
-            }
-            return count;
-        }
+      }
+      Certificate[] certs;
+      try {
+        certs = session.getPeerCertificates();
+      } catch (SSLPeerUnverifiedException spue) {
+        InputStream in = ssl.getInputStream();
+        in.available();
+        // Didn't trigger anything interesting?  Okay, just throw
+        // original.
+        throw spue;
+      }
+      X509Certificate x509 = (X509Certificate) certs[0];
+      check(host, x509);
     }
 
-    static class Certificates {
-      public static String[] getCNs(X509Certificate cert) {
-        final List<String> cnList = new LinkedList<String>();
+    @Override
+    public void check(String[] host, X509Certificate cert)
+        throws SSLException {
+      String[] cns = Certificates.getCNs(cert);
+      String[] subjectAlts = Certificates.getDNSSubjectAlts(cert);
+      try {
+        check(host, cns, subjectAlts);
+      } catch (SSLException e) {
+        LOG.error("Host check error {}", e);
+        throw e;
+      }
+    }
+
+    public void check(final String[] hosts, final String[] cns,
+                      final String[] subjectAlts, final boolean ie6,
+                      final boolean strictWithSubDomains)
+        throws SSLException {
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Hosts:{}, CNs:{} subjectAlts:{}, ie6:{}, " +
+                "strictWithSubDomains{}", Arrays.toString(hosts),
+            Arrays.toString(cns), Arrays.toString(subjectAlts), ie6,
+            strictWithSubDomains);
+      }
+      // Build up lists of allowed hosts For logging/debugging purposes.
+      StringBuilder buf = new StringBuilder(32);
+      buf.append('<');
+      for (int i = 0; i < hosts.length; i++) {
+        String h = hosts[i];
+        h = h != null ? StringUtils.toLowerCase(h.trim()) : "";
+        hosts[i] = h;
+        if (i > 0) {
+          buf.append('/');
+        }
+        buf.append(h);
+      }
+      buf.append('>');
+      String hostnames = buf.toString();
+      // Build the list of names we're going to check.  Our DEFAULT and
+      // STRICT implementations of the HostnameVerifier only use the
+      // first CN provided.  All other CNs are ignored.
+      // (Firefox, wget, curl, Sun Java 1.4, 5, 6 all work this way).
+      final Set<String> names = new TreeSet<String>();
+      if (cns != null && cns.length > 0 && cns[0] != null) {
+        names.add(cns[0]);
+        if (ie6) {
+          for (int i = 1; i < cns.length; i++) {
+            names.add(cns[i]);
+          }
+        }
+      }
+      if (subjectAlts != null) {
+        for (int i = 0; i < subjectAlts.length; i++) {
+          if (subjectAlts[i] != null) {
+            names.add(subjectAlts[i]);
+          }
+        }
+      }
+      if (names.isEmpty()) {
+        String msg = "Certificate for " + hosts[0] + " doesn't contain CN or DNS subjectAlt";
+        throw new SSLException(msg);
+      }
+
+      // StringBuilder for building the error message.
+      buf = new StringBuilder();
+
+      boolean match = false;
+      out:
+      for (Iterator<String> it = names.iterator(); it.hasNext();) {
+        // Don't trim the CN, though!
+        final String cn = StringUtils.toLowerCase(it.next());
+        // Store CN in StringBuilder in case we need to report an error.
+        buf.append(" <")
+            .append(cn)
+            .append('>');
+        if (it.hasNext()) {
+          buf.append(" OR");
+        }
+
+        // The CN better have at least two dots if it wants wildcard
+        // action.  It also can't be [*.co.uk] or [*.co.jp] or
+        // [*.org.uk], etc...
+        boolean doWildcard = cn.startsWith("*.") &&
+            cn.lastIndexOf('.') >= 0 &&
+            !isIP4Address(cn) &&
+            acceptableCountryWildcard(cn);
+
+        for (int i = 0; i < hosts.length; i++) {
+          final String hostName =
+              StringUtils.toLowerCase(hosts[i].trim());
+          if (doWildcard) {
+            match = hostName.endsWith(cn.substring(1));
+            if (match && strictWithSubDomains) {
+              // If we're in strict mode, then [*.foo.com] is not
+              // allowed to match [a.b.foo.com]
+              match = countDots(hostName) == countDots(cn);
+            }
+          } else {
+            match = hostName.equals(cn);
+          }
+          if (match) {
+            break out;
+          }
+        }
+      }
+      if (!match) {
+        throw new SSLException("hostname in certificate didn't match: " + hostnames + " !=" + buf);
+      }
+    }
+
+    public static boolean isIP4Address(final String cn) {
+      boolean isIP4 = true;
+      String tld = cn;
+      int x = cn.lastIndexOf('.');
+      // We only bother analyzing the characters after the final dot
+      // in the name.
+      if (x >= 0 && x + 1 < cn.length()) {
+        tld = cn.substring(x + 1);
+      }
+      for (int i = 0; i < tld.length(); i++) {
+        if (!Character.isDigit(tld.charAt(0))) {
+          isIP4 = false;
+          break;
+        }
+      }
+      return isIP4;
+    }
+
+    public static boolean acceptableCountryWildcard(final String cn) {
+      int cnLen = cn.length();
+      if (cnLen >= 7 && cnLen <= 9) {
+        // Look for the '.' in the 3rd-last position:
+        if (cn.charAt(cnLen - 3) == '.') {
+          // Trim off the [*.] and the [.XX].
+          String s = cn.substring(2, cnLen - 3);
+          // And test against the sorted array of bad 2lds:
+          int x = Arrays.binarySearch(BAD_COUNTRY_2LDS, s);
+          return x < 0;
+        }
+      }
+      return true;
+    }
+
+    public static boolean isLocalhost(String host) {
+      host = host != null ? StringUtils.toLowerCase(host.trim()) : "";
+      if (host.startsWith("::1")) {
+        int x = host.lastIndexOf('%');
+        if (x >= 0) {
+          host = host.substring(0, x);
+        }
+      }
+      int x = Arrays.binarySearch(LOCALHOSTS, host);
+      return x >= 0;
+    }
+
+    /**
+     * Counts the number of dots "." in a string.
+     *
+     * @param s string to count dots from
+     * @return number of dots
+     */
+    public static int countDots(final String s) {
+      int count = 0;
+      for (int i = 0; i < s.length(); i++) {
+        if (s.charAt(i) == '.') {
+          count++;
+        }
+      }
+      return count;
+    }
+  }
+
+  static class Certificates {
+    public static String[] getCNs(X509Certificate cert) {
+      final List<String> cnList = new LinkedList<String>();
         /*
           Sebastian Hauer's original StrictSSLProtocolSocketFactory used
           getName() and had the following comment:
@@ -542,69 +542,69 @@ public interface SSLHostnameVerifier extends javax.net.ssl.HostnameVerifier {
            Looks like toString() even works with non-ascii domain names!
            I tested it with "&#x82b1;&#x5b50;.co.jp" and it worked fine.
           */
-        String subjectPrincipal = cert.getSubjectX500Principal().toString();
-        StringTokenizer st = new StringTokenizer(subjectPrincipal, ",");
-        while (st.hasMoreTokens()) {
-            String tok = st.nextToken();
-            int x = tok.indexOf("CN=");
-            if (x >= 0) {
-                cnList.add(tok.substring(x + 3));
-            }
-        }
-        if (!cnList.isEmpty()) {
-            String[] cns = new String[cnList.size()];
-            cnList.toArray(cns);
-            return cns;
-        } else {
-            return null;
+      String subjectPrincipal = cert.getSubjectX500Principal().toString();
+      StringTokenizer st = new StringTokenizer(subjectPrincipal, ",");
+      while (st.hasMoreTokens()) {
+        String tok = st.nextToken();
+        int x = tok.indexOf("CN=");
+        if (x >= 0) {
+          cnList.add(tok.substring(x + 3));
         }
       }
-
-
-      /**
-       * Extracts the array of SubjectAlt DNS names from an X509Certificate.
-       * Returns null if there aren't any.
-       * <p>
-       * Note:  Java doesn't appear able to extract international characters
-       * from the SubjectAlts.  It can only extract international characters
-       * from the CN field.
-       * <p>
-       * (Or maybe the version of OpenSSL I'm using to test isn't storing the
-       * international characters correctly in the SubjectAlts?).
-       *
-       * @param cert X509Certificate
-       * @return Array of SubjectALT DNS names stored in the certificate.
-       */
-      public static String[] getDNSSubjectAlts(X509Certificate cert) {
-          final List<String> subjectAltList = new LinkedList<String>();
-          Collection<List<?>> c = null;
-          try {
-              c = cert.getSubjectAlternativeNames();
-          }
-          catch (CertificateParsingException cpe) {
-              // Should probably log.debug() this?
-              cpe.printStackTrace();
-          }
-          if (c != null) {
-              Iterator<List<?>> it = c.iterator();
-              while (it.hasNext()) {
-                  List<?> list = it.next();
-                  int type = ((Integer) list.get(0)).intValue();
-                  // If type is 2, then we've got a dNSName
-                  if (type == 2) {
-                      String s = (String) list.get(1);
-                      subjectAltList.add(s);
-                  }
-              }
-          }
-          if (!subjectAltList.isEmpty()) {
-              String[] subjectAlts = new String[subjectAltList.size()];
-              subjectAltList.toArray(subjectAlts);
-              return subjectAlts;
-          } else {
-              return null;
-          }
+      if (!cnList.isEmpty()) {
+        String[] cns = new String[cnList.size()];
+        cnList.toArray(cns);
+        return cns;
+      } else {
+        return null;
       }
     }
+
+
+    /**
+     * Extracts the array of SubjectAlt DNS names from an X509Certificate.
+     * Returns null if there aren't any.
+     * <p>
+     * Note:  Java doesn't appear able to extract international characters
+     * from the SubjectAlts.  It can only extract international characters
+     * from the CN field.
+     * <p>
+     * (Or maybe the version of OpenSSL I'm using to test isn't storing the
+     * international characters correctly in the SubjectAlts?).
+     *
+     * @param cert X509Certificate
+     * @return Array of SubjectALT DNS names stored in the certificate.
+     */
+    public static String[] getDNSSubjectAlts(X509Certificate cert) {
+      final List<String> subjectAltList = new LinkedList<String>();
+      Collection<List<?>> c = null;
+      try {
+        c = cert.getSubjectAlternativeNames();
+      }
+      catch (CertificateParsingException cpe) {
+        // Should probably log.debug() this?
+        cpe.printStackTrace();
+      }
+      if (c != null) {
+        Iterator<List<?>> it = c.iterator();
+        while (it.hasNext()) {
+          List<?> list = it.next();
+          int type = ((Integer) list.get(0)).intValue();
+          // If type is 2, then we've got a dNSName
+          if (type == 2) {
+            String s = (String) list.get(1);
+            subjectAltList.add(s);
+          }
+        }
+      }
+      if (!subjectAltList.isEmpty()) {
+        String[] subjectAlts = new String[subjectAltList.size()];
+        subjectAltList.toArray(subjectAlts);
+        return subjectAlts;
+      } else {
+        return null;
+      }
+    }
+  }
 
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/SSLHostnameVerifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/SSLHostnameVerifier.java
@@ -74,235 +74,235 @@ import org.slf4j.LoggerFactory;
 @InterfaceStability.Evolving
 public interface SSLHostnameVerifier extends javax.net.ssl.HostnameVerifier {
 
-  @Override
-  boolean verify(String host, SSLSession session);
+    @Override
+    boolean verify(String host, SSLSession session);
 
-  void check(String host, SSLSocket ssl) throws IOException;
+    void check(String host, SSLSocket ssl) throws IOException;
 
-  void check(String host, X509Certificate cert) throws SSLException;
+    void check(String host, X509Certificate cert) throws SSLException;
 
-  void check(String host, String[] cns, String[] subjectAlts)
-      throws SSLException;
+    void check(String host, String[] cns, String[] subjectAlts)
+        throws SSLException;
 
-  void check(String[] hosts, SSLSocket ssl) throws IOException;
+    void check(String[] hosts, SSLSocket ssl) throws IOException;
 
-  void check(String[] hosts, X509Certificate cert) throws SSLException;
+    void check(String[] hosts, X509Certificate cert) throws SSLException;
 
-
-  /**
-   * Checks to see if the supplied hostname matches any of the supplied CNs
-   * or "DNS" Subject-Alts.  Most implementations only look at the first CN,
-   * and ignore any additional CNs.  Most implementations do look at all of
-   * the "DNS" Subject-Alts. The CNs or Subject-Alts may contain wildcards
-   * according to RFC 2818.
-   *
-   * @param cns         CN fields, in order, as extracted from the X.509
-   *                    certificate.
-   * @param subjectAlts Subject-Alt fields of type 2 ("DNS"), as extracted
-   *                    from the X.509 certificate.
-   * @param hosts       The array of hostnames to verify.
-   * @throws SSLException If verification failed.
-   */
-  void check(String[] hosts, String[] cns, String[] subjectAlts)
-      throws SSLException;
-
-
-  /**
-   * The DEFAULT HostnameVerifier works the same way as Curl and Firefox.
-   * <p>
-   * The hostname must match either the first CN, or any of the subject-alts.
-   * A wildcard can occur in the CN, and in any of the subject-alts.
-   * <p>
-   * The only difference between DEFAULT and STRICT is that a wildcard (such
-   * as "*.foo.com") with DEFAULT matches all subdomains, including
-   * "a.b.foo.com".
-   */
-  public final static SSLHostnameVerifier DEFAULT =
-      new AbstractVerifier() {
-        @Override
-        public final void check(final String[] hosts, final String[] cns,
-                                final String[] subjectAlts)
-            throws SSLException {
-          check(hosts, cns, subjectAlts, false, false);
-        }
-
-        @Override
-        public final String toString() { return "DEFAULT"; }
-      };
-
-
-  /**
-   * The DEFAULT_AND_LOCALHOST HostnameVerifier works like the DEFAULT
-   * one with one additional relaxation:  a host of "localhost",
-   * "localhost.localdomain", "127.0.0.1", "::1" will always pass, no matter
-   * what is in the server's certificate.
-   */
-  public final static SSLHostnameVerifier DEFAULT_AND_LOCALHOST =
-      new AbstractVerifier() {
-        @Override
-        public final void check(final String[] hosts, final String[] cns,
-                                final String[] subjectAlts)
-            throws SSLException {
-          if (isLocalhost(hosts[0])) {
-            return;
-          }
-          check(hosts, cns, subjectAlts, false, false);
-        }
-
-        @Override
-        public final String toString() { return "DEFAULT_AND_LOCALHOST"; }
-      };
-
-  /**
-   * The STRICT HostnameVerifier works the same way as java.net.URL in Sun
-   * Java 1.4, Sun Java 5, Sun Java 6.  It's also pretty close to IE6.
-   * This implementation appears to be compliant with RFC 2818 for dealing
-   * with wildcards.
-   * <p>
-   * The hostname must match either the first CN, or any of the subject-alts.
-   * A wildcard can occur in the CN, and in any of the subject-alts.  The
-   * one divergence from IE6 is how we only check the first CN.  IE6 allows
-   * a match against any of the CNs present.  We decided to follow in
-   * Sun Java 1.4's footsteps and only check the first CN.
-   * <p>
-   * A wildcard such as "*.foo.com" matches only subdomains in the same
-   * level, for example "a.foo.com".  It does not match deeper subdomains
-   * such as "a.b.foo.com".
-   */
-  public final static SSLHostnameVerifier STRICT =
-      new AbstractVerifier() {
-        @Override
-        public final void check(final String[] host, final String[] cns,
-                                final String[] subjectAlts)
-            throws SSLException {
-          check(host, cns, subjectAlts, false, true);
-        }
-
-        @Override
-        public final String toString() { return "STRICT"; }
-      };
-
-  /**
-   * The STRICT_IE6 HostnameVerifier works just like the STRICT one with one
-   * minor variation:  the hostname can match against any of the CN's in the
-   * server's certificate, not just the first one.  This behaviour is
-   * identical to IE6's behaviour.
-   */
-  public final static SSLHostnameVerifier STRICT_IE6 =
-      new AbstractVerifier() {
-        @Override
-        public final void check(final String[] host, final String[] cns,
-                                final String[] subjectAlts)
-            throws SSLException {
-          check(host, cns, subjectAlts, true, true);
-        }
-
-        @Override
-        public final String toString() { return "STRICT_IE6"; }
-      };
-
-  /**
-   * The ALLOW_ALL HostnameVerifier essentially turns hostname verification
-   * off.  This implementation is a no-op, and never throws the SSLException.
-   */
-  public final static SSLHostnameVerifier ALLOW_ALL =
-      new AbstractVerifier() {
-        @Override
-        public final void check(final String[] host, final String[] cns,
-                                final String[] subjectAlts) {
-          // Allow everything - so never blowup.
-        }
-
-        @Override
-        public final String toString() { return "ALLOW_ALL"; }
-      };
-
-  abstract class AbstractVerifier implements SSLHostnameVerifier {
 
     /**
-     * Writes as SSLFactory logs as it is the only consumer of this verifier
-     * class.
-     */
-    static final Logger LOG = LoggerFactory.getLogger(SSLFactory.class);
-
-    /**
-     * This contains a list of 2nd-level domains that aren't allowed to
-     * have wildcards when combined with country-codes.
-     * For example: [*.co.uk].
-     * <p>
-     * The [*.co.uk] problem is an interesting one.  Should we just hope
-     * that CA's would never foolishly allow such a certificate to happen?
-     * Looks like we're the only implementation guarding against this.
-     * Firefox, Curl, Sun Java 1.4, 5, 6 don't bother with this check.
-     */
-    private final static String[] BAD_COUNTRY_2LDS =
-        {"ac", "co", "com", "ed", "edu", "go", "gouv", "gov", "info",
-            "lg", "ne", "net", "or", "org"};
-
-    private final static String[] LOCALHOSTS = {"::1", "127.0.0.1",
-        "localhost",
-        "localhost.localdomain"};
-
-
-    static {
-      // Just in case developer forgot to manually sort the array.  :-)
-      Arrays.sort(BAD_COUNTRY_2LDS);
-      Arrays.sort(LOCALHOSTS);
-    }
-
-    protected AbstractVerifier() {}
-
-    /**
-     * The javax.net.ssl.HostnameVerifier contract.
+     * Checks to see if the supplied hostname matches any of the supplied CNs
+     * or "DNS" Subject-Alts.  Most implementations only look at the first CN,
+     * and ignore any additional CNs.  Most implementations do look at all of
+     * the "DNS" Subject-Alts. The CNs or Subject-Alts may contain wildcards
+     * according to RFC 2818.
      *
-     * @param host    'hostname' we used to create our socket
-     * @param session SSLSession with the remote server
-     * @return true if the host matched the one in the certificate.
+     * @param cns         CN fields, in order, as extracted from the X.509
+     *                    certificate.
+     * @param subjectAlts Subject-Alt fields of type 2 ("DNS"), as extracted
+     *                    from the X.509 certificate.
+     * @param hosts       The array of hostnames to verify.
+     * @throws SSLException If verification failed.
      */
-    @Override
-    public boolean verify(String host, SSLSession session) {
-      try {
-        Certificate[] certs = session.getPeerCertificates();
-        X509Certificate x509 = (X509Certificate) certs[0];
-        check(new String[]{host}, x509);
-        return true;
-      }
-      catch (SSLException e) {
-        return false;
-      }
-    }
+    void check(String[] hosts, String[] cns, String[] subjectAlts)
+        throws SSLException;
 
-    @Override
-    public void check(String host, SSLSocket ssl) throws IOException {
-      check(new String[]{host}, ssl);
-    }
 
-    @Override
-    public void check(String host, X509Certificate cert)
-        throws SSLException {
-      check(new String[]{host}, cert);
-    }
+    /**
+     * The DEFAULT HostnameVerifier works the same way as Curl and Firefox.
+     * <p>
+     * The hostname must match either the first CN, or any of the subject-alts.
+     * A wildcard can occur in the CN, and in any of the subject-alts.
+     * <p>
+     * The only difference between DEFAULT and STRICT is that a wildcard (such
+     * as "*.foo.com") with DEFAULT matches all subdomains, including
+     * "a.b.foo.com".
+     */
+    public final static SSLHostnameVerifier DEFAULT =
+        new AbstractVerifier() {
+            @Override
+            public final void check(final String[] hosts, final String[] cns,
+                                    final String[] subjectAlts)
+                throws SSLException {
+                check(hosts, cns, subjectAlts, false, false);
+            }
 
-    @Override
-    public void check(String host, String[] cns, String[] subjectAlts)
-        throws SSLException {
-      check(new String[]{host}, cns, subjectAlts);
-    }
+            @Override
+            public final String toString() { return "DEFAULT"; }
+        };
 
-    @Override
-    public void check(String host[], SSLSocket ssl)
-        throws IOException {
-      if (host == null) {
-        throw new NullPointerException("host to verify is null");
-      }
 
-      SSLSession session = ssl.getSession();
-      if (session == null) {
-        // In our experience this only happens under IBM 1.4.x when
-        // spurious (unrelated) certificates show up in the server'
-        // chain.  Hopefully this will unearth the real problem:
-        InputStream in = ssl.getInputStream();
-        in.available();
+    /**
+     * The DEFAULT_AND_LOCALHOST HostnameVerifier works like the DEFAULT
+     * one with one additional relaxation:  a host of "localhost",
+     * "localhost.localdomain", "127.0.0.1", "::1" will always pass, no matter
+     * what is in the server's certificate.
+     */
+    public final static SSLHostnameVerifier DEFAULT_AND_LOCALHOST =
+        new AbstractVerifier() {
+            @Override
+            public final void check(final String[] hosts, final String[] cns,
+                                    final String[] subjectAlts)
+                throws SSLException {
+                if (isLocalhost(hosts[0])) {
+                    return;
+                }
+                check(hosts, cns, subjectAlts, false, false);
+            }
+
+            @Override
+            public final String toString() { return "DEFAULT_AND_LOCALHOST"; }
+        };
+
+    /**
+     * The STRICT HostnameVerifier works the same way as java.net.URL in Sun
+     * Java 1.4, Sun Java 5, Sun Java 6.  It's also pretty close to IE6.
+     * This implementation appears to be compliant with RFC 2818 for dealing
+     * with wildcards.
+     * <p>
+     * The hostname must match either the first CN, or any of the subject-alts.
+     * A wildcard can occur in the CN, and in any of the subject-alts.  The
+     * one divergence from IE6 is how we only check the first CN.  IE6 allows
+     * a match against any of the CNs present.  We decided to follow in
+     * Sun Java 1.4's footsteps and only check the first CN.
+     * <p>
+     * A wildcard such as "*.foo.com" matches only subdomains in the same
+     * level, for example "a.foo.com".  It does not match deeper subdomains
+     * such as "a.b.foo.com".
+     */
+    public final static SSLHostnameVerifier STRICT =
+        new AbstractVerifier() {
+            @Override
+            public final void check(final String[] host, final String[] cns,
+                                    final String[] subjectAlts)
+                throws SSLException {
+                check(host, cns, subjectAlts, false, true);
+            }
+
+            @Override
+            public final String toString() { return "STRICT"; }
+        };
+
+    /**
+     * The STRICT_IE6 HostnameVerifier works just like the STRICT one with one
+     * minor variation:  the hostname can match against any of the CN's in the
+     * server's certificate, not just the first one.  This behaviour is
+     * identical to IE6's behaviour.
+     */
+    public final static SSLHostnameVerifier STRICT_IE6 =
+        new AbstractVerifier() {
+            @Override
+            public final void check(final String[] host, final String[] cns,
+                                    final String[] subjectAlts)
+                throws SSLException {
+                check(host, cns, subjectAlts, true, true);
+            }
+
+            @Override
+            public final String toString() { return "STRICT_IE6"; }
+        };
+
+    /**
+     * The ALLOW_ALL HostnameVerifier essentially turns hostname verification
+     * off.  This implementation is a no-op, and never throws the SSLException.
+     */
+    public final static SSLHostnameVerifier ALLOW_ALL =
+        new AbstractVerifier() {
+            @Override
+            public final void check(final String[] host, final String[] cns,
+                                    final String[] subjectAlts) {
+                // Allow everything - so never blowup.
+            }
+
+            @Override
+            public final String toString() { return "ALLOW_ALL"; }
+        };
+
+    abstract class AbstractVerifier implements SSLHostnameVerifier {
+
+        /**
+         * Writes as SSLFactory logs as it is the only consumer of this verifier
+         * class.
+         */
+        static final Logger LOG = LoggerFactory.getLogger(SSLFactory.class);
+
+        /**
+         * This contains a list of 2nd-level domains that aren't allowed to
+         * have wildcards when combined with country-codes.
+         * For example: [*.co.uk].
+         * <p>
+         * The [*.co.uk] problem is an interesting one.  Should we just hope
+         * that CA's would never foolishly allow such a certificate to happen?
+         * Looks like we're the only implementation guarding against this.
+         * Firefox, Curl, Sun Java 1.4, 5, 6 don't bother with this check.
+         */
+        private final static String[] BAD_COUNTRY_2LDS =
+            {"ac", "co", "com", "ed", "edu", "go", "gouv", "gov", "info",
+                "lg", "ne", "net", "or", "org"};
+
+        private final static String[] LOCALHOSTS = {"::1", "127.0.0.1",
+            "localhost",
+            "localhost.localdomain"};
+
+
+        static {
+            // Just in case developer forgot to manually sort the array.  :-)
+            Arrays.sort(BAD_COUNTRY_2LDS);
+            Arrays.sort(LOCALHOSTS);
+        }
+
+        protected AbstractVerifier() {}
+
+        /**
+         * The javax.net.ssl.HostnameVerifier contract.
+         *
+         * @param host    'hostname' we used to create our socket
+         * @param session SSLSession with the remote server
+         * @return true if the host matched the one in the certificate.
+         */
+        @Override
+        public boolean verify(String host, SSLSession session) {
+            try {
+                Certificate[] certs = session.getPeerCertificates();
+                X509Certificate x509 = (X509Certificate) certs[0];
+                check(new String[]{host}, x509);
+                return true;
+            }
+            catch (SSLException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public void check(String host, SSLSocket ssl) throws IOException {
+            check(new String[]{host}, ssl);
+        }
+
+        @Override
+        public void check(String host, X509Certificate cert)
+            throws SSLException {
+            check(new String[]{host}, cert);
+        }
+
+        @Override
+        public void check(String host, String[] cns, String[] subjectAlts)
+            throws SSLException {
+            check(new String[]{host}, cns, subjectAlts);
+        }
+
+        @Override
+        public void check(String host[], SSLSocket ssl)
+            throws IOException {
+            if (host == null) {
+                throw new NullPointerException("host to verify is null");
+            }
+
+            SSLSession session = ssl.getSession();
+            if (session == null) {
+                // In our experience this only happens under IBM 1.4.x when
+                // spurious (unrelated) certificates show up in the server'
+                // chain.  Hopefully this will unearth the real problem:
+                InputStream in = ssl.getInputStream();
+                in.available();
                 /*
                   If you're looking at the 2 lines of code above because
                   you're running into a problem, you probably have two
@@ -319,207 +319,207 @@ public interface SSLHostnameVerifier extends javax.net.ssl.HostnameVerifier {
                           to a non-IBM JVM.
                 */
 
-        // If ssl.getInputStream().available() didn't cause an
-        // exception, maybe at least now the session is available?
-        session = ssl.getSession();
-        if (session == null) {
-          // If it's still null, probably a startHandshake() will
-          // unearth the real problem.
-          ssl.startHandshake();
+                // If ssl.getInputStream().available() didn't cause an
+                // exception, maybe at least now the session is available?
+                session = ssl.getSession();
+                if (session == null) {
+                    // If it's still null, probably a startHandshake() will
+                    // unearth the real problem.
+                    ssl.startHandshake();
 
-          // Okay, if we still haven't managed to cause an exception,
-          // might as well go for the NPE.  Or maybe we're okay now?
-          session = ssl.getSession();
+                    // Okay, if we still haven't managed to cause an exception,
+                    // might as well go for the NPE.  Or maybe we're okay now?
+                    session = ssl.getSession();
+                }
+            }
+            Certificate[] certs;
+            try {
+                certs = session.getPeerCertificates();
+            } catch (SSLPeerUnverifiedException spue) {
+                InputStream in = ssl.getInputStream();
+                in.available();
+                // Didn't trigger anything interesting?  Okay, just throw
+                // original.
+                throw spue;
+            }
+            X509Certificate x509 = (X509Certificate) certs[0];
+            check(host, x509);
         }
-      }
-      Certificate[] certs;
-      try {
-        certs = session.getPeerCertificates();
-      } catch (SSLPeerUnverifiedException spue) {
-        InputStream in = ssl.getInputStream();
-        in.available();
-        // Didn't trigger anything interesting?  Okay, just throw
-        // original.
-        throw spue;
-      }
-      X509Certificate x509 = (X509Certificate) certs[0];
-      check(host, x509);
-    }
 
-    @Override
-    public void check(String[] host, X509Certificate cert)
-        throws SSLException {
-      String[] cns = Certificates.getCNs(cert);
-      String[] subjectAlts = Certificates.getDNSSubjectAlts(cert);
-      try {
-        check(host, cns, subjectAlts);
-      } catch (SSLException e) {
-        LOG.error("Host check error {}", e);
-        throw e;
-      }
-    }
-
-    public void check(final String[] hosts, final String[] cns,
-                      final String[] subjectAlts, final boolean ie6,
-                      final boolean strictWithSubDomains)
-        throws SSLException {
-      if (LOG.isTraceEnabled()) {
-        LOG.trace("Hosts:{}, CNs:{} subjectAlts:{}, ie6:{}, " +
-                "strictWithSubDomains{}", Arrays.toString(hosts),
-            Arrays.toString(cns), Arrays.toString(subjectAlts), ie6,
-            strictWithSubDomains);
-      }
-      // Build up lists of allowed hosts For logging/debugging purposes.
-      StringBuilder buf = new StringBuilder(32);
-      buf.append('<');
-      for (int i = 0; i < hosts.length; i++) {
-        String h = hosts[i];
-        h = h != null ? StringUtils.toLowerCase(h.trim()) : "";
-        hosts[i] = h;
-        if (i > 0) {
-          buf.append('/');
+        @Override
+        public void check(String[] host, X509Certificate cert)
+            throws SSLException {
+            String[] cns = Certificates.getCNs(cert);
+            String[] subjectAlts = Certificates.getDNSSubjectAlts(cert);
+            try {
+                check(host, cns, subjectAlts);
+            } catch (SSLException e) {
+                LOG.error("Host check error {}", e);
+                throw e;
+            }
         }
-        buf.append(h);
-      }
-      buf.append('>');
-      String hostnames = buf.toString();
-      // Build the list of names we're going to check.  Our DEFAULT and
-      // STRICT implementations of the HostnameVerifier only use the
-      // first CN provided.  All other CNs are ignored.
-      // (Firefox, wget, curl, Sun Java 1.4, 5, 6 all work this way).
-      final Set<String> names = new TreeSet<String>();
-      if (cns != null && cns.length > 0 && cns[0] != null) {
-        names.add(cns[0]);
-        if (ie6) {
-          for (int i = 1; i < cns.length; i++) {
-            names.add(cns[i]);
-          }
-        }
-      }
-      if (subjectAlts != null) {
-        for (int i = 0; i < subjectAlts.length; i++) {
-          if (subjectAlts[i] != null) {
-            names.add(subjectAlts[i]);
-          }
-        }
-      }
-      if (names.isEmpty()) {
-        String msg = "Certificate for " + hosts[0] + " doesn't contain CN or DNS subjectAlt";
-        throw new SSLException(msg);
-      }
 
-      // StringBuilder for building the error message.
-      buf = new StringBuilder();
+        public void check(final String[] hosts, final String[] cns,
+                          final String[] subjectAlts, final boolean ie6,
+                          final boolean strictWithSubDomains)
+            throws SSLException {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Hosts:{}, CNs:{} subjectAlts:{}, ie6:{}, " +
+                    "strictWithSubDomains{}", Arrays.toString(hosts),
+                    Arrays.toString(cns), Arrays.toString(subjectAlts), ie6,
+                    strictWithSubDomains);
+            }
+            // Build up lists of allowed hosts For logging/debugging purposes.
+            StringBuilder buf = new StringBuilder(32);
+            buf.append('<');
+            for (int i = 0; i < hosts.length; i++) {
+                String h = hosts[i];
+                h = h != null ? StringUtils.toLowerCase(h.trim()) : "";
+                hosts[i] = h;
+                if (i > 0) {
+                    buf.append('/');
+                }
+                buf.append(h);
+            }
+            buf.append('>');
+            String hostnames = buf.toString();
+            // Build the list of names we're going to check.  Our DEFAULT and
+            // STRICT implementations of the HostnameVerifier only use the
+            // first CN provided.  All other CNs are ignored.
+            // (Firefox, wget, curl, Sun Java 1.4, 5, 6 all work this way).
+            final Set<String> names = new TreeSet<String>();
+            if (cns != null && cns.length > 0 && cns[0] != null) {
+                names.add(cns[0]);
+                if (ie6) {
+                    for (int i = 1; i < cns.length; i++) {
+                        names.add(cns[i]);
+                    }
+                }
+            }
+            if (subjectAlts != null) {
+                for (int i = 0; i < subjectAlts.length; i++) {
+                    if (subjectAlts[i] != null) {
+                        names.add(subjectAlts[i]);
+                    }
+                }
+            }
+            if (names.isEmpty()) {
+                String msg = "Certificate for " + hosts[0] + " doesn't contain CN or DNS subjectAlt";
+                throw new SSLException(msg);
+            }
 
-      boolean match = false;
-      out:
-      for (Iterator<String> it = names.iterator(); it.hasNext();) {
-        // Don't trim the CN, though!
-        final String cn = StringUtils.toLowerCase(it.next());
-        // Store CN in StringBuilder in case we need to report an error.
-        buf.append(" <")
+            // StringBuilder for building the error message.
+            buf = new StringBuilder();
+
+            boolean match = false;
+            out:
+            for (Iterator<String> it = names.iterator(); it.hasNext();) {
+                // Don't trim the CN, though!
+                final String cn = StringUtils.toLowerCase(it.next());
+                // Store CN in StringBuilder in case we need to report an error.
+            buf.append(" <")
             .append(cn)
             .append('>');
-        if (it.hasNext()) {
-          buf.append(" OR");
-        }
+                if (it.hasNext()) {
+                    buf.append(" OR");
+                }
 
-        // The CN better have at least two dots if it wants wildcard
-        // action.  It also can't be [*.co.uk] or [*.co.jp] or
-        // [*.org.uk], etc...
-        boolean doWildcard = cn.startsWith("*.") &&
-            cn.lastIndexOf('.') >= 0 &&
-            !isIP4Address(cn) &&
-            acceptableCountryWildcard(cn);
+                // The CN better have at least two dots if it wants wildcard
+                // action.  It also can't be [*.co.uk] or [*.co.jp] or
+                // [*.org.uk], etc...
+                boolean doWildcard = cn.startsWith("*.") &&
+                                     cn.lastIndexOf('.') >= 0 &&
+                                     !isIP4Address(cn) &&
+                                     acceptableCountryWildcard(cn);
 
-        for (int i = 0; i < hosts.length; i++) {
-          final String hostName =
-              StringUtils.toLowerCase(hosts[i].trim());
-          if (doWildcard) {
-            match = hostName.endsWith(cn.substring(1));
-            if (match && strictWithSubDomains) {
-              // If we're in strict mode, then [*.foo.com] is not
-              // allowed to match [a.b.foo.com]
-              match = countDots(hostName) == countDots(cn);
+                for (int i = 0; i < hosts.length; i++) {
+                    final String hostName =
+                        StringUtils.toLowerCase(hosts[i].trim());
+                    if (doWildcard) {
+                        match = hostName.endsWith(cn.substring(1));
+                        if (match && strictWithSubDomains) {
+                            // If we're in strict mode, then [*.foo.com] is not
+                            // allowed to match [a.b.foo.com]
+                            match = countDots(hostName) == countDots(cn);
+                        }
+                    } else {
+                        match = hostName.equals(cn);
+                    }
+                    if (match) {
+                        break out;
+                    }
+                }
             }
-          } else {
-            match = hostName.equals(cn);
-          }
-          if (match) {
-            break out;
-          }
+            if (!match) {
+                throw new SSLException("hostname in certificate didn't match: " + hostnames + " !=" + buf);
+            }
         }
-      }
-      if (!match) {
-        throw new SSLException("hostname in certificate didn't match: " + hostnames + " !=" + buf);
-      }
+
+        public static boolean isIP4Address(final String cn) {
+            boolean isIP4 = true;
+            String tld = cn;
+            int x = cn.lastIndexOf('.');
+            // We only bother analyzing the characters after the final dot
+            // in the name.
+            if (x >= 0 && x + 1 < cn.length()) {
+                tld = cn.substring(x + 1);
+            }
+            for (int i = 0; i < tld.length(); i++) {
+                if (!Character.isDigit(tld.charAt(0))) {
+                    isIP4 = false;
+                    break;
+                }
+            }
+            return isIP4;
+        }
+
+        public static boolean acceptableCountryWildcard(final String cn) {
+            int cnLen = cn.length();
+            if (cnLen >= 7 && cnLen <= 9) {
+                // Look for the '.' in the 3rd-last position:
+                if (cn.charAt(cnLen - 3) == '.') {
+                    // Trim off the [*.] and the [.XX].
+                    String s = cn.substring(2, cnLen - 3);
+                    // And test against the sorted array of bad 2lds:
+                    int x = Arrays.binarySearch(BAD_COUNTRY_2LDS, s);
+                    return x < 0;
+                }
+            }
+            return true;
+        }
+
+        public static boolean isLocalhost(String host) {
+            host = host != null ? StringUtils.toLowerCase(host.trim()) : "";
+            if (host.startsWith("::1")) {
+                int x = host.lastIndexOf('%');
+                if (x >= 0) {
+                    host = host.substring(0, x);
+                }
+            }
+            int x = Arrays.binarySearch(LOCALHOSTS, host);
+            return x >= 0;
+        }
+
+        /**
+         * Counts the number of dots "." in a string.
+         *
+         * @param s string to count dots from
+         * @return number of dots
+         */
+        public static int countDots(final String s) {
+            int count = 0;
+            for (int i = 0; i < s.length(); i++) {
+                if (s.charAt(i) == '.') {
+                    count++;
+                }
+            }
+            return count;
+        }
     }
 
-    public static boolean isIP4Address(final String cn) {
-      boolean isIP4 = true;
-      String tld = cn;
-      int x = cn.lastIndexOf('.');
-      // We only bother analyzing the characters after the final dot
-      // in the name.
-      if (x >= 0 && x + 1 < cn.length()) {
-        tld = cn.substring(x + 1);
-      }
-      for (int i = 0; i < tld.length(); i++) {
-        if (!Character.isDigit(tld.charAt(0))) {
-          isIP4 = false;
-          break;
-        }
-      }
-      return isIP4;
-    }
-
-    public static boolean acceptableCountryWildcard(final String cn) {
-      int cnLen = cn.length();
-      if (cnLen >= 7 && cnLen <= 9) {
-        // Look for the '.' in the 3rd-last position:
-        if (cn.charAt(cnLen - 3) == '.') {
-          // Trim off the [*.] and the [.XX].
-          String s = cn.substring(2, cnLen - 3);
-          // And test against the sorted array of bad 2lds:
-          int x = Arrays.binarySearch(BAD_COUNTRY_2LDS, s);
-          return x < 0;
-        }
-      }
-      return true;
-    }
-
-    public static boolean isLocalhost(String host) {
-      host = host != null ? StringUtils.toLowerCase(host.trim()) : "";
-      if (host.startsWith("::1")) {
-        int x = host.lastIndexOf('%');
-        if (x >= 0) {
-          host = host.substring(0, x);
-        }
-      }
-      int x = Arrays.binarySearch(LOCALHOSTS, host);
-      return x >= 0;
-    }
-
-    /**
-     * Counts the number of dots "." in a string.
-     *
-     * @param s string to count dots from
-     * @return number of dots
-     */
-    public static int countDots(final String s) {
-      int count = 0;
-      for (int i = 0; i < s.length(); i++) {
-        if (s.charAt(i) == '.') {
-          count++;
-        }
-      }
-      return count;
-    }
-  }
-
-  static class Certificates {
-    public static String[] getCNs(X509Certificate cert) {
-      final List<String> cnList = new LinkedList<String>();
+    static class Certificates {
+      public static String[] getCNs(X509Certificate cert) {
+        final List<String> cnList = new LinkedList<String>();
         /*
           Sebastian Hauer's original StrictSSLProtocolSocketFactory used
           getName() and had the following comment:
@@ -542,69 +542,69 @@ public interface SSLHostnameVerifier extends javax.net.ssl.HostnameVerifier {
            Looks like toString() even works with non-ascii domain names!
            I tested it with "&#x82b1;&#x5b50;.co.jp" and it worked fine.
           */
-      String subjectPrincipal = cert.getSubjectX500Principal().toString();
-      StringTokenizer st = new StringTokenizer(subjectPrincipal, ",");
-      while (st.hasMoreTokens()) {
-        String tok = st.nextToken();
-        int x = tok.indexOf("CN=");
-        if (x >= 0) {
-          cnList.add(tok.substring(x + 3));
+        String subjectPrincipal = cert.getSubjectX500Principal().toString();
+        StringTokenizer st = new StringTokenizer(subjectPrincipal, ",");
+        while (st.hasMoreTokens()) {
+            String tok = st.nextToken();
+            int x = tok.indexOf("CN=");
+            if (x >= 0) {
+                cnList.add(tok.substring(x + 3));
+            }
+        }
+        if (!cnList.isEmpty()) {
+            String[] cns = new String[cnList.size()];
+            cnList.toArray(cns);
+            return cns;
+        } else {
+            return null;
         }
       }
-      if (!cnList.isEmpty()) {
-        String[] cns = new String[cnList.size()];
-        cnList.toArray(cns);
-        return cns;
-      } else {
-        return null;
-      }
-    }
 
 
-    /**
-     * Extracts the array of SubjectAlt DNS names from an X509Certificate.
-     * Returns null if there aren't any.
-     * <p>
-     * Note:  Java doesn't appear able to extract international characters
-     * from the SubjectAlts.  It can only extract international characters
-     * from the CN field.
-     * <p>
-     * (Or maybe the version of OpenSSL I'm using to test isn't storing the
-     * international characters correctly in the SubjectAlts?).
-     *
-     * @param cert X509Certificate
-     * @return Array of SubjectALT DNS names stored in the certificate.
-     */
-    public static String[] getDNSSubjectAlts(X509Certificate cert) {
-      final List<String> subjectAltList = new LinkedList<String>();
-      Collection<List<?>> c = null;
-      try {
-        c = cert.getSubjectAlternativeNames();
-      }
-      catch (CertificateParsingException cpe) {
-        // Should probably log.debug() this?
-        cpe.printStackTrace();
-      }
-      if (c != null) {
-        Iterator<List<?>> it = c.iterator();
-        while (it.hasNext()) {
-          List<?> list = it.next();
-          int type = ((Integer) list.get(0)).intValue();
-          // If type is 2, then we've got a dNSName
-          if (type == 2) {
-            String s = (String) list.get(1);
-            subjectAltList.add(s);
+      /**
+       * Extracts the array of SubjectAlt DNS names from an X509Certificate.
+       * Returns null if there aren't any.
+       * <p>
+       * Note:  Java doesn't appear able to extract international characters
+       * from the SubjectAlts.  It can only extract international characters
+       * from the CN field.
+       * <p>
+       * (Or maybe the version of OpenSSL I'm using to test isn't storing the
+       * international characters correctly in the SubjectAlts?).
+       *
+       * @param cert X509Certificate
+       * @return Array of SubjectALT DNS names stored in the certificate.
+       */
+      public static String[] getDNSSubjectAlts(X509Certificate cert) {
+          final List<String> subjectAltList = new LinkedList<String>();
+          Collection<List<?>> c = null;
+          try {
+              c = cert.getSubjectAlternativeNames();
           }
-        }
-      }
-      if (!subjectAltList.isEmpty()) {
-        String[] subjectAlts = new String[subjectAltList.size()];
-        subjectAltList.toArray(subjectAlts);
-        return subjectAlts;
-      } else {
-        return null;
+          catch (CertificateParsingException cpe) {
+              // Should probably log.debug() this?
+              cpe.printStackTrace();
+          }
+          if (c != null) {
+              Iterator<List<?>> it = c.iterator();
+              while (it.hasNext()) {
+                  List<?> list = it.next();
+                  int type = ((Integer) list.get(0)).intValue();
+                  // If type is 2, then we've got a dNSName
+                  if (type == 2) {
+                      String s = (String) list.get(1);
+                      subjectAltList.add(s);
+                  }
+              }
+          }
+          if (!subjectAltList.isEmpty()) {
+              String[] subjectAlts = new String[subjectAltList.size()];
+              subjectAltList.toArray(subjectAlts);
+              return subjectAlts;
+          } else {
+              return null;
+          }
       }
     }
-  }
 
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Shell.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Shell.java
@@ -1014,7 +1014,7 @@ public abstract class Shell {
     BufferedReader inReader =
             new BufferedReader(new InputStreamReader(process.getInputStream(),
                 StandardCharsets.UTF_8));
-    final StringBuffer errMsg = new StringBuffer();
+    final StringBuilder errMsg = new StringBuilder();
 
     // read error and input streams as this would free up the buffers
     // free the error stream buffer
@@ -1208,7 +1208,7 @@ public abstract class Shell {
       implements CommandExecutor {
 
     private String[] command;
-    private StringBuffer output;
+    private StringBuilder output;
 
 
     public ShellCommandExecutor(String[] execString) {
@@ -1289,7 +1289,7 @@ public abstract class Shell {
 
     @Override
     protected void parseExecResult(BufferedReader lines) throws IOException {
-      output = new StringBuffer();
+      output = new StringBuilder();
       char[] buf = new char[512];
       int nRead;
       while ( (nRead = lines.read(buf, 0, buf.length)) > 0 ) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/StringUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/StringUtils.java
@@ -1334,7 +1334,7 @@ public class StringUtils {
 
       int inputLineLength = str.length();
       int offset = 0;
-      StringBuffer wrappedLine = new StringBuffer(inputLineLength + 32);
+      StringBuilder wrappedLine = new StringBuilder(inputLineLength + 32);
 
       while(inputLineLength - offset > wrapLength) {
         if(str.charAt(offset) == 32) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestCount.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestCount.java
@@ -580,7 +580,7 @@ public class TestCount {
     public String toString(boolean hOption,
         boolean tOption, List<StorageType> types) {
       if (tOption) {
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         result.append(hOption ? HUMAN : BYTES);
 
         for (StorageType type : types) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredentialProviderFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredentialProviderFactory.java
@@ -114,7 +114,7 @@ public class TestCredentialProviderFactory {
   }
 
   private static char[] generatePassword(int length) {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     Random r = new Random();
     for (int i = 0; i < length; i++) {
       sb.append(chars[r.nextInt(chars.length)]);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestShell.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestShell.java
@@ -480,7 +480,7 @@ public class TestShell extends Assert {
   @Test(timeout=120000)
   public void testDestroyAllShellProcesses() throws Throwable {
     Assume.assumeFalse(WINDOWS);
-    StringBuffer sleepCommand = new StringBuffer();
+    StringBuilder sleepCommand = new StringBuilder();
     sleepCommand.append("sleep 200");
     String[] shellCmd = {"bash", "-c", sleepCommand.toString()};
     final ShellCommandExecutor shexc1 = new ShellCommandExecutor(shellCmd);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/functional/TestRemoteIterators.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/functional/TestRemoteIterators.java
@@ -86,7 +86,7 @@ public class TestRemoteIterators extends AbstractHadoopTestBase {
    */
   @Test
   public void testSingleton() throws Throwable {
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     String name = "singleton";
     RemoteIterator<String> it = remoteIteratorFromSingleton(name);
     assertStringValueContains(it, "SingletonIterator");

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
@@ -167,7 +167,7 @@ public class TestKMS {
       if (kmsUrl == null || kmsUrl.size() == 0) {
         return null;
       }
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
 
       for (int i = 0; i < kmsUrl.size(); i++) {
         sb.append(KMSClientProvider.SCHEME_NAME + "://" +

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSck.java
@@ -195,7 +195,7 @@ public class DFSck extends Configured implements Tool {
     final String cookiePrefix = "Cookie:";
     boolean allDone = false;
     while (!allDone) {
-      final StringBuffer url = new StringBuffer(baseUrl);
+      final StringBuilder url = new StringBuilder(baseUrl);
       if (cookie > 0) {
         url.append("&startblockafter=").append(String.valueOf(cookie));
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineEditsViewer/OfflineEditsXmlLoader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineEditsViewer/OfflineEditsXmlLoader.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.hdfs.util.XMLUtils.InvalidXmlException;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLogOp;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLogOpCodes;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLogOp.OpInstanceCache;
-import org.apache.hadoop.hdfs.tools.offlineEditsViewer.OfflineEditsViewer;
 import org.apache.hadoop.hdfs.util.XMLUtils.Stanza;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
@@ -57,7 +56,7 @@ class OfflineEditsXmlLoader
   private Stanza stanza;
   private Stack<Stanza> stanzaStack;
   private FSEditLogOpCodes opCode;
-  private StringBuffer cbuf;
+  private StringBuilder cbuf;
   private long nextTxId;
   private final OpInstanceCache opCache = new OpInstanceCache();
   
@@ -119,7 +118,7 @@ class OfflineEditsXmlLoader
     stanza = null;
     stanzaStack = new Stack<Stanza>();
     opCode = null;
-    cbuf = new StringBuffer();
+    cbuf = new StringBuilder();
     nextTxId = -1;
   }
   
@@ -182,7 +181,7 @@ class OfflineEditsXmlLoader
   @Override
   public void endElement (String uri, String name, String qName) {
     String str = XMLUtils.unmangleXmlString(cbuf.toString(), false).trim();
-    cbuf = new StringBuffer();
+    cbuf = new StringBuilder();
     switch (state) {
     case EXPECT_EDITS_TAG:
       throw new InvalidXmlException("expected <EDITS/>");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/PBImageCorruption.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/PBImageCorruption.java
@@ -85,7 +85,7 @@ public class PBImageCorruption {
   }
 
   String getType() {
-    StringBuffer s = new StringBuffer();
+    StringBuilder s = new StringBuilder();
     if (type.contains(PBImageCorruptionType.CORRUPT_NODE)) {
       s.append(PBImageCorruptionType.CORRUPT_NODE);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/DFSTestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/DFSTestUtil.java
@@ -340,7 +340,7 @@ public class DFSTestUtil {
         for (int idx = 0; idx < nLevels; idx++) {
           levels[idx] = gen.nextInt(10);
         }
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (int idx = 0; idx < nLevels; idx++) {
           sb.append(dirNames[levels[idx]]);
           sb.append("/");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestHDFSTrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestHDFSTrash.java
@@ -180,7 +180,7 @@ public class TestHDFSTrash {
       FileSystem fileSystem, Configuration config) throws IOException {
     // generate an unique path per instance
     UUID trashId = UUID.randomUUID();
-    StringBuffer sb = new StringBuffer()
+    StringBuilder sb = new StringBuilder()
         .append(ugi.getUserName())
         .append("-")
         .append(trashId.toString());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
@@ -1833,7 +1833,7 @@ public class TestBlockManager {
     DataInputStream in = new DataInputStream(fstream);
 
     BufferedReader reader = new BufferedReader(new InputStreamReader(in));
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     String line;
     try {
       while ((line = reader.readLine()) != null) {
@@ -1861,7 +1861,7 @@ public class TestBlockManager {
     FileInputStream fstream = new FileInputStream(file);
     DataInputStream in = new DataInputStream(fstream);
     BufferedReader reader = new BufferedReader(new InputStreamReader(in));
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     String line;
     try {
       while ((line = reader.readLine()) != null) {
@@ -1933,7 +1933,7 @@ public class TestBlockManager {
     FileInputStream fstream = new FileInputStream(file);
     DataInputStream in = new DataInputStream(fstream);
     BufferedReader reader = new BufferedReader(new InputStreamReader(in));
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     String line;
     try {
       while ((line = reader.readLine()) != null) {
@@ -1989,7 +1989,7 @@ public class TestBlockManager {
     FileInputStream fstream = new FileInputStream(file);
     DataInputStream in = new DataInputStream(fstream);
     BufferedReader reader = new BufferedReader(new InputStreamReader(in));
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     String line;
     try {
       while ((line = reader.readLine()) != null) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/web/resources/TestWebHdfsDataLocality.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/web/resources/TestWebHdfsDataLocality.java
@@ -196,7 +196,7 @@ public class TestWebHdfsDataLocality {
       //For GETFILECHECKSUM, OPEN and APPEND,
       //the chosen datanode must be different with exclude nodes.
 
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       for (int i = 0; i < 2; i++) {
         sb.append(locations[i].getXferAddr());
         { // test GETFILECHECKSUM

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/ConfBlock.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/ConfBlock.java
@@ -83,7 +83,7 @@ public class ConfBlock extends HtmlBlock {
               __().
       tbody();
       for (ConfEntryInfo entry : info.getProperties()) {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         String[] sources = entry.getSource();
         //Skip the last entry, because it is always the same HDFS file, and
         // output them in reverse order so most recent is output first

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRecovery.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRecovery.java
@@ -2080,7 +2080,7 @@ public class TestRecovery {
 
   private void validateOutput() throws IOException {
     File expectedFile = new File(new Path(outputDir, partFile).toString());
-    StringBuffer expectedOutput = new StringBuffer();
+    StringBuilder expectedOutput = new StringBuilder();
     expectedOutput.append(key1).append('\t').append(val1).append("\n");
     expectedOutput.append(val1).append("\n");
     expectedOutput.append(val2).append("\n");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempts.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempts.java
@@ -516,7 +516,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
     String expectDiag = "";
     List<String> diagnosticsList = ta.getDiagnostics();
     if (diagnosticsList != null && !diagnostics.isEmpty()) {
-      StringBuffer b = new StringBuffer();
+      StringBuilder b = new StringBuilder();
       for (String diag : diagnosticsList) {
         b.append(diag);
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java
@@ -600,7 +600,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
     String diagString = "";
     List<String> diagList = job.getDiagnostics();
     if (diagList != null && !diagList.isEmpty()) {
-      StringBuffer b = new StringBuffer();
+      StringBuilder b = new StringBuilder();
       for (String diag : diagList) {
         b.append(diag);
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapred/LocalJobRunner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapred/LocalJobRunner.java
@@ -1027,8 +1027,8 @@ public class LocalJobRunner implements ClientProtocol {
     String taskId = t.getTaskID().toString();
     boolean isCleanup = t.isTaskCleanupTask();
     String user = t.getUser();
-    StringBuffer childMapredLocalDir =
-        new StringBuffer(localDirs[0] + Path.SEPARATOR
+    StringBuilder childMapredLocalDir =
+        new StringBuilder(localDirs[0] + Path.SEPARATOR
             + getLocalTaskDir(user, jobId, taskId, isCleanup));
     for (int i = 1; i < localDirs.length; i++) {
       childMapredLocalDir.append("," + localDirs[i] + Path.SEPARATOR

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapreduce/v2/util/MRWebAppUtil.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapreduce/v2/util/MRWebAppUtil.java
@@ -145,7 +145,7 @@ public class MRWebAppUtil {
     InetSocketAddress address = NetUtils.createSocketAddr(
       hsAddress, getDefaultJHSWebappPort(),
       getDefaultJHSWebappURLWithoutScheme());
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     if (address.getAddress() != null &&
         (address.getAddress().isAnyLocalAddress() ||
          address.getAddress().isLoopbackAddress())) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/test/java/org/apache/hadoop/mapred/TestLocalModeWithNewApis.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/test/java/org/apache/hadoop/mapred/TestLocalModeWithNewApis.java
@@ -102,7 +102,7 @@ public class TestLocalModeWithNewApis {
   static String readOutput(Path outDir, Configuration conf) 
       throws IOException {
     FileSystem fs = outDir.getFileSystem(conf);
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
 
     Path[] fileList = FileUtil.stat2Paths(fs.listStatus(outDir,
            new Utils.OutputFileUtils.OutputFilesFilter()));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/FileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/FileInputFormat.java
@@ -470,7 +470,7 @@ public abstract class FileInputFormat<K, V> implements InputFormat<K, V> {
    */ 
   public static void setInputPaths(JobConf conf, Path... inputPaths) {
     Path path = new Path(conf.getWorkingDirectory(), inputPaths[0]);
-    StringBuffer str = new StringBuffer(StringUtils.escapeString(path.toString()));
+    StringBuilder str = new StringBuilder(StringUtils.escapeString(path.toString()));
     for(int i = 1; i < inputPaths.length;i++) {
       str.append(StringUtils.COMMA_STR);
       path = new Path(conf.getWorkingDirectory(), inputPaths[i]);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/InvalidInputException.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/InvalidInputException.java
@@ -61,7 +61,7 @@ public class InvalidInputException extends IOException {
    * @return the concatenated messages from all of the problems.
    */
   public String getMessage() {
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     Iterator<IOException> itr = problems.iterator();
     while(itr.hasNext()) {
       result.append(itr.next().getMessage());

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/MultiFileSplit.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/MultiFileSplit.java
@@ -70,7 +70,7 @@ public class MultiFileSplit extends CombineFileSplit {
 
   @Override
   public String toString() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     for(int i=0; i < getPaths().length; i++) {
       sb.append(getPath(i).toUri().getPath() + ":0+" + getLength(i));
       if (i < getPaths().length -1) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/SortedRanges.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/SortedRanges.java
@@ -207,7 +207,7 @@ class SortedRanges implements Writable{
   }
   
   public String toString() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     Iterator<Range> it = ranges.iterator();
     while(it.hasNext()) {
       Range range = it.next();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/TaskLog.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/TaskLog.java
@@ -518,8 +518,8 @@ public class TaskLog {
                                 throws IOException {
     
     String stdout = FileUtil.makeShellPath(stdoutFilename);
-    String stderr = FileUtil.makeShellPath(stderrFilename);    
-    StringBuffer mergedCmd = new StringBuffer();
+    String stderr = FileUtil.makeShellPath(stderrFilename);
+    StringBuilder mergedCmd = new StringBuilder();
     
     // Export the pid of taskJvm to env variable JVM_PID.
     // Currently pid is not used on Windows
@@ -606,7 +606,7 @@ public class TaskLog {
    */
   public static String addCommand(List<String> cmd, boolean isExecutable) 
   throws IOException {
-    StringBuffer command = new StringBuffer();
+    StringBuilder command = new StringBuilder();
     for(String s: cmd) {
     	command.append('\'');
       if (isExecutable) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/lib/FieldSelectionMapReduce.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/lib/FieldSelectionMapReduce.java
@@ -96,7 +96,7 @@ public class FieldSelectionMapReduce<K, V>
       LoggerFactory.getLogger("FieldSelectionMapReduce");
 
   private String specToString() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("fieldSeparator: ").append(fieldSeparator).append("\n");
 
     sb.append("mapOutputKeyValueSpec: ").append(mapOutputKeyValueSpec).append(

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/Job.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/Job.java
@@ -476,7 +476,7 @@ public class Job extends JobContextImpl implements JobContext, AutoCloseable {
     } catch (IOException e) {
     } catch (InterruptedException ie) {
     }
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("Job: ").append(status.getJobID()).append("\n");
     sb.append("Job File: ").append(status.getJobFile()).append("\n");
     sb.append("Job Tracking URL : ").append(status.getTrackingUrl());

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobStatus.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobStatus.java
@@ -636,7 +636,7 @@ public class JobStatus implements Writable, Cloneable {
   }
   
   public String toString() {
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     buffer.append("job-id : " + jobid);
     buffer.append("uber-mode : " + isUber);
     buffer.append("map-progress : " + mapProgress);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/TaskCompletionEvent.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/TaskCompletionEvent.java
@@ -188,7 +188,7 @@ public class TaskCompletionEvent implements Writable{
     
   @Override
   public String toString(){
-    StringBuffer buf = new StringBuffer(); 
+    StringBuilder buf = new StringBuilder();
     buf.append("Task Id : "); 
     buf.append(taskId); 
     buf.append(", Status : ");  

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/aggregate/ValueHistogram.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/aggregate/ValueHistogram.java
@@ -83,7 +83,7 @@ public class ValueHistogram implements ValueAggregator<String> {
   public String getReport() {
     long[] counts = new long[items.size()];
 
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     Iterator<Object> iter = items.values().iterator();
     int i = 0;
     while (iter.hasNext()) {
@@ -133,7 +133,7 @@ public class ValueHistogram implements ValueAggregator<String> {
    * the histogram
    */
   public String getReportDetails() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     Iterator<Entry<Object,Object>> iter = items.entrySet().iterator();
     while (iter.hasNext()) {
       Entry<Object,Object> en = iter.next();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/fieldsel/FieldSelectionHelper.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/fieldsel/FieldSelectionHelper.java
@@ -121,10 +121,10 @@ public class FieldSelectionHelper {
       int allFieldsFrom, String separator) {
     String retv = null;
     int i = 0;
-    StringBuffer sb = null;
+    StringBuilder sb = null;
     if (fieldList != null && fieldList.size() > 0) {
       if (sb == null) {
-        sb = new StringBuffer();
+        sb = new StringBuilder();
       }
       for (Integer index : fieldList) {
         if (index < fields.length) {
@@ -135,7 +135,7 @@ public class FieldSelectionHelper {
     }
     if (allFieldsFrom >= 0) {
       if (sb == null) {
-        sb = new StringBuffer();
+        sb = new StringBuilder();
       }
       for (i = allFieldsFrom; i < fields.length; i++) {
         sb.append(fields[i]).append(separator);
@@ -168,7 +168,7 @@ public class FieldSelectionHelper {
   public static String specToString(String fieldSeparator, String keyValueSpec,
       int allValueFieldsFrom, List<Integer> keyFieldList,
       List<Integer> valueFieldList) {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("fieldSeparator: ").append(fieldSeparator).append("\n");
 
     sb.append("keyValueSpec: ").append(keyValueSpec).append("\n");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/CombineFileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/CombineFileInputFormat.java
@@ -803,7 +803,7 @@ public abstract class CombineFileInputFormat<K, V>
     }
 
     public String toString() {
-      StringBuffer buf = new StringBuffer();
+      StringBuilder buf = new StringBuilder();
       buf.append("[");
       for (PathFilter f: filters) {
         buf.append(f);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/CombineFileSplit.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/CombineFileSplit.java
@@ -175,7 +175,7 @@ public class CombineFileSplit extends InputSplit implements Writable {
   
   @Override
  public String toString() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     for (int i = 0; i < paths.length; i++) {
       if (i == 0 ) {
         sb.append("Paths:");
@@ -188,7 +188,7 @@ public class CombineFileSplit extends InputSplit implements Writable {
     }
     if (locations != null) {
       String locs = "";
-      StringBuffer locsb = new StringBuffer();
+      StringBuilder locsb = new StringBuilder();
       for (int i = 0; i < locations.length; i++) {
         locsb.append(locations[i] + ":");
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/FileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/FileInputFormat.java
@@ -569,7 +569,7 @@ public abstract class FileInputFormat<K, V> extends InputFormat<K, V> {
                                    Path... inputPaths) throws IOException {
     Configuration conf = job.getConfiguration();
     Path path = inputPaths[0].getFileSystem(conf).makeQualified(inputPaths[0]);
-    StringBuffer str = new StringBuffer(StringUtils.escapeString(path.toString()));
+    StringBuilder str = new StringBuilder(StringUtils.escapeString(path.toString()));
     for(int i = 1; i < inputPaths.length;i++) {
       str.append(StringUtils.COMMA_STR);
       path = inputPaths[i].getFileSystem(conf).makeQualified(inputPaths[i]);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/InvalidInputException.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/InvalidInputException.java
@@ -60,7 +60,7 @@ public class InvalidInputException extends IOException {
    * @return the concatenated messages from all of the problems.
    */
   public String getMessage() {
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     Iterator<IOException> itr = problems.iterator();
     while(itr.hasNext()) {
       result.append(itr.next().getMessage());

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/jobcontrol/ControlledJob.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/jobcontrol/ControlledJob.java
@@ -90,7 +90,7 @@ public class ControlledJob {
 	
   @Override
   public String toString() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("job name:\t").append(this.job.getJobName()).append("\n");
     sb.append("job id:\t").append(this.controlID).append("\n");
     sb.append("job state:\t").append(this.state).append("\n");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/join/TupleWritable.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/join/TupleWritable.java
@@ -147,7 +147,7 @@ public class TupleWritable implements Writable, Iterable<Writable> {
    * <tt>[&lt;child1&gt;,&lt;child2&gt;,...,&lt;childn&gt;]</tt>
    */
   public String toString() {
-    StringBuffer buf = new StringBuffer("[");
+    StringBuilder buf = new StringBuilder("[");
     for (int i = 0; i < values.length; ++i) {
       buf.append(has(i) ? values[i].toString() : "");
       buf.append(",");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/split/JobSplit.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/split/JobSplit.java
@@ -123,7 +123,7 @@ public class JobSplit {
     
     @Override
     public String toString() {
-      StringBuffer buf = new StringBuffer();
+      StringBuilder buf = new StringBuilder();
       buf.append("data-size : " + inputDataLength + "\n");
       buf.append("start-offset : " + startOffset + "\n");
       buf.append("locations : " + "\n");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/Fetcher.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/Fetcher.java
@@ -678,7 +678,7 @@ public class Fetcher<K, V> extends Thread {
   private URL getMapOutputURL(MapHost host, Collection<TaskAttemptID> maps
                               )  throws MalformedURLException {
     // Get the base url
-    StringBuffer url = new StringBuffer(host.getBaseUrl());
+    StringBuilder url = new StringBuilder(host.getBaseUrl());
     
     boolean first = true;
     for (TaskAttemptID mapId : maps) {
@@ -688,8 +688,10 @@ public class Fetcher<K, V> extends Thread {
       url.append(mapId);
       first = false;
     }
-   
-    LOG.debug("MapOutput URL for " + host + " -> " + url.toString());
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("MapOutput URL for " + host + " -> " + url.toString());
+    }
     return new URL(url.toString());
   }
   

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/ShuffleSchedulerImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/ShuffleSchedulerImpl.java
@@ -171,7 +171,7 @@ public class ShuffleSchedulerImpl<K,V> implements ShuffleScheduler<K,V> {
   }
 
   static URI getBaseURI(TaskAttemptID reduceId, String url) {
-    StringBuffer baseUrl = new StringBuffer(url);
+    StringBuilder baseUrl = new StringBuilder(url);
     if (!url.endsWith("/")) {
       baseUrl.append("/");
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/tools/CLI.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/tools/CLI.java
@@ -520,7 +520,7 @@ public class CLI extends Configured implements Tool {
   }
   
   private String getJobPriorityNames() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     for (JobPriority p : JobPriority.values()) {
       // UNDEFINED_PRIORITY need not to be displayed in usage
       if (JobPriority.UNDEFINED_PRIORITY == p) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestFileOutputCommitter.java
@@ -175,7 +175,7 @@ public class TestFileOutputCommitter {
   private void validateContent(Path dir) throws IOException {
     File fdir = new File(dir.toUri().getPath());
     File expectedFile = new File(fdir, partFile);
-    StringBuffer expectedOutput = new StringBuffer();
+    StringBuilder expectedOutput = new StringBuilder();
     expectedOutput.append(key1).append('\t').append(val1).append("\n");
     expectedOutput.append(val1).append("\n");
     expectedOutput.append(val2).append("\n");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
@@ -227,7 +227,7 @@ public class TestFileOutputCommitter {
   private void validateContent(File dir) throws IOException {
     File expectedFile = new File(dir, partFile);
     assertTrue("Could not find "+expectedFile, expectedFile.exists());
-    StringBuffer expectedOutput = new StringBuffer();
+    StringBuilder expectedOutput = new StringBuilder();
     expectedOutput.append(key1).append('\t').append(val1).append("\n");
     expectedOutput.append(val1).append("\n");
     expectedOutput.append(val2).append("\n");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsJobBlock.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsJobBlock.java
@@ -109,7 +109,7 @@ public class HsJobBlock extends HtmlBlock {
     // todo - switch to use JobInfo
     List<String> diagnostics = j.getDiagnostics();
     if(diagnostics != null && !diagnostics.isEmpty()) {
-      StringBuffer b = new StringBuffer();
+      StringBuilder b = new StringBuilder();
       for(String diag: diagnostics) {
         b.append(addTaskLinks(diag));
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/dao/JobInfo.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/dao/JobInfo.java
@@ -117,7 +117,7 @@ public class JobInfo {
       this.diagnostics = "";
       List<String> diagnostics = job.getDiagnostics();
       if (diagnostics != null && !diagnostics.isEmpty()) {
-        StringBuffer b = new StringBuffer();
+        StringBuilder b = new StringBuilder();
         for (String diag : diagnostics) {
           b.append(diag);
         }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesAttempts.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesAttempts.java
@@ -534,7 +534,7 @@ public class TestHsWebServicesAttempts extends JerseyTestBase {
     String expectDiag = "";
     List<String> diagnosticsList = ta.getDiagnostics();
     if (diagnosticsList != null && !diagnostics.isEmpty()) {
-      StringBuffer b = new StringBuffer();
+      StringBuilder b = new StringBuilder();
       for (String diag : diagnosticsList) {
         b.append(diag);
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/VerifyJobsUtils.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/VerifyJobsUtils.java
@@ -108,7 +108,7 @@ public class VerifyJobsUtils {
     String diagString = "";
     List<String> diagList = job.getDiagnostics();
     if (diagList != null && !diagList.isEmpty()) {
-      StringBuffer b = new StringBuffer();
+      StringBuilder b = new StringBuilder();
       for (String diag : diagList) {
         b.append(diag);
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/RandomTextWriterJob.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/RandomTextWriterJob.java
@@ -204,7 +204,7 @@ public class RandomTextWriterJob extends Configured implements Tool {
     }
     
     private Text generateSentence(int noWords) {
-      StringBuffer sentence = new StringBuffer();
+      StringBuilder sentence = new StringBuilder();
       String space = " ";
       for (int i=0; i < noWords; ++i) {
         sentence.append(words[random.nextInt(words.length)]);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/AccumulatingReducer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/AccumulatingReducer.java
@@ -73,7 +73,7 @@ public class AccumulatingReducer extends MapReduceBase
 
     // concatenate strings
     if (field.startsWith(VALUE_TYPE_STRING)) {
-      StringBuffer sSum = new StringBuffer();
+      StringBuilder sSum = new StringBuilder();
       while (values.hasNext())
         sSum.append(values.next().toString()).append(";");
       output.collect(key, new Text(sSum.toString()));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/JHLogAnalyzer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/JHLogAnalyzer.java
@@ -773,7 +773,7 @@ public class JHLogAnalyzer {
     /**
      * Read lines until one ends with a " ." or "\" "
      */
-    private StringBuffer resBuffer = new StringBuffer();
+    private StringBuilder resBuffer = new StringBuilder();
     private String readLine(BufferedReader reader) throws IOException {
       resBuffer.setLength(0);
       reader.mark(maxJobDelimiterLineLength);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/MRBench.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/MRBench.java
@@ -132,7 +132,7 @@ public class MRBench extends Configured implements Tool{
    */
   private static String pad(long number, int length) {
     String str = String.valueOf(number);
-    StringBuffer value = new StringBuffer(); 
+    StringBuilder value = new StringBuilder();
     for (int i = str.length(); i < length; i++) {
       value.append("0"); 
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestConcatenatedCompressedInput.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestConcatenatedCompressedInput.java
@@ -677,7 +677,7 @@ public class TestConcatenatedCompressedInput {
   }
 
   private static String unquote(String in) {
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     for(int i=0; i < in.length(); ++i) {
       char ch = in.charAt(i);
       if (ch == '\\') {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestFixedLengthInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestFixedLengthInputFormat.java
@@ -236,7 +236,7 @@ public class TestFixedLengthInputFormat {
     }
     Writer writer = new OutputStreamWriter(ostream);
     try {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       for (int i = 0; i < numRecords; i++) {
         for (int j = 0; j < recordLen; j++) {
           sb.append(chars[charRand.nextInt(chars.length)]);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCFileOutputCommitter.java
@@ -105,7 +105,7 @@ public class TestMRCJCFileOutputCommitter {
     
     // validate output
     File expectedFile = new File(new Path(outDir, file).toString());
-    StringBuffer expectedOutput = new StringBuffer();
+    StringBuilder expectedOutput = new StringBuilder();
     expectedOutput.append(key1).append('\t').append(val1).append("\n");
     expectedOutput.append(val1).append("\n");
     expectedOutput.append(val2).append("\n");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMapProgress.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMapProgress.java
@@ -119,7 +119,7 @@ public class TestMapProgress {
     
     public AMFeedback statusUpdate(TaskAttemptID taskId, TaskStatus taskStatus) 
     throws IOException, InterruptedException {
-      StringBuffer buf = new StringBuffer("Task ");
+      StringBuilder buf = new StringBuilder("Task ");
       buf.append(taskId);
       if (taskStatus != null) {
         buf.append(" making progress to ");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMapRed.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMapRed.java
@@ -763,7 +763,7 @@ public class TestMapRed extends Configured implements Tool {
       SequenceFile.Writer writer = SequenceFile.createWriter(fs, conf, inFile,
                                                              Text.class, Text.class);
 
-      StringBuffer content = new StringBuffer();
+      StringBuilder content = new StringBuilder();
 
       for (int i = 0; i < 1000; i++) {
         content.append(i).append(": This is one more line of content\n");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMiniMRClasspath.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMiniMRClasspath.java
@@ -80,7 +80,7 @@ public class TestMiniMRClasspath {
     FileSystem fs = FileSystem.get(fileSys, conf);
     configureWordCount(fs, conf, input, numMaps, numReduces, inDir, outDir);
     JobClient.runJob(conf);
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     {
       Path[] parents = FileUtil.stat2Paths(fs.listStatus(outDir.getParent()));
       Path[] fileList = FileUtil.stat2Paths(fs.listStatus(outDir,
@@ -137,7 +137,7 @@ public class TestMiniMRClasspath {
     // set the tests jar file
     conf.setJarByClass(TestMiniMRClasspath.class);
     JobClient.runJob(conf);
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     Path[] fileList = FileUtil.stat2Paths(fs.listStatus(outDir,
                                  new Utils.OutputFileUtils
                                           .OutputFilesFilter()));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMultipleTextOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMultipleTextOutputFormat.java
@@ -106,7 +106,7 @@ public class TestMultipleTextOutputFormat {
     File expectedFile_11 = new File(new Path(workDir, file_11).toString()); 
 
     //System.out.printf("expectedFile_11: %s\n", new Path(workDir, file_11).toString());
-    StringBuffer expectedOutput = new StringBuffer();
+    StringBuilder expectedOutput = new StringBuilder();
     for (int i = 10; i < 20; i++) {
       expectedOutput.append(""+i).append('\t').append(""+i).append("\n");
     }
@@ -118,7 +118,7 @@ public class TestMultipleTextOutputFormat {
     
     File expectedFile_12 = new File(new Path(workDir, file_12).toString()); 
     //System.out.printf("expectedFile_12: %s\n", new Path(workDir, file_12).toString());
-    expectedOutput = new StringBuffer();
+    expectedOutput = new StringBuilder();
     for (int i = 20; i < 30; i++) {
       expectedOutput.append(""+i).append('\t').append(""+i).append("\n");
     }
@@ -130,7 +130,7 @@ public class TestMultipleTextOutputFormat {
     
     File expectedFile_13 = new File(new Path(workDir, file_13).toString()); 
     //System.out.printf("expectedFile_13: %s\n", new Path(workDir, file_13).toString());
-    expectedOutput = new StringBuffer();
+    expectedOutput = new StringBuilder();
     for (int i = 30; i < 40; i++) {
       expectedOutput.append(""+i).append('\t').append(""+i).append("\n");
     }
@@ -142,7 +142,7 @@ public class TestMultipleTextOutputFormat {
     
     File expectedFile_2 = new File(new Path(workDir, file_2).toString()); 
     //System.out.printf("expectedFile_2: %s\n", new Path(workDir, file_2).toString());
-    expectedOutput = new StringBuffer();
+    expectedOutput = new StringBuilder();
     for (int i = 10; i < 40; i++) {
       expectedOutput.append(""+i).append('\t').append(""+i).append("\n");
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTextInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTextInputFormat.java
@@ -548,7 +548,7 @@ public class TestTextInputFormat {
   }
   
   private static String unquote(String in) {
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     for(int i=0; i < in.length(); ++i) {
       char ch = in.charAt(i);
       if (ch == '\\') {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTextOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTextOutputFormat.java
@@ -94,7 +94,7 @@ public class TestTextOutputFormat {
       theRecordWriter.close(reporter);
     }
     File expectedFile = new File(new Path(workDir, file).toString());
-    StringBuilder expectedOutput = new StringBuilder();
+    StringBuffer expectedOutput = new StringBuffer();
     expectedOutput.append(key1).append('\t').append(val1).append("\n");
     expectedOutput.append(val1).append("\n");
     expectedOutput.append(val2).append("\n");
@@ -123,9 +123,9 @@ public class TestTextOutputFormat {
     // A reporter that does nothing
     Reporter reporter = Reporter.NULL;
 
-    TextOutputFormat<Object, Object> theOutputFormat = new TextOutputFormat<>();
-    RecordWriter<Object, Object> theRecordWriter =
-        theOutputFormat.getRecordWriter(localFs, job, file, reporter);
+    TextOutputFormat<Object,Object> theOutputFormat = new TextOutputFormat<Object,Object>();
+    RecordWriter<Object,Object> theRecordWriter =
+      theOutputFormat.getRecordWriter(localFs, job, file, reporter);
 
     Text key1 = new Text("key1");
     Text key2 = new Text("key2");
@@ -147,7 +147,7 @@ public class TestTextOutputFormat {
       theRecordWriter.close(reporter);
     }
     File expectedFile = new File(new Path(workDir, file).toString());
-    StringBuilder expectedOutput = new StringBuilder();
+    StringBuffer expectedOutput = new StringBuffer();
     expectedOutput.append(key1).append(separator).append(val1).append("\n");
     expectedOutput.append(val1).append("\n");
     expectedOutput.append(val2).append("\n");
@@ -165,68 +165,68 @@ public class TestTextOutputFormat {
    */
   @Test
   public void testCompress() throws IOException {
-    JobConf job = new JobConf();
-    job.set(JobContext.TASK_ATTEMPT_ID, attempt);
-    job.set(org.apache.hadoop.mapreduce.lib.output.FileOutputFormat.COMPRESS, "true");
+   JobConf job = new JobConf();
+   job.set(JobContext.TASK_ATTEMPT_ID, attempt);
+   job.set(org.apache.hadoop.mapreduce.lib.output.FileOutputFormat.COMPRESS,"true");
 
-    FileOutputFormat.setOutputPath(job, workDir.getParent().getParent());
-    FileOutputFormat.setWorkOutputPath(job, workDir);
-    FileSystem fs = workDir.getFileSystem(job);
-    if (!fs.mkdirs(workDir)) {
-      fail("Failed to create output directory");
-    }
-    String file = "test_compress.txt";
+   FileOutputFormat.setOutputPath(job, workDir.getParent().getParent());
+   FileOutputFormat.setWorkOutputPath(job, workDir);
+   FileSystem fs = workDir.getFileSystem(job);
+   if (!fs.mkdirs(workDir)) {
+     fail("Failed to create output directory");
+   }
+   String file = "test_compress.txt";
 
-    // A reporter that does nothing
-    Reporter reporter = Reporter.NULL;
+   // A reporter that does nothing
+   Reporter reporter = Reporter.NULL;
 
-    TextOutputFormat<Object, Object> theOutputFormat = new TextOutputFormat<>();
-    RecordWriter<Object, Object> theRecordWriter =
-        theOutputFormat.getRecordWriter(localFs, job, file, reporter);
-    Text key1 = new Text("key1");
-    Text key2 = new Text("key2");
-    Text val1 = new Text("val1");
-    Text val2 = new Text("val2");
-    NullWritable nullWritable = NullWritable.get();
+   TextOutputFormat<Object,Object> theOutputFormat = new TextOutputFormat<Object,Object>();
+   RecordWriter<Object,Object> theRecordWriter =
+     theOutputFormat.getRecordWriter(localFs, job, file, reporter);
+   Text key1 = new Text("key1");
+   Text key2 = new Text("key2");
+   Text val1 = new Text("val1");
+   Text val2 = new Text("val2");
+   NullWritable nullWritable = NullWritable.get();
 
-    try {
-      theRecordWriter.write(key1, val1);
-      theRecordWriter.write(null, nullWritable);
-      theRecordWriter.write(null, val1);
-      theRecordWriter.write(nullWritable, val2);
-      theRecordWriter.write(key2, nullWritable);
-      theRecordWriter.write(key1, null);
-      theRecordWriter.write(null, null);
-      theRecordWriter.write(key2, val2);
+   try {
+     theRecordWriter.write(key1, val1);
+     theRecordWriter.write(null, nullWritable);
+     theRecordWriter.write(null, val1);
+     theRecordWriter.write(nullWritable, val2);
+     theRecordWriter.write(key2, nullWritable);
+     theRecordWriter.write(key1, null);
+     theRecordWriter.write(null, null);
+     theRecordWriter.write(key2, val2);
 
-    } finally {
-      theRecordWriter.close(reporter);
-    }
-    StringBuilder expectedOutput = new StringBuilder();
-    expectedOutput.append(key1).append("\t").append(val1).append("\n");
-    expectedOutput.append(val1).append("\n");
-    expectedOutput.append(val2).append("\n");
-    expectedOutput.append(key2).append("\n");
-    expectedOutput.append(key1).append("\n");
-    expectedOutput.append(key2).append("\t").append(val2).append("\n");
+   } finally {
+     theRecordWriter.close(reporter);
+   }
+   StringBuffer expectedOutput = new StringBuffer();
+   expectedOutput.append(key1).append("\t").append(val1).append("\n");
+   expectedOutput.append(val1).append("\n");
+   expectedOutput.append(val2).append("\n");
+   expectedOutput.append(key2).append("\n");
+   expectedOutput.append(key1).append("\n");
+   expectedOutput.append(key2).append("\t").append(val2).append("\n");
 
-    DefaultCodec codec = new DefaultCodec();
-    codec.setConf(job);
-    Path expectedFile = new Path(workDir, file + codec.getDefaultExtension());
-    final FileInputStream istream = new FileInputStream(expectedFile.toString());
-    CompressionInputStream cistream = codec.createInputStream(istream);
-    LineReader reader = new LineReader(cistream);
+   DefaultCodec codec = new DefaultCodec();
+   codec.setConf(job);
+   Path expectedFile = new Path(workDir, file + codec.getDefaultExtension());
+   final FileInputStream istream = new FileInputStream(expectedFile.toString());
+   CompressionInputStream cistream = codec.createInputStream(istream);
+   LineReader reader = new LineReader(cistream);
 
-    String output = "";
-    Text out = new Text();
-    while (reader.readLine(out) > 0) {
-      output += out;
-      output += "\n";
-    }
-    reader.close();
+   String output = "";
+   Text out = new Text();
+   while (reader.readLine(out) > 0) {
+     output += out;
+     output += "\n";
+   }
+   reader.close();
 
-    assertEquals(expectedOutput.toString(), output);
-  }
+   assertEquals(expectedOutput.toString(), output);
+ }
   public static void main(String[] args) throws Exception {
     new TestTextOutputFormat().testFormat();
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTextOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTextOutputFormat.java
@@ -165,68 +165,68 @@ public class TestTextOutputFormat {
    */
   @Test
   public void testCompress() throws IOException {
-   JobConf job = new JobConf();
-   job.set(JobContext.TASK_ATTEMPT_ID, attempt);
-   job.set(org.apache.hadoop.mapreduce.lib.output.FileOutputFormat.COMPRESS,"true");
+    JobConf job = new JobConf();
+    job.set(JobContext.TASK_ATTEMPT_ID, attempt);
+    job.set(org.apache.hadoop.mapreduce.lib.output.FileOutputFormat.COMPRESS,"true");
 
-   FileOutputFormat.setOutputPath(job, workDir.getParent().getParent());
-   FileOutputFormat.setWorkOutputPath(job, workDir);
-   FileSystem fs = workDir.getFileSystem(job);
-   if (!fs.mkdirs(workDir)) {
-     fail("Failed to create output directory");
-   }
-   String file = "test_compress.txt";
+    FileOutputFormat.setOutputPath(job, workDir.getParent().getParent());
+    FileOutputFormat.setWorkOutputPath(job, workDir);
+    FileSystem fs = workDir.getFileSystem(job);
+    if (!fs.mkdirs(workDir)) {
+      fail("Failed to create output directory");
+    }
+    String file = "test_compress.txt";
 
-   // A reporter that does nothing
-   Reporter reporter = Reporter.NULL;
+    // A reporter that does nothing
+    Reporter reporter = Reporter.NULL;
 
-   TextOutputFormat<Object,Object> theOutputFormat = new TextOutputFormat<Object,Object>();
-   RecordWriter<Object,Object> theRecordWriter =
-     theOutputFormat.getRecordWriter(localFs, job, file, reporter);
-   Text key1 = new Text("key1");
-   Text key2 = new Text("key2");
-   Text val1 = new Text("val1");
-   Text val2 = new Text("val2");
-   NullWritable nullWritable = NullWritable.get();
+    TextOutputFormat<Object,Object> theOutputFormat = new TextOutputFormat<Object,Object>();
+    RecordWriter<Object,Object> theRecordWriter =
+      theOutputFormat.getRecordWriter(localFs, job, file, reporter);
+    Text key1 = new Text("key1");
+    Text key2 = new Text("key2");
+    Text val1 = new Text("val1");
+    Text val2 = new Text("val2");
+    NullWritable nullWritable = NullWritable.get();
 
-   try {
-     theRecordWriter.write(key1, val1);
-     theRecordWriter.write(null, nullWritable);
-     theRecordWriter.write(null, val1);
-     theRecordWriter.write(nullWritable, val2);
-     theRecordWriter.write(key2, nullWritable);
-     theRecordWriter.write(key1, null);
-     theRecordWriter.write(null, null);
-     theRecordWriter.write(key2, val2);
+    try {
+      theRecordWriter.write(key1, val1);
+      theRecordWriter.write(null, nullWritable);
+      theRecordWriter.write(null, val1);
+      theRecordWriter.write(nullWritable, val2);
+      theRecordWriter.write(key2, nullWritable);
+      theRecordWriter.write(key1, null);
+      theRecordWriter.write(null, null);
+      theRecordWriter.write(key2, val2);
 
-   } finally {
-     theRecordWriter.close(reporter);
-   }
-   StringBuilder expectedOutput = new StringBuilder();
-   expectedOutput.append(key1).append("\t").append(val1).append("\n");
-   expectedOutput.append(val1).append("\n");
-   expectedOutput.append(val2).append("\n");
-   expectedOutput.append(key2).append("\n");
-   expectedOutput.append(key1).append("\n");
-   expectedOutput.append(key2).append("\t").append(val2).append("\n");
+    } finally {
+      theRecordWriter.close(reporter);
+    }
+    StringBuilder expectedOutput = new StringBuilder();
+    expectedOutput.append(key1).append("\t").append(val1).append("\n");
+    expectedOutput.append(val1).append("\n");
+    expectedOutput.append(val2).append("\n");
+    expectedOutput.append(key2).append("\n");
+    expectedOutput.append(key1).append("\n");
+    expectedOutput.append(key2).append("\t").append(val2).append("\n");
 
-   DefaultCodec codec = new DefaultCodec();
-   codec.setConf(job);
-   Path expectedFile = new Path(workDir, file + codec.getDefaultExtension());
-   final FileInputStream istream = new FileInputStream(expectedFile.toString());
-   CompressionInputStream cistream = codec.createInputStream(istream);
-   LineReader reader = new LineReader(cistream);
+    DefaultCodec codec = new DefaultCodec();
+    codec.setConf(job);
+    Path expectedFile = new Path(workDir, file + codec.getDefaultExtension());
+    final FileInputStream istream = new FileInputStream(expectedFile.toString());
+    CompressionInputStream cistream = codec.createInputStream(istream);
+    LineReader reader = new LineReader(cistream);
 
-   String output = "";
-   Text out = new Text();
-   while (reader.readLine(out) > 0) {
-     output += out;
-     output += "\n";
-   }
-   reader.close();
+    String output = "";
+    Text out = new Text();
+    while (reader.readLine(out) > 0) {
+      output += out;
+      output += "\n";
+    }
+    reader.close();
 
-   assertEquals(expectedOutput.toString(), output);
- }
+    assertEquals(expectedOutput.toString(), output);
+  }
   public static void main(String[] args) throws Exception {
     new TestTextOutputFormat().testFormat();
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTextOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTextOutputFormat.java
@@ -94,7 +94,7 @@ public class TestTextOutputFormat {
       theRecordWriter.close(reporter);
     }
     File expectedFile = new File(new Path(workDir, file).toString());
-    StringBuffer expectedOutput = new StringBuffer();
+    StringBuilder expectedOutput = new StringBuilder();
     expectedOutput.append(key1).append('\t').append(val1).append("\n");
     expectedOutput.append(val1).append("\n");
     expectedOutput.append(val2).append("\n");
@@ -147,7 +147,7 @@ public class TestTextOutputFormat {
       theRecordWriter.close(reporter);
     }
     File expectedFile = new File(new Path(workDir, file).toString());
-    StringBuffer expectedOutput = new StringBuffer();
+    StringBuilder expectedOutput = new StringBuilder();
     expectedOutput.append(key1).append(separator).append(val1).append("\n");
     expectedOutput.append(val1).append("\n");
     expectedOutput.append(val2).append("\n");
@@ -202,7 +202,7 @@ public class TestTextOutputFormat {
    } finally {
      theRecordWriter.close(reporter);
    }
-   StringBuffer expectedOutput = new StringBuffer();
+   StringBuilder expectedOutput = new StringBuilder();
    expectedOutput.append(key1).append("\t").append(val1).append("\n");
    expectedOutput.append(val1).append("\n");
    expectedOutput.append(val2).append("\n");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTextOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTextOutputFormat.java
@@ -123,9 +123,9 @@ public class TestTextOutputFormat {
     // A reporter that does nothing
     Reporter reporter = Reporter.NULL;
 
-    TextOutputFormat<Object,Object> theOutputFormat = new TextOutputFormat<Object,Object>();
-    RecordWriter<Object,Object> theRecordWriter =
-      theOutputFormat.getRecordWriter(localFs, job, file, reporter);
+    TextOutputFormat<Object, Object> theOutputFormat = new TextOutputFormat<>();
+    RecordWriter<Object, Object> theRecordWriter =
+        theOutputFormat.getRecordWriter(localFs, job, file, reporter);
 
     Text key1 = new Text("key1");
     Text key2 = new Text("key2");
@@ -167,7 +167,7 @@ public class TestTextOutputFormat {
   public void testCompress() throws IOException {
     JobConf job = new JobConf();
     job.set(JobContext.TASK_ATTEMPT_ID, attempt);
-    job.set(org.apache.hadoop.mapreduce.lib.output.FileOutputFormat.COMPRESS,"true");
+    job.set(org.apache.hadoop.mapreduce.lib.output.FileOutputFormat.COMPRESS, "true");
 
     FileOutputFormat.setOutputPath(job, workDir.getParent().getParent());
     FileOutputFormat.setWorkOutputPath(job, workDir);
@@ -180,9 +180,9 @@ public class TestTextOutputFormat {
     // A reporter that does nothing
     Reporter reporter = Reporter.NULL;
 
-    TextOutputFormat<Object,Object> theOutputFormat = new TextOutputFormat<Object,Object>();
-    RecordWriter<Object,Object> theRecordWriter =
-      theOutputFormat.getRecordWriter(localFs, job, file, reporter);
+    TextOutputFormat<Object, Object> theOutputFormat = new TextOutputFormat<>();
+    RecordWriter<Object, Object> theRecordWriter =
+        theOutputFormat.getRecordWriter(localFs, job, file, reporter);
     Text key1 = new Text("key1");
     Text key2 = new Text("key2");
     Text val1 = new Text("val1");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/UtilsForTests.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/UtilsForTests.java
@@ -91,7 +91,7 @@ public class UtilsForTests {
   }
 
   public static String formatBytes(long numBytes) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     boolean bDetails = true;
     double num = numBytes;
 
@@ -116,7 +116,7 @@ public class UtilsForTests {
   }
 
   public static String formatBytes2(long numBytes) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     long u = 0;
     if (numBytes >= TB) {
       u = numBytes / TB;
@@ -145,7 +145,7 @@ public class UtilsForTests {
   static final String regexpSpecials = "[]()?*+|.!^-\\~@";
 
   public static String regexpEscape(String plain) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     char[] ch = plain.toCharArray();
     int csup = ch.length;
     for (int c = 0; c < csup; c++) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/jobcontrol/JobControlTestUtils.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/jobcontrol/JobControlTestUtils.java
@@ -82,7 +82,7 @@ public class JobControlTestUtils {
   private static String generateRandomLine() {
     long r = rand.nextLong() % 7;
     long n = r + 20;
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     for (int i = 0; i < n; i++) {
       sb.append(generateRandomWord()).append(" ");
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/MapReduceTestUtil.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/MapReduceTestUtil.java
@@ -97,7 +97,7 @@ public class MapReduceTestUtil {
   public static String generateRandomLine() {
     long r = rand.nextLong() % 7;
     long n = r + 20;
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     for (int i = 0; i < n; i++) {
       sb.append(generateRandomWord()).append(" ");
     }
@@ -401,7 +401,7 @@ public class MapReduceTestUtil {
   public static String readOutput(Path outDir, Configuration conf) 
       throws IOException {
     FileSystem fs = outDir.getFileSystem(conf);
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
 
     Path[] fileList = FileUtil.stat2Paths(fs.listStatus(outDir,
            new Utils.OutputFileUtils.OutputFilesFilter()));
@@ -436,7 +436,7 @@ public class MapReduceTestUtil {
       org.apache.hadoop.mapred.TaskAttemptID taskId, boolean isCleanup)
       throws IOException {
     // string buffer to store task log
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     int res;
 
     // reads the whole tasklog into inputstream

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/RandomTextWriter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/RandomTextWriter.java
@@ -100,7 +100,7 @@ public class RandomTextWriter extends Configured implements Tool {
 
   public static String generateSentenceWithRand(ThreadLocalRandom rand,
       int noWords) {
-    StringBuffer sentence = new StringBuffer(words[rand.nextInt(words.length)]);
+    StringBuilder sentence = new StringBuilder(words[rand.nextInt(words.length)]);
     for (int i = 1; i < noWords; i++) {
       sentence.append(" ").append(words[rand.nextInt(words.length)]);
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestFixedLengthInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestFixedLengthInputFormat.java
@@ -262,7 +262,7 @@ public class TestFixedLengthInputFormat {
     }
     Writer writer = new OutputStreamWriter(ostream);
     try {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       for (int i = 0; i < numRecords; i++) {
         for (int j = 0; j < recordLen; j++) {
           sb.append(chars[charRand.nextInt(chars.length)]);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestMRCJCFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestMRCJCFileOutputCommitter.java
@@ -119,7 +119,7 @@ public class TestMRCJCFileOutputCommitter {
 
     // validate output
     File expectedFile = new File(new Path(outDir, partFile).toString());
-    StringBuffer expectedOutput = new StringBuffer();
+    StringBuilder expectedOutput = new StringBuilder();
     expectedOutput.append(key1).append('\t').append(val1).append("\n");
     expectedOutput.append(val1).append("\n");
     expectedOutput.append(val2).append("\n");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/MiniMRYarnCluster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/MiniMRYarnCluster.java
@@ -106,7 +106,7 @@ public class MiniMRYarnCluster extends MiniYARNCluster {
               JHAdminConfig.DEFAULT_MR_HISTORY_WEBAPP_ADDRESS,
               JHAdminConfig.DEFAULT_MR_HISTORY_WEBAPP_PORT);    }
     address = NetUtils.getConnectAddress(address);
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     InetAddress resolved = address.getAddress();
     if (resolved == null || resolved.isAnyLocalAddress() || 
         resolved.isLoopbackAddress()) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/RandomTextWriter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/RandomTextWriter.java
@@ -154,7 +154,7 @@ public class RandomTextWriter extends Configured implements Tool {
     }
     
     private Text generateSentence(int noWords) {
-      StringBuffer sentence = new StringBuffer();
+      StringBuilder sentence = new StringBuilder();
       String space = " ";
       for (int i=0; i < noWords; ++i) {
         sentence.append(words[random.nextInt(words.length)]);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/dancing/Pentomino.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/dancing/Pentomino.java
@@ -142,7 +142,7 @@ public class Pentomino {
   public static String stringifySolution(int width, int height, 
                                          List<List<ColumnName>> solution) {
     String[][] picture = new String[height][width];
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     // for each piece placement...
     for(List<ColumnName> row: solution) {
       // go through to find which piece was placed

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/dancing/Sudoku.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/dancing/Sudoku.java
@@ -66,7 +66,7 @@ public class Sudoku {
    */
   static String stringifySolution(int size, List<List<ColumnName>> solution) {
     int[][] picture = new int[size][size];
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     // go through the rows selected in the model and build a picture of the
     // solution.
     for(List<ColumnName> row: solution) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/terasort/TeraScheduler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/terasort/TeraScheduler.java
@@ -47,7 +47,7 @@ class TeraScheduler {
       this.filename = filename;
     }
     public String toString() {
-      StringBuffer result = new StringBuffer();
+      StringBuilder result = new StringBuilder();
       result.append(filename);
       result.append(" on ");
       for(Host host: locations) {
@@ -64,7 +64,7 @@ class TeraScheduler {
       this.hostname = hostname;
     }
     public String toString() {
-      StringBuffer result = new StringBuffer();
+      StringBuilder result = new StringBuilder();
       result.append(splits.size());
       result.append(" ");
       result.append(hostname);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitProtocol.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitProtocol.java
@@ -722,7 +722,7 @@ public abstract class AbstractITCommitProtocol extends AbstractCommitITest {
     }
     Path expectedFile = getPart0000(dir);
     log().debug("Validating content in {}", expectedFile);
-    StringBuffer expectedOutput = new StringBuffer();
+    StringBuilder expectedOutput = new StringBuilder();
     expectedOutput.append(KEY_1).append('\t').append(VAL_1).append("\n");
     expectedOutput.append(VAL_1).append("\n");
     expectedOutput.append(VAL_2).append("\n");

--- a/hadoop-tools/hadoop-datajoin/src/main/java/org/apache/hadoop/contrib/utils/join/JobBase.java
+++ b/hadoop-tools/hadoop-datajoin/src/main/java/org/apache/hadoop/contrib/utils/join/JobBase.java
@@ -143,7 +143,7 @@ public abstract class JobBase implements Mapper, Reducer {
    * 
    */
   protected String getReport() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
 
     Iterator iter = this.longCounters.entrySet().iterator();
     while (iter.hasNext()) {

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpSync.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpSync.java
@@ -614,7 +614,7 @@ class DistCpSync {
     if (sourcePath.equals(renameItem.getSource())) {
       return renameItem.getTarget();
     }
-    StringBuffer sb = new StringBuffer(sourcePath.toString());
+    StringBuilder sb = new StringBuilder(sourcePath.toString());
     String remain =
         sb.substring(renameItem.getSource().toString().length() + 1);
     return new Path(renameItem.getTarget(), remain);

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
@@ -155,7 +155,7 @@ public class DistCpUtils {
    * @return - String containing first letters of each attribute to preserve
    */
   public static String packAttributes(EnumSet<FileAttribute> attributes) {
-    StringBuffer buffer = new StringBuffer(FileAttribute.values().length);
+    StringBuilder buffer = new StringBuilder(FileAttribute.values().length);
     int len = 0;
     for (FileAttribute attribute : attributes) {
       buffer.append(attribute.name().charAt(0));

--- a/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/datatypes/NodeName.java
+++ b/hadoop-tools/hadoop-rumen/src/main/java/org/apache/hadoop/tools/rumen/datatypes/NodeName.java
@@ -140,7 +140,7 @@ public class NodeName implements AnonymizableDataType<String> {
   }
   
   private void anonymize(StatePool pool) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     NodeNameState state = (NodeNameState) pool.getState(getClass());
     if (state == null) {
       state = new NodeNameState();

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/PipeMapRed.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/PipeMapRed.java
@@ -254,7 +254,7 @@ public abstract class PipeMapRed {
   }
 
   String safeEnvVarName(String var) {
-    StringBuffer safe = new StringBuffer();
+    StringBuilder safe = new StringBuilder();
     int len = var.length();
     for (int i = 0; i < len; i++) {
       char c = var.charAt(i);

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/StreamJob.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/StreamJob.java
@@ -291,7 +291,7 @@ public class StreamJob implements Tool {
         LOG.warn("-file option is deprecated, please use generic option" +
         		" -files instead.");
 
-        StringBuffer fileList = new StringBuffer();
+        StringBuilder fileList = new StringBuilder();
         for (String file : values) {
           packageFiles_.add(file);
           try {

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/StreamXmlRecordReader.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/StreamXmlRecordReader.java
@@ -23,9 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.regex.*;
 
 import org.apache.hadoop.io.DataOutputBuffer;
-import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.mapred.Reporter;

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestMultipleArchiveFiles.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestMultipleArchiveFiles.java
@@ -128,7 +128,7 @@ public class TestMultipleArchiveFiles extends TestStreaming
   }
 
   protected void checkOutput() throws IOException {
-    StringBuffer output = new StringBuffer(256);
+    StringBuilder output = new StringBuilder(256);
     Path[] fileList = FileUtil.stat2Paths(fileSys.listStatus(
                                             new Path(OUTPUT_DIR)));
     for (int i = 0; i < fileList.length; i++){

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/UtilTest.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/UtilTest.java
@@ -86,7 +86,7 @@ class UtilTest {
   }
 
   public static String collate(List<String> args, String sep) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     Iterator<String> it = args.iterator();
     while (it.hasNext()) {
       if (buf.length() > 0) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/timeline/TimelineEntityGroupId.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/timeline/TimelineEntityGroupId.java
@@ -144,7 +144,7 @@ public class TimelineEntityGroupId implements
 
   public static TimelineEntityGroupId
       fromString(String timelineEntityGroupIdStr) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     Iterator<String> it = SPLITTER.split(timelineEntityGroupIdStr).iterator();
     if (!it.next().equals(TIMELINE_ENTITY_GROUPID_STR_PREFIX)) {
       throw new IllegalArgumentException(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/resource/PlacementConstraint.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/resource/PlacementConstraint.java
@@ -413,7 +413,7 @@ public class PlacementConstraint {
 
     @Override
     public String toString() {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       if (TargetType.ALLOCATION_TAG == this.targetType) {
         // following by a comma separated tags
         sb.append(String.join(",", getTargetValues()));
@@ -643,7 +643,7 @@ public class PlacementConstraint {
 
     @Override
     public String toString() {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       sb.append("cardinality").append(",").append(getScope()).append(",");
       for (String tag : getAllocationTags()) {
         sb.append(tag).append(",");
@@ -717,7 +717,7 @@ public class PlacementConstraint {
 
     @Override
     public String toString() {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       sb.append("and(");
       Iterator<AbstractConstraint> it = getChildren().iterator();
       while (it.hasNext()) {
@@ -759,7 +759,7 @@ public class PlacementConstraint {
 
     @Override
     public String toString() {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       sb.append("or(");
       Iterator<AbstractConstraint> it = getChildren().iterator();
       while (it.hasNext()) {
@@ -805,7 +805,7 @@ public class PlacementConstraint {
 
     @Override
     public String toString() {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       sb.append("DelayedOr(");
       Iterator<TimedPlacementConstraint> it = getChildren().iterator();
       while (it.hasNext()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestLogsCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestLogsCLI.java
@@ -1491,7 +1491,7 @@ public class TestLogsCLI {
   private String readContainerContent(Path containerPath,
       FileSystem fs) throws IOException {
     assertTrue(fs.exists(containerPath));
-    StringBuffer inputLine = new StringBuffer();
+    StringBuilder inputLine = new StringBuilder();
     try (BufferedReader reader = new BufferedReader(new InputStreamReader(
         fs.open(containerPath)))) {
       String tmp;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/Apps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/Apps.java
@@ -87,7 +87,7 @@ public class Apps {
   private static void setEnvFromString(Map<String, String> env,
       String envVar, String varString, String classPathSeparator) {
     Matcher m = VAR_SUBBER.matcher(varString);
-    StringBuilder sb = new StringBuilder();
+    StringBuffer sb = new StringBuffer();
     while (m.find()) {
       String var = m.group(1);
       // do variable substitution of $var from passed in environment or from

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/Apps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/Apps.java
@@ -87,7 +87,7 @@ public class Apps {
   private static void setEnvFromString(Map<String, String> env,
       String envVar, String varString, String classPathSeparator) {
     Matcher m = VAR_SUBBER.matcher(varString);
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     while (m.find()) {
       String var = m.group(1);
       // do variable substitution of $var from passed in environment or from

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ProcfsBasedProcessTree.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ProcfsBasedProcessTree.java
@@ -568,7 +568,7 @@ public class ProcfsBasedProcessTree extends ResourceCalculatorProcessTree {
    */
   @Override
   public String toString() {
-    StringBuffer pTree = new StringBuffer("[ ");
+    StringBuilder pTree = new StringBuilder("[ ");
     for (String p : processTree.keySet()) {
       pTree.append(p);
       pTree.append(" ");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/view/JQueryUI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/view/JQueryUI.java
@@ -130,7 +130,7 @@ public class JQueryUI extends HtmlBlock {
         }
         // for inserting stateSaveInit
         int pos = init.indexOf('{') + 1;  
-        init = new StringBuffer(init).insert(pos, stateSaveInit).toString(); 
+        init = new StringBuilder(init).insert(pos, stateSaveInit).toString();
         list.add(join(id, "DataTable =  $('#", id, "').dataTable(", init,
                       ").fnSetFilteringDelay(188);"));
         String postInit = $(postInitID(DATATABLES, id));
@@ -146,7 +146,7 @@ public class JQueryUI extends HtmlBlock {
         init = defaultInit;
       }      
       int pos = init.indexOf('{') + 1;  
-      init = new StringBuffer(init).insert(pos, stateSaveInit).toString();  
+      init = new StringBuilder(init).insert(pos, stateSaveInit).toString();
       list.add(join("  $('", escapeEcmaScript(selector), "').dataTable(", init,
                ").fnSetFilteringDelay(288);"));      
       

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/TestAggregatedLogFormat.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/TestAggregatedLogFormat.java
@@ -401,7 +401,7 @@ public class TestAggregatedLogFormat {
         new BufferedReader(new FileReader(new File(remoteAppLogFile
             .toUri().getRawPath())));
     String line;
-    StringBuffer sb = new StringBuffer("");
+    StringBuilder sb = new StringBuilder("");
     while ((line = in.readLine()) != null) {
       LOG.info(line);
       sb.append(line);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/sql/FederationQueryRunner.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/sql/FederationQueryRunner.java
@@ -181,7 +181,7 @@ public class FederationQueryRunner {
       causeMessage = "";
     }
 
-    StringBuffer msg = new StringBuffer(causeMessage);
+    StringBuilder msg = new StringBuilder(causeMessage);
     msg.append(" Query: ");
     msg.append(sql);
     msg.append(" Parameters: ");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/deletion/task/DockerContainerDeletionTask.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/deletion/task/DockerContainerDeletionTask.java
@@ -65,7 +65,7 @@ public class DockerContainerDeletionTask extends DeletionTask
    */
   @Override
   public String toString() {
-    StringBuffer sb = new StringBuffer("DockerContainerDeletionTask : ");
+    StringBuilder sb = new StringBuilder("DockerContainerDeletionTask : ");
     sb.append("  id : ").append(this.getTaskId());
     sb.append("  containerId : ").append(this.containerId);
     return sb.toString().trim();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/privileged/PrivilegedOperationExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/privileged/PrivilegedOperationExecutor.java
@@ -281,7 +281,7 @@ public class PrivilegedOperationExecutor {
       return null;
     }
 
-    StringBuffer finalOpArg = new StringBuffer(PrivilegedOperation
+    StringBuilder finalOpArg = new StringBuilder(PrivilegedOperation
         .CGROUP_ARG_PREFIX);
     boolean noTasks = true;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/NetworkPacketTaggingHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/NetworkPacketTaggingHandlerImpl.java
@@ -104,7 +104,7 @@ public class NetworkPacketTaggingHandlerImpl
     //executable.
     String tasksFile = cGroupsHandler.getPathForCGroupTasks(
         CGroupsHandler.CGroupController.NET_CLS, containerIdStr);
-    String opArg = new StringBuffer(PrivilegedOperation.CGROUP_ARG_PREFIX)
+    String opArg = new StringBuilder(PrivilegedOperation.CGROUP_ARG_PREFIX)
         .append(tasksFile).toString();
     List<PrivilegedOperation> ops = new ArrayList<>();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TrafficControlBandwidthHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TrafficControlBandwidthHandlerImpl.java
@@ -101,7 +101,7 @@ public class TrafficControlBandwidthHandlerImpl
     containerBandwidthMbit = (int) Math.ceil((double) yarnBandwidthMbit /
         MAX_CONTAINER_COUNT);
 
-    StringBuffer logLine = new StringBuffer("strict mode is set to :")
+    StringBuilder logLine = new StringBuilder("strict mode is set to :")
         .append(strictMode).append(System.lineSeparator());
 
     if (strictMode) {
@@ -152,7 +152,7 @@ public class TrafficControlBandwidthHandlerImpl
     //executable.
     String tasksFile = cGroupsHandler.getPathForCGroupTasks(
         CGroupsHandler.CGroupController.NET_CLS, containerIdStr);
-    String opArg = new StringBuffer(PrivilegedOperation.CGROUP_ARG_PREFIX)
+    String opArg = new StringBuilder(PrivilegedOperation.CGROUP_ARG_PREFIX)
         .append(tasksFile).toString();
     List<PrivilegedOperation> ops = new ArrayList<>();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TrafficController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TrafficController.java
@@ -225,7 +225,7 @@ import java.util.regex.Pattern;
       if (pattern.matcher(state).find()) {
         LOG.debug("Matched regex: {}", regex);
       } else {
-        String logLine = new StringBuffer("Failed to match regex: ")
+        String logLine = new StringBuilder("Failed to match regex: ")
               .append(regex).append(" Current state: ").append(state).toString();
         LOG.warn(logLine);
         return false;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/DockerCommand.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/DockerCommand.java
@@ -85,7 +85,7 @@ public abstract class DockerCommand {
 
   @Override
   public String toString() {
-    StringBuffer ret = new StringBuffer(this.command);
+    StringBuilder ret = new StringBuilder(this.command);
     for (Map.Entry<String, List<String>> entry : commandArguments.entrySet()) {
       ret.append(" ").append(entry.getKey());
       ret.append("=").append(StringUtils.join(",", entry.getValue()));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/LocalCacheDirectoryManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/LocalCacheDirectoryManager.java
@@ -165,7 +165,7 @@ public class LocalCacheDirectoryManager {
       String relativePath = "";
       if (directoryNo > 0) {
         String tPath = Integer.toString(directoryNo - 1, DIRECTORIES_PER_LEVEL);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (tPath.length() == 1) {
           sb.append(tPath.charAt(0));
         } else {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nvidia/NvidiaGPUPluginForRuntimeV2.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nvidia/NvidiaGPUPluginForRuntimeV2.java
@@ -172,7 +172,7 @@ public class NvidiaGPUPluginForRuntimeV2 implements DevicePlugin,
     if (yarnRuntime == YarnRuntimeType.RUNTIME_DOCKER) {
       String nvidiaRuntime = "nvidia";
       String nvidiaVisibleDevices = "NVIDIA_VISIBLE_DEVICES";
-      StringBuffer gpuMinorNumbersSB = new StringBuffer();
+      StringBuilder gpuMinorNumbersSB = new StringBuilder();
       for (Device device : allocatedDevices) {
         gpuMinorNumbersSB.append(device.getMinorNumber() + ",");
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMStateStoreService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMStateStoreService.java
@@ -186,7 +186,7 @@ public abstract class NMStateStoreService extends AbstractService {
 
     @Override
     public String toString() {
-      return new StringBuffer("Status: ").append(getStatus())
+      return new StringBuilder("Status: ").append(getStatus())
           .append(", Exit code: ").append(exitCode)
           .append(", Version: ").append(version)
           .append(", Start Time: ").append(startTime)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/privileged/TestPrivilegedOperationExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/privileged/TestPrivilegedOperationExecutor.java
@@ -213,7 +213,7 @@ public class TestPrivilegedOperationExecutor {
     try {
       PrivilegedOperation op = PrivilegedOperationExecutor
           .squashCGroupOperations(ops);
-      String expected = new StringBuffer
+      String expected = new StringBuilder
           (PrivilegedOperation.CGROUP_ARG_PREFIX)
           .append(cGroupTasks1).append(PrivilegedOperation
               .LINUX_FILE_PATH_SEPARATOR)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestNetworkPacketTaggingHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestNetworkPacketTaggingHandlerImpl.java
@@ -70,7 +70,7 @@ public class TestNetworkPacketTaggingHandlerImpl {
     privilegedOperationExecutorMock = mock(PrivilegedOperationExecutor.class);
     cGroupsHandlerMock = mock(CGroupsHandler.class);
     conf = new YarnConfiguration();
-    tmpPath = new StringBuffer(System.getProperty("test.build.data"))
+    tmpPath = new StringBuilder(System.getProperty("test.build.data"))
         .append('/').append("hadoop.tmp.dir").toString();
     containerIdMock = mock(ContainerId.class);
     containerMock = mock(Container.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestTrafficControlBandwidthHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestTrafficControlBandwidthHandlerImpl.java
@@ -73,7 +73,7 @@ public class TestTrafficControlBandwidthHandlerImpl {
     cGroupsHandlerMock = mock(CGroupsHandler.class);
     trafficControllerMock = mock(TrafficController.class);
     conf = new YarnConfiguration();
-    tmpPath = new StringBuffer(System.getProperty("test.build.data")).append
+    tmpPath = new StringBuilder(System.getProperty("test.build.data")).append
         ('/').append("hadoop.tmp.dir").toString();
     device = YarnConfiguration.DEFAULT_NM_NETWORK_RESOURCE_INTERFACE;
     containerIdMock = mock(ContainerId.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestTrafficController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestTrafficController.java
@@ -96,7 +96,7 @@ public class TestTrafficController {
   public void setup() {
     privilegedOperationExecutorMock = mock(PrivilegedOperationExecutor.class);
     conf = new YarnConfiguration();
-    tmpPath = new StringBuffer(System.getProperty("test.build.data")).append
+    tmpPath = new StringBuilder(System.getProperty("test.build.data")).append
         ('/').append("hadoop.tmp.dir").toString();
 
     conf.set("hadoop.tmp.dir", tmpPath);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDockerContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDockerContainerRuntime.java
@@ -173,7 +173,7 @@ public class TestDockerContainerRuntime {
   private String[] testCapabilities;
   private final String signalPid = "1234";
   private final String tmpPath =
-      new StringBuffer(System.getProperty("test.build.data"))
+      new StringBuilder(System.getProperty("test.build.data"))
       .append('/').append("hadoop.tmp.dir").toString();
 
   private static final String RUNTIME_TYPE = "DOCKER";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestHdfsManifestToResourcesPlugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestHdfsManifestToResourcesPlugin.java
@@ -54,7 +54,7 @@ public class TestHdfsManifestToResourcesPlugin {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestHdfsManifestToResourcesPlugin.class);
   private Configuration conf;
-  private String tmpPath = new StringBuffer(
+  private String tmpPath = new StringBuilder(
       System.getProperty("test.build.data"))
       .append('/').append("hadoop.tmp.dir").toString();
   private static final String LAYER_MEDIA_TYPE =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestImageTagToManifestPlugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestImageTagToManifestPlugin.java
@@ -54,7 +54,7 @@ public class TestImageTagToManifestPlugin {
   private MockImageTagToManifestPlugin mockImageTagToManifestPlugin;
   private Configuration conf;
   private String tmpPath =
-      new StringBuffer(System.getProperty("test.build.data"))
+      new StringBuilder(System.getProperty("test.build.data"))
       .append('/').append("hadoop.tmp.dir").toString();
   private ObjectMapper mapper;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestRuncContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestRuncContainerRuntime.java
@@ -168,7 +168,7 @@ public class TestRuncContainerRuntime {
     mockExecutor = Mockito
         .mock(PrivilegedOperationExecutor.class);
     mockCGroupsHandler = Mockito.mock(CGroupsHandler.class);
-    tmpPath = new StringBuffer(System.getProperty("test.build.data"))
+    tmpPath = new StringBuilder(System.getProperty("test.build.data"))
       .append('/').append("hadoop.tmp.dir").toString();
     containerId = "container_e11_1518975676334_14532816_01_000001";
     container = mock(Container.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerCommandExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerCommandExecutor.java
@@ -85,7 +85,7 @@ public class TestDockerCommandExecutor {
     mockExecutor = mock(PrivilegedOperationExecutor.class);
     mockCGroupsHandler = mock(CGroupsHandler.class);
     configuration = new Configuration();
-    String tmpPath = new StringBuffer(System.getProperty("test.build.data"))
+    String tmpPath = new StringBuilder(System.getProperty("test.build.data"))
         .append('/').append("hadoop.tmp.dir").toString();
     configuration.set("hadoop.tmp.dir", tmpPath);
     runtime = new DockerLinuxContainerRuntime(mockExecutor, mockCGroupsHandler);
@@ -115,7 +115,7 @@ public class TestDockerCommandExecutor {
     LocalDirsHandlerService localDirsHandler =
         mock(LocalDirsHandlerService.class);
 
-    String tmpPath = new StringBuffer(System.getProperty("test.build.data"))
+    String tmpPath = new StringBuilder(System.getProperty("test.build.data"))
         .append('/').append("hadoop.tmp.dir").toString();
 
     ConcurrentMap<ContainerId, Container> containerMap =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestLocalCacheDirectoryManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestLocalCacheDirectoryManager.java
@@ -47,7 +47,7 @@ public class TestLocalCacheDirectoryManager {
 
     // Testing path generation from "0" to "0/0/z/z"
     for (int i = 1; i <= 37 * 36 * 36; i++) {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       String num = Integer.toString(i - 1, 36);
       if (num.length() == 1) {
         sb.append(num.charAt(0));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/deviceframework/TestDevicePluginAdapter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/deviceframework/TestDevicePluginAdapter.java
@@ -977,7 +977,7 @@ public class TestDevicePluginAdapter {
       if (version.equals("v2")) {
         String nvidiaRuntime = "nvidia";
         String nvidiaVisibleDevices = "NVIDIA_VISIBLE_DEVICES";
-        StringBuffer gpuMinorNumbersSB = new StringBuffer();
+        StringBuilder gpuMinorNumbersSB = new StringBuilder();
         for (Device device : allocatedDevices) {
           gpuMinorNumbersSB.append(device.getMinorNumber() + ",");
         }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/PlanQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/PlanQueue.java
@@ -72,7 +72,7 @@ public class PlanQueue extends AbstractManagedParentQueue {
     updateQuotas(configuredUserLimit, configuredUserLimitFactor,
         maxAppsForReservation, configuredMaxAppsPerUserForReservation);
 
-    StringBuffer queueInfo = new StringBuffer();
+    StringBuilder queueInfo = new StringBuilder();
     queueInfo.append("Created Plan Queue: ").append(queueName)
         .append("\nwith capacity: [").append(super.getCapacity())
         .append("]\nwith max capacity: [").append(super.getMaximumCapacity())

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
@@ -600,7 +600,7 @@ public class RMWebServices extends WebServices implements RMWebServiceProtocol {
    * @return The str String after escaping invalid xml characters.
    */
   public static String escapeInvalidXMLCharacters(String str) {
-    StringBuffer out = new StringBuffer();
+    StringBuilder out = new StringBuilder();
     final int strlen = str.length();
     final String substitute = "\uFFFD";
     int idx = 0;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/AllocationTagsInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/AllocationTagsInfo.java
@@ -45,7 +45,7 @@ public class AllocationTagsInfo {
 
   @Override
   public String toString() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     Iterator<AllocationTagInfo> it = allocationTagInfo.iterator();
     while (it.hasNext()) {
       AllocationTagInfo current = it.next();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/TestPlacementProcessor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/TestPlacementProcessor.java
@@ -896,7 +896,7 @@ public class TestPlacementProcessor {
     for (MockNM nm : nodes) {
       Map<String, Long> nmTags = atm
           .getAllocationTagsWithCount(nm.getNodeId());
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       if (nmTags != null) {
         nmTags.forEach((tag, count) ->
             sb.append(tag + "(" + count + "),"));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/algorithm/TestCircularIterator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/algorithm/TestCircularIterator.java
@@ -35,7 +35,7 @@ public class TestCircularIterator {
     List<String> list = Arrays.asList("a", "b", "c", "d");
     CircularIterator<String> ci =
         new CircularIterator<>(null, list.iterator(), list);
-    StringBuffer sb = new StringBuffer("");
+    StringBuilder sb = new StringBuilder("");
     while (ci.hasNext()) {
       sb.append(ci.next());
     }
@@ -44,7 +44,7 @@ public class TestCircularIterator {
     Iterator<String> lIter = list.iterator();
     lIter.next();
     lIter.next();
-    sb = new StringBuffer("");
+    sb = new StringBuilder("");
     ci = new CircularIterator<>(null, lIter, list);
     while (ci.hasNext()) {
       sb.append(ci.next());
@@ -55,7 +55,7 @@ public class TestCircularIterator {
     lIter.next();
     lIter.next();
     lIter.next();
-    sb = new StringBuffer("");
+    sb = new StringBuilder("");
     ci = new CircularIterator<>("x", lIter, list);
     while (ci.hasNext()) {
       sb.append(ci.next());
@@ -65,7 +65,7 @@ public class TestCircularIterator {
     list = Arrays.asList("a");
     lIter = list.iterator();
     lIter.next();
-    sb = new StringBuffer("");
+    sb = new StringBuilder("");
     ci = new CircularIterator<>("y", lIter, list);
     while (ci.hasNext()) {
       sb.append(ci.next());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestQueuePlacementPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestQueuePlacementPolicy.java
@@ -99,7 +99,7 @@ public class TestQueuePlacementPolicy {
 
   @Test
   public void testSpecifiedUserPolicy() throws Exception {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='specified' />");
     sb.append("  <rule name='user' />");
@@ -118,7 +118,7 @@ public class TestQueuePlacementPolicy {
 
   @Test
   public void testNoCreate() throws Exception {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='specified' />");
     sb.append("  <rule name='user' create=\"false\" />");
@@ -144,7 +144,7 @@ public class TestQueuePlacementPolicy {
 
   @Test
   public void testSpecifiedThenReject() throws Exception {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='specified' />");
     sb.append("  <rule name='reject' />");
@@ -160,7 +160,7 @@ public class TestQueuePlacementPolicy {
 
   @Test
   public void testOmittedTerminalRule()  {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='specified' />");
     sb.append("  <rule name='user' create=\"false\" />");
@@ -170,7 +170,7 @@ public class TestQueuePlacementPolicy {
 
   @Test
   public void testTerminalRuleInMiddle() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='specified' />");
     sb.append("  <rule name='default' />");
@@ -184,7 +184,7 @@ public class TestQueuePlacementPolicy {
     // The default rule is no longer considered terminal when the create flag
     // is false. The throw now happens when configuring not when assigning the
     // application
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='secondaryGroupExistingQueue' create='true'/>");
     sb.append("  <rule name='default' queue='otherdefault' create='false'/>");
@@ -197,7 +197,7 @@ public class TestQueuePlacementPolicy {
     // This test covers the use case where we would like default rule
     // to point to a different queue by default rather than root.default
     createQueue(FSQueueType.LEAF, "root.someDefaultQueue");
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='specified' create='false' />");
     sb.append("  <rule name='default' queue='root.someDefaultQueue'/>");
@@ -212,7 +212,7 @@ public class TestQueuePlacementPolicy {
   @Test
   public void testNestedUserQueueParsingErrors() {
     // No nested rule specified in hierarchical user queue
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='nestedUserQueue'/>");
     sb.append("</queuePlacementPolicy>");
@@ -220,7 +220,7 @@ public class TestQueuePlacementPolicy {
     assertIfExceptionThrown(sb);
 
     // Specified nested rule is not a FSPlacementRule
-    sb = new StringBuffer();
+    sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='nestedUserQueue'>");
     sb.append("    <rule name='unknownRule'/>");
@@ -230,7 +230,7 @@ public class TestQueuePlacementPolicy {
     assertIfExceptionThrown(sb);
 
     // Parent rule is rule that cannot be one: reject or nestedUserQueue
-    sb = new StringBuffer();
+    sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='nestedUserQueue'>");
     sb.append("    <rule name='reject'/>");
@@ -241,7 +241,7 @@ public class TestQueuePlacementPolicy {
 
     // If the parent rule does not have the create flag the nested rule is not
     // terminal
-    sb = new StringBuffer();
+    sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='nestedUserQueue'>");
     sb.append("    <rule name='primaryGroup' create='false'/>");
@@ -253,7 +253,7 @@ public class TestQueuePlacementPolicy {
 
   @Test
   public void testMultipleParentRules() throws Exception {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='nestedUserQueue'>");
     sb.append("    <rule name='primaryGroup'/>");
@@ -275,7 +275,7 @@ public class TestQueuePlacementPolicy {
   @Test
   public void testBrokenRules() throws Exception {
     // broken rule should fail configuring
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule />");
     sb.append("</queuePlacementPolicy>");
@@ -283,7 +283,7 @@ public class TestQueuePlacementPolicy {
     assertIfExceptionThrown(sb);
 
     // policy without rules ignoring policy
-    sb = new StringBuffer();
+    sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <notarule />");
     sb.append("</queuePlacementPolicy>");
@@ -291,7 +291,7 @@ public class TestQueuePlacementPolicy {
     createPolicy(sb.toString());
 
     // broken rule should fail configuring
-    sb = new StringBuffer();
+    sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='user'>");
     sb.append("    <rule />");
@@ -302,7 +302,7 @@ public class TestQueuePlacementPolicy {
 
     // parent rule not set to something known: no parent rule is required
     // required case is only for nestedUserQueue tested earlier
-    sb = new StringBuffer();
+    sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='user'>");
     sb.append("    <notarule />");
@@ -312,7 +312,7 @@ public class TestQueuePlacementPolicy {
     createPolicy(sb.toString());
   }
 
-  private void assertIfExceptionThrown(StringBuffer sb) {
+  private void assertIfExceptionThrown(StringBuilder sb) {
     Throwable th = null;
     try {
       createPolicy(sb.toString());
@@ -336,7 +336,7 @@ public class TestQueuePlacementPolicy {
 
   @Test
   public void testNestedUserQueueParsing() throws Exception {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='specified' />");
     sb.append("  <rule name='nestedUserQueue'>");
@@ -349,7 +349,7 @@ public class TestQueuePlacementPolicy {
 
   @Test
   public void testNestedUserQueuePrimaryGroup() throws Exception {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='specified' create='false' />");
     sb.append("  <rule name='nestedUserQueue'>");
@@ -380,7 +380,7 @@ public class TestQueuePlacementPolicy {
   @Test
   public void testNestedUserQueuePrimaryGroupNoCreate() throws Exception {
     // Primary group rule has create='false'
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='nestedUserQueue'>");
     sb.append("       <rule name='primaryGroup' create='false'/>");
@@ -402,7 +402,7 @@ public class TestQueuePlacementPolicy {
     assertEquals("root.user1group.user1", context.getQueue());
 
     // Both Primary group and nestedUserQueue rule has create='false'
-    sb = new StringBuffer();
+    sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='nestedUserQueue' create='false'>");
     sb.append("       <rule name='primaryGroup' create='false'/>");
@@ -426,7 +426,7 @@ public class TestQueuePlacementPolicy {
 
   @Test
   public void testNestedUserQueueSecondaryGroup() throws Exception {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='nestedUserQueue'>");
     sb.append("       <rule name='secondaryGroupExistingQueue'/>");
@@ -452,7 +452,7 @@ public class TestQueuePlacementPolicy {
   public void testNestedUserQueueSpecificRule() throws Exception {
     // This test covers the use case where users can specify different parent
     // queues and want user queues under those.
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='nestedUserQueue'>");
     sb.append("       <rule name='specified' create='false'/>");
@@ -477,7 +477,7 @@ public class TestQueuePlacementPolicy {
   public void testNestedUserQueueDefaultRule() throws Exception {
     // This test covers the use case where we would like user queues to be
     // created under a default parent queue
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='specified' create='false' />");
     sb.append("  <rule name='nestedUserQueue'>");
@@ -492,7 +492,7 @@ public class TestQueuePlacementPolicy {
 
     // Same as above but now with the create flag false for the parent
     createQueue(FSQueueType.PARENT, "root.parent");
-    sb = new StringBuffer();
+    sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='specified' create='false' />");
     sb.append("  <rule name='nestedUserQueue'>");
@@ -509,7 +509,7 @@ public class TestQueuePlacementPolicy {
     // Parent queue returned is already a configured LEAF, should fail and the
     // context is null.
     createQueue(FSQueueType.LEAF, "root.parent");
-    sb = new StringBuffer();
+    sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='specified' create='false' />");
     sb.append("  <rule name='nestedUserQueue'>");
@@ -526,7 +526,7 @@ public class TestQueuePlacementPolicy {
   @Test
   public void testUserContainsPeriod() throws Exception {
     // This test covers the user case where the username contains periods.
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='user' />");
     sb.append("</queuePlacementPolicy>");
@@ -535,7 +535,7 @@ public class TestQueuePlacementPolicy {
     context = placementManager.placeApplication(asc, "first.last");
     assertEquals("root.first_dot_last", context.getQueue());
 
-    sb = new StringBuffer();
+    sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='specified' create='false' />");
     sb.append("  <rule name='nestedUserQueue'>");
@@ -553,7 +553,7 @@ public class TestQueuePlacementPolicy {
 
   @Test
   public void testGroupContainsPeriod() throws Exception {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='specified' create='false' />");
     sb.append("  <rule name='nestedUserQueue'>");
@@ -580,7 +580,7 @@ public class TestQueuePlacementPolicy {
 
   @Test
   public void testEmptyGroupsPrimaryGroupRule() throws Exception {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='primaryGroup' create=\"false\" />");
     sb.append("  <rule name='default' />");
@@ -596,7 +596,7 @@ public class TestQueuePlacementPolicy {
 
   @Test
   public void testSpecifiedQueueWithSpaces() throws Exception {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("<queuePlacementPolicy>");
     sb.append("  <rule name='specified'/>");
     sb.append("  <rule name='default'/>");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
@@ -1906,7 +1906,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       ClientMethod remoteMethod = new ClientMethod("addToClusterNodeLabels", argsClasses, args);
       Map<SubClusterInfo, Response> responseInfoMap =
           invokeConcurrent(subClustersActives, remoteMethod, Response.class);
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       // SubCluster-0:SUCCESS,SubCluster-1:SUCCESS
       responseInfoMap.forEach((subClusterInfo, response) ->
           buildAppendMsg(subClusterInfo, buffer, response));
@@ -1964,7 +1964,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
           new ClientMethod("removeFromClusterNodeLabels", argsClasses, args);
       Map<SubClusterInfo, Response> responseInfoMap =
           invokeConcurrent(subClustersActives, remoteMethod, Response.class);
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       // SubCluster-0:SUCCESS,SubCluster-1:SUCCESS
       responseInfoMap.forEach((subClusterInfo, response) ->
           buildAppendMsg(subClusterInfo, buffer, response));
@@ -1993,10 +1993,10 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
    * Build Append information.
    *
    * @param subClusterInfo subCluster information.
-   * @param buffer StringBuffer.
+   * @param buffer StringBuilder.
    * @param response response message.
    */
-  private void buildAppendMsg(SubClusterInfo subClusterInfo, StringBuffer buffer,
+  private void buildAppendMsg(SubClusterInfo subClusterInfo, StringBuilder buffer,
       Response response) {
     SubClusterId subClusterId = subClusterInfo.getSubClusterId();
     String state = response != null &&


### PR DESCRIPTION
### Description of PR

HADOOP-19134

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

