### PR TITLE
HADOOP-19155. Fix TestZKSignerSecretProvider failing unit test

### DIFF
--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestRandomSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestRandomSignerSecretProvider.java
@@ -91,7 +91,7 @@ public class TestRandomSignerSecretProvider {
       super(seed);
     }
     @Override
-    protected synchronized void rollSecret() {
+    protected void rollSecret() {
       // this is a no-op: simply used for Mockito to verify that rollSecret()
       // is periodically called at the expected frequency
     }

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestZKSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestZKSignerSecretProvider.java
@@ -120,7 +120,7 @@ public class TestZKSignerSecretProvider {
       super(seed);
     }
     @Override
-    protected synchronized void rollSecret() {
+    protected void rollSecret() {
       // this is a no-op: simply used for Mockito to verify that rollSecret()
       // is periodically called at the expected frequency
     }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

- TestZKSignerSecretProvider and TestRandomSignerSecretProvider{} unit test occasional failure

- The reason was that the MockZKSignerSecretProvider class rollSecret method is synchronized

- Sometimes verify (secretProvider, timeout (timeout). AtLeastOnce ()). RollSecret () method first in RolloverSignerSecretProvider scheduler thread lock, this results in a timeout
![image](https://github.com/apache/hadoop/assets/22268305/adef3a28-9580-4c25-ab75-a8f20090189e)
![image](https://github.com/apache/hadoop/assets/22268305/d4ce7066-5d3d-4c84-bfb7-f00f8b5c305c)
![image](https://github.com/apache/hadoop/assets/22268305/33ba6a5f-9625-4f2a-b41d-f529d0c29be9)



### How was this patch tested?
unit test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

