### PR TITLE
YARN-11685. Create a config to enable/disable cgroup v2 functionality

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2805,6 +2805,14 @@ public class YarnConfiguration extends Configuration {
       20;
 
   /**
+   * Boolean indicating whether cgroup v2 is enabled.
+   */
+  public static final String NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED =
+      NM_PREFIX + "linux-container-executor.cgroups.v2.enabled";
+
+  public static final boolean DEFAULT_NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED = false;
+
+  /**
    * Indicates if memory and CPU limits will be set for the Windows Job
    * Object for the containers launched by the default container executor.
    */

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -2465,6 +2465,12 @@
   </property>
 
   <property>
+    <name>yarn.nodemanager.linux-container-executor.cgroups.v2.enabled</name>
+    <value>false</value>
+    <description>Boolean indicating whether cgroup v2 is enabled.</description>
+  </property>
+
+  <property>
     <description>T-file compression types used to compress aggregated logs.</description>
     <name>yarn.nodemanager.log-aggregation.compression-type</name>
     <value>none</value>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/ResourceHandlerModule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/ResourceHandlerModule.java
@@ -70,9 +70,9 @@ public class ResourceHandlerModule {
   private static volatile CGroupsHandler cGroupsHandler;
   private static volatile CGroupsBlkioResourceHandlerImpl
       cGroupsBlkioResourceHandler;
-  private static volatile AbstractCGroupsMemoryResourceHandler
+  private static volatile MemoryResourceHandler
       cGroupsMemoryResourceHandler;
-  private static volatile AbstractCGroupsCpuResourceHandler
+  private static volatile CpuResourceHandler
       cGroupsCpuResourceHandler;
 
   /**
@@ -139,7 +139,7 @@ public class ResourceHandlerModule {
     return cGroupsCpuResourceHandler;
   }
 
-  private static AbstractCGroupsCpuResourceHandler initCGroupsCpuResourceHandler(
+  private static CpuResourceHandler initCGroupsCpuResourceHandler(
       Configuration conf) throws ResourceHandlerException {
     boolean cgroupsCpuEnabled =
         conf.getBoolean(YarnConfiguration.NM_CPU_RESOURCE_ENABLED,
@@ -257,7 +257,7 @@ public class ResourceHandlerModule {
     return null;
   }
 
-  private static AbstractCGroupsMemoryResourceHandler
+  private static MemoryResourceHandler
       getCgroupsMemoryResourceHandler(
       Configuration conf) throws ResourceHandlerException {
     if (cGroupsMemoryResourceHandler == null) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/ResourceHandlerModule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/ResourceHandlerModule.java
@@ -360,6 +360,21 @@ public class ResourceHandlerModule {
     resourceHandlerChain = null;
   }
 
+  @VisibleForTesting
+  static void resetCgroupsHandler() {
+    cGroupsHandler = null;
+  }
+
+  @VisibleForTesting
+  static void resetCpuResourceHandler() {
+    cGroupsCpuResourceHandler = null;
+  }
+
+  @VisibleForTesting
+  static void resetMemoryResourceHandler() {
+    cGroupsMemoryResourceHandler = null;
+  }
+
   /**
    * If a cgroup mount directory is specified, it returns cgroup directories
    * with valid names.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestResourceHandlerModule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestResourceHandlerModule.java
@@ -164,7 +164,7 @@ public class TestResourceHandlerModule {
     conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, true);
 
     initResourceHandlerChain(conf);
- 
+
     Assert.assertTrue(ResourceHandlerModule.getMemoryResourceHandler()
         instanceof CGroupsV2MemoryResourceHandlerImpl);
     Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestResourceHandlerModule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestResourceHandlerModule.java
@@ -49,6 +49,9 @@ public class TestResourceHandlerModule {
     networkEnabledConf.setBoolean(YarnConfiguration.NM_NETWORK_RESOURCE_ENABLED,
         true);
     ResourceHandlerModule.nullifyResourceHandlerChain();
+    ResourceHandlerModule.resetCgroupsHandler();
+    ResourceHandlerModule.resetCpuResourceHandler();
+    ResourceHandlerModule.resetMemoryResourceHandler();
   }
 
   @Test
@@ -109,6 +112,71 @@ public class TestResourceHandlerModule {
       Assert.assertTrue(resourceHandlers.get(0) == handler);
     } else {
       Assert.fail("Null returned");
+    }
+  }
+
+  @Test
+  public void testCpuResourceHandlerClassForCgroupV1() throws ResourceHandlerException {
+    Configuration conf = new YarnConfiguration();
+    conf.setBoolean(YarnConfiguration.NM_CPU_RESOURCE_ENABLED, true);
+    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, false);
+
+    initResourceHandlerChain(conf);
+
+    Assert.assertTrue(ResourceHandlerModule.getCpuResourceHandler()
+        instanceof CGroupsCpuResourceHandlerImpl);
+    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
+        instanceof CGroupsHandlerImpl);
+  }
+
+  @Test
+  public void testCpuResourceHandlerClassForCgroupV2() throws ResourceHandlerException {
+    Configuration conf = new YarnConfiguration();
+    conf.setBoolean(YarnConfiguration.NM_CPU_RESOURCE_ENABLED, true);
+    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, true);
+
+    initResourceHandlerChain(conf);
+
+    Assert.assertTrue(ResourceHandlerModule.getCpuResourceHandler()
+        instanceof CGroupsV2CpuResourceHandlerImpl);
+    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
+        instanceof CGroupsV2HandlerImpl);
+  }
+
+  @Test
+  public void testMemoryResourceHandlerClassForCgroupV1() throws ResourceHandlerException {
+    Configuration conf = new YarnConfiguration();
+    conf.setBoolean(YarnConfiguration.NM_MEMORY_RESOURCE_ENABLED, true);
+    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, false);
+
+    initResourceHandlerChain(conf);
+
+    Assert.assertTrue(ResourceHandlerModule.getMemoryResourceHandler()
+        instanceof CGroupsMemoryResourceHandlerImpl);
+    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
+        instanceof CGroupsHandlerImpl);
+  }
+
+  @Test
+  public void testMemoryResourceHandlerClassForCgroupV2() throws ResourceHandlerException {
+    Configuration conf = new YarnConfiguration();
+    conf.setBoolean(YarnConfiguration.NM_MEMORY_RESOURCE_ENABLED, true);
+    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, true);
+
+    initResourceHandlerChain(conf);
+ 
+    Assert.assertTrue(ResourceHandlerModule.getMemoryResourceHandler()
+        instanceof CGroupsV2MemoryResourceHandlerImpl);
+    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
+        instanceof CGroupsV2HandlerImpl);
+  }
+
+  private void initResourceHandlerChain(Configuration conf) throws ResourceHandlerException {
+    ResourceHandlerChain resourceHandlerChain =
+        ResourceHandlerModule.getConfiguredResourceHandlerChain(conf,
+            mock(Context.class));
+    if (resourceHandlerChain == null) {
+      Assert.fail("Could not initialize resource handler chain");
     }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Various OS's mount the cgroup v2 differently, some of them mount both the v1 and v2 structure, others mount a hybrid structure. To avoid initialization issues the cgroup v1/v2 functionality should be set by a config property.

### How was this patch tested?
Unit tests

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

