### PR TITLE
HDFS-17478. FSPermissionChecker optimization by initializing AccessControlEnforcer in constructor

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSPermissionChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSPermissionChecker.java
@@ -89,7 +89,7 @@ public class FSPermissionChecker implements AccessControlEnforcer {
   private final Collection<String> groups;
   private final boolean isSuper;
   private final INodeAttributeProvider attributeProvider;
-  private final AccessControlEnforcer  accessControlEnforcer;
+  private final AccessControlEnforcer accessControlEnforcer;
   private final boolean authorizeWithContext;
   private final long accessControlEnforcerReportingThresholdMs;
 


### PR DESCRIPTION
### Description of PR
Updated FsPermissionChecker to initialize accessControlEnforcer with INodeAttributeProvider.getExternalAccessControlEnforcer() and use this instance to authorize accesses, instead of calling INodeAttributeProvider.getExternalAccessControlEnforcer() for every authorization.

### How was this patch tested?
Built hadoop-hdfs.jar with this patch, started the namenode configured with Ranger authorizer and verified that accesses to HDFS paths are authorized by Ranger policies correctly.

No new functionality is introduced in this patch, hence no changes to tests.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?