### PR TITLE
HADOOP-19141. Vector IO: Update default values consistently

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1423,12 +1423,12 @@ public final class Constants {
   /**
    * Default minimum seek in bytes during vectored reads : {@value}.
    */
-  public static final int DEFAULT_AWS_S3_VECTOR_READS_MIN_SEEK_SIZE = 4896; // 4K
+  public static final int DEFAULT_AWS_S3_VECTOR_READS_MIN_SEEK_SIZE = 4096; // 4K
 
   /**
    * Default maximum read size in bytes during vectored reads : {@value}.
    */
-  public static final int DEFAULT_AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE = 1253376; //1M
+  public static final int DEFAULT_AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE = 1048576; //1M
 
   /**
    * Maximum number of range reads a single input stream can have


### PR DESCRIPTION
### Description of PR

This PR updates two Vector IO default values.

```
- public static final int DEFAULT_AWS_S3_VECTOR_READS_MIN_SEEK_SIZE = 4896; // 4K
+ public static final int DEFAULT_AWS_S3_VECTOR_READS_MIN_SEEK_SIZE = 4096; // 4K
- public static final int DEFAULT_AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE = 1253376; //1M
+ public static final int DEFAULT_AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE = 1048576; //1M
```

If a user set a configuration like the documented `4K` or `1M`, Apache Hadoop will use 4096 and 1048576 which are different from the AS-IS defined value of `Constants.java`. Thus, this PR fixes `Constants.java` with the values, 4096 and 1048576.
https://github.com/apache/hadoop/blob/87fb97777745b2cefed6bef57490b84676d2343d/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java#L779-L782


### How was this patch tested?

1. Apache Hadoop uses 1M as `1048576  = 1024 x 1024` historically like the following.
https://github.com/apache/hadoop/blob/87fb97777745b2cefed6bef57490b84676d2343d/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java#L521

    So, the default value of Vector IO is inconsistent from not only the other values but also from its comment, `//1M`, and its documentation, `1M`.
https://github.com/apache/hadoop/blob/87fb97777745b2cefed6bef57490b84676d2343d/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java#L1431

    https://github.com/apache/hadoop/blob/87fb97777745b2cefed6bef57490b84676d2343d/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md?plain=1#L79

2. The AS-IS default values of Vector IO are also inconsistent from the values of Vector IO test cases.
https://github.com/apache/hadoop/blob/87fb97777745b2cefed6bef57490b84676d2343d/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractVectoredRead.java#L144-L147

3. The inconsistency happens for `4K` in the same way.
https://github.com/apache/hadoop/blob/87fb97777745b2cefed6bef57490b84676d2343d/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java#L1426
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

