### PR TITLE
HDFS-17458. Remove unnecessary BP lock in ReplicaMap.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaMap.java
@@ -269,7 +269,7 @@ class ReplicaMap {
       if (m == null) {
         // Add an entry for block pool if it does not exist already
         m = new LightWeightResizableGSet<Block, ReplicaInfo>();
-        map.putIfAbsent(bpid, m);
+        map.put(bpid, m);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaMap.java
@@ -175,7 +175,7 @@ class ReplicaMap {
         if (curSet == null && !replicaSet.isEmpty()) {
           // Add an entry for block pool if it does not exist already
           curSet = new LightWeightResizableGSet<>();
-          map.putIfAbsent(bp, curSet);
+          map.put(bp, curSet);
         }
         for (ReplicaInfo replicaInfo : replicaSet) {
           checkBlock(replicaInfo);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaMap.java
@@ -256,11 +256,9 @@ class ReplicaMap {
    */
   void replicas(String bpid, Consumer<Iterator<ReplicaInfo>> consumer) {
     LightWeightResizableGSet<Block, ReplicaInfo> m = null;
-    try (AutoCloseDataSetLock l = lockManager.readLock(LockLevel.BLOCK_POOl, bpid)) {
-      m = map.get(bpid);
-      if (m !=null) {
-        m.getIterator(consumer);
-      }
+    m = map.get(bpid);
+    if (m !=null) {
+      m.getIterator(consumer);
     }
   }
 


### PR DESCRIPTION
### Description of PR

In [HDFS-16429](https://issues.apache.org/jira/browse/HDFS-16429) we make LightWeightResizableGSet to be thread safe, and in [HDFS-16511](https://issues.apache.org/jira/browse/HDFS-16511)  we change some methods in ReplicaMap to acquire read lock instead of acquiring write lock.

This PR try to remove unnecessary Block_Pool read lock further.

Recently, I performed stress tests on datanodes to measure their read/write operations/second.

Before we removing some lock（createRbw、finalizeBlock etc.）, it can only achieve ~2K write ops. After optimizing, it can achieve more than 5K write ops.

I have summarize all caller methods of ReplicaMap#get, ReplicaMap#remove, ReplicaMap#replicas, ReplicaMap#add.
It is safe to remove.

Below table is ReplicaMap#add's invocation point.
|method name | notes|
|-- | --|
append | VOLUME writeLock
createRbw | BLOCK_POOL readLock with inner VOLUME writeLock
convertTemporaryToRbw | VOLUME writeLock
finalizeReplica | VOLUME writeLock
checkAndUpdate | VOLUME writeLock
initReplicaRecoveryImpl | VOLUME writeLock（initReplicaRecovery）
updateReplicaUnderRecovery | VOLUME writeLock（在updateReplicaUnderRecovery）
evictBlocks | VOLUME writeLock
resolveDuplicateReplicas | VOLUME writeLock(checkAndUpdate)
readReplicasFromCache | not in dataset lock，dataset initialize。