### PR TITLE
HDFS-17455. Fix Client throw IndexOutOfBoundsException in DFSInputStream#fetchBlockAt

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.classification.VisibleForTesting;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
+import org.apache.hadoop.hdfs.security.token.block.InvalidBlockTokenException;
 
 /**
  * Used for injecting faults in DFSClient and DFSOutputStream tests.
@@ -69,4 +70,5 @@ public class DFSClientFaultInjector {
 
   public void onCreateBlockReader(LocatedBlock block, int chunkIndex, long offset, long length) {}
 
+  public void failCreateBlockReader() throws InvalidBlockTokenException {}
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -525,6 +525,10 @@ public class DFSInputStream extends FSInputStream
               newBlocks.getLocatedBlocks());
         }
       }
+      if (targetBlockIdx >= locatedBlocks.locatedBlockCount()) {
+        DFSClient.LOG.debug("Could not find target position " + offset);
+        throw new EOFException("Could not find target position " + offset);
+      }
       return locatedBlocks.get(targetBlockIdx);
     }
   }
@@ -642,6 +646,7 @@ public class DFSInputStream extends FSInputStream
       targetBlock = retval.block;
 
       try {
+        DFSClientFaultInjector.get().failCreateBlockReader();
         blockReader = getBlockReader(targetBlock, offsetIntoBlock,
             targetBlock.getBlockSize() - offsetIntoBlock, targetAddr,
             storageType, chosenNode);

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -520,9 +520,8 @@ public class DFSInputStream extends FSInputStream
         // Update the LastLocatedBlock, if offset is for last block.
         if (offset >= locatedBlocks.getFileLength()) {
           setLocatedBlocksFields(newBlocks, getLastBlockLength(newBlocks));
-          // Here locatedBlocks has been updated, need to check offset again.
-          // If offset to the portion of the last block, will return the last block,
-          // otherwise the block containing the specified offset needs to be searched again.
+          // After updating the locatedBlock, the block to which the offset belongs
+          // should be researched like {@link DFSInputStream#getBlockAt(long)}.
           if (offset >= locatedBlocks.getFileLength()) {
             return locatedBlocks.getLastLocatedBlock();
           } else {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -520,14 +520,19 @@ public class DFSInputStream extends FSInputStream
         // Update the LastLocatedBlock, if offset is for last block.
         if (offset >= locatedBlocks.getFileLength()) {
           setLocatedBlocksFields(newBlocks, getLastBlockLength(newBlocks));
+          // Here locatedBlocks has been updated, need to check offset again.
+          // If offset to the portion of the last block, will return the last block,
+          // otherwise the block containing the specified offset needs to be searched again.
+          if (offset >= locatedBlocks.getFileLength()) {
+            return locatedBlocks.getLastLocatedBlock();
+          } else {
+            targetBlockIdx = locatedBlocks.findBlock(offset);
+            assert targetBlockIdx >= 0 && targetBlockIdx < locatedBlocks.locatedBlockCount();
+          }
         } else {
           locatedBlocks.insertRange(targetBlockIdx,
               newBlocks.getLocatedBlocks());
         }
-      }
-      if (targetBlockIdx >= locatedBlocks.locatedBlockCount()) {
-        DFSClient.LOG.debug("Could not find target position " + offset);
-        throw new EOFException("Could not find target position " + offset);
       }
       return locatedBlocks.get(targetBlockIdx);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSInputStream.java
@@ -305,8 +305,6 @@ public class TestDFSInputStream {
   public void testCreateBlockReaderWhenInvalidBlockTokenException() throws
       IOException, InterruptedException, TimeoutException {
     GenericTestUtils.setLogLevel(DFSClient.LOG, Level.DEBUG);
-    GenericTestUtils.LogCapturer logs =
-        GenericTestUtils.LogCapturer.captureLogs(DFSClient.LOG);
     Configuration conf = new Configuration();
     DFSClientFaultInjector oldFaultInjector = DFSClientFaultInjector.get();
     try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build()) {
@@ -363,9 +361,6 @@ public class TestDFSInputStream {
         int read = in.read(buf, 0, bufLen);
         assertEquals(1024, read);
       }
-
-      assertTrue(logs.getOutput().contains("Could not find target position 1"));
-      logs.clearOutput();
     } finally {
       DFSClientFaultInjector.set(oldFaultInjector);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSInputStream.java
@@ -317,7 +317,7 @@ public class TestDFSInputStream {
       long fileLen = 1024 * 64;
       EnumSet<CreateFlag> createFlags = EnumSet.of(CREATE);
       FSDataOutputStream out =  fs.create(path, FsPermission.getFileDefault(), createFlags,
-          fs.getConf().getInt(IO_FILE_BUFFER_SIZE_KEY, 4096),(short) 3,
+          fs.getConf().getInt(IO_FILE_BUFFER_SIZE_KEY, 4096), (short) 3,
           fs.getDefaultBlockSize(path), null);
       int bufferLen = 1024;
       byte[] toWrite = new byte[bufferLen];


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17455

When the client read data, connect to the datanode, because at this time the datanode access token is invalid will throw InvalidBlockTokenException. At this time, when call fetchBlockAt method will throw java.lang.IndexOutOfBoundsException causing read data failed.

**Root case:**

- The HDFS file contains only one RBW block, with a block data size of 2048KB.
- The client open this file and seeks to the offset of 1024 to read data.
- Call DFSInputStream#getBlockReader method connect to the datanode, because at this time the datanode access token is invalid will throw InvalidBlockTokenException., and call DFSInputStream#fetchBlockAt will throw java.lang.IndexOutOfBoundsException.

```
private synchronized DatanodeInfo blockSeekTo(long target)
     throws IOException {
   if (target >= getFileLength()) {
   // the target size is smaller than fileLength (completeBlockSize + lastBlockBeingWrittenLength),
   // here at this time target is 1024 and getFileLength is 2048
     throw new IOException("Attempted to read past end of file");
   }
   ...
   while (true) {
     ...
     try {
       blockReader = getBlockReader(targetBlock, offsetIntoBlock,
           targetBlock.getBlockSize() - offsetIntoBlock, targetAddr,
           storageType, chosenNode);
       if(connectFailedOnce) {
         DFSClient.LOG.info("Successfully connected to " + targetAddr +
                            " for " + targetBlock.getBlock());
       }
       return chosenNode;
     } catch (IOException ex) {
       ...
       } else if (refetchToken > 0 && tokenRefetchNeeded(ex, targetAddr)) {
         refetchToken--;
         // Here will catch InvalidBlockTokenException.
         fetchBlockAt(target);
       } else {
         ...
       }
     }
   }
 }

private LocatedBlock fetchBlockAt(long offset, long length, boolean useCache)
      throws IOException {
    maybeRegisterBlockRefresh();
    synchronized(infoLock) {
      // Here the locatedBlocks only contains one locatedBlock, at this time the offset is 1024 and fileLength is 0,
      // so the targetBlockIdx is -2
      int targetBlockIdx = locatedBlocks.findBlock(offset);
      if (targetBlockIdx < 0) { // block is not cached
        targetBlockIdx = LocatedBlocks.getInsertIndex(targetBlockIdx);
        // Here the targetBlockIdx is 1;
        useCache = false;
      }
      if (!useCache) { // fetch blocks
        final LocatedBlocks newBlocks = (length == 0)
            ? dfsClient.getLocatedBlocks(src, offset)
            : dfsClient.getLocatedBlocks(src, offset, length);
        if (newBlocks == null || newBlocks.locatedBlockCount() == 0) {
          throw new EOFException("Could not find target position " + offset);
        }
        // Update the LastLocatedBlock, if offset is for last block.
        if (offset >= locatedBlocks.getFileLength()) {
          setLocatedBlocksFields(newBlocks, getLastBlockLength(newBlocks));
        } else {
          locatedBlocks.insertRange(targetBlockIdx,
              newBlocks.getLocatedBlocks());
        }
      }
      // Here the locatedBlocks only contains one locatedBlock, so will throw java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
      return locatedBlocks.get(targetBlockIdx);
    }
  }
```

The client exception:
```
java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
        at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
        at java.base/java.util.Objects.checkIndex(Objects.java:359)
        at java.base/java.util.ArrayList.get(ArrayList.java:427)
        at org.apache.hadoop.hdfs.protocol.LocatedBlocks.get(LocatedBlocks.java:87)
        at org.apache.hadoop.hdfs.DFSInputStream.fetchBlockAt(DFSInputStream.java:569)
        at org.apache.hadoop.hdfs.DFSInputStream.fetchBlockAt(DFSInputStream.java:540)
        at org.apache.hadoop.hdfs.DFSInputStream.blockSeekTo(DFSInputStream.java:704)
        at org.apache.hadoop.hdfs.DFSInputStream.readWithStrategy(DFSInputStream.java:884)
        at org.apache.hadoop.hdfs.DFSInputStream.read(DFSInputStream.java:957)
        at org.apache.hadoop.hdfs.DFSInputStream.read(DFSInputStream.java:804)

```

The datanode exception:
```
2024-03-27 15:56:35,477 WARN  datanode.DataNode (DataXceiver.java:checkAccess(1487)) [DataXceiver for client DFSClient_NONMAPREDUCE_475786505_1 at /xxx [Sending block BP-xxx:blk_1138933918_65194340]] - Block token verification failed: op=READ_BLOCK, remoteAddress=/XXX, message=Can't re-compute password for block_token_identifier (expiryDate=1711562193469, keyId=1775816931, userId=test, blockPoolId=BP-xxx-xxx-xxx, blockId=1138933918, access modes=[READ], storageTypes= [SSD, SSD, SSD], storageIds= [DS-xxx1, DS-xxx2,DS-xxx3]), since the required block key (keyID=1775816931) doesn't exist
```



