### PR TITLE
HDFS-17497. The number of bytes of the last committed block should be calculated into the file length

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfo.java
@@ -387,6 +387,19 @@ public abstract class BlockInfo extends Block
     return getBlockUCState().equals(BlockUCState.UNDER_RECOVERY);
   }
 
+  /**
+   * Is this block still under construction or recoery.
+   *
+   * @return true if the state of the block is
+   * {@link BlockUCState#UNDER_CONSTRUCTION} or
+   * {@link BlockUCState#UNDER_RECOVERY}
+   */
+  public final boolean isUnderConstructionOrRecovery() {
+    final BlockUCState state = getBlockUCState();
+    return state.equals(BlockUCState.UNDER_CONSTRUCTION) ||
+        state.equals(BlockUCState.UNDER_RECOVERY);
+  }
+
   public final boolean isCompleteOrCommitted() {
     final BlockUCState state = getBlockUCState();
     return state.equals(BlockUCState.COMPLETE) ||

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfoStriped.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfoStriped.java
@@ -81,7 +81,7 @@ public class BlockInfoStriped extends BlockInfo {
    * Otherwise it returns the number of data units specified by erasure coding policy.
    */
   public short getRealDataBlockNum() {
-    if (isComplete() || getBlockUCState() == BlockUCState.COMMITTED) {
+    if (isCompleteOrCommitted()) {
       return (short) Math.min(getDataBlockNum(),
           (getNumBytes() - 1) / ecPolicy.getCellSize() + 1);
     } else {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfoStriped.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfoStriped.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.protocol.BlockType;
-import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.BlockUCState;
 import org.apache.hadoop.hdfs.util.StripedBlockUtil;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -94,7 +94,6 @@ import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.ReplicaState;
 import org.apache.hadoop.hdfs.server.namenode.CachedBlock;
 import org.apache.hadoop.hdfs.server.namenode.INode.BlocksMapUpdateInfo;
 import org.apache.hadoop.hdfs.server.namenode.INodeFile;
-import org.apache.hadoop.hdfs.server.namenode.INodesInPath;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.Namesystem;
 import org.apache.hadoop.hdfs.server.namenode.ha.HAContext;
@@ -1193,13 +1192,12 @@ public class BlockManager implements BlockStatsMXBean {
    * 
    * @param bc block collection
    * @param commitBlock - contains client reported block length and generation
-   * @param iip - INodes in path to bc
    * @return true if the last block is changed to committed state.
    * @throws IOException if the block does not have at least a minimal number
    * of replicas reported from data-nodes.
    */
   public boolean commitOrCompleteLastBlock(BlockCollection bc,
-      Block commitBlock, INodesInPath iip) throws IOException {
+      Block commitBlock) throws IOException {
     if(commitBlock == null)
       return false; // not committing, this is a block allocation retry
     BlockInfo lastBlock = bc.getLastBlock();
@@ -1231,13 +1229,13 @@ public class BlockManager implements BlockStatsMXBean {
       if (committed) {
         addExpectedReplicasToPending(lastBlock);
       }
-      completeBlock(lastBlock, iip, false);
+      completeBlock(lastBlock, false);
     } else if (pendingRecoveryBlocks.isUnderRecovery(lastBlock)) {
       // We've just finished recovery for this block, complete
       // the block forcibly disregarding number of replicas.
       // This is to ignore minReplication, the block will be closed
       // and then replicated out.
-      completeBlock(lastBlock, iip, true);
+      completeBlock(lastBlock, true);
       updateNeededReconstructions(lastBlock, 1, 0);
     }
     return committed;
@@ -1276,14 +1274,12 @@ public class BlockManager implements BlockStatsMXBean {
   /**
    * Convert a specified block of the file to a complete block.
    * @param curBlock - block to be completed
-   * @param iip - INodes in path to file containing curBlock; if null,
-   *              this will be resolved internally
    * @param force - force completion of the block
    * @throws IOException if the block does not have at least a minimal number
    * of replicas reported from data-nodes.
    */
-  private void completeBlock(BlockInfo curBlock, INodesInPath iip,
-      boolean force) throws IOException {
+  private void completeBlock(BlockInfo curBlock, boolean force)
+      throws IOException {
     if (curBlock.isComplete()) {
       return;
     }
@@ -1298,7 +1294,7 @@ public class BlockManager implements BlockStatsMXBean {
           "Cannot complete block: block has not been COMMITTED by the client");
     }
 
-    convertToCompleteBlock(curBlock, iip);
+    curBlock.convertToCompleteBlock();
 
     // Since safe-mode only counts complete blocks, and we now have
     // one more complete block, we need to adjust the total up, and
@@ -1314,22 +1310,6 @@ public class BlockManager implements BlockStatsMXBean {
   }
 
   /**
-   * Convert a specified block of the file to a complete block.
-   * Skips validity checking and safe mode block total updates; use
-   * {@link BlockManager#completeBlock} to include these.
-   * @param curBlock - block to be completed
-   * @param iip - INodes in path to file containing curBlock; if null,
-   *              this will be resolved internally
-   * @throws IOException if the block does not have at least a minimal number
-   * of replicas reported from data-nodes.
-   */
-  private void convertToCompleteBlock(BlockInfo curBlock, INodesInPath iip)
-      throws IOException {
-    curBlock.convertToCompleteBlock();
-    namesystem.getFSDirectory().updateSpaceForCompleteBlock(curBlock, iip);
-  }
-
-  /**
    * Force the given block in the given file to be marked as complete,
    * regardless of whether enough replicas are present. This is necessary
    * when tailing edit logs as a Standby.
@@ -1337,7 +1317,7 @@ public class BlockManager implements BlockStatsMXBean {
   public void forceCompleteBlock(final BlockInfo block) throws IOException {
     List<ReplicaUnderConstruction> staleReplicas = block.commitBlock(block);
     removeStaleReplicas(staleReplicas, block);
-    completeBlock(block, null, true);
+    completeBlock(block, true);
   }
 
   /**
@@ -1601,13 +1581,13 @@ public class BlockManager implements BlockStatsMXBean {
       createLocatedBlockList(locatedBlocks, blocks, offset, length, mode);
       if (!inSnapshot) {
         final BlockInfo last = blocks[blocks.length - 1];
-        final long lastPos = last.isComplete()?
-            fileSizeExcludeBlocksUnderConstruction - last.getNumBytes()
-            : fileSizeExcludeBlocksUnderConstruction;
+        final long lastPos = last.isUnderConstructionOrRecovery()?
+            fileSizeExcludeBlocksUnderConstruction
+            : fileSizeExcludeBlocksUnderConstruction - last.getNumBytes();
 
         locatedBlocks
           .lastBlock(createLocatedBlock(locatedBlocks, last, lastPos, mode))
-          .lastComplete(last.isComplete());
+          .lastComplete(!last.isUnderConstructionOrRecovery());
       } else {
         locatedBlocks
           .lastBlock(createLocatedBlock(locatedBlocks, blocks,
@@ -3738,7 +3718,7 @@ public class BlockManager implements BlockStatsMXBean {
     int numCurrentReplica = countLiveNodes(storedBlock);
     if (storedBlock.getBlockUCState() == BlockUCState.COMMITTED
         && hasMinStorage(storedBlock, numCurrentReplica)) {
-      completeBlock(storedBlock, null, false);
+      completeBlock(storedBlock, false);
     } else if (storedBlock.isComplete() && result == AddBlockResult.ADDED) {
       // check whether safe replication is reached for the block
       // only complete blocks are counted towards that.
@@ -3818,7 +3798,7 @@ public class BlockManager implements BlockStatsMXBean {
     if(storedBlock.getBlockUCState() == BlockUCState.COMMITTED &&
         hasMinStorage(storedBlock, numUsableReplicas)) {
       addExpectedReplicasToPending(storedBlock);
-      completeBlock(storedBlock, null, false);
+      completeBlock(storedBlock, false);
     } else if (storedBlock.isComplete() && result == AddBlockResult.ADDED) {
       // check whether safe replication is reached for the block
       // only complete blocks are counted towards that

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -1586,8 +1586,8 @@ public class BlockManager implements BlockStatsMXBean {
             : fileSizeExcludeBlocksUnderConstruction - last.getNumBytes();
 
         locatedBlocks
-          .lastBlock(createLocatedBlock(locatedBlocks, last, lastPos, mode))
-          .lastComplete(!last.isUnderConstructionOrRecovery());
+            .lastBlock(createLocatedBlock(locatedBlocks, last, lastPos, mode))
+            .lastComplete(!last.isUnderConstructionOrRecovery());
       } else {
         locatedBlocks
           .lastBlock(createLocatedBlock(locatedBlocks, blocks,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -3887,7 +3887,11 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       final Block commitBlock) throws IOException {
     assert hasWriteLock();
     Preconditions.checkArgument(fileINode.isUnderConstruction());
-    blockManager.commitOrCompleteLastBlock(fileINode, commitBlock, iip);
+    if (!blockManager.commitOrCompleteLastBlock(fileINode, commitBlock)) {
+      return;
+    }
+    // Updating QuotaUsage when committing block since block size will not be changed
+    getFSDirectory().updateSpaceForCommittedBlock(commitBlock, iip);
   }
 
   void addCommittedBlocksToPending(final INodeFile pendingFile) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FileUnderConstructionFeature.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FileUnderConstructionFeature.java
@@ -60,7 +60,7 @@ public class FileUnderConstructionFeature implements INode.Feature {
     BlockInfo lastBlock = f.getLastBlock();
     assert (lastBlock != null) : "The last block for path "
         + f.getFullPathName() + " is null when updating its length";
-    assert !lastBlock.isComplete()
+    assert !lastBlock.isCompleteOrCommitted()
         : "The last block for path " + f.getFullPathName()
             + " is not under-construction when updating its length";
     lastBlock.setNumBytes(lastBlockLength);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
@@ -991,7 +991,7 @@ public class INodeFile extends INodeWithAdditionalFields
     //check if the last block is BlockInfoUnderConstruction
     BlockInfo lastBlk = blocks[last];
     long size = lastBlk.getNumBytes();
-    if (!lastBlk.isComplete()) {
+    if (lastBlk.isUnderConstructionOrRecovery()) {
        if (!includesLastUcBlock) {
          size = 0;
        } else if (usePreferredBlockSize4LastUcBlock) {
@@ -1026,7 +1026,7 @@ public class INodeFile extends INodeWithAdditionalFields
     QuotaCounts counts = new QuotaCounts.Builder().build();
     for (BlockInfo b : blocks) {
       Preconditions.checkState(b.isStriped());
-      long blockSize = b.isComplete() ?
+      long blockSize = !b.isUnderConstructionOrRecovery() ?
           ((BlockInfoStriped)b).spaceConsumed() : getPreferredBlockSize() *
           ((BlockInfoStriped)b).getTotalBlockNum();
       counts.addStorageSpace(blockSize);
@@ -1056,8 +1056,8 @@ public class INodeFile extends INodeWithAdditionalFields
 
     final short replication = getPreferredBlockReplication();
     for (BlockInfo b : blocks) {
-      long blockSize = b.isComplete() ? b.getNumBytes() :
-          getPreferredBlockSize();
+      long blockSize = b.isUnderConstructionOrRecovery() ?
+          getPreferredBlockSize() : b.getNumBytes();
       counts.addStorageSpace(blockSize * replication);
       if (bsp != null) {
         List<StorageType> types = bsp.chooseStorageTypes(replication);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -61,6 +61,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -97,6 +98,7 @@ import org.apache.hadoop.hdfs.client.HdfsDataOutputStream;
 import org.apache.hadoop.hdfs.client.impl.LeaseRenewer;
 import org.apache.hadoop.hdfs.DFSOpsCountStatistics.OpType;
 import org.apache.hadoop.hdfs.net.Peer;
+import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.protocol.CacheDirectiveInfo;
 import org.apache.hadoop.hdfs.protocol.CachePoolInfo;
 import org.apache.hadoop.hdfs.protocol.ECTopologyVerifierResult;
@@ -107,10 +109,14 @@ import org.apache.hadoop.hdfs.protocol.HdfsConstants.RollingUpgradeAction;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants.SafeModeAction;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants.StoragePolicySatisfierMode;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
+import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.hdfs.protocol.OpenFileEntry;
 import org.apache.hadoop.hdfs.protocol.OpenFilesIterator;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfo;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockManager;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockPlacementPolicy;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockPlacementPolicyRackFaultTolerant;
+import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsDatasetSpi;
@@ -2211,6 +2217,79 @@ public class TestDistributedFileSystem {
       dfs.enableErasureCodingPolicy("RS-10-4-1024k");
       result = dfs.getECTopologyResultForPolicies();
       assertFalse(result.isSupported());
+    }
+  }
+
+  @Test
+  public void testReadFileWithMultipleCommittedBlock() throws Exception {
+    HdfsConfiguration conf = getTestConfiguration();
+    // allow two committed blocks.
+    conf.setInt(DFS_NAMENODE_FILE_CLOSE_NUM_COMMITTED_ALLOWED_KEY, 2);
+    int blockSize = 1024;
+    conf.setInt(HdfsClientConfigKeys.DFS_BLOCK_SIZE_KEY, blockSize);
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(3).build()) {
+      cluster.waitActive();
+      BlockManager blockManager = cluster.getNameNode(0).getNamesystem().getBlockManager();
+      final DistributedFileSystem dfs = cluster.getFileSystem();
+      Path dir = new Path("/dir`");
+      dfs.mkdirs(dir);
+      String filePath = "/dir1/file1";
+
+      DataNodeTestUtils.pauseIBR(cluster.getDataNodes().get(0));
+      DataNodeTestUtils.pauseIBR(cluster.getDataNodes().get(1));
+      DataNodeTestUtils.pauseIBR(cluster.getDataNodes().get(2));
+
+      FSDataOutputStream str = dfs.create(new Path(filePath));
+
+      byte[] data = new byte[3 * blockSize];
+      ThreadLocalRandom.current().nextBytes(data);
+      str.write(data);
+
+      // there are three committed blocks in this file, so close will throw IOException.
+      LambdaTestUtils.intercept(IOException.class, "", str::close);
+
+      LocatedBlocks locatedBlocks = dfs.getClient().getLocatedBlocks(filePath, 0);
+
+      // This file is still in UnderConstruction.
+      Assert.assertTrue(locatedBlocks.isUnderConstruction());
+
+      // This file contains three committed blocks
+      Assert.assertEquals(3, locatedBlocks.getLocatedBlocks().size());
+      locatedBlocks.getLocatedBlocks().forEach( k -> {
+        Block block = k.getBlock().getLocalBlock();
+        BlockInfo storedBlock = blockManager.getStoredBlock(block);
+        Assert.assertEquals(HdfsServerConstants.BlockUCState.COMMITTED,
+            storedBlock.getBlockUCState());
+        Assert.assertEquals(blockSize, storedBlock.getNumBytes());
+      });
+
+      // The file length in the locatedBlocks should contain the bytes of the last committed block.
+      Assert.assertEquals(3 * blockSize, locatedBlocks.getFileLength());
+
+      // The last block in the locatedBlocks should be complete, so that InputStream doesn't
+      // get visibleLength for the last committed block since the fileLength already contains
+      // the bytes of the last committed block.
+      Assert.assertTrue(locatedBlocks.isLastBlockComplete());
+
+      try (final DFSInputStream inputStream = dfs.getClient()
+          .open(filePath, 4096, true)) {
+        assertEquals(3 * blockSize, inputStream.getFileLength());
+        assertEquals(inputStream.getLocatedBlocks().getFileLength(), inputStream.getFileLength());
+      }
+
+      DataNodeTestUtils.resumeIBR(cluster.getDataNodes().get(0));
+      DataNodeTestUtils.resumeIBR(cluster.getDataNodes().get(1));
+      DataNodeTestUtils.resumeIBR(cluster.getDataNodes().get(2));
+
+      // Try to complete this file.
+      LambdaTestUtils.await(10000, 4000,
+          () -> dfs.recoverLease(new Path(filePath)));
+
+      LocatedBlocks locatedBlocks1 = dfs.getClient().getLocatedBlocks(filePath, 0);
+      // This file is complete right now.
+      Assert.assertFalse(locatedBlocks1.isUnderConstruction());
+      Assert.assertEquals(locatedBlocks.getFileLength(), locatedBlocks1.getFileLength());
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -2256,7 +2256,7 @@ public class TestDistributedFileSystem {
 
       // This file contains three committed blocks
       Assert.assertEquals(3, locatedBlocks.getLocatedBlocks().size());
-      locatedBlocks.getLocatedBlocks().forEach( k -> {
+      locatedBlocks.getLocatedBlocks().forEach(k -> {
         Block block = k.getBlock().getLocalBlock();
         BlockInfo storedBlock = blockManager.getStoredBlock(block);
         Assert.assertEquals(HdfsServerConstants.BlockUCState.COMMITTED,
@@ -2272,7 +2272,7 @@ public class TestDistributedFileSystem {
       // the bytes of the last committed block.
       Assert.assertTrue(locatedBlocks.isLastBlockComplete());
 
-      try (final DFSInputStream inputStream = dfs.getClient()
+      try (DFSInputStream inputStream = dfs.getClient()
           .open(filePath, 4096, true)) {
         assertEquals(3 * blockSize, inputStream.getFileLength());
         assertEquals(inputStream.getLocatedBlocks().getFileLength(), inputStream.getFileLength());


### PR DESCRIPTION
One in-writing HDFS file may contains multiple committed blocks, as follows (assume one file contains three blocks)
<div class="table-wrap">

  | Block 1 | Block 2 | Block 3
-- | -- | -- | --
Case 1 | Complete | Commit | UnderConstruction
Case 2 | Complete | Commit | Commit
Case 3 | Commit | Commit | Commit

</div>
But the logic for committed blocks is mixed when computing file size, it ignores the bytes of the last committed block and contains the bytes of other committed blocks.

```
public final long computeFileSize(boolean includesLastUcBlock,
    boolean usePreferredBlockSize4LastUcBlock) {
  if (blocks.length == 0) {
    return 0;
  }
  final int last = blocks.length - 1;
  //check if the last block is BlockInfoUnderConstruction
  BlockInfo lastBlk = blocks[last];
  long size = lastBlk.getNumBytes();
  // the last committed block is not complete, so it's bytes may be ignored.
  if (!lastBlk.isComplete()) {
     if (!includesLastUcBlock) {
       size = 0;
     } else if (usePreferredBlockSize4LastUcBlock) {
       size = isStriped()?
           getPreferredBlockSize() *
               ((BlockInfoStriped)lastBlk).getDataBlockNum() :
           getPreferredBlockSize();
     }
  }
  // The bytes of other committed blocks are calculated into the file length.
  for (int i = 0; i < last; i++) {
    size += blocks[i].getNumBytes();
  }
  return size;
} 
```

The bytes of one committed block will not be changed, so the bytes of the last committed block should be calculated into the file length too.

And the logic for committed blocks is mixed too when computing file length in DFSInputStream. Normally DFSInputStream does not need to get visible length for committed block regardless of whether the committed block is the last block or not.

~~HDFS-10843~~ encountered one bug which actually caused by the committed block, but ~~HDFS-10843~~ fixed that bug by updating quota usage when completing block. The num of bytes of the committed block will no longer change, so we should update the quota usage when the block is committed, which can reduce the delta quota usage in time.

So there are somethings we need to do:

- Unify the calculation logic for all committed blocks in `computeFileSize` of `INodeFile`
- Unify the calculation logic for all committed blocks in `getFileLength` of `DFSInputStream`
- Update quota usage when committing block
