### PR TITLE
HDFS-17467. IncrementalBlockReportManager#getPerStorageIBR may throw NPE when remove volumes.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/IncrementalBlockReportManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/IncrementalBlockReportManager.java
@@ -261,6 +261,9 @@ class IncrementalBlockReportManager {
 
   synchronized void notifyNamenodeBlock(ReceivedDeletedBlockInfo rdbi,
       DatanodeStorage storage, boolean isOnTransientStorage) {
+    if (storage == null) {
+      return;
+    }
     addRDBI(rdbi, storage);
 
     final BlockStatus status = rdbi.getStatus();


### PR DESCRIPTION
### Description of PR
Refer to HDFS-17467.

When we remove volumes, it may cause IncrementalBlockReportManager#getPerStorageIBR throws NPE.

Consider below situation:

1、we have down createRbw、finalizeBlock.  But have not done datanode.closeBlock in method `BlockReceiver.PacketResponder#finalizeBlock`.

2、we remove volume which replica was written to and it executes such code: `storageMap.remove(storageUuid);`

3、 we begin to execute datanode.closeBlock which try to send IBR to NameNode. but when getting DatanodeStorage from storageMap using 

storageUuid, we will get null because we have remove this storageUuid key from storageMap.

4、Throw NPE in getPerStorageIBR method, because ConcurrentHashMap don't allow null key.


So, we should check whether storage is null before we invoke CHM#get. If storage is null, we directly return. It's OK, because removeVolume will remove all replicas on that volume, please check FsDatasetImpl#removeVolumes method for below codes:

```java
          // Removed all replica information for the blocks on the volume.
          // Unlike updating the volumeMap in addVolume(), this operation does
          // not scan disks.
          for (String bpid : volumeMap.getBlockPoolList()) {
            List<ReplicaInfo> blocks = blkToInvalidate
                .computeIfAbsent(bpid, (k) -> new ArrayList<>());
            volumeMap.replicas(bpid, (iterator) -> {
              while (iterator.hasNext()) {
                ReplicaInfo block = iterator.next();
                final StorageLocation blockStorageLocation =
                    block.getVolume().getStorageLocation();
                LOG.trace("checking for block " + block.getBlockId() +
                    " with storageLocation " + blockStorageLocation);
                if (blockStorageLocation.equals(sdLocation)) {
                  blocks.add(block);
                  iterator.remove();
                }
              }
            });
          }
```