### PR TITLE
HDFS-17461. Fix spotbugs in PeerCache#getInternal

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/PeerCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/PeerCache.java
@@ -155,7 +155,7 @@ public class PeerCache {
 
   private synchronized Peer getInternal(DatanodeID dnId, boolean isDomain) {
     List<Value> sockStreamList = multimap.get(new Key(dnId, isDomain));
-    if (sockStreamList == null) {
+    if (sockStreamList.isEmpty()) {
       return null;
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/PeerCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/PeerCache.java
@@ -155,10 +155,6 @@ public class PeerCache {
 
   private synchronized Peer getInternal(DatanodeID dnId, boolean isDomain) {
     List<Value> sockStreamList = multimap.get(new Key(dnId, isDomain));
-    if (sockStreamList.isEmpty()) {
-      return null;
-    }
-
     Iterator<Value> iter = sockStreamList.iterator();
     while (iter.hasNext()) {
       Value candidate = iter.next();


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17461

Fix spotbugs in PeerCache#getInternal

Spotbugs warnings：
https://ci-hadoop.apache.org/job/hadoop-multibranch/job/PR-6710/4/artifact/out/branch-spotbugs-hadoop-hdfs-project_hadoop-hdfs-client-warnings.html

` private final LinkedListMultimap<Key, Value> multimap = LinkedListMultimap.create();`
Returns a collection view containing the values associated with key in this multimap, if any. Note that even when (containsKey(key) is false, get(key) still returns an empty collection, not null.
