### PR TITLE
HDFS-17424 [FGL] DelegationTokenSecretManager supports fine-grained lock

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/delegation/DelegationTokenSecretManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/delegation/DelegationTokenSecretManager.java
@@ -402,8 +402,7 @@ public class DelegationTokenSecretManager
       // the secret manager.
       // TODO: delegation token is a very independent system, so
       // it's proper to use an seperated r/w lock instead of fs lock
-      // for getting/renewing/expiring/canceling token or updating
-      // master key.
+      // for getting/renewing/expiring/canceling token or updating master key.
       namesystem.readLockInterruptibly(FSNamesystemLockMode.FS);
       try {
         // this monitor isn't necessary if stopped while holding write lock

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/delegation/DelegationTokenSecretManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/delegation/DelegationTokenSecretManager.java
@@ -402,9 +402,6 @@ public class DelegationTokenSecretManager
       // closes the edit log files. Doing this inside the
       // fsn lock will prevent being interrupted when stopping
       // the secret manager.
-      // TODO: delegation token is a very independent system, so
-      // it's proper to use an seperated r/w lock instead of fs lock
-      // for getting/renewing/expiring/canceling token or updating master key.
       namesystem.readLockInterruptibly(FSNamesystemLockMode.FS);
       try {
         // this monitor isn't necessary if stopped while holding write lock

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/delegation/DelegationTokenSecretManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/delegation/DelegationTokenSecretManager.java
@@ -22,7 +22,9 @@ import java.io.DataInput;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map.Entry;
 
 import org.apache.hadoop.hdfs.server.namenode.fgl.FSNamesystemLockMode;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -6486,7 +6486,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       "the DT manager before entering safemode!";
     // edit log rolling is not thread-safe and must be protected by the
     // fsn lock.  not updating namespace so read lock is sufficient.
-    assert hasReadLock();
+    assert hasReadLock(FSNamesystemLockMode.FS);
     getEditLog().logUpdateMasterKey(key);
     getEditLog().logSync();
   }
@@ -6502,7 +6502,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       "the DT manager before entering safemode!";
     // edit log rolling is not thread-safe and must be protected by the
     // fsn lock.  not updating namespace so read lock is sufficient.
-    assert hasReadLock();
+    assert hasReadLock(FSNamesystemLockMode.FS);
     // do not logSync so expiration edits are batched
     getEditLog().logCancelDelegationToken(id);
   }  


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

