### PR TITLE
HDFS-17444. Add getJournalSyncerStarted jmx metrics, to Indicates whether the JournalSyncer thread has been started.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNode.java
@@ -406,6 +406,18 @@ public class JournalNode implements Tool, Configurable, JournalNodeMXBean {
   }
 
   @Override // JournalNodeMXBean
+  public String getJournalSyncerStatus() {
+    StringBuilder sbuilder = new StringBuilder();
+    journalSyncersById.keySet().forEach((jid) ->
+        sbuilder.append(jid)
+            .append(","));
+    if (sbuilder.length() > 0) {
+      sbuilder.deleteCharAt(sbuilder.length() - 1);
+    }
+    return "[" + sbuilder.toString() + "]";
+  }
+
+  @Override // JournalNodeMXBean
   public String getHostAndPort() {
     return NetUtils.getHostPortString(rpcServer.getAddress());
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeMXBean.java
@@ -37,6 +37,17 @@ public interface JournalNodeMXBean {
   String getJournalsStatus();
 
   /**
+   * Query JournalSyncer status.
+   *
+   * @return JournalSyncer status.
+   *
+   * example: "[ns1,ns3]" string means:
+   * JournalSyncer thread for ns1 and ns3 has enter working state,
+   * but for ns2 has not enter working state yet
+   */
+  String getJournalSyncerStatus();
+
+  /**
    * Get host and port of JournalNode.
    *
    * @return colon separated host and port.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeMXBean.java
@@ -80,9 +80,20 @@ public class TestJournalNodeMXBean {
     assertEquals(jn.getJournalsStatus(), journalStatus);
     assertFalse(journalStatus.contains(NAMESERVICE));
 
+    // getJournalSyncerStatus
+    String journalSyncerStarted = (String) mbs.getAttribute(mxbeanName,
+        "JournalSyncerStatus");
+    assertEquals(jn.getJournalSyncerStatus(), journalSyncerStarted);
+    assertFalse(journalSyncerStarted.contains(NAMESERVICE));
+
     // format the journal ns1
     final NamespaceInfo fakeNsInfo = new NamespaceInfo(NS_ID, "mycluster", "my-bp", 0L);
     jn.getOrCreateJournal(NAMESERVICE).format(fakeNsInfo, false);
+
+    // check again after getOrCreateJournal
+    journalSyncerStarted = (String) mbs.getAttribute(mxbeanName,
+        "JournalSyncerStatus");
+    assertTrue(journalSyncerStarted.contains(NAMESERVICE));
 
     // check again after format
     // getJournalsStatus


### PR DESCRIPTION
The JornalNode JVM process is not immediately in a normal state until the JournalSyncer thread is started.
For some management platforms such as Ambari rolling restart JournalNode, we need a jmx metric to determine whether the JournalSyncer thread is started and enter working state for current namespace before restarting the next JournalNode. Otherwise, restart too quickly and more than half of JournalNodes will be out of order, causing the NameNode to die.

When i add it , the effect is as follows:
![image](https://github.com/apache/hadoop/assets/65019264/73c859be-fca4-49c1-b718-8f2946c6cb41)
