### PR TITLE
HDFS-17471. Correct the percentage of sample range.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/metrics/BlockReaderIoProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/metrics/BlockReaderIoProvider.java
@@ -65,7 +65,7 @@ public class BlockReaderIoProvider {
   public int read(FileChannel dataIn, ByteBuffer dst, long position)
       throws IOException{
     final int nRead;
-    if (isEnabled && (ThreadLocalRandom.current().nextInt() < sampleRangeMax)) {
+    if (isEnabled && (ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE) < sampleRangeMax)) {
       long begin = timer.monotonicNow();
       nRead = dataIn.read(dst, position);
       long latency = timer.monotonicNow() - begin;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ProfilingFileIoEvents.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ProfilingFileIoEvents.java
@@ -80,7 +80,7 @@ class ProfilingFileIoEvents {
 
   public long beforeFileIo(@Nullable FsVolumeSpi volume,
       FileIoProvider.OPERATION op, long len) {
-    if (isEnabled && ThreadLocalRandom.current().nextInt() < sampleRangeMax) {
+    if (isEnabled && ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE) < sampleRangeMax) {
       DataNodeVolumeMetrics metrics = getVolumeMetrics(volume);
       if (metrics != null) {
         return Time.monotonicNow();


### PR DESCRIPTION
JIRA: HDFS-17471.
The percentage of file I/O events to be profiled for DataNode disk statistics is inaccurate.