### PR TITLE
HDFS-17477. IncrementalBlockReport race condition additional edge cases

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -3349,6 +3349,7 @@ public class BlockManager implements BlockStatsMXBean {
     // scan the report and process newly reported blocks
     for (BlockReportReplica iblk : newReport) {
       ReplicaState iState = iblk.getState();
+      removeQueuedBlock(storageInfo, iblk);
       LOG.debug("Reported block {} on {} size {} replicaState = {}", iblk, dn,
           iblk.getNumBytes(), iState);
       BlockInfo storedBlock = processReportedBlock(storageInfo,
@@ -3417,8 +3418,6 @@ public class BlockManager implements BlockStatsMXBean {
 
     LOG.debug("Reported block {} on {} size {} replicaState = {}", block, dn,
         block.getNumBytes(), reportedState);
-
-    removeQueuedBlock(storageInfo, block);
     if (shouldPostponeBlocksFromFuture && isGenStampInFuture(block)) {
       queueReportedBlock(storageInfo, block, reportedState,
           QUEUE_REASON_FUTURE_GENSTAMP);
@@ -4570,6 +4569,7 @@ public class BlockManager implements BlockStatsMXBean {
 
     final DatanodeDescriptor node = storageInfo.getDatanodeDescriptor();
 
+    removeQueuedBlock(storageInfo, block);
     LOG.debug("Reported block {} on {} size {} replicaState = {}",
         block, node, block.getNumBytes(), reportedState);
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -3263,6 +3263,7 @@ public class BlockManager implements BlockStatsMXBean {
     for (BlockReportReplica iblk : report) {
       ReplicaState reportedState = iblk.getState();
 
+      removeQueuedBlock(storageInfo, iblk);
       if (LOG.isDebugEnabled()) {
         LOG.debug("Initial report of block {} on {} size {} replicaState = {}",
             iblk.getBlockName(), storageInfo.getDatanodeDescriptor(),
@@ -3417,6 +3418,7 @@ public class BlockManager implements BlockStatsMXBean {
     LOG.debug("Reported block {} on {} size {} replicaState = {}", block, dn,
         block.getNumBytes(), reportedState);
 
+    removeQueuedBlock(storageInfo, block);
     if (shouldPostponeBlocksFromFuture && isGenStampInFuture(block)) {
       queueReportedBlock(storageInfo, block, reportedState,
           QUEUE_REASON_FUTURE_GENSTAMP);
@@ -3494,6 +3496,16 @@ public class BlockManager implements BlockStatsMXBean {
           block, reportedState, storageInfo.getDatanodeDescriptor(), reason);
     }
     pendingDNMessages.enqueueReportedBlock(storageInfo, block, reportedState);
+  }
+
+  /**
+   * Queue the given reported block for later processing in the
+   * standby node. @see PendingDataNodeMessages.
+   */
+  private void removeQueuedBlock(DatanodeStorageInfo storageInfo, Block block) {
+    LOG.debug("Removing queued block {} from datanode {} from pending queue.",
+        block, storageInfo.getDatanodeDescriptor());
+    pendingDNMessages.removeQueuedBlock(storageInfo, block);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingDataNodeMessages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingDataNodeMessages.java
@@ -155,7 +155,7 @@ public class TestPendingDataNodeMessages {
         msgs.takeBlockQueue(block1Gs2DifferentInstance);
     assertEquals(Joiner.on(",").join(rbis),
         Joiner.on(",").join(q));
-    assertEquals(2, msgs.count());
+    assertEquals(0, msgs.count());
 
     // Should be null if we pull again;
     assertNull(msgs.takeBlockQueue(block1Gs2));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingDataNodeMessages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingDataNodeMessages.java
@@ -67,14 +67,16 @@ public class TestPendingDataNodeMessages {
     msgs.enqueueReportedBlock(storageInfo1, block1Gs2, ReplicaState.FINALIZED);
     msgs.enqueueReportedBlock(storageInfo2, block1Gs2, ReplicaState.FINALIZED);
     List<ReportedBlockInfo> rbis = Arrays.asList(
+        new ReportedBlockInfo(storageInfo1, block1Gs1, ReplicaState.FINALIZED),
+        new ReportedBlockInfo(storageInfo2, block1Gs1, ReplicaState.FINALIZED),
         new ReportedBlockInfo(storageInfo1, block1Gs2, ReplicaState.FINALIZED),
         new ReportedBlockInfo(storageInfo2, block1Gs2, ReplicaState.FINALIZED));
 
-    assertEquals(2, msgs.count());
+    assertEquals(4, msgs.count());
     
     // Nothing queued yet for block 2
     assertNull(msgs.takeBlockQueue(block2Gs1));
-    assertEquals(2, msgs.count());
+    assertEquals(4, msgs.count());
     
     Queue<ReportedBlockInfo> q =
       msgs.takeBlockQueue(block1Gs2DifferentInstance);
@@ -122,5 +124,41 @@ public class TestPendingDataNodeMessages {
     } finally {
       cluster.shutdown();
     }
+  }
+
+  @Test
+  public void testRemoveQueuedBlock() {
+    DatanodeDescriptor fakeDN1 = DFSTestUtil.getDatanodeDescriptor(
+        "localhost", 8898, "/default-rack");
+    DatanodeDescriptor fakeDN2 = DFSTestUtil.getDatanodeDescriptor(
+        "localhost", 8899, "/default-rack");
+    DatanodeStorage storage1 = new DatanodeStorage("STORAGE_ID_1");
+    DatanodeStorage storage2 = new DatanodeStorage("STORAGE_ID_2");
+    DatanodeStorageInfo storageInfo1 = new DatanodeStorageInfo(fakeDN1, storage1);
+    DatanodeStorageInfo storageInfo2 = new DatanodeStorageInfo(fakeDN2, storage2);
+    msgs.enqueueReportedBlock(storageInfo1, block1Gs1, ReplicaState.FINALIZED);
+    msgs.enqueueReportedBlock(storageInfo2, block1Gs1, ReplicaState.FINALIZED);
+    msgs.enqueueReportedBlock(storageInfo1, block1Gs2, ReplicaState.FINALIZED);
+    msgs.enqueueReportedBlock(storageInfo2, block1Gs2, ReplicaState.FINALIZED);
+    List<ReportedBlockInfo> rbis = Arrays.asList(
+        new ReportedBlockInfo(storageInfo2, block1Gs1, ReplicaState.FINALIZED),
+        new ReportedBlockInfo(storageInfo2, block1Gs2, ReplicaState.FINALIZED));
+
+    assertEquals(4, msgs.count());
+
+    // Nothing queued yet for block 2
+    assertNull(msgs.takeBlockQueue(block2Gs1));
+    assertEquals(4, msgs.count());
+
+    msgs.removeQueuedBlock(storageInfo1, block1Gs1);
+    Queue<ReportedBlockInfo> q =
+        msgs.takeBlockQueue(block1Gs2DifferentInstance);
+    assertEquals(Joiner.on(",").join(rbis),
+        Joiner.on(",").join(q));
+    assertEquals(2, msgs.count());
+
+    // Should be null if we pull again;
+    assertNull(msgs.takeBlockQueue(block1Gs2));
+    assertEquals(0, msgs.count());
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
@@ -27,14 +27,18 @@ import static org.mockito.Mockito.times;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockManager;
 import org.apache.hadoop.hdfs.server.namenode.ha.HATestUtil;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.mockito.invocation.InvocationOnMock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -246,6 +250,7 @@ public class TestIncrementalBlockReports {
 
       NameNode nn1 = cluster.getNameNode(0);
       NameNode nn2 = cluster.getNameNode(1);
+      BlockManager bm2 = nn2.getNamesystem().getBlockManager();
       FileSystem fs = HATestUtil.configureFailoverFs(cluster, conf);
       List<InvocationOnMock> ibrsToStandby = new ArrayList<>();
       List<DatanodeProtocolClientSideTranslatorPB> spies = new ArrayList<>();
@@ -262,7 +267,6 @@ public class TestIncrementalBlockReports {
               }
             }
           }
-          ibrsToStandby.add(inv);
           return null;
         }).when(nnSpy).blockReceivedAndDeleted(
             any(DatanodeRegistration.class),
@@ -289,8 +293,9 @@ public class TestIncrementalBlockReports {
         }
       }
 
-      assertEquals("There should be 3 pending messages from DNs", 3,
-          nn2.getNamesystem().getBlockManager().getPendingDataNodeMessageCount());
+      GenericTestUtils.waitFor(() -> bm2.getPendingDataNodeMessageCount() == 0,
+          1000, 30000,
+          "There should be 0 pending DN messages");
       ibrsToStandby.clear();
       // We need to trigger another edit log roll so that the pendingDNMessages
       // are processed.
@@ -308,6 +313,9 @@ public class TestIncrementalBlockReports {
       }
       ibrsToStandby.clear();
       ibrPhaser.arriveAndDeregister();
+      GenericTestUtils.waitFor(() -> bm2.getPendingDataNodeMessageCount() == 0,
+          1000, 30000,
+          "There should be 0 pending DN messages");
       ExtendedBlock block = DFSTestUtil.getFirstBlock(fs, TEST_FILE_PATH);
       HATestUtil.waitForStandbyToCatchUp(nn1, nn2);
       LOG.info("==================================");
@@ -319,6 +327,194 @@ public class TestIncrementalBlockReports {
       cluster.waitActive(1);
 
       assertEquals("There should not be any corrupt replicas", 0,
+          nn2.getNamesystem().getBlockManager()
+              .numCorruptReplicas(block.getLocalBlock()));
+    } finally {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testIBRRaceCondition2() throws Exception {
+    cluster.shutdown();
+    Configuration conf = new Configuration();
+    HAUtil.setAllowStandbyReads(conf, true);
+    conf.setInt(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, 1);
+    cluster = new MiniDFSCluster.Builder(conf)
+        .nnTopology(MiniDFSNNTopology.simpleHATopology())
+        .numDataNodes(3)
+        .build();
+    try {
+      cluster.waitActive();
+      cluster.transitionToActive(0);
+
+      NameNode nn1 = cluster.getNameNode(0);
+      NameNode nn2 = cluster.getNameNode(1);
+      BlockManager bm2 = nn2.getNamesystem().getBlockManager();
+      FileSystem fs = HATestUtil.configureFailoverFs(cluster, conf);
+      List<InvocationOnMock> ibrsToStandby = new ArrayList<>();
+      List<DatanodeProtocolClientSideTranslatorPB> spies = new ArrayList<>();
+      Phaser ibrPhaser = new Phaser(1);
+      for (DataNode dn : cluster.getDataNodes()) {
+        DatanodeProtocolClientSideTranslatorPB nnSpy =
+            InternalDataNodeTestUtils.spyOnBposToNN(dn, nn2);
+        doAnswer((inv) -> {
+          for (StorageReceivedDeletedBlocks srdb :
+              inv.getArgument(2, StorageReceivedDeletedBlocks[].class)) {
+            for (ReceivedDeletedBlockInfo block : srdb.getBlocks()) {
+              if (block.getStatus().equals(BlockStatus.RECEIVED_BLOCK)) {
+                ibrsToStandby.add(inv);
+                ibrPhaser.arriveAndDeregister();
+              }
+            }
+          }
+          return null;
+        }).when(nnSpy).blockReceivedAndDeleted(
+            any(DatanodeRegistration.class),
+            anyString(),
+            any(StorageReceivedDeletedBlocks[].class));
+        spies.add(nnSpy);
+      }
+
+      LOG.info("==================================");
+      // Force the DNs to delay report to the SNN
+      ibrPhaser.bulkRegister(9);
+      DFSTestUtil.writeFile(fs, TEST_FILE_PATH, TEST_FILE_DATA);
+      DFSTestUtil.appendFile(fs, TEST_FILE_PATH, TEST_FILE_DATA);
+      DFSTestUtil.appendFile(fs, TEST_FILE_PATH, TEST_FILE_DATA);
+      HATestUtil.waitForStandbyToCatchUp(nn1, nn2);
+      // SNN has caught up to the latest edit log so we send the IBRs to SNN
+      int phase = ibrPhaser.arrive();
+      ibrPhaser.awaitAdvanceInterruptibly(phase, 60, TimeUnit.SECONDS);
+      for (InvocationOnMock sendIBRs : ibrsToStandby) {
+        try {
+          sendIBRs.callRealMethod();
+        } catch (Throwable t) {
+          LOG.error("Exception thrown while calling sendIBRs: ", t);
+        }
+      }
+
+      GenericTestUtils.waitFor(() -> bm2.getPendingDataNodeMessageCount() == 0,
+          1000, 30000,
+          "There should be 0 pending DN messages");
+      ibrsToStandby.clear();
+      ibrPhaser.arriveAndDeregister();
+      ExtendedBlock block = DFSTestUtil.getFirstBlock(fs, TEST_FILE_PATH);
+      HATestUtil.waitForStandbyToCatchUp(nn1, nn2);
+      LOG.info("==================================");
+
+      // Trigger an active switch to force SNN to mark blocks as corrupt if they
+      // have a bad genstamp in the pendingDNMessages queue.
+      cluster.transitionToStandby(0);
+      cluster.transitionToActive(1);
+      cluster.waitActive(1);
+
+      assertEquals("There should not be any corrupt replicas", 0,
+          nn2.getNamesystem().getBlockManager()
+              .numCorruptReplicas(block.getLocalBlock()));
+    } finally {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testIBRRaceCondition3() throws Exception {
+    cluster.shutdown();
+    Configuration conf = new Configuration();
+    HAUtil.setAllowStandbyReads(conf, true);
+    conf.setInt(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, 1);
+    cluster = new MiniDFSCluster.Builder(conf)
+        .nnTopology(MiniDFSNNTopology.simpleHATopology())
+        .numDataNodes(3)
+        .build();
+    try {
+      cluster.waitActive();
+      cluster.transitionToActive(0);
+
+      NameNode nn1 = cluster.getNameNode(0);
+      NameNode nn2 = cluster.getNameNode(1);
+      BlockManager bm2 = nn2.getNamesystem().getBlockManager();
+      FileSystem fs = HATestUtil.configureFailoverFs(cluster, conf);
+      LinkedHashMap<Long, List<InvocationOnMock>> ibrsToStandby =
+          new LinkedHashMap<>();
+      AtomicLong lowestGenStamp = new AtomicLong(Long.MAX_VALUE);
+      List<DatanodeProtocolClientSideTranslatorPB> spies = new ArrayList<>();
+      Phaser ibrPhaser = new Phaser(1);
+      for (DataNode dn : cluster.getDataNodes()) {
+        DatanodeProtocolClientSideTranslatorPB nnSpy =
+            InternalDataNodeTestUtils.spyOnBposToNN(dn, nn2);
+        doAnswer((inv) -> {
+          for (StorageReceivedDeletedBlocks srdb :
+              inv.getArgument(2, StorageReceivedDeletedBlocks[].class)) {
+            for (ReceivedDeletedBlockInfo block : srdb.getBlocks()) {
+              if (block.getStatus().equals(BlockStatus.RECEIVED_BLOCK)) {
+                long genStamp = block.getBlock().getGenerationStamp();
+                ibrsToStandby.putIfAbsent(genStamp, new ArrayList<>());
+                ibrsToStandby.get(genStamp).add(inv);
+                lowestGenStamp.getAndUpdate((prev) -> Math.min(prev, genStamp));
+                ibrPhaser.arriveAndDeregister();
+              }
+            }
+          }
+          return null;
+        }).when(nnSpy).blockReceivedAndDeleted(
+            any(DatanodeRegistration.class),
+            anyString(),
+            any(StorageReceivedDeletedBlocks[].class));
+        spies.add(nnSpy);
+      }
+
+      LOG.info("==================================");
+      // Force the DNs to delay report to the SNN
+      ibrPhaser.bulkRegister(9);
+      DFSTestUtil.writeFile(fs, TEST_FILE_PATH, TEST_FILE_DATA);
+      DFSTestUtil.appendFile(fs, TEST_FILE_PATH, TEST_FILE_DATA);
+      DFSTestUtil.appendFile(fs, TEST_FILE_PATH, TEST_FILE_DATA);
+      HATestUtil.waitForStandbyToCatchUp(nn1, nn2);
+      // SNN has caught up to the latest edit log so we send the IBRs to SNN
+      int phase = ibrPhaser.arrive();
+      ibrPhaser.awaitAdvanceInterruptibly(phase, 60, TimeUnit.SECONDS);
+      ibrsToStandby.forEach((genStamp, ibrs) -> {
+        if (lowestGenStamp.get() != genStamp) {
+          ibrs.removeIf(inv -> {
+            try {
+              inv.callRealMethod();
+            } catch (Throwable t) {
+              LOG.error("Exception thrown while calling sendIBRs: ", t);
+            }
+            return true;
+          });
+        }
+      });
+
+      GenericTestUtils.waitFor(() -> bm2.getPendingDataNodeMessageCount() == 0,
+          1000, 30000,
+          "There should be 0 pending DN messages");
+      ibrPhaser.arriveAndDeregister();
+      ExtendedBlock block = DFSTestUtil.getFirstBlock(fs, TEST_FILE_PATH);
+      HATestUtil.waitForStandbyToCatchUp(nn1, nn2);
+
+      // Send old ibrs to simulate actual stale or corrupt DNs
+      for (InvocationOnMock sendIBR : ibrsToStandby.get(lowestGenStamp.get())) {
+        try {
+          sendIBR.callRealMethod();
+        } catch (Throwable t) {
+          LOG.error("Exception thrown while calling sendIBRs: ", t);
+        }
+      }
+
+      GenericTestUtils.waitFor(() -> bm2.getPendingDataNodeMessageCount() == 3,
+          1000, 30000,
+          "There should be 0 pending DN messages");
+      LOG.info("==================================");
+
+      // Trigger an active switch to force SNN to mark blocks as corrupt if they
+      // have a bad genstamp in the pendingDNMessages queue.
+      cluster.transitionToStandby(0);
+      cluster.transitionToActive(1);
+      cluster.waitActive(1);
+
+      assertEquals("There should be 1 corrupt replica", 1,
           nn2.getNamesystem().getBlockManager()
               .numCorruptReplicas(block.getLocalBlock()));
     } finally {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
#### Summary
[HDFS-17453](https://issues.apache.org/jira/browse/HDFS-17453) fixes a race condition between IncrementalBlockReports (IBR) and the Edit Log Tailer which can cause the Standby NameNode (SNN) to incorrectly mark blocks as corrupt when it transitions to Active. There are a few edge cases that [HDFS-17453](https://issues.apache.org/jira/browse/HDFS-17453) does not cover.

For Example:
1. SNN1 loads the edits for b1gs1 and b1gs2.
2. DN1 reports b1gs1 to SNN1, so it gets queued for later processing.
3. DN1 reports b1gs2 to SNN1 so it gets added to the blocks map.
4. SNN1 transitions to Active (ANN1).
5. ANN1 processes the pending DN message queue and marks DN1->b1gs1 as corrupt because it was still in the queue.

#### Changes
Processing a block from a DN-block pair should always remove any queued messages from the pendingDNMessage queue. This prevents older IBRs from being leaked and causing corrupt blocks when the standby NN becomes active.

**Before**:
- Process IBR
  - If the reported block's genstamp is not future or past, then update the blocks map
  - If the reported block's genstamp is from the future or the past, then keep only the latest IBR in the pendingDNMessage queue.

**After**:
- Process IBR
  - Remove the all queued messages from the reported block-DN pair from the pendingDNMessage queue.
  - If the reported block's genstamp is not future or past, then update the blocks map.
  - If the reported block's genstamp is from the future or the past then queue it.

### How was this patch tested?
Added unit tests and updated unit tests added in [HDFS-17453](https://issues.apache.org/jira/browse/HDFS-17453)

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

