### PR TITLE
HDFS-17452 : DfsRouterAdmin RefreshCallQueue fails when authorization is enabled

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
@@ -1299,7 +1299,14 @@ public class RouterAdmin extends Configured implements Tool {
    * @throws IOException if the operation was not successful.
    */
   private int refreshCallQueue() throws IOException {
+    // for security authorization
+    // server principal for this call
+    // should be Routers's one.
     Configuration conf = getConf();
+    
+    conf.set(CommonConfigurationKeys.HADOOP_SECURITY_SERVICE_USER_NAME_KEY,
+        conf.get(RBFConfigKeys.DFS_ROUTER_KERBEROS_PRINCIPAL_KEY, ""));
+
     String hostport =  getConf().getTrimmed(
         RBFConfigKeys.DFS_ROUTER_ADMIN_ADDRESS_KEY,
         RBFConfigKeys.DFS_ROUTER_ADMIN_ADDRESS_DEFAULT);


### PR DESCRIPTION
### Description of PR

Adding the  kerberos principal key for Router refreshCallQueue command


### How was this patch tested?
On a federated hadoop cluster kerberos was enabled and the command failed. After locally making the change and testing with hadoop jar the command was successful.


