### PR TITLE
improvement: yetus exit

### DIFF
--- a/dev-support/bin/yetus-wrapper
+++ b/dev-support/bin/yetus-wrapper
@@ -93,6 +93,7 @@ fi
 ###
 if [[ -n "${YETUS_HOME}" && -x "${YETUS_HOME}/bin/${WANTED}" ]]; then
   exec "${YETUS_HOME}/bin/${WANTED}" "${ARGV[@]}"
+  exit 0
 fi
 
 #
@@ -117,6 +118,7 @@ HADOOP_PATCHPROCESS=${mytmpdir}
 ##
 if [[ -x "${HADOOP_PATCHPROCESS}/${YETUS_PREFIX}-${HADOOP_YETUS_VERSION}/bin/${WANTED}" ]]; then
   exec "${HADOOP_PATCHPROCESS}/${YETUS_PREFIX}-${HADOOP_YETUS_VERSION}/bin/${WANTED}" "${ARGV[@]}"
+  exit 0
 fi
 
 ##


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
1. If there is a local YETUS_HOME, use it directly and exit after execution. If you don't exit, it will continue to execute down the line, which is not necessary.
2. If you have already downloaded it locally, use it directly and exit after execution. If you do not exit, it will continue to the next execution, there is no need.
3. If the above execution, are not quit, will still download the yetus, and then execute the yetus, and wait for the script execution is completed before exiting.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

