### PR TITLE
HDFS-17453. IncrementalBlockReport can have race condition with Edit Log Tailer

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -3493,8 +3493,7 @@ public class BlockManager implements BlockStatsMXBean {
               " from datanode {} for later processing because {}.",
           block, reportedState, storageInfo.getDatanodeDescriptor(), reason);
     }
-    pendingDNMessages.enqueueReportedBlock(storageInfo, block, reportedState,
-        isGenStampInFuture(block));
+    pendingDNMessages.enqueueReportedBlock(storageInfo, block, reportedState);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -3493,7 +3493,8 @@ public class BlockManager implements BlockStatsMXBean {
               " from datanode {} for later processing because {}.",
           block, reportedState, storageInfo.getDatanodeDescriptor(), reason);
     }
-    pendingDNMessages.enqueueReportedBlock(storageInfo, block, reportedState);
+    pendingDNMessages.enqueueReportedBlock(storageInfo, block, reportedState,
+        isGenStampInFuture(block));
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingDataNodeMessages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingDataNodeMessages.java
@@ -95,6 +95,9 @@ class PendingDataNodeMessages {
   
   void enqueueReportedBlock(DatanodeStorageInfo storageInfo, Block block,
       ReplicaState reportedState) {
+    if (storageInfo == null || block == null || reportedState == null) {
+      return;
+    }
     long genStamp = block.getGenerationStamp();
     Queue<ReportedBlockInfo> queue = null;
     if (BlockIdManager.isStripedBlockID(block.getBlockId())) {
@@ -111,7 +114,7 @@ class PendingDataNodeMessages {
     // the old reported block will be processed and marked as corrupt by the ANN.
     // See HDFS-17453
     int size = queue.size();
-    if (queue.removeIf(rbi -> rbi.storageInfo.equals(storageInfo) &&
+    if (queue.removeIf(rbi -> storageInfo.equals(rbi.storageInfo) &&
         rbi.block.getGenerationStamp() < genStamp)) {
       count -= (size - queue.size());
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingDataNodeMessages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingDataNodeMessages.java
@@ -115,7 +115,7 @@ class PendingDataNodeMessages {
     // See HDFS-17453
     int size = queue.size();
     if (queue.removeIf(rbi -> storageInfo.equals(rbi.storageInfo) &&
-        rbi.block.getGenerationStamp() < genStamp)) {
+        rbi.block.getGenerationStamp() <= genStamp)) {
       count -= (size - queue.size());
     }
     queue.add(new ReportedBlockInfo(storageInfo, new Block(block), reportedState));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingDataNodeMessages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingDataNodeMessages.java
@@ -105,7 +105,6 @@ class PendingDataNodeMessages {
           .getBlockId()));
       queue = getBlockQueue(blkId);
     } else {
-      block = new Block(block);
       queue = getBlockQueue(block);
     }
     // We only want the latest non-future reported block to be queued for each

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingDataNodeMessages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingDataNodeMessages.java
@@ -109,6 +109,7 @@ class PendingDataNodeMessages {
     // DataNode. Otherwise, there can be a race condition that causes an old
     // reported block to be kept in the queue until the SNN switches to ANN and
     // the old reported block will be processed and marked as corrupt by the ANN.
+    // See HDFS-17453
     if (!isGenStampInFuture) {
       queue.removeIf(rbi -> rbi.storageInfo.equals(storageInfo) &&
           rbi.block.getGenerationStamp() < genStamp);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingDataNodeMessages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingDataNodeMessages.java
@@ -95,9 +95,10 @@ class PendingDataNodeMessages {
   
   void enqueueReportedBlock(DatanodeStorageInfo storageInfo, Block block,
       ReplicaState reportedState) {
-    if (storageInfo == null || block == null || reportedState == null) {
+    if (storageInfo == null || block == null) {
       return;
     }
+    block = new Block(block);
     long genStamp = block.getGenerationStamp();
     Queue<ReportedBlockInfo> queue = null;
     if (BlockIdManager.isStripedBlockID(block.getBlockId())) {
@@ -117,7 +118,7 @@ class PendingDataNodeMessages {
         rbi.block.getGenerationStamp() <= genStamp)) {
       count -= (size - queue.size());
     }
-    queue.add(new ReportedBlockInfo(storageInfo, new Block(block), reportedState));
+    queue.add(new ReportedBlockInfo(storageInfo, block, reportedState));
     count++;
   }
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingDataNodeMessages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingDataNodeMessages.java
@@ -54,8 +54,10 @@ public class TestPendingDataNodeMessages {
 
   @Test
   public void testQueues() {
-    DatanodeDescriptor fakeDN1 = DFSTestUtil.getDatanodeDescriptor("localhost", 8898, "/default-rack");
-    DatanodeDescriptor fakeDN2 = DFSTestUtil.getDatanodeDescriptor("localhost", 8899, "/default-rack");
+    DatanodeDescriptor fakeDN1 = DFSTestUtil.getDatanodeDescriptor(
+        "localhost", 8898, "/default-rack");
+    DatanodeDescriptor fakeDN2 = DFSTestUtil.getDatanodeDescriptor(
+        "localhost", 8899, "/default-rack");
     DatanodeStorage storage = new DatanodeStorage("STORAGE_ID");
     DatanodeStorageInfo storageInfo1 = new DatanodeStorageInfo(fakeDN1, storage);
     DatanodeStorageInfo storageInfo2 = new DatanodeStorageInfo(fakeDN2, storage);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingDataNodeMessages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingDataNodeMessages.java
@@ -58,9 +58,10 @@ public class TestPendingDataNodeMessages {
         "localhost", 8898, "/default-rack");
     DatanodeDescriptor fakeDN2 = DFSTestUtil.getDatanodeDescriptor(
         "localhost", 8899, "/default-rack");
-    DatanodeStorage storage = new DatanodeStorage("STORAGE_ID");
-    DatanodeStorageInfo storageInfo1 = new DatanodeStorageInfo(fakeDN1, storage);
-    DatanodeStorageInfo storageInfo2 = new DatanodeStorageInfo(fakeDN2, storage);
+    DatanodeStorage storage1 = new DatanodeStorage("STORAGE_ID_1");
+    DatanodeStorage storage2 = new DatanodeStorage("STORAGE_ID_2");
+    DatanodeStorageInfo storageInfo1 = new DatanodeStorageInfo(fakeDN1, storage1);
+    DatanodeStorageInfo storageInfo2 = new DatanodeStorageInfo(fakeDN2, storage2);
     msgs.enqueueReportedBlock(storageInfo1, block1Gs1, ReplicaState.FINALIZED);
     msgs.enqueueReportedBlock(storageInfo2, block1Gs1, ReplicaState.FINALIZED);
     msgs.enqueueReportedBlock(storageInfo1, block1Gs2, ReplicaState.FINALIZED);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingDataNodeMessages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingDataNodeMessages.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.hdfs.server.blockmanagement;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Queue;
 
 import org.apache.hadoop.conf.Configuration;
@@ -30,7 +32,6 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.protocol.Block;
-import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 import org.apache.hadoop.hdfs.protocol.SystemErasureCodingPolicies;
 import org.apache.hadoop.hdfs.server.blockmanagement.PendingDataNodeMessages.ReportedBlockInfo;
@@ -62,6 +63,9 @@ public class TestPendingDataNodeMessages {
     msgs.enqueueReportedBlock(storageInfo2, block1Gs1, ReplicaState.FINALIZED);
     msgs.enqueueReportedBlock(storageInfo1, block1Gs2, ReplicaState.FINALIZED);
     msgs.enqueueReportedBlock(storageInfo2, block1Gs2, ReplicaState.FINALIZED);
+    List<ReportedBlockInfo> rbis = Arrays.asList(
+        new ReportedBlockInfo(storageInfo1, block1Gs2, ReplicaState.FINALIZED),
+        new ReportedBlockInfo(storageInfo2, block1Gs2, ReplicaState.FINALIZED));
 
     assertEquals(2, msgs.count());
     
@@ -71,9 +75,7 @@ public class TestPendingDataNodeMessages {
     
     Queue<ReportedBlockInfo> q =
       msgs.takeBlockQueue(block1Gs2DifferentInstance);
-    assertEquals(
-        "ReportedBlockInfo [block=blk_1_2, dn=/default-rack/localhost:8898, reportedState=FINALIZED]," +
-        "ReportedBlockInfo [block=blk_1_2, dn=/default-rack/localhost:8899, reportedState=FINALIZED]",
+    assertEquals(Joiner.on(",").join(rbis),
         Joiner.on(",").join(q));
     assertEquals(0, msgs.count());
     

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
@@ -17,14 +17,25 @@
  */
 package org.apache.hadoop.hdfs.server.datanode;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
+import org.apache.hadoop.hdfs.server.namenode.ha.HATestUtil;
+import org.mockito.invocation.InvocationOnMock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -55,6 +66,9 @@ public class TestIncrementalBlockReports {
   private static final long DUMMY_BLOCK_ID = 5678;
   private static final long DUMMY_BLOCK_LENGTH = 1024 * 1024;
   private static final long DUMMY_BLOCK_GENSTAMP = 1000;
+  private static final String TEST_FILE_DATA = "hello world";
+  private static final String TEST_FILE = "/TestStandbyBlockManagement";
+  private static final Path TEST_FILE_PATH = new Path(TEST_FILE);
 
   private MiniDFSCluster cluster = null;
   private Configuration conf;
@@ -213,6 +227,93 @@ public class TestIncrementalBlockReports {
     } finally {
       cluster.shutdown();
       cluster = null;
+    }
+  }
+
+  @Test
+  public void testIBRRaceCondition() throws Exception {
+    cluster.shutdown();
+    Configuration conf = new Configuration();
+    HAUtil.setAllowStandbyReads(conf, true);
+    conf.setInt(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, 1);
+    cluster = new MiniDFSCluster.Builder(conf)
+        .nnTopology(MiniDFSNNTopology.simpleHATopology())
+        .numDataNodes(3)
+        .build();
+    try {
+      cluster.waitActive();
+      cluster.transitionToActive(0);
+
+      NameNode nn1 = cluster.getNameNode(0);
+      NameNode nn2 = cluster.getNameNode(1);
+      FileSystem fs = HATestUtil.configureFailoverFs(cluster, conf);
+      List<InvocationOnMock> ibrsToStandby = new ArrayList<>();
+      List<DatanodeProtocolClientSideTranslatorPB> spies = new ArrayList<>();
+      Phaser ibrPhaser = new Phaser(1);
+      for (DataNode dn : cluster.getDataNodes()) {
+        DatanodeProtocolClientSideTranslatorPB nnSpy =
+            InternalDataNodeTestUtils.spyOnBposToNN(dn, nn2);
+        doAnswer((inv) -> {
+          for (StorageReceivedDeletedBlocks srdb :
+              inv.getArgument(2, StorageReceivedDeletedBlocks[].class)) {
+            for (ReceivedDeletedBlockInfo block : srdb.getBlocks()) {
+              if (block.getStatus().equals(BlockStatus.RECEIVED_BLOCK)) {
+                ibrPhaser.arriveAndDeregister();
+              }
+            }
+          }
+          ibrsToStandby.add(inv);
+          return null;
+        }).when(nnSpy).blockReceivedAndDeleted(
+            any(DatanodeRegistration.class),
+            anyString(),
+            any(StorageReceivedDeletedBlocks[].class));
+        spies.add(nnSpy);
+      }
+
+      Thread.sleep(1000);
+      LOG.info("==================================");
+      ibrPhaser.bulkRegister(9);
+      DFSTestUtil.writeFile(fs, TEST_FILE_PATH, TEST_FILE_DATA);
+      DFSTestUtil.appendFile(fs, TEST_FILE_PATH, TEST_FILE_DATA);
+      DFSTestUtil.appendFile(fs, TEST_FILE_PATH, TEST_FILE_DATA);
+      HATestUtil.waitForStandbyToCatchUp(nn1, nn2);
+      int phase = ibrPhaser.arrive();
+      ibrPhaser.awaitAdvanceInterruptibly(phase, 60, TimeUnit.SECONDS);
+      for (InvocationOnMock sendIBRs : ibrsToStandby) {
+        try {
+          sendIBRs.callRealMethod();
+        } catch (Throwable t) {
+          LOG.error("Exception thrown while calling sendIBRs: ", t);
+        }
+      }
+      ibrsToStandby.clear();
+      ibrPhaser.bulkRegister(6);
+      DFSTestUtil.appendFile(fs, TEST_FILE_PATH, TEST_FILE_DATA);
+      DFSTestUtil.appendFile(fs, TEST_FILE_PATH, TEST_FILE_DATA);
+      phase = ibrPhaser.arrive();
+      ibrPhaser.awaitAdvanceInterruptibly(phase, 60, TimeUnit.SECONDS);
+      for (InvocationOnMock sendIBRs : ibrsToStandby) {
+        try {
+          sendIBRs.callRealMethod();
+        } catch (Throwable t) {
+          LOG.error("Exception thrown while calling sendIBRs: ", t);
+        }
+      }
+      ibrsToStandby.clear();
+      ibrPhaser.arriveAndDeregister();
+      ExtendedBlock block = DFSTestUtil.getFirstBlock(fs, TEST_FILE_PATH);
+      HATestUtil.waitForStandbyToCatchUp(nn1, nn2);
+      LOG.info("==================================");
+
+      cluster.transitionToStandby(0);
+      cluster.transitionToActive(1);
+      cluster.waitActive(1);
+
+      assertEquals(0, nn2.getNamesystem().getBlockManager()
+          .numCorruptReplicas(block.getLocalBlock()));
+    } finally {
+      cluster.shutdown();
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
@@ -233,7 +233,7 @@ public class TestIncrementalBlockReports {
   @Test
   public void testIBRRaceCondition() throws Exception {
     cluster.shutdown();
-    Configuration conf = new Configuration();
+    conf = new Configuration();
     HAUtil.setAllowStandbyReads(conf, true);
     conf.setInt(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, 1);
     cluster = new MiniDFSCluster.Builder(conf)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
@@ -287,6 +287,9 @@ public class TestIncrementalBlockReports {
           LOG.error("Exception thrown while calling sendIBRs: ", t);
         }
       }
+
+      assertEquals("There should be 3 pending messages from DNs", 3,
+          nn2.getNamesystem().getBlockManager().getPendingDataNodeMessageCount());
       ibrsToStandby.clear();
       ibrPhaser.bulkRegister(6);
       DFSTestUtil.appendFile(fs, TEST_FILE_PATH, TEST_FILE_DATA);
@@ -310,8 +313,9 @@ public class TestIncrementalBlockReports {
       cluster.transitionToActive(1);
       cluster.waitActive(1);
 
-      assertEquals(0, nn2.getNamesystem().getBlockManager()
-          .numCorruptReplicas(block.getLocalBlock()));
+      assertEquals("There should not be any corrupt replicas", 0,
+          nn2.getNamesystem().getBlockManager()
+              .numCorruptReplicas(block.getLocalBlock()));
     } finally {
       cluster.shutdown();
     }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

# Description of PR
## Summary

There is a race condition between IncrementalBlockReports (IBR) and EditLogTailer in Standby NameNode (SNN) which can lead to leaked IBRs and false corrupt blocks after HA Failover. The race condition occurs when the SNN loads the edit logs before it receives the block reports from DataNode (DN).
## Example

In the following example there is a block (b1) with 3 generation stamps (gs1, gs2, gs3).
 1. SNN1 loads edit logs for b1gs1 and b1gs2.
 1. DN1 sends the IBR for b1gs1 to SNN1.
 1. SNN1 will determine that the reported block b1gs1 from DN1 is corrupt and it will be queued for later. [BlockManager.java](https://github.com/apache/hadoop/blob/6ed73896f6e8b4b7c720eff64193cb30b3e77fb2/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java#L3447C1-L3464C6)
``` java
    BlockToMarkCorrupt c = checkReplicaCorrupt(
        block, reportedState, storedBlock, ucState, dn);
    if (c != null) {
      if (shouldPostponeBlocksFromFuture) {
        // If the block is an out-of-date generation stamp or state,
        // but we're the standby, we shouldn't treat it as corrupt,
        // but instead just queue it for later processing.
        // Storing the reported block for later processing, as that is what
        // comes from the IBR / FBR and hence what we should use to compare
        // against the memory state.
        // See HDFS-6289 and HDFS-15422 for more context.
        queueReportedBlock(storageInfo, block, reportedState,
            QUEUE_REASON_CORRUPT_STATE);
      } else {
        toCorrupt.add(c);
      }
      return storedBlock;
    }
```
 4. DN1 sends IBR for b1gs2 and b1gs3 to SNN1.
 1. SNN1 processes b1sg2 and updates the blocks map.
 1. SNN1 queues b1gs3 for later because it determines that b1gs3 is a future genstamp.
 1. SNN1 loads b1gs3 edit logs and processes the queued reports for b1.
 1. SNN1 processes b1gs1 first and puts it back in the queue.
 1. SNN1 processes b1gs3 next and updates the blocks map.
 1. Later, SNN1 becomes the Active NameNode (ANN) during an HA Failover.
 1. SNN1 will catch to the latest edit logs, then process all queued block reports to become the ANN.
 1. ANN1 will process b1gs1 and mark it as corrupt.

If the example above happens for every DN which stores b1, then when the HA failover happens, b1 will be incorrectly marked as corrupt. This will be fixed when the first DN sends a FullBlockReport or an IBR for b1.

## Logs from Active Cluster

I added the following logs to confirm this issue in an active cluster:
``` java
BlockToMarkCorrupt c = checkReplicaCorrupt(
    block, reportedState, storedBlock, ucState, dn);
if (c != null) {
  DatanodeStorageInfo storedStorageInfo = storedBlock.findStorageInfo(dn);
  LOG.info("Found corrupt block {} [{}, {}] from DN {}. Stored block {} from DN {}",
      block, reportedState.name(), ucState.name(), storageInfo, storedBlock, storedStorageInfo);
  if (storageInfo.equals(storedStorageInfo) &&
        storedBlock.getGenerationStamp() > block.getGenerationStamp()) {
    LOG.info("Stored Block {} from the same DN {} has a newer GenStamp." +
        storedBlock, storedStorageInfo);
  }
  if (shouldPostponeBlocksFromFuture) {
    // If the block is an out-of-date generation stamp or state,
    // but we're the standby, we shouldn't treat it as corrupt,
    // but instead just queue it for later processing.
    // Storing the reported block for later processing, as that is what
    // comes from the IBR / FBR and hence what we should use to compare
    // against the memory state.
    // See HDFS-6289 and HDFS-15422 for more context.
    queueReportedBlock(storageInfo, block, reportedState,
        QUEUE_REASON_CORRUPT_STATE);
    LOG.info("Queueing the block {} for later processing", block);
  } else {
    toCorrupt.add(c);
    LOG.info("Marking the block {} as corrupt", block);
  }
  return storedBlock;
}
```

Logs from nn1 (Active):
``` java
2024-04-03T03:00:52.524-0700,INFO,[IPC Server handler 6 on default port 443],org.apache.hadoop.hdfs.server.namenode.FSNamesystem,"updatePipeline(blk_66092666802_65700910634, newGS=65700925027, newLength=10485760, newNodes=[[DN1]:10010, [DN2]:10010, [DN3]:10010, client=client1)"
2024-04-03T03:00:52.539-0700,INFO,[IPC Server handler 6 on default port 443],org.apache.hadoop.hdfs.server.namenode.FSNamesystem,"updatePipeline(blk_66092666802_65700910634 => blk_66092666802_65700925027) success"
2024-04-03T03:01:07.413-0700,INFO,[IPC Server handler 6 on default port 443],org.apache.hadoop.hdfs.server.namenode.FSNamesystem,"updatePipeline(blk_66092666802_65700925027, newGS=65700933553, newLength=20971520, newNodes=[[DN1]:10010, [DN2]:10010, [DN3]:10010, client=client1)"
2024-04-03T03:01:07.413-0700,INFO,[IPC Server handler 6 on default port 443],org.apache.hadoop.hdfs.server.namenode.FSNamesystem,"updatePipeline(blk_66092666802_65700925027 => blk_66092666802_65700933553) success"
```

Logs from nn2 (Standby):
``` java
2024-04-03T03:01:23.067-0700,INFO,[Block report processor],org.apache.hadoop.hdfs.server.blockmanagement.BlockManager,"Found corrupt block blk_66092666802_65700925027 [FINALIZED, COMPLETE] from DN [DISK]DS-1:NORMAL:[DN1]:10010. Stored block blk_66092666802_65700933553 from DN null"
2024-04-03T03:01:23.067-0700,INFO,[Block report processor],org.apache.hadoop.hdfs.server.blockmanagement.BlockManager,"Queueing the block blk_66092666802_65700925027 for later processing"
2024-04-03T03:01:24.159-0700,INFO,[Block report processor],org.apache.hadoop.hdfs.server.blockmanagement.BlockManager,"Found corrupt block blk_66092666802_65700925027 [FINALIZED, COMPLETE] from DN [DISK]DS-3:NORMAL:[DN3]:10010. Stored block blk_66092666802_65700933553 from DN null"
2024-04-03T03:01:24.159-0700,INFO,[Block report processor],org.apache.hadoop.hdfs.server.blockmanagement.BlockManager,"Queueing the block blk_66092666802_65700925027 for later processing"
2024-04-03T03:01:24.159-0700,INFO,[Block report processor],org.apache.hadoop.hdfs.server.blockmanagement.BlockManager,"Found corrupt block blk_66092666802_65700925027 [FINALIZED, COMPLETE] from DN [DISK]DS-2:NORMAL:[DN2]:10010. Stored block blk_66092666802_65700933553 from DN null"
2024-04-03T03:01:24.159-0700,INFO,[Block report processor],org.apache.hadoop.hdfs.server.blockmanagement.BlockManager,"Queueing the block blk_66092666802_65700925027 for later processing"
```

Logs from nn2 when it transitions to Active:
``` java
2024-04-03T15:39:09.050-0700,INFO,[IPC Server handler 8 on default port 8020],org.apache.hadoop.hdfs.server.blockmanagement.BlockManager,"Found corrupt block blk_66092666802_65700925027 [FINALIZED, COMPLETE] from DN [DISK]DS-1:NORMAL:[DN1]:10010. Stored block blk_66092666802_65700933553 from DN [DISK]DS-1:NORMAL:[DN1]:10010"
2024-04-03T15:39:09.050-0700,INFO,[IPC Server handler 8 on default port 8020],org.apache.hadoop.hdfs.server.blockmanagement.BlockManager,"Stored Block blk_66092666802_65700933553 from the same DN [DISK]DS-1:NORMAL:[DN1]:10010 has a newer GenStamp."
2024-04-03T15:39:09.050-0700,INFO,[IPC Server handler 8 on default port 8020],org.apache.hadoop.hdfs.server.blockmanagement.BlockManager,"Marking the block blk_66092666802_65700925027 as corrupt"
2024-04-03T15:39:09.050-0700,INFO,[IPC Server handler 8 on default port 8020],org.apache.hadoop.hdfs.server.blockmanagement.BlockManager,"Found corrupt block blk_66092666802_65700925027 [FINALIZED, COMPLETE] from DN [DISK]DS-2:NORMAL:[DN2]:10010. Stored block blk_66092666802_65700933553 from DN [DISK]DS-2:NORMAL:[DN2]:10010"
2024-04-03T15:39:09.050-0700,INFO,[IPC Server handler 8 on default port 8020],org.apache.hadoop.hdfs.server.blockmanagement.BlockManager,"Stored Block blk_66092666802_65700933553 from the same DN [DISK]DS-2:NORMAL:[DN2]:10010 has a newer GenStamp."
2024-04-03T15:39:09.050-0700,INFO,[IPC Server handler 8 on default port 8020],org.apache.hadoop.hdfs.server.blockmanagement.BlockManager,"Marking the block blk_66092666802_65700925027 as corrupt"
2024-04-03T15:39:09.050-0700,INFO,[IPC Server handler 8 on default port 8020],org.apache.hadoop.hdfs.server.blockmanagement.BlockManager,"Found corrupt block blk_66092666802_65700925027 [FINALIZED, COMPLETE] from DN [DISK]DS-3:NORMAL:[DN3]:10010. Stored block blk_66092666802_65700933553 from DN [DISK]DS-3:NORMAL:[DN3]:10010"
2024-04-03T15:39:09.050-0700,INFO,[IPC Server handler 8 on default port 8020],org.apache.hadoop.hdfs.server.blockmanagement.BlockManager,"Stored Block blk_66092666802_65700933553 from the same DN [DISK]DS-3:NORMAL:[DN3]:10010 has a newer GenStamp."
2024-04-03T15:39:09.050-0700,INFO,[IPC Server handler 8 on default port 8020],org.apache.hadoop.hdfs.server.blockmanagement.BlockManager,"Marking the block blk_66092666802_65700925027 as corrupt"
```
 

## How was this patch tested?


## For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

