### PR TITLE
HDFS-17475. Add verifyReadable command to check if files are readable

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DebugAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DebugAdmin.java
@@ -97,7 +97,6 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.util.DataChecksum;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Time;
-import org.apache.hadoop.util.Timer;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 
@@ -665,8 +664,8 @@ public class DebugAdmin extends Configured implements Tool {
   }
 
   private class VerifyReadableCommand extends DebugCommand {
-    DistributedFileSystem dfs;
-    boolean suppressed = false;
+    private DistributedFileSystem dfs;
+    private boolean suppressed = false;
 
     VerifyReadableCommand() {
       super("verifyReadable",

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSCommands.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSCommands.md
@@ -737,7 +737,7 @@ Usage: `hdfs debug verifyReadable
             [-path <HDFS path> | -input <input>]
             [-output <output>]
             [-concurrency <concurrency>]
-            [-suppressed]`
+            [-verbose]`
 
 | COMMAND\_OPTION | Description                                                                                                    |
 |:----------------|:---------------------------------------------------------------------------------------------------------------|
@@ -745,13 +745,16 @@ Usage: `hdfs debug verifyReadable
 | *input*         | Input file with paths to check, one path per line     .                                                        |
 | *output*        | Output file with results, one result per line containing a path with an integer: 0 = readable, 1 = unreadable. |
 | *concurrency*   | Maximum number of paths to process simultaneously at any time.                                                 |
-| *suppressed*    | Do not print if there is no issue with a path. Still print errors.                                             |
+| *verbose*       | Print to console for readable paths (as well as errors). Write more details to output file.                    |
 
 Check if one or multiple paths are readable:
 * File path exists.
 * User has read access to the file.
 * No missing block.
 * All blocks have at least 1 readable replica.
+
+When `-output` is used with `-verbose`, each result line has this
+format: `path|result|blocks_checked/total_blocks|failed_block|block_details`.
 
 dfsadmin with ViewFsOverloadScheme
 ----------------------------------

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSCommands.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSCommands.md
@@ -730,6 +730,29 @@ Usage: `hdfs debug verifyEC -file <file> [-blockId <blk_Id>] [-skipFailureBlocks
 
 Verify the correctness of erasure coding on an erasure coded file.
 
+
+### `verifyReadable`
+
+Usage: `hdfs debug verifyReadable
+            [-path <HDFS path> | -input <input>]
+            [-output <output>]
+            [-concurrency <concurrency>]
+            [-suppressed]`
+
+| COMMAND\_OPTION | Description                                                                                                    |
+|:----------------|:---------------------------------------------------------------------------------------------------------------|
+| *HDFS path*     | HDFS path to check. Will take priority over `-input`.                                                          |
+| *input*         | Input file with paths to check, one path per line     .                                                        |
+| *output*        | Output file with results, one result per line containing a path with an integer: 0 = readable, 1 = unreadable. |
+| *concurrency*   | Maximum number of paths to process simultaneously at any time.                                                 |
+| *suppressed*    | Do not print if there is no issue with a path. Still print errors.                                             |
+
+Check if one or multiple paths are readable:
+* File path exists.
+* User has read access to the file.
+* No missing block.
+* All blocks have at least 1 readable replica.
+
 dfsadmin with ViewFsOverloadScheme
 ----------------------------------
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestVerifyReadable.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestVerifyReadable.java
@@ -1,0 +1,237 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.tools;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.protocol.Block;
+import org.apache.hadoop.hdfs.protocol.HdfsLocatedFileStatus;
+import org.apache.hadoop.hdfs.server.datanode.DataNode;
+import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsDatasetSpi;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestVerifyReadable {
+  private Configuration conf = new Configuration();
+  private MiniDFSCluster cluster;
+  private DebugAdmin admin;
+  private static final short REPLICATION = 2;
+  private static final long BLOCK_SIZE = 1024;
+
+  @Before
+  public void setUp() throws Exception {
+    conf.setInt(DFSConfigKeys.DFS_REPLICATION_KEY, REPLICATION);
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCK_SIZE);
+    conf.setBoolean(DFSConfigKeys.DFS_BLOCK_ACCESS_TOKEN_ENABLE_KEY, true);
+    // Faster timeout for testing
+    conf.setInt(CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_KEY, 1);
+    conf.setLong(CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_RETRY_INTERVAL_KEY, 300);
+    admin = new DebugAdmin(conf);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
+    }
+  }
+
+  private int runDebugCommand(Path path, String input, String output, int concurrency) {
+    List<String> args = new ArrayList<>();
+    args.add("verifyReadable");
+    if (path != null) {
+      args.add("-path");
+      args.add(path.toString());
+    }
+    if (input != null) {
+      args.add("-input");
+      args.add(input);
+    }
+    if (output != null) {
+      args.add("-output");
+      args.add(output);
+    }
+    if (concurrency > 1) {
+      args.add("-concurrency");
+      args.add(String.valueOf(concurrency));
+    }
+    return admin.run(args.toArray(new String[0]));
+  }
+
+  @Test
+  public void testReadable() throws Exception {
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build();
+    cluster.waitActive();
+    DistributedFileSystem fs = cluster.getFileSystem();
+
+    // Successful case with various block lengths and replications
+    {
+      Path testPath = new Path("/testReadable1Repl.txt");
+      DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE, (short) 1, 1234);
+      Assert.assertEquals(0, runDebugCommand(testPath, null, null, 1));
+
+      testPath = new Path("/testReadable3Repl.txt");
+      DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE, (short) 3, 1234);
+      Assert.assertEquals(0, runDebugCommand(testPath, null, null, 1));
+
+      testPath = new Path("/testReadableLong3Repl.txt");
+      DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE * 16, (short) 3, 1234);
+      Assert.assertEquals(0, runDebugCommand(testPath, null, null, 1));
+    }
+
+    // Simple failure cases
+    {
+      // File not found
+      Path testPath = new Path("/test404.txt");
+      Assert.assertEquals(1, runDebugCommand(testPath, null, null, 1));
+    }
+
+    // Missing replicas
+    {
+      // Deleted replica
+      Path testPath = new Path("/testMissingBlocks.txt");
+      DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE * 3, (short) 2, 1234);
+      // Still readable with 1 replica left
+      deleteReplica(fs, testPath, 1, 1);
+      Assert.assertEquals(0, runDebugCommand(testPath, null, null, 1));
+      // Unreadable when all replicas are gone for a block
+      deleteReplica(fs, testPath, 1, 0);
+      Assert.assertEquals(1, runDebugCommand(testPath, null, null, 1));
+    }
+
+    // Down DNs
+    {
+      Path testPath = new Path("/testMissingDNs.txt");
+      DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE * 3, (short) 2, 1234);
+      // Still readable with 1 replica left
+      shutdownDn(fs, testPath, 1, 1);
+      Assert.assertEquals(0, runDebugCommand(testPath, null, null, 1));
+      // Unreadable when all replicas are gone for a block
+      shutdownDn(fs, testPath, 1, 0);
+      Assert.assertEquals(1, runDebugCommand(testPath, null, null, 1));
+    }
+  }
+
+  @Test
+  public void testReadableWithInputOutput() throws Exception {
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build();
+    cluster.waitActive();
+    DistributedFileSystem fs = cluster.getFileSystem();
+
+    // Run the same test in testReadable but with input and output file
+    File inputPath = File.createTempFile("testReadableIn", ".txt");
+    File outputPath = File.createTempFile("testReadableOut", ".txt");
+    BufferedWriter inputWriter =
+        new BufferedWriter(new OutputStreamWriter(Files.newOutputStream(inputPath.toPath())));
+
+    // Successful case with various block lengths and replications
+    Path testPath = new Path("/testReadable1Repl.txt");
+    DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE, (short) 1, 1234);
+    inputWriter.write("/testReadable1Repl.txt\n");
+
+    testPath = new Path("/testReadable3Repl.txt");
+    DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE, (short) 3, 1234);
+    inputWriter.write("/testReadable3Repl.txt\n");
+
+    testPath = new Path("/testReadableLong3Repl.txt");
+    DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE * 16, (short) 3, 1234);
+    inputWriter.write("/testReadableLong3Repl.txt\n");
+
+    // File not found
+    inputWriter.write("/test404.txt\n");
+
+    // Missing replicas
+    // Deleted replica
+    testPath = new Path("/testMissingBlocks.txt");
+    DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE * 3, (short) 2, 1234);
+    deleteReplica(fs, testPath, 1, 1);
+    deleteReplica(fs, testPath, 1, 0);
+    inputWriter.write("/testMissingBlocks.txt\n");
+
+    inputWriter.flush();
+    inputWriter.close();
+    runDebugCommand(null, inputPath.getAbsolutePath(), outputPath.getAbsolutePath(), 2);
+    Map<String, Integer> results = new HashMap<>();
+
+    BufferedReader outputReader =
+        new BufferedReader(new InputStreamReader(Files.newInputStream(outputPath.toPath())));
+    String line;
+    while ((line = outputReader.readLine()) != null) {
+      String[] split = line.split("\\s");
+      results.put(split[0], Integer.parseInt(split[1]));
+    }
+    outputReader.close();
+
+    Assert.assertEquals(0, results.get("/testReadable1Repl.txt").intValue());
+    Assert.assertEquals(0, results.get("/testReadable3Repl.txt").intValue());
+    Assert.assertEquals(0, results.get("/testReadableLong3Repl.txt").intValue());
+    Assert.assertEquals(1, results.get("/test404.txt").intValue());
+    Assert.assertEquals(1, results.get("/testMissingBlocks.txt").intValue());
+  }
+
+  private void deleteReplica(FileSystem fs, Path path, int blkIdx, int dnIndex) throws IOException {
+    HdfsLocatedFileStatus locs = (HdfsLocatedFileStatus) fs.listFiles(path, true).next();
+    String dnToInvalidate =
+        locs.getLocatedBlocks().get(blkIdx).getLocations()[dnIndex].getDatanodeUuid();
+    DataNode matchedDn = null;
+    for (DataNode dn : cluster.getDataNodes()) {
+      if (dn.getDatanodeUuid().equals(dnToInvalidate)) {
+        matchedDn = dn;
+        break;
+      }
+    }
+    FsDatasetSpi fsdataset = matchedDn.getFSDataset();
+    fsdataset.invalidate(cluster.getNamesystem().getBlockPoolId(),
+        new Block[] { locs.getLocatedBlocks().get(blkIdx).getBlock().getLocalBlock() });
+  }
+
+  private void shutdownDn(FileSystem fs, Path path, int blkIdx, int dnIndex) throws IOException {
+    HdfsLocatedFileStatus locs = (HdfsLocatedFileStatus) fs.listFiles(path, true).next();
+    String dnToShutdown =
+        locs.getLocatedBlocks().get(blkIdx).getLocations()[dnIndex].getDatanodeUuid();
+    int idx = 0;
+    for (DataNode dn : cluster.getDataNodes()) {
+      if (dn.getDatanodeUuid().equals(dnToShutdown)) {
+        cluster.shutdownDataNode(idx);
+        break;
+      }
+      idx++;
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestVerifyReadable.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestVerifyReadable.java
@@ -101,51 +101,43 @@ public class TestVerifyReadable {
     DistributedFileSystem fs = cluster.getFileSystem();
 
     // Successful case with various block lengths and replications
-    {
-      Path testPath = new Path("/testReadable1Repl.txt");
-      DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE, (short) 1, 1234);
-      Assert.assertEquals(0, runDebugCommand(testPath, null, null, 1));
+    Path testPath = new Path("/testReadable1Repl.txt");
+    DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE, (short) 1, 1234);
+    Assert.assertEquals(0, runDebugCommand(testPath, null, null, 1));
 
-      testPath = new Path("/testReadable3Repl.txt");
-      DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE, (short) 3, 1234);
-      Assert.assertEquals(0, runDebugCommand(testPath, null, null, 1));
+    testPath = new Path("/testReadable3Repl.txt");
+    DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE, (short) 3, 1234);
+    Assert.assertEquals(0, runDebugCommand(testPath, null, null, 1));
 
-      testPath = new Path("/testReadableLong3Repl.txt");
-      DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE * 16, (short) 3, 1234);
-      Assert.assertEquals(0, runDebugCommand(testPath, null, null, 1));
-    }
+    testPath = new Path("/testReadableLong3Repl.txt");
+    DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE * 16, (short) 3, 1234);
+    Assert.assertEquals(0, runDebugCommand(testPath, null, null, 1));
 
     // Simple failure cases
-    {
-      // File not found
-      Path testPath = new Path("/test404.txt");
-      Assert.assertEquals(1, runDebugCommand(testPath, null, null, 1));
-    }
+    // File not found
+    testPath = new Path("/test404.txt");
+    Assert.assertEquals(1, runDebugCommand(testPath, null, null, 1));
 
     // Missing replicas
-    {
-      // Deleted replica
-      Path testPath = new Path("/testMissingBlocks.txt");
-      DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE * 3, (short) 2, 1234);
-      // Still readable with 1 replica left
-      deleteReplica(fs, testPath, 1, 1);
-      Assert.assertEquals(0, runDebugCommand(testPath, null, null, 1));
-      // Unreadable when all replicas are gone for a block
-      deleteReplica(fs, testPath, 1, 0);
-      Assert.assertEquals(1, runDebugCommand(testPath, null, null, 1));
-    }
+    // Deleted replica
+    testPath = new Path("/testMissingBlocks.txt");
+    DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE * 3, (short) 2, 1234);
+    // Still readable with 1 replica left
+    deleteReplica(fs, testPath, 1, 1);
+    Assert.assertEquals(0, runDebugCommand(testPath, null, null, 1));
+    // Unreadable when all replicas are gone for a block
+    deleteReplica(fs, testPath, 1, 0);
+    Assert.assertEquals(1, runDebugCommand(testPath, null, null, 1));
 
     // Down DNs
-    {
-      Path testPath = new Path("/testMissingDNs.txt");
-      DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE * 3, (short) 2, 1234);
-      // Still readable with 1 replica left
-      shutdownDn(fs, testPath, 1, 1);
-      Assert.assertEquals(0, runDebugCommand(testPath, null, null, 1));
-      // Unreadable when all replicas are gone for a block
-      shutdownDn(fs, testPath, 1, 0);
-      Assert.assertEquals(1, runDebugCommand(testPath, null, null, 1));
-    }
+    testPath = new Path("/testMissingDNs.txt");
+    DFSTestUtil.createFile(fs, testPath, BLOCK_SIZE * 3, (short) 2, 1234);
+    // Still readable with 1 replica left
+    shutdownDn(fs, testPath, 1, 1);
+    Assert.assertEquals(0, runDebugCommand(testPath, null, null, 1));
+    // Unreadable when all replicas are gone for a block
+    shutdownDn(fs, testPath, 1, 0);
+    Assert.assertEquals(1, runDebugCommand(testPath, null, null, 1));
   }
 
   @Test
@@ -218,7 +210,7 @@ public class TestVerifyReadable {
     }
     FsDatasetSpi fsdataset = matchedDn.getFSDataset();
     fsdataset.invalidate(cluster.getNamesystem().getBlockPoolId(),
-        new Block[] { locs.getLocatedBlocks().get(blkIdx).getBlock().getLocalBlock() });
+        new Block[] {locs.getLocatedBlocks().get(blkIdx).getBlock().getLocalBlock()});
   }
 
   private void shutdownDn(FileSystem fs, Path path, int blkIdx, int dnIndex) throws IOException {


### PR DESCRIPTION
### Description of PR

Sometimes a job can fail due to one unreadable file down the line due to missing replicas or dead DNs or other reason. This command allows users to check whether files are readable by checking for metadata on DNs without executing full read pipelines of the files.

### How was this patch tested?

Unit tests, local deployment, production. Also tested for performance.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
