### PR TITLE
YARN-11686. Correct traversing indexs when scheduling asynchronously using Capacity Scheduler

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
@@ -562,7 +562,7 @@ public class CapacityScheduler extends
 
       boolean printSkippedNodeLogging = isPrintSkippedNodeLogging(cs);
 
-      // Allocate containers of node [start, end)
+      // Allocate containers of node [start, end]
       for (FiCaSchedulerNode node : nodes) {
         if (current++ >= start) {
           if (shouldSkipNodeSchedule(node, cs, printSkippedNodeLogging)) {
@@ -576,7 +576,7 @@ public class CapacityScheduler extends
 
       // Allocate containers of node [0, start)
       for (FiCaSchedulerNode node : nodes) {
-        if (current++ > start) {
+        if (current++ >= start) {
           break;
         }
         if (shouldSkipNodeSchedule(node, cs, printSkippedNodeLogging)) {
@@ -594,7 +594,7 @@ public class CapacityScheduler extends
       int partitionSize = partitions.size();
       // First randomize the start point
       int start = random.nextInt(partitionSize);
-      // Allocate containers of partition [start, end)
+      // Allocate containers of partition [start, end]
       for (String partition : partitions) {
         if (current++ >= start) {
           CandidateNodeSet<FiCaSchedulerNode> candidates =
@@ -610,7 +610,7 @@ public class CapacityScheduler extends
 
       // Allocate containers of partition [0, start)
       for (String partition : partitions) {
-        if (current++ > start) {
+        if (current++ >= start) {
           break;
         }
         CandidateNodeSet<FiCaSchedulerNode> candidates =


### PR DESCRIPTION
### Description of PR
When scheduling asynchronously using Capacity Scheduler, the traversing indexs in `CapacityScheduler#schedule` will always contains `start` index twice. This may not in line with the original intention and needs to be corrected.

### How was this patch tested?
Manual test. This is a minor logic change, so  I think there's no need to add new tests.
I add debug log to print node  when actually traversing nodes. 
And before this patch，it always contains start node twice. After this patch, it looks good.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

