### PR TITLE
HADOOP-19156. ZooKeeper based state stores use different ZK address configs.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
@@ -124,7 +124,6 @@ public final class ZKCuratorManager {
 
   /**
    * Start the connection to the ZooKeeper ensemble.
-   * 
    * @param zkHostPort Host:Port of the ZooKeeper.
    * @throws IOException If the connection cannot be started.
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
@@ -126,7 +126,7 @@ public final class ZKCuratorManager {
    * Start the connection to the ZooKeeper ensemble.
    * @throws IOException If the connection cannot be started.
    */
-  public void start() throws IOException{
+  public void start() throws IOException {
     this.start(new ArrayList<>());
   }
 
@@ -135,7 +135,7 @@ public final class ZKCuratorManager {
    * @param authInfos List of authentication keys.
    * @throws IOException If the connection cannot be started.
    */
-  public void start(List<AuthInfo> authInfos) throws IOException{
+  public void start(List<AuthInfo> authInfos) throws IOException {
     this.start(authInfos, false);
   }
 
@@ -144,7 +144,7 @@ public final class ZKCuratorManager {
    * @param zkHostPort Host:Port of the ZooKeeper.
    * @throws IOException If the connection cannot be started.
    */
-  public void start(String zkHostPort) throws IOException{
+  public void start(String zkHostPort) throws IOException {
     this.start(new ArrayList<>(), false, zkHostPort);
   }
 
@@ -154,7 +154,7 @@ public final class ZKCuratorManager {
    * @param sslEnabled If the connection should be SSL/TLS encrypted.
    * @throws IOException If the connection cannot be started.
    */
-  public void start(List<AuthInfo> authInfos, boolean sslEnabled) throws IOException{
+  public void start(List<AuthInfo> authInfos, boolean sslEnabled) throws IOException {
     this.start(authInfos, sslEnabled, null);
   }
 
@@ -167,7 +167,7 @@ public final class ZKCuratorManager {
    * @throws IOException            If the connection cannot be started.
    */
   public void start(List<AuthInfo> authInfos, boolean sslEnabled, String zkHostPort)
-      throws IOException{
+      throws IOException {
 
     ZKClientConfig zkClientConfig = new ZKClientConfig();
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
@@ -126,8 +126,8 @@ public final class ZKCuratorManager {
    * Start the connection to the ZooKeeper ensemble.
    * @throws IOException If the connection cannot be started.
    */
-  public void start() throws IOException{
-    this.start(new ArrayList<>());
+  public void start(String zkHostPort) throws IOException{
+    this.start(new ArrayList<>(), zkHostPort);
   }
 
   /**
@@ -135,8 +135,8 @@ public final class ZKCuratorManager {
    * @param authInfos List of authentication keys.
    * @throws IOException If the connection cannot be started.
    */
-  public void start(List<AuthInfo> authInfos) throws IOException {
-    this.start(authInfos, false);
+  public void start(List<AuthInfo> authInfos, String zkHostPort) throws IOException {
+    this.start(authInfos, false, zkHostPort);
   }
 
   /**
@@ -146,19 +146,12 @@ public final class ZKCuratorManager {
    * @param sslEnabled If the connection should be SSL/TLS encrypted.
    * @throws IOException            If the connection cannot be started.
    */
-  public void start(List<AuthInfo> authInfos, boolean sslEnabled)
+  public void start(List<AuthInfo> authInfos, boolean sslEnabled, String zkHostPort)
       throws IOException{
 
     ZKClientConfig zkClientConfig = new ZKClientConfig();
 
     // Connect to the ZooKeeper ensemble
-    String zkHostPort = conf.get(CommonConfigurationKeys.ZK_ADDRESS);
-    if (zkHostPort == null) {
-      throw new IOException(
-          CommonConfigurationKeys.ZK_ADDRESS + " is not configured.");
-    }
-    LOG.debug("Configured {} as {}", CommonConfigurationKeys.ZK_ADDRESS, zkHostPort);
-
     int numRetries = conf.getInt(CommonConfigurationKeys.ZK_NUM_RETRIES,
         CommonConfigurationKeys.ZK_NUM_RETRIES_DEFAULT);
     int zkSessionTimeout = conf.getInt(CommonConfigurationKeys.ZK_TIMEOUT_MS,

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
@@ -124,6 +124,8 @@ public final class ZKCuratorManager {
 
   /**
    * Start the connection to the ZooKeeper ensemble.
+   * 
+   * @param zkHostPort Host:Port of the ZooKeeper.
    * @throws IOException If the connection cannot be started.
    */
   public void start(String zkHostPort) throws IOException{
@@ -133,6 +135,7 @@ public final class ZKCuratorManager {
   /**
    * Start the connection to the ZooKeeper ensemble.
    * @param authInfos List of authentication keys.
+   * @param zkHostPort Host:Port of the ZooKeeper.
    * @throws IOException If the connection cannot be started.
    */
   public void start(List<AuthInfo> authInfos, String zkHostPort) throws IOException {
@@ -144,6 +147,7 @@ public final class ZKCuratorManager {
    *
    * @param authInfos  List of authentication keys.
    * @param sslEnabled If the connection should be SSL/TLS encrypted.
+   * @param zkHostPort Host:Port of the ZooKeeper.
    * @throws IOException            If the connection cannot be started.
    */
   public void start(List<AuthInfo> authInfos, boolean sslEnabled, String zkHostPort)

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
@@ -124,21 +124,38 @@ public final class ZKCuratorManager {
 
   /**
    * Start the connection to the ZooKeeper ensemble.
-   * @param zkHostPort Host:Port of the ZooKeeper.
    * @throws IOException If the connection cannot be started.
    */
-  public void start(String zkHostPort) throws IOException{
-    this.start(new ArrayList<>(), zkHostPort);
+  public void start() throws IOException{
+    this.start(new ArrayList<>());
   }
 
   /**
    * Start the connection to the ZooKeeper ensemble.
    * @param authInfos List of authentication keys.
+   * @throws IOException If the connection cannot be started.
+   */
+  public void start(List<AuthInfo> authInfos) throws IOException{
+    this.start(authInfos, false);
+  }
+
+  /**
+   * Start the connection to the ZooKeeper ensemble.
    * @param zkHostPort Host:Port of the ZooKeeper.
    * @throws IOException If the connection cannot be started.
    */
-  public void start(List<AuthInfo> authInfos, String zkHostPort) throws IOException {
-    this.start(authInfos, false, zkHostPort);
+  public void start(String zkHostPort) throws IOException{
+    this.start(new ArrayList<>(), false, zkHostPort);
+  }
+
+  /**
+   * Start the connection to the ZooKeeper ensemble.
+   * @param authInfos  List of authentication keys.
+   * @param sslEnabled If the connection should be SSL/TLS encrypted.
+   * @throws IOException If the connection cannot be started.
+   */
+  public void start(List<AuthInfo> authInfos, boolean sslEnabled) throws IOException{
+    this.start(authInfos, sslEnabled, null);
   }
 
   /**
@@ -155,6 +172,15 @@ public final class ZKCuratorManager {
     ZKClientConfig zkClientConfig = new ZKClientConfig();
 
     // Connect to the ZooKeeper ensemble
+    if (zkHostPort == null) {
+      zkHostPort = conf.get(CommonConfigurationKeys.ZK_ADDRESS);
+      if (zkHostPort == null) {
+        throw new IOException(
+            CommonConfigurationKeys.ZK_ADDRESS + " is not configured.");
+      }
+      LOG.debug("Configured {} as {}", CommonConfigurationKeys.ZK_ADDRESS, zkHostPort);
+    }
+
     int numRetries = conf.getInt(CommonConfigurationKeys.ZK_NUM_RETRIES,
         CommonConfigurationKeys.ZK_NUM_RETRIES_DEFAULT);
     int zkSessionTimeout = conf.getInt(CommonConfigurationKeys.ZK_TIMEOUT_MS,

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/curator/TestSecureZKCuratorManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/curator/TestSecureZKCuratorManager.java
@@ -71,9 +71,9 @@ public class TestSecureZKCuratorManager {
             DELETE_DATA_DIRECTORY_ON_CLOSE, SERVER_ID, TICK_TIME, MAX_CLIENT_CNXNS,
             customConfiguration);
     this.server = new TestingServer(spec, true);
-    this.hadoopConf.set(CommonConfigurationKeys.ZK_ADDRESS, this.server.getConnectString());
+    String zkHostPort = this.server.getConnectString();
     this.curator = new ZKCuratorManager(this.hadoopConf);
-    this.curator.start(new ArrayList<>(), true);
+    this.curator.start(new ArrayList<>(), true, zkHostPort);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/curator/TestZKCuratorManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/curator/TestZKCuratorManager.java
@@ -60,11 +60,10 @@ public class TestZKCuratorManager {
     this.server = new TestingServer();
 
     Configuration conf = new Configuration();
-    conf.set(
-        CommonConfigurationKeys.ZK_ADDRESS, this.server.getConnectString());
+    String zkHostPort = this.server.getConnectString();
 
     this.curator = new ZKCuratorManager(conf);
-    this.curator.start();
+    this.curator.start(zkHostPort);
   }
 
   @After

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -257,6 +257,8 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
       FEDERATION_STORE_ZK_DRIVER_PREFIX + "async.max.threads";
   public static final int FEDERATION_STORE_ZK_ASYNC_MAX_THREADS_DEFAULT =
       -1;
+  public static final String FEDERATION_STORE_ZK_ADDRESS =
+      FEDERATION_STORE_ZK_DRIVER_PREFIX + "address";
 
   // HDFS Router-based federation File based store implementation specific configs
   public static final String FEDERATION_STORE_FILE_ASYNC_THREADS =

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/driver/impl/StateStoreZooKeeperImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/driver/impl/StateStoreZooKeeperImpl.java
@@ -105,10 +105,6 @@ public class StateStoreZooKeeperImpl extends StateStoreSerializableImpl {
       LOG.info("Init StateStoreZookeeperImpl by sync mode.");
     }
     String zkHostPort = conf.get(RBFConfigKeys.FEDERATION_STORE_ZK_ADDRESS);
-    if (zkHostPort == null) {
-      LOG.error("{} is not configured.", RBFConfigKeys.FEDERATION_STORE_ZK_ADDRESS);
-      return false;
-    }
     try {
       this.zkManager = new ZKCuratorManager(conf);
       this.zkManager.start(zkHostPort);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/driver/impl/StateStoreZooKeeperImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/driver/impl/StateStoreZooKeeperImpl.java
@@ -104,9 +104,14 @@ public class StateStoreZooKeeperImpl extends StateStoreSerializableImpl {
     } else {
       LOG.info("Init StateStoreZookeeperImpl by sync mode.");
     }
+    String zkHostPort = conf.get(RBFConfigKeys.FEDERATION_STORE_ZK_ADDRESS);
+    if (zkHostPort == null) {
+      LOG.error("{} is not configured.", RBFConfigKeys.FEDERATION_STORE_ZK_ADDRESS);
+      return false;
+    }
     try {
       this.zkManager = new ZKCuratorManager(conf);
-      this.zkManager.start();
+      this.zkManager.start(zkHostPort);
       this.zkAcl = ZKCuratorManager.getZKAcls(conf);
     } catch (IOException e) {
       LOG.error("Cannot initialize the ZK connection", e);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -379,6 +379,13 @@
   </property>
 
   <property>
+    <name>dfs.federation.router.store.driver.zk.address</name>
+    <description>
+      Host:Port of the ZooKeeper for StateStoreZooKeeperImpl.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.federation.router.store.driver.zk.parent-path</name>
     <value>/hdfs-federation</value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterHeartbeatService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterHeartbeatService.java
@@ -22,7 +22,6 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.hdfs.server.federation.RouterConfigBuilder;
 import org.apache.hadoop.hdfs.server.federation.store.RouterStore;
 import org.apache.hadoop.hdfs.server.federation.store.StateStoreService;
@@ -40,6 +39,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.waitStateStore;
+import static org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl.FEDERATION_STORE_ZK_ADDRESS;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -74,7 +74,7 @@ public class TestRouterHeartbeatService {
         .retryPolicy(new RetryNTimes(100, 100))
         .build();
     curatorFramework.start();
-    routerConfig.set(CommonConfigurationKeys.ZK_ADDRESS, connectStr);
+    routerConfig.set(FEDERATION_STORE_ZK_ADDRESS, connectStr);
     router.init(routerConfig);
     router.start();
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterHeartbeatService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterHeartbeatService.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.waitStateStore;
-import static org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl.FEDERATION_STORE_ZK_ADDRESS;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -74,7 +73,7 @@ public class TestRouterHeartbeatService {
         .retryPolicy(new RetryNTimes(100, 100))
         .build();
     curatorFramework.start();
-    routerConfig.set(FEDERATION_STORE_ZK_ADDRESS, connectStr);
+    routerConfig.set(RBFConfigKeys.FEDERATION_STORE_ZK_ADDRESS, connectStr);
     router.init(routerConfig);
     router.start();
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTableCacheRefresh.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTableCacheRefresh.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdfs.server.federation.router;
 
-import static org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl.FEDERATION_STORE_ZK_ADDRESS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -81,7 +80,7 @@ public class TestRouterMountTableCacheRefresh {
     conf.setClass(RBFConfigKeys.FEDERATION_FILE_RESOLVER_CLIENT_CLASS,
         RBFConfigKeys.FEDERATION_FILE_RESOLVER_CLIENT_CLASS_DEFAULT,
         FileSubclusterResolver.class);
-    conf.set(FEDERATION_STORE_ZK_ADDRESS, connectString);
+    conf.set(RBFConfigKeys.FEDERATION_STORE_ZK_ADDRESS, connectString);
     conf.setBoolean(RBFConfigKeys.DFS_ROUTER_STORE_ENABLE, true);
     cluster.addRouterOverrides(conf);
     cluster.startCluster();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTableCacheRefresh.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTableCacheRefresh.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.federation.router;
 
+import static org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl.FEDERATION_STORE_ZK_ADDRESS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -32,7 +33,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.hdfs.server.federation.FederationTestUtils;
 import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
 import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.RouterContext;
@@ -81,7 +81,7 @@ public class TestRouterMountTableCacheRefresh {
     conf.setClass(RBFConfigKeys.FEDERATION_FILE_RESOLVER_CLIENT_CLASS,
         RBFConfigKeys.FEDERATION_FILE_RESOLVER_CLIENT_CLASS_DEFAULT,
         FileSubclusterResolver.class);
-    conf.set(CommonConfigurationKeys.ZK_ADDRESS, connectString);
+    conf.set(FEDERATION_STORE_ZK_ADDRESS, connectString);
     conf.setBoolean(RBFConfigKeys.DFS_ROUTER_STORE_ENABLE, true);
     cluster.addRouterOverrides(conf);
     cluster.startCluster();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTableCacheRefreshSecure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTableCacheRefreshSecure.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs.server.federation.router;
 
 import static org.apache.hadoop.fs.contract.router.SecurityConfUtil.initSecurity;
+import static org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl.FEDERATION_STORE_ZK_ADDRESS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -30,7 +31,6 @@ import java.util.List;
 
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.hdfs.server.federation.FederationTestUtils;
 import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
 import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.RouterContext;
@@ -86,7 +86,7 @@ public class TestRouterMountTableCacheRefreshSecure {
     conf.setClass(RBFConfigKeys.FEDERATION_FILE_RESOLVER_CLIENT_CLASS,
         RBFConfigKeys.FEDERATION_FILE_RESOLVER_CLIENT_CLASS_DEFAULT,
         FileSubclusterResolver.class);
-    conf.set(CommonConfigurationKeys.ZK_ADDRESS, connectString);
+    conf.set(FEDERATION_STORE_ZK_ADDRESS, connectString);
     conf.setBoolean(RBFConfigKeys.DFS_ROUTER_STORE_ENABLE, true);
     cluster = new MiniRouterDFSCluster(false, numNameservices, conf);
     cluster.addRouterOverrides(conf);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTableCacheRefreshSecure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTableCacheRefreshSecure.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdfs.server.federation.router;
 
 import static org.apache.hadoop.fs.contract.router.SecurityConfUtil.initSecurity;
-import static org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl.FEDERATION_STORE_ZK_ADDRESS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -86,7 +85,7 @@ public class TestRouterMountTableCacheRefreshSecure {
     conf.setClass(RBFConfigKeys.FEDERATION_FILE_RESOLVER_CLIENT_CLASS,
         RBFConfigKeys.FEDERATION_FILE_RESOLVER_CLIENT_CLASS_DEFAULT,
         FileSubclusterResolver.class);
-    conf.set(FEDERATION_STORE_ZK_ADDRESS, connectString);
+    conf.set(RBFConfigKeys.FEDERATION_STORE_ZK_ADDRESS, connectString);
     conf.setBoolean(RBFConfigKeys.DFS_ROUTER_STORE_ENABLE, true);
     cluster = new MiniRouterDFSCluster(false, numNameservices, conf);
     cluster.addRouterOverrides(conf);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
@@ -32,7 +32,6 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys;
 import org.apache.hadoop.hdfs.server.federation.store.StateStoreUtils;
 import org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl;
@@ -71,7 +70,7 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
     // Create the ZK State Store
     Configuration conf =
         getStateStoreConfiguration(StateStoreZooKeeperImpl.class);
-    conf.set(CommonConfigurationKeys.ZK_ADDRESS, connectString);
+    conf.set(RBFConfigKeys.FEDERATION_STORE_ZK_ADDRESS, connectString);
     // Disable auto-repair of connection
     conf.setLong(RBFConfigKeys.FEDERATION_STORE_CONNECTION_TEST_MS,
         TimeUnit.HOURS.toMillis(1));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -4023,7 +4023,7 @@ public class YarnConfiguration extends Configuration {
 
   public static final String DEFAULT_FEDERATION_STATESTORE_CLIENT_CLASS =
       "org.apache.hadoop.yarn.server.federation.store.impl.MemoryFederationStateStore";
-  
+
   public static final String FEDERATION_STATESTORE_ZK_ADDRESS =
       FEDERATION_PREFIX + "state-store.zk.address";
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -112,8 +112,6 @@ public class YarnConfiguration extends Configuration {
             SYSTEM_METRICS_PUBLISHER_ENABLED),
         new DeprecationDelta(RM_ZK_ACL, CommonConfigurationKeys.ZK_ACL),
         new DeprecationDelta(RM_ZK_AUTH, CommonConfigurationKeys.ZK_AUTH),
-        new DeprecationDelta(RM_ZK_ADDRESS,
-            CommonConfigurationKeys.ZK_ADDRESS),
         new DeprecationDelta(RM_ZK_NUM_RETRIES,
             CommonConfigurationKeys.ZK_NUM_RETRIES),
         new DeprecationDelta(RM_ZK_TIMEOUT_MS,
@@ -4025,6 +4023,9 @@ public class YarnConfiguration extends Configuration {
 
   public static final String DEFAULT_FEDERATION_STATESTORE_CLIENT_CLASS =
       "org.apache.hadoop.yarn.server.federation.store.impl.MemoryFederationStateStore";
+  
+  public static final String FEDERATION_STATESTORE_ZK_ADDRESS =
+      FEDERATION_PREFIX + "state-store.zk.address";
 
   public static final String FEDERATION_CACHE_TIME_TO_LIVE_SECS =
       FEDERATION_PREFIX + "cache-ttl.secs";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/conf/TestYarnConfigurationFields.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/conf/TestYarnConfigurationFields.java
@@ -142,7 +142,6 @@ public class TestYarnConfigurationFields extends TestConfigurationFieldsBase {
         .add(YarnConfiguration.RM_SYSTEM_METRICS_PUBLISHER_ENABLED);
 
     // skip deprecated ZooKeeper settings
-    configurationPropsToSkipCompare.add(YarnConfiguration.RM_ZK_ADDRESS);
     configurationPropsToSkipCompare.add(YarnConfiguration.RM_ZK_NUM_RETRIES);
     configurationPropsToSkipCompare.add(YarnConfiguration.RM_ZK_TIMEOUT_MS);
     configurationPropsToSkipCompare.add(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -582,6 +582,15 @@
   </property>
 
   <property>
+    <description>Host:Port of the ZooKeeper server to be used by the RM. This
+      must be supplied when using the ZooKeeper based implementation of the
+      RM state store and/or embedded automatic failover in an HA setting.
+    </description>
+    <name>yarn.resourcemanager.zk-address</name>
+    <!--value>127.0.0.1:2181</value-->
+  </property>
+
+  <property>
     <description>Full path of the ZooKeeper znode where RM state will be
     stored. This must be supplied when using
     org.apache.hadoop.yarn.server.resourcemanager.recovery.ZKRMStateStore
@@ -3776,6 +3785,13 @@
     </description>
     <name>yarn.federation.state-store.class</name>
     <value>org.apache.hadoop.yarn.server.federation.store.impl.MemoryFederationStateStore</value>
+  </property>
+
+  <property>
+    <description>
+      Host:Port of the ZooKeeper server to be used by the federation state store
+    </description>
+    <name>yarn.federation.state-store.zk.address</name>
   </property>
 
   <property>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.federation.proto.YarnServerFederationProtos.SubClusterIdProto;
 import org.apache.hadoop.yarn.federation.proto.YarnServerFederationProtos.SubClusterInfoProto;
 import org.apache.hadoop.yarn.federation.proto.YarnServerFederationProtos.SubClusterPolicyConfigurationProto;
@@ -265,9 +266,14 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
     baseZNode = conf.get(
         YarnConfiguration.FEDERATION_STATESTORE_ZK_PARENT_PATH,
         YarnConfiguration.DEFAULT_FEDERATION_STATESTORE_ZK_PARENT_PATH);
+    String zkHostPort = conf.get(YarnConfiguration.FEDERATION_STATESTORE_ZK_ADDRESS);
+    if (zkHostPort == null) {
+      throw new YarnRuntimeException(
+              YarnConfiguration.FEDERATION_STATESTORE_ZK_ADDRESS + " is not configured.");
+    }
     try {
       this.zkManager = new ZKCuratorManager(conf);
-      this.zkManager.start();
+      this.zkManager.start(zkHostPort);
     } catch (IOException e) {
       LOG.error("Cannot initialize the ZK connection", e);
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
@@ -267,10 +267,6 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
         YarnConfiguration.FEDERATION_STATESTORE_ZK_PARENT_PATH,
         YarnConfiguration.DEFAULT_FEDERATION_STATESTORE_ZK_PARENT_PATH);
     String zkHostPort = conf.get(YarnConfiguration.FEDERATION_STATESTORE_ZK_ADDRESS);
-    if (zkHostPort == null) {
-      throw new YarnRuntimeException(
-              YarnConfiguration.FEDERATION_STATESTORE_ZK_ADDRESS + " is not configured.");
-    }
     try {
       this.zkManager = new ZKCuratorManager(conf);
       this.zkManager.start(zkHostPort);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.federation.proto.YarnServerFederationProtos.SubClusterIdProto;
 import org.apache.hadoop.yarn.federation.proto.YarnServerFederationProtos.SubClusterInfoProto;
 import org.apache.hadoop.yarn.federation.proto.YarnServerFederationProtos.SubClusterPolicyConfigurationProto;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestZookeeperFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestZookeeperFederationStateStore.java
@@ -27,7 +27,6 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.metrics2.MetricsRecord;
 import org.apache.hadoop.metrics2.impl.MetricsCollectorImpl;
 import org.apache.hadoop.metrics2.impl.MetricsRecords;
@@ -94,7 +93,7 @@ public class TestZookeeperFederationStateStore extends FederationStateStoreBaseT
       curatorFramework.start();
 
       Configuration conf = new YarnConfiguration();
-      conf.set(CommonConfigurationKeys.ZK_ADDRESS, connectString);
+      conf.set(YarnConfiguration.FEDERATION_STATESTORE_ZK_ADDRESS, connectString);
       conf.setInt(YarnConfiguration.FEDERATION_STATESTORE_MAX_APPLICATIONS, 10);
       setConf(conf);
     } catch (Exception e) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -410,6 +410,11 @@ public class ResourceManager extends CompositeService
    */
   public ZKCuratorManager createAndStartZKManager(Configuration
       config) throws IOException {
+    String zkHostPort = config.get(YarnConfiguration.RM_ZK_ADDRESS);
+    if (zkHostPort == null) {
+      throw new YarnRuntimeException(
+              YarnConfiguration.RM_ZK_ADDRESS + " is not configured.");
+    }
     ZKCuratorManager manager = new ZKCuratorManager(config);
 
     // Get authentication
@@ -432,7 +437,7 @@ public class ResourceManager extends CompositeService
         config.getBoolean(CommonConfigurationKeys.ZK_CLIENT_SSL_ENABLED,
             config.getBoolean(YarnConfiguration.RM_ZK_CLIENT_SSL_ENABLED,
                 YarnConfiguration.DEFAULT_RM_ZK_CLIENT_SSL_ENABLED));
-    manager.start(authInfos, isSSLEnabled);
+    manager.start(authInfos, isSSLEnabled, zkHostPort);
     return manager;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -411,10 +411,6 @@ public class ResourceManager extends CompositeService
   public ZKCuratorManager createAndStartZKManager(Configuration
       config) throws IOException {
     String zkHostPort = config.get(YarnConfiguration.RM_ZK_ADDRESS);
-    if (zkHostPort == null) {
-      throw new YarnRuntimeException(
-              YarnConfiguration.RM_ZK_ADDRESS + " is not configured.");
-    }
     ZKCuratorManager manager = new ZKCuratorManager(config);
 
     // Get authentication

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/RMHATestBase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/RMHATestBase.java
@@ -64,7 +64,7 @@ public abstract class RMHATestBase extends ClientBaseWithFixes{
     configuration.setBoolean(YarnConfiguration.RECOVERY_ENABLED, true);
     configuration.set(YarnConfiguration.RM_STORE,
         ZKRMStateStore.class.getName());
-    configuration.set(CommonConfigurationKeys.ZK_ADDRESS, hostPort);
+    configuration.set(YarnConfiguration.RM_ZK_ADDRESS, hostPort);
     configuration.setInt(CommonConfigurationKeys.ZK_TIMEOUT_MS, ZK_TIMEOUT_MS);
     configuration.setBoolean(YarnConfiguration.AUTO_FAILOVER_ENABLED, false);
     configuration.set(YarnConfiguration.RM_CLUSTER_ID, "test-yarn-cluster");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestZKRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestZKRMStateStore.java
@@ -213,7 +213,7 @@ public class TestZKRMStateStore extends RMStateStoreTestBase {
 
     private RMStateStore createStore(Configuration conf) throws Exception {
       workingZnode = "/jira/issue/3077/rmstore";
-      conf.set(CommonConfigurationKeys.ZK_ADDRESS,
+      conf.set(YarnConfiguration.RM_ZK_ADDRESS,
           curatorTestingServer.getConnectString());
       conf.set(YarnConfiguration.ZK_RM_STATE_STORE_PARENT_PATH, workingZnode);
       conf.setLong(YarnConfiguration.RM_EPOCH, epoch);
@@ -347,7 +347,7 @@ public class TestZKRMStateStore extends RMStateStoreTestBase {
       public RMStateStore getRMStateStore() throws Exception {
         YarnConfiguration conf = new YarnConfiguration();
         workingZnode = "/jira/issue/3077/rmstore";
-        conf.set(CommonConfigurationKeys.ZK_ADDRESS,
+        conf.set(YarnConfiguration.RM_ZK_ADDRESS,
             curatorTestingServer.getConnectString());
         conf.set(YarnConfiguration.ZK_RM_STATE_STORE_PARENT_PATH, workingZnode);
         this.store = new TestZKRMStateStoreInternal(conf, workingZnode) {
@@ -388,7 +388,7 @@ public class TestZKRMStateStore extends RMStateStoreTestBase {
     conf.set(YarnConfiguration.RM_HA_IDS, rmIds);
     conf.setBoolean(YarnConfiguration.RECOVERY_ENABLED, true);
     conf.set(YarnConfiguration.RM_STORE, ZKRMStateStore.class.getName());
-    conf.set(CommonConfigurationKeys.ZK_ADDRESS,
+    conf.set(YarnConfiguration.RM_ZK_ADDRESS,
         curatorTestServer.getConnectString());
     conf.setInt(CommonConfigurationKeys.ZK_TIMEOUT_MS, ZK_TIMEOUT_MS);
     conf.set(YarnConfiguration.RM_HA_ID, rmId);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestZKRMStateStoreZKClientConnections.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestZKRMStateStoreZKClientConnections.java
@@ -88,7 +88,7 @@ public class TestZKRMStateStoreZKClientConnections {
 
     public RMStateStore getRMStateStore(Configuration conf) throws Exception {
       String workingZnode = "/Test";
-      conf.set(CommonConfigurationKeys.ZK_ADDRESS,
+      conf.set(YarnConfiguration.RM_ZK_ADDRESS,
           testingServer.getConnectString());
       conf.set(YarnConfiguration.ZK_RM_STATE_STORE_PARENT_PATH, workingZnode);
       this.store = new TestZKRMStateStore(conf, workingZnode);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/TestZKConfigurationStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/TestZKConfigurationStore.java
@@ -23,7 +23,6 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.ha.HAServiceProtocol;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.service.Service;
@@ -100,7 +99,7 @@ public class TestZKConfigurationStore extends
     curatorTestingServer = setupCuratorServer();
     curatorFramework = setupCuratorFramework(curatorTestingServer);
 
-    conf.set(CommonConfigurationKeys.ZK_ADDRESS,
+    conf.set(YarnConfiguration.RM_ZK_ADDRESS,
         curatorTestingServer.getConnectString());
     rm = new MockRM(conf);
     rm.start();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
@@ -177,7 +177,7 @@ ZooKeeper: one must set the ZooKeeper settings for Hadoop:
 | Property                            | Example                                                                             | Description                             |
 |:------------------------------------|:------------------------------------------------------------------------------------|:----------------------------------------|
 | `yarn.federation.state-store.class` | `org.apache.hadoop.yarn.server.federation.store.impl.ZookeeperFederationStateStore` | The type of state-store to use.         |
-| `hadoop.zk.address`                 | `host:port`                                                                         | The address for the ZooKeeper ensemble. |
+| `yarn.federation.state-store.zk.address`                 | `host:port`                                                                         | The address for the ZooKeeper ensemble. |
 
 SQL: one must setup the following parameters:
 
@@ -1006,7 +1006,7 @@ Example of Machine-Role Mapping(Exclude HDFS):
 
 <!-- ZK Address. -->
 <property>
-  <name>hadoop.zk.address</name>
+  <name>yarn.federation.state-store.zk.address</name>
   <value>zkHost:zkPort</value>
 </property>
 
@@ -1067,7 +1067,7 @@ $HADOOP_HOME/bin/yarn --daemon start resourcemanager
 
 <!-- ZK Address. -->
 <property>
-  <name>hadoop.zk.address</name>
+  <name>yarn.federation.state-store.zk.address</name>
   <value>zkHost:zkPort</value>
 </property>
 
@@ -1135,7 +1135,7 @@ After we have finished configuring the `YARN-2` cluster, we can proceed with sta
 
 <!-- ZK Address. -->
 <property>
-  <name>hadoop.zk.address</name>
+  <name>yarn.federation.state-store.zk.address</name>
   <value>zkHost:zkPort</value>
 </property>
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/ResourceManagerHA.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/ResourceManagerHA.md
@@ -56,7 +56,7 @@ Most of the failover functionality is tunable using various configuration proper
 
 | Configuration Properties | Description |
 |:---- |:---- |
-| `hadoop.zk.address` | Address of the ZK-quorum. Used both for the state-store and embedded leader-election. |
+| `yarn.resourcemanager.zk-address` | Address of the ZK-quorum. Used both for the state-store and embedded leader-election. |
 | `yarn.resourcemanager.ha.enabled` | Enable RM HA. |
 | `yarn.resourcemanager.ha.rm-ids` | List of logical IDs for the RMs. e.g., "rm1,rm2". |
 | `yarn.resourcemanager.hostname.`*rm-id* | For each *rm-id*, specify the hostname the RM corresponds to. Alternately, one could set each of the RM's service addresses. |
@@ -112,7 +112,7 @@ Here is the sample of minimal setup for RM failover.
   <value>master2:8088</value>
 </property>
 <property>
-  <name>hadoop.zk.address</name>
+  <name>yarn.resourcemanager.zk-address</name>
   <value>zk1:2181,zk2:2181,zk3:2181</value>
 </property>
 ```

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/ResourceManagerRestart.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/ResourceManagerRestart.md
@@ -93,7 +93,7 @@ This section describes the configurations involved to enable RM Restart feature.
 
 | Property | Description |
 |:---- |:---- |
-| `hadoop.zk.address` | Comma separated list of Host:Port pairs. Each corresponds to a ZooKeeper server (e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002") to be used by the RM for storing RM state. |
+| `yarn.resourcemanager.zk-address` | Comma separated list of Host:Port pairs. Each corresponds to a ZooKeeper server (e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002") to be used by the RM for storing RM state. |
 | `yarn.resourcemanager.zk-state-store.parent-path` | The full path of the root znode where RM state will be stored. Default value is /rmstore. |
 
 * Configure the retry policy state-store client uses to connect with the ZooKeeper server.
@@ -157,7 +157,7 @@ Below is a minimum set of configurations for enabling RM work-preserving restart
        (e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002") to be used by the RM for storing RM state.
        This must be supplied when using org.apache.hadoop.yarn.server.resourcemanager.recovery.ZKRMStateStore
        as the value for yarn.resourcemanager.store.class</description>
-       <name>hadoop.zk.address</name>
+       <name>yarn.resourcemanager.zk-address</name>
        <value>127.0.0.1:2181</value>
      </property>
 


### PR DESCRIPTION
### Description of PR
Currently, the Zookeeper-based state stores of RM, YARN Federation, and HDFS Federation use the same ZK address config `hadoop.zk.address`. But in our production environment, we hope that different services can use different ZKs to avoid mutual influence.

This jira adds separate ZK address configs for each service.
### How was this patch tested?
unit test

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

