### PR TITLE
YARN-11690. Update container executor to use CGROUP2_SUPER_MAGIC in cgroup 2 scenarios

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.c
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.c
@@ -242,7 +242,7 @@ static int write_pid_to_cgroup_as_root(const char* cgroup_file, pid_t pid) {
            strerror(errno));
     rc = -1;
     goto cleanup;
-  } else if (buf.f_type != CGROUP_SUPER_MAGIC || buf.f_type != CGROUP2_SUPER_MAGIC) {
+  } else if (buf.f_type != CGROUP_SUPER_MAGIC && buf.f_type != CGROUP2_SUPER_MAGIC) {
     fprintf(LOGFILE, "Pid file %s is not located on cgroup/cgroup2 filesystem\n", cgroup_file);
     rc = -1;
     goto cleanup;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.c
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.c
@@ -74,6 +74,11 @@
 #include "compat/unlinkat.h"
 #endif
 
+// include cgroup2 super magic number if not defined
+#ifndef CGROUP2_SUPER_MAGIC
+#define CGROUP2_SUPER_MAGIC 0x63677270
+#endif
+
 static const int DEFAULT_MIN_USERID = 1000;
 
 static const char* DEFAULT_BANNED_USERS[] = {"yarn", "mapred", "hdfs", "bin", 0};

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.c
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.c
@@ -242,8 +242,8 @@ static int write_pid_to_cgroup_as_root(const char* cgroup_file, pid_t pid) {
            strerror(errno));
     rc = -1;
     goto cleanup;
-  } else if (buf.f_type != CGROUP_SUPER_MAGIC) {
-    fprintf(LOGFILE, "Pid file %s is not located on cgroup filesystem\n", cgroup_file);
+  } else if (buf.f_type != CGROUP_SUPER_MAGIC || buf.f_type != CGROUP2_SUPER_MAGIC) {
+    fprintf(LOGFILE, "Pid file %s is not located on cgroup/cgroup2 filesystem\n", cgroup_file);
     rc = -1;
     goto cleanup;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.h
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.h
@@ -80,11 +80,6 @@ enum operations {
 #define ROOT_VAR_TMP_DIR "private_var_slash_tmp"
 #define COMMAND_FILE_SECTION "command-execution"
 
-// include cgroup2 super magic number if not defined
-#ifndef CGROUP2_SUPER_MAGIC
-#define CGROUP2_SUPER_MAGIC 0x63677270
-#endif
-
 extern struct passwd *user_detail;
 extern struct section executor_cfg;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.h
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.h
@@ -80,6 +80,11 @@ enum operations {
 #define ROOT_VAR_TMP_DIR "private_var_slash_tmp"
 #define COMMAND_FILE_SECTION "command-execution"
 
+// include cgroup2 super magic number if not defined
+#ifndef CGROUP2_SUPER_MAGIC
+#define CGROUP2_SUPER_MAGIC 0x63677270
+#endif
+
 extern struct passwd *user_detail;
 extern struct section executor_cfg;
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

The container executor function write_pid_to_cgroup_as_root writes the PID of the newly launched container to the correct cgroup.procs file. However it checks if the file is mounted on a cgroup filesystem, and does that check using the magic number, which differs for v1 and v2. This should handle v1 or v2 filesystems as well.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

