### PR TITLE
HDFS-17502. Adjust the log format of the printStatistics() in FSEditLog.java

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLog.java
@@ -790,13 +790,13 @@ public class FSEditLog implements LogsPurgeable {
     StringBuilder buf = new StringBuilder();
     buf.append("Number of transactions: ")
         .append(numTransactions)
-        .append(" Total time for transactions(ms): ")
+        .append(", Total time for transactions(ms): ")
         .append(totalTimeTransactions)
-        .append(" Number of transactions batched in Syncs: ")
+        .append(", Number of transactions batched in Syncs: ")
         .append(numTransactionsBatchedInSync.longValue())
-        .append(" Number of syncs: ")
+        .append(", Number of syncs: ")
         .append(editLogStream.getNumSync())
-        .append(" SyncTimes(ms): ")
+        .append(", SyncTimes(ms): ")
         .append(journalSet.getSyncTimes());
     LOG.info(buf.toString());
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The current log format of printStatistics() is:
```
2024-04-27 21:15:05,429 [main] INFO  namenode.FSEditLog (FSEditLog.java:printStatistics(801)) - Number of transactions: 2 Total time for transactions(ms): 2 Number of transactions batched in Syncs: 0 Number of syncs: 3 SyncTimes(ms): 1 0
```
There are no separators between different keys, making it difficult to read. The modified format is：
```
2024-04-27 21:15:05,429 [main] INFO  namenode.FSEditLog (FSEditLog.java:printStatistics(801)) - Number of transactions: 2, Total time for transactions(ms): 2, Number of transactions batched in Syncs: 0, Number of syncs: 3, SyncTimes(ms): 1 0 
```

### How was this patch tested?
This patch only updates the log format and does not need to add new test cases.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

