### PR TITLE
YARN-11687. Update CGroupsResourceCalculator to track usages using cgroupv2

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -216,7 +216,6 @@ com.aliyun:aliyun-java-sdk-kms:2.11.0
 com.aliyun:aliyun-java-sdk-ram:3.1.0
 com.aliyun:aliyun-java-sdk-sts:3.0.0
 com.aliyun.oss:aliyun-sdk-oss:3.13.2
-com.amazonaws:aws-java-sdk-bundle:1.12.599
 com.cedarsoftware:java-util:1.9.0
 com.cedarsoftware:json-io:2.5.1
 com.fasterxml.jackson.core:jackson-annotations:2.12.7

--- a/dev-support/bin/yetus-wrapper
+++ b/dev-support/bin/yetus-wrapper
@@ -77,7 +77,7 @@ WANTED="$1"
 shift
 ARGV=("$@")
 
-HADOOP_YETUS_VERSION=${HADOOP_YETUS_VERSION:-0.14.0}
+HADOOP_YETUS_VERSION=${HADOOP_YETUS_VERSION:-0.14.1}
 BIN=$(yetus_abs "${BASH_SOURCE-$0}")
 BINDIR=$(dirname "${BIN}")
 
@@ -123,7 +123,7 @@ fi
 ## need to DL, etc
 ##
 
-BASEURL="https://archive.apache.org/dist/yetus/${HADOOP_YETUS_VERSION}/"
+BASEURL="https://downloads.apache.org/yetus/${HADOOP_YETUS_VERSION}/"
 TARBALL="${YETUS_PREFIX}-${HADOOP_YETUS_VERSION}-bin.tar"
 
 GPGBIN=$(command -v gpg)

--- a/dev-support/docker/Dockerfile_windows_10
+++ b/dev-support/docker/Dockerfile_windows_10
@@ -61,8 +61,8 @@ RUN powershell Invoke-WebRequest -URI https://cdn.azul.com/zulu/bin/zulu8.62.0.1
 RUN powershell Expand-Archive -Path $Env:TEMP\zulu8.62.0.19-ca-jdk8.0.332-win_x64.zip -DestinationPath "C:\Java"
 
 # Install Apache Maven.
-RUN powershell Invoke-WebRequest -URI https://archive.apache.org/dist/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -OutFile $Env:TEMP\apache-maven-3.8.6-bin.zip
-RUN powershell Expand-Archive -Path $Env:TEMP\apache-maven-3.8.6-bin.zip -DestinationPath "C:\Maven"
+RUN powershell Invoke-WebRequest -URI https://downloads.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.zip -OutFile $Env:TEMP\apache-maven-3.8.8-bin.zip
+RUN powershell Expand-Archive -Path $Env:TEMP\apache-maven-3.8.8-bin.zip -DestinationPath "C:\Maven"
 
 # Install CMake 3.19.0.
 RUN powershell Invoke-WebRequest -URI https://cmake.org/files/v3.19/cmake-3.19.0-win64-x64.zip -OutFile $Env:TEMP\cmake-3.19.0-win64-x64.zip
@@ -135,7 +135,7 @@ ENV MAVEN_OPTS '-Xmx2048M -Xss128M'
 ENV IS_WINDOWS 1
 RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 RUN setx PATH "%PATH%;%JAVA_HOME%\bin"
-RUN setx PATH "%PATH%;C:\Maven\apache-maven-3.8.6\bin"
+RUN setx PATH "%PATH%;C:\Maven\apache-maven-3.8.8\bin"
 RUN setx PATH "%PATH%;C:\CMake\cmake-3.19.0-win64-x64\bin"
 RUN setx PATH "%PATH%;C:\ZStd"
 RUN setx PATH "%PATH%;C:\Program Files\Git\usr\bin"

--- a/hadoop-common-project/hadoop-auth/pom.xml
+++ b/hadoop-common-project/hadoop-auth/pom.xml
@@ -136,7 +136,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.kerby</groupId>
-      <artifactId>kerb-simplekdc</artifactId>
+      <artifactId>kerb-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kerby</groupId>
+      <artifactId>kerb-util</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.directory.server</groupId>

--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -1911,7 +1911,7 @@ function hadoop_start_secure_daemon
   if [[ ! -f "${jsvc}" ]]; then
     hadoop_error "JSVC_HOME is not set or set incorrectly. jsvc is required to run secure"
     hadoop_error "or privileged daemons. Please download and install jsvc from "
-    hadoop_error "http://archive.apache.org/dist/commons/daemon/binaries/ "
+    hadoop_error "https://downloads.apache.org/commons/daemon/binaries/ "
     hadoop_error "and set JSVC_HOME to the directory containing the jsvc binary."
     exit 1
   fi

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/CryptoUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/CryptoUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.crypto;
+
+import java.security.Provider;
+import java.security.Security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.store.LogExactlyOnce;
+
+/** Utility methods for the crypto related features. */
+@InterfaceAudience.Private
+public final class CryptoUtils {
+  static final Logger LOG = LoggerFactory.getLogger(CryptoUtils.class);
+  private static final LogExactlyOnce LOG_FAILED_TO_LOAD_CLASS = new LogExactlyOnce(LOG);
+  private static final LogExactlyOnce LOG_FAILED_TO_ADD_PROVIDER = new LogExactlyOnce(LOG);
+
+  private static final String BOUNCY_CASTLE_PROVIDER_CLASS
+      = "org.bouncycastle.jce.provider.BouncyCastleProvider";
+  static final String BOUNCY_CASTLE_PROVIDER_NAME = "BC";
+
+  /**
+   * Get the security provider value specified in
+   * {@link CommonConfigurationKeysPublic#HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_KEY}
+   * from the given conf.
+   *
+   * @param conf the configuration
+   * @return the configured provider, if there is any; otherwise, return an empty string.
+   */
+  public static String getJceProvider(Configuration conf) {
+    final String provider = conf.getTrimmed(
+        CommonConfigurationKeysPublic.HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_KEY, "");
+    final boolean autoAdd = conf.getBoolean(
+        CommonConfigurationKeysPublic.HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_AUTO_ADD_KEY,
+        CommonConfigurationKeysPublic.HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_AUTO_ADD_DEFAULT);
+
+    // For backward compatible, auto-add BOUNCY_CASTLE_PROVIDER_CLASS when the provider is "BC".
+    if (autoAdd && BOUNCY_CASTLE_PROVIDER_NAME.equals(provider)) {
+      try {
+        // Use reflection in order to avoid statically loading the class.
+        final Class<?> clazz = Class.forName(BOUNCY_CASTLE_PROVIDER_CLASS);
+        Security.addProvider((Provider) clazz.getConstructor().newInstance());
+        LOG.debug("Successfully added security provider {}", provider);
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Trace", new Throwable());
+        }
+      } catch (ClassNotFoundException e) {
+        LOG_FAILED_TO_LOAD_CLASS.warn("Failed to load " + BOUNCY_CASTLE_PROVIDER_CLASS, e);
+      } catch (Exception e) {
+        LOG_FAILED_TO_ADD_PROVIDER.warn("Failed to add security provider for {}", provider, e);
+      }
+    }
+    return provider;
+  }
+
+  private CryptoUtils() { }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyProvider.java
@@ -26,7 +26,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
-import java.security.Security;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -35,17 +34,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.crypto.CryptoUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 
 import javax.crypto.KeyGenerator;
 
-import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_KEY;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_CRYPTO_JCEKS_KEY_SERIALFILTER;
 
 /**
@@ -410,10 +408,7 @@ public abstract class KeyProvider implements Closeable {
                       JCEKS_KEY_SERIALFILTER_DEFAULT);
       System.setProperty(JCEKS_KEY_SERIAL_FILTER, serialFilter);
     }
-    String jceProvider = conf.get(HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_KEY);
-    if (BouncyCastleProvider.PROVIDER_NAME.equals(jceProvider)) {
-      Security.addProvider(new BouncyCastleProvider());
-    }
+    CryptoUtils.getJceProvider(conf);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/package-info.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Crypto related classes. */
+package org.apache.hadoop.crypto;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -773,6 +773,9 @@ public class CommonConfigurationKeysPublic {
    */
   public static final String HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_KEY =
     "hadoop.security.crypto.jce.provider";
+  public static final String HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_AUTO_ADD_KEY =
+      "hadoop.security.crypto.jce.provider.auto-add";
+  public static final boolean HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_AUTO_ADD_DEFAULT = true;
   /**
    * @see
    * <a href="{@docRoot}/../hadoop-project-dist/hadoop-common/core-default.xml">

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/CodecPool.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/CodecPool.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.ReflectionUtils;
 
@@ -152,6 +153,9 @@ public class CodecPool {
       compressor = codec.createCompressor();
       LOG.info("Got brand-new compressor ["+codec.getDefaultExtension()+"]");
     } else {
+      if (conf == null && codec instanceof Configurable) {
+        conf = ((Configurable)codec).getConf();
+      }
       compressor.reinit(conf);
       if(LOG.isDebugEnabled()) {
         LOG.debug("Got recycled compressor");

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SaslConstants.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SaslConstants.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.security;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * SASL related constants.
+ */
+@InterfaceAudience.LimitedPrivate({"HDFS", "MapReduce"})
+@InterfaceStability.Evolving
+public class SaslConstants {
+  public static final Logger LOG = LoggerFactory.getLogger(SaslConstants.class);
+
+  private static final String SASL_MECHANISM_ENV = "HADOOP_SASL_MECHANISM";
+  public static final String SASL_MECHANISM;
+  private static final String SASL_MECHANISM_DEFAULT = "DIGEST-MD5";
+
+  static {
+    final String mechanism = System.getenv(SASL_MECHANISM_ENV);
+    LOG.debug("{} = {} (env)", SASL_MECHANISM_ENV, mechanism);
+    SASL_MECHANISM = mechanism != null? mechanism : SASL_MECHANISM_DEFAULT;
+    LOG.debug("{} = {} (effective)", SASL_MECHANISM_ENV, SASL_MECHANISM);
+  }
+
+  private SaslConstants() {}
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SaslRpcServer.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SaslRpcServer.java
@@ -223,8 +223,8 @@ public class SaslRpcServer {
     SIMPLE((byte) 80, ""),
     KERBEROS((byte) 81, "GSSAPI"),
     @Deprecated
-    DIGEST((byte) 82, "DIGEST-MD5"),
-    TOKEN((byte) 82, "DIGEST-MD5"),
+    DIGEST((byte) 82, SaslConstants.SASL_MECHANISM),
+    TOKEN((byte) 82, SaslConstants.SASL_MECHANISM),
     PLAIN((byte) 83, "PLAIN");
 
     /** The code for this method. */
@@ -273,7 +273,7 @@ public class SaslRpcServer {
     }
   };
 
-  /** CallbackHandler for SASL DIGEST-MD5 mechanism */
+  /** CallbackHandler for SASL mechanism. */
   @InterfaceStability.Evolving
   public static class SaslDigestCallbackHandler implements CallbackHandler {
     private SecretManager<TokenIdentifier> secretManager;
@@ -309,7 +309,7 @@ public class SaslRpcServer {
           continue; // realm is ignored
         } else {
           throw new UnsupportedCallbackException(callback,
-              "Unrecognized SASL DIGEST-MD5 Callback");
+              "Unrecognized SASL Callback");
         }
       }
       if (pc != null) {
@@ -319,11 +319,8 @@ public class SaslRpcServer {
         UserGroupInformation user = null;
         user = tokenIdentifier.getUser(); // may throw exception
         connection.attemptingUser = user;
-        
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("SASL server DIGEST-MD5 callback: setting password "
-              + "for client: " + tokenIdentifier.getUser());
-        }
+
+        LOG.debug("SASL server callback: setting password for client: {}", user);
         pc.setPassword(password);
       }
       if (ac != null) {
@@ -339,8 +336,7 @@ public class SaslRpcServer {
             UserGroupInformation logUser =
               getIdentifier(authzid, secretManager).getUser();
             String username = logUser == null ? null : logUser.getUserName();
-            LOG.debug("SASL server DIGEST-MD5 callback: setting "
-                + "canonicalized client ID: " + username);
+            LOG.debug("SASL server callback: setting authorizedID: {}", username);
           }
           ac.setAuthorizedID(authzid);
         }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -88,6 +88,7 @@ import org.apache.hadoop.security.authentication.util.KerberosUtil;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.util.Shell;
+import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Time;
 
 import org.slf4j.Logger;
@@ -1934,10 +1935,7 @@ public class UserGroupInformation {
   @InterfaceAudience.Public
   @InterfaceStability.Evolving
   public <T> T doAs(PrivilegedAction<T> action) {
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("PrivilegedAction [as: {}][action: {}]", this, action,
-          new Exception());
-    }
+    tracePrivilegedAction(action);
     return Subject.doAs(subject, action);
   }
   
@@ -1957,10 +1955,7 @@ public class UserGroupInformation {
   public <T> T doAs(PrivilegedExceptionAction<T> action
                     ) throws IOException, InterruptedException {
     try {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("PrivilegedAction [as: {}][action: {}]", this, action,
-            new Exception());
-      }
+      tracePrivilegedAction(action);
       return Subject.doAs(subject, action);
     } catch (PrivilegedActionException pae) {
       Throwable cause = pae.getCause();
@@ -1979,6 +1974,14 @@ public class UserGroupInformation {
       } else {
         throw new UndeclaredThrowableException(cause);
       }
+    }
+  }
+
+  private void tracePrivilegedAction(Object action) {
+    if (LOG.isTraceEnabled()) {
+      // would be nice if action included a descriptive toString()
+      LOG.trace("PrivilegedAction [as: {}][action: {}][from: {}]", this, action,
+          StringUtils.getStackTrace(new Throwable()));
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.crypto.SecretKey;
 
@@ -122,10 +123,10 @@ extends AbstractDelegationTokenIdentifier>
    */
   private DelegationKey currentKey;
   
-  private long keyUpdateInterval;
-  private long tokenMaxLifetime;
-  private long tokenRemoverScanInterval;
-  private long tokenRenewInterval;
+  private final long keyUpdateInterval;
+  private final long tokenMaxLifetime;
+  private final long tokenRemoverScanInterval;
+  private final long tokenRenewInterval;
   /**
    * Whether to store a token's tracking ID in its TokenInformation.
    * Can be overridden by a subclass.
@@ -139,6 +140,8 @@ extends AbstractDelegationTokenIdentifier>
    * not get interrupted.
    */
   protected Object noInterruptsLock = new Object();
+
+  private final ReentrantReadWriteLock apiLock = new ReentrantReadWriteLock(true);
 
   /**
    * Create a secret manager
@@ -169,21 +172,29 @@ extends AbstractDelegationTokenIdentifier>
   public void startThreads() throws IOException {
     Preconditions.checkState(!running);
     updateCurrentKey();
-    synchronized (this) {
+    this.apiLock.writeLock().lock();
+    try {
       running = true;
       tokenRemoverThread = new Daemon(new ExpiredTokenRemover());
       tokenRemoverThread.start();
+    } finally {
+      this.apiLock.writeLock().unlock();
     }
   }
   
   /**
    * Reset all data structures and mutable state.
    */
-  public synchronized void reset() {
-    setCurrentKeyId(0);
-    allKeys.clear();
-    setDelegationTokenSeqNum(0);
-    currentTokens.clear();
+  public void reset() {
+    this.apiLock.writeLock().lock();
+    try {
+      setCurrentKeyId(0);
+      allKeys.clear();
+      setDelegationTokenSeqNum(0);
+      currentTokens.clear();
+    } finally {
+      this.apiLock.writeLock().unlock();
+    }
   }
 
   /**
@@ -210,17 +221,27 @@ extends AbstractDelegationTokenIdentifier>
    * @param key delegation key.
    * @throws IOException raised on errors performing I/O.
    */
-  public synchronized void addKey(DelegationKey key) throws IOException {
+  public void addKey(DelegationKey key) throws IOException {
     if (running) // a safety check
       throw new IOException("Can't add delegation key to a running SecretManager.");
-    if (key.getKeyId() > getCurrentKeyId()) {
-      setCurrentKeyId(key.getKeyId());
+    this.apiLock.writeLock().lock();
+    try {
+      if (key.getKeyId() > getCurrentKeyId()) {
+        setCurrentKeyId(key.getKeyId());
+      }
+      allKeys.put(key.getKeyId(), key);
+    } finally {
+      this.apiLock.writeLock().unlock();
     }
-    allKeys.put(key.getKeyId(), key);
   }
 
-  public synchronized DelegationKey[] getAllKeys() {
-    return allKeys.values().toArray(new DelegationKey[0]);
+  public DelegationKey[] getAllKeys() {
+    this.apiLock.readLock().lock();
+    try {
+      return allKeys.values().toArray(new DelegationKey[0]);
+    } finally {
+      this.apiLock.readLock().unlock();
+    }
   }
 
   // HDFS
@@ -263,8 +284,13 @@ extends AbstractDelegationTokenIdentifier>
    *
    * @return currentId.
    */
-  protected synchronized int getCurrentKeyId() {
-    return currentId;
+  protected int getCurrentKeyId() {
+    this.apiLock.readLock().lock();
+    try {
+      return currentId;
+    } finally {
+      this.apiLock.readLock().unlock();
+    }
   }
 
   /**
@@ -273,8 +299,13 @@ extends AbstractDelegationTokenIdentifier>
    *
    * @return currentId.
    */
-  protected synchronized int incrementCurrentKeyId() {
-    return ++currentId;
+  protected int incrementCurrentKeyId() {
+    this.apiLock.writeLock().lock();
+    try {
+      return ++currentId;
+    } finally {
+      this.apiLock.writeLock().unlock();
+    }
   }
 
   /**
@@ -283,8 +314,13 @@ extends AbstractDelegationTokenIdentifier>
    *
    * @param keyId keyId.
    */
-  protected synchronized void setCurrentKeyId(int keyId) {
-    currentId = keyId;
+  protected void setCurrentKeyId(int keyId) {
+    this.apiLock.writeLock().lock();
+    try {
+      currentId = keyId;
+    } finally {
+      this.apiLock.writeLock().unlock();
+    }
   }
 
   /**
@@ -293,8 +329,13 @@ extends AbstractDelegationTokenIdentifier>
    *
    * @return delegationTokenSequenceNumber.
    */
-  protected synchronized int getDelegationTokenSeqNum() {
-    return delegationTokenSequenceNumber;
+  protected int getDelegationTokenSeqNum() {
+    this.apiLock.readLock().lock();
+    try {
+      return delegationTokenSequenceNumber;
+    } finally {
+      this.apiLock.readLock().unlock();
+    }
   }
 
   /**
@@ -303,8 +344,13 @@ extends AbstractDelegationTokenIdentifier>
    *
    * @return delegationTokenSequenceNumber.
    */
-  protected synchronized int incrementDelegationTokenSeqNum() {
-    return ++delegationTokenSequenceNumber;
+  protected int incrementDelegationTokenSeqNum() {
+    this.apiLock.writeLock().lock();
+    try {
+      return ++delegationTokenSequenceNumber;
+    } finally {
+      this.apiLock.writeLock().unlock();
+    }
   }
 
   /**
@@ -313,8 +359,13 @@ extends AbstractDelegationTokenIdentifier>
    *
    * @param seqNum seqNum.
    */
-  protected synchronized void setDelegationTokenSeqNum(int seqNum) {
-    delegationTokenSequenceNumber = seqNum;
+  protected void setDelegationTokenSeqNum(int seqNum) {
+    this.apiLock.writeLock().lock();
+    try {
+      delegationTokenSequenceNumber = seqNum;
+    } finally {
+      this.apiLock.writeLock().unlock();
+    }
   }
 
   /**
@@ -401,34 +452,39 @@ extends AbstractDelegationTokenIdentifier>
    * @param renewDate token renew time
    * @throws IOException raised on errors performing I/O.
    */
-  public synchronized void addPersistedDelegationToken(
+  public void addPersistedDelegationToken(
       TokenIdent identifier, long renewDate) throws IOException {
     if (running) {
       // a safety check
       throw new IOException(
           "Can't add persisted delegation token to a running SecretManager.");
     }
-    int keyId = identifier.getMasterKeyId();
-    DelegationKey dKey = allKeys.get(keyId);
-    byte[] password = null;
-    if (dKey == null) {
-      LOG.warn("No KEY found for persisted identifier, expiring stored token "
-          + formatTokenId(identifier));
-      // make sure the token is expired
-      renewDate = 0L;
-    } else {
-      password = createPassword(identifier.getBytes(), dKey.getKey());
-    }
-    if (identifier.getSequenceNumber() > getDelegationTokenSeqNum()) {
-      setDelegationTokenSeqNum(identifier.getSequenceNumber());
-    }
-    if (getTokenInfo(identifier) == null) {
-      currentTokens.put(identifier, new DelegationTokenInformation(renewDate,
-          password, getTrackingIdIfEnabled(identifier)));
-      addTokenForOwnerStats(identifier);
-    } else {
-      throw new IOException("Same delegation token being added twice: "
-          + formatTokenId(identifier));
+    this.apiLock.writeLock().lock();
+    try {
+      int keyId = identifier.getMasterKeyId();
+      DelegationKey dKey = allKeys.get(keyId);
+      byte[] password = null;
+      if (dKey == null) {
+        LOG.warn("No KEY found for persisted identifier, expiring stored token " + formatTokenId(
+            identifier));
+        // make sure the token is expired
+        renewDate = 0L;
+      } else {
+        password = createPassword(identifier.getBytes(), dKey.getKey());
+      }
+      if (identifier.getSequenceNumber() > getDelegationTokenSeqNum()) {
+        setDelegationTokenSeqNum(identifier.getSequenceNumber());
+      }
+      if (getTokenInfo(identifier) == null) {
+        currentTokens.put(identifier, new DelegationTokenInformation(renewDate, password,
+            getTrackingIdIfEnabled(identifier)));
+        addTokenForOwnerStats(identifier);
+      } else {
+        throw new IOException("Same delegation token being added twice: " +
+            formatTokenId(identifier));
+      }
+    } finally {
+      this.apiLock.writeLock().unlock();
     }
   }
 
@@ -441,17 +497,18 @@ extends AbstractDelegationTokenIdentifier>
     LOG.info("Updating the current master key for generating delegation tokens");
     /* Create a new currentKey with an estimated expiry date. */
     int newCurrentId;
-    synchronized (this) {
-      newCurrentId = incrementCurrentKeyId();
-    }
+    newCurrentId = incrementCurrentKeyId();
     DelegationKey newKey = new DelegationKey(newCurrentId, System
         .currentTimeMillis()
         + keyUpdateInterval + tokenMaxLifetime, generateSecret());
     //Log must be invoked outside the lock on 'this'
     logUpdateMasterKey(newKey);
-    synchronized (this) {
+    this.apiLock.writeLock().lock();
+    try {
       currentKey = newKey;
       storeDelegationKey(currentKey);
+    } finally {
+      this.apiLock.writeLock().unlock();
     }
   }
   
@@ -461,7 +518,8 @@ extends AbstractDelegationTokenIdentifier>
    * @throws IOException raised on errors performing I/O.
    */
   protected void rollMasterKey() throws IOException {
-    synchronized (this) {
+    this.apiLock.writeLock().lock();
+    try {
       removeExpiredKeys();
       /* set final expiry date for retiring currentKey */
       currentKey.setExpiryDate(Time.now() + tokenMaxLifetime);
@@ -471,46 +529,59 @@ extends AbstractDelegationTokenIdentifier>
        * allKeys just in case.
        */
       updateDelegationKey(currentKey);
+    } finally {
+      this.apiLock.writeLock().unlock();
     }
     updateCurrentKey();
   }
 
-  private synchronized void removeExpiredKeys() {
-    long now = Time.now();
-    for (Iterator<Map.Entry<Integer, DelegationKey>> it = allKeys.entrySet()
-        .iterator(); it.hasNext();) {
-      Map.Entry<Integer, DelegationKey> e = it.next();
-      if (e.getValue().getExpiryDate() < now) {
-        it.remove();
-        // ensure the tokens generated by this current key can be recovered
-        // with this current key after this current key is rolled
-        if(!e.getValue().equals(currentKey))
-          removeStoredMasterKey(e.getValue());
+  private void removeExpiredKeys() {
+    this.apiLock.writeLock().lock();
+    try {
+      long now = Time.now();
+      for (Iterator<Map.Entry<Integer, DelegationKey>> it =
+           allKeys.entrySet().iterator(); it.hasNext();) {
+        Map.Entry<Integer, DelegationKey> e = it.next();
+        if (e.getValue().getExpiryDate() < now) {
+          it.remove();
+          // ensure the tokens generated by this current key can be recovered
+          // with this current key after this current key is rolled
+          if (!e.getValue().equals(currentKey)) {
+            removeStoredMasterKey(e.getValue());
+          }
+        }
       }
+    } finally {
+      this.apiLock.writeLock().unlock();
     }
   }
   
   @Override
-  protected synchronized byte[] createPassword(TokenIdent identifier) {
-    int sequenceNum;
-    long now = Time.now();
-    sequenceNum = incrementDelegationTokenSeqNum();
-    identifier.setIssueDate(now);
-    identifier.setMaxDate(now + tokenMaxLifetime);
-    identifier.setMasterKeyId(currentKey.getKeyId());
-    identifier.setSequenceNumber(sequenceNum);
-    LOG.info("Creating password for identifier: " + formatTokenId(identifier)
-        + ", currentKey: " + currentKey.getKeyId());
-    byte[] password = createPassword(identifier.getBytes(), currentKey.getKey());
-    DelegationTokenInformation tokenInfo = new DelegationTokenInformation(now
-        + tokenRenewInterval, password, getTrackingIdIfEnabled(identifier));
+  protected byte[] createPassword(TokenIdent identifier) {
+    this.apiLock.writeLock().lock();
     try {
-      METRICS.trackStoreToken(() -> storeToken(identifier, tokenInfo));
-    } catch (IOException ioe) {
-      LOG.error("Could not store token " + formatTokenId(identifier) + "!!",
-          ioe);
+      int sequenceNum;
+      long now = Time.now();
+      sequenceNum = incrementDelegationTokenSeqNum();
+      identifier.setIssueDate(now);
+      identifier.setMaxDate(now + tokenMaxLifetime);
+      identifier.setMasterKeyId(currentKey.getKeyId());
+      identifier.setSequenceNumber(sequenceNum);
+      LOG.info("Creating password for identifier: " + formatTokenId(identifier) +
+          ", currentKey: " + currentKey.getKeyId());
+      byte[] password = createPassword(identifier.getBytes(), currentKey.getKey());
+      DelegationTokenInformation tokenInfo =
+          new DelegationTokenInformation(now + tokenRenewInterval, password,
+              getTrackingIdIfEnabled(identifier));
+      try {
+        METRICS.trackStoreToken(() -> storeToken(identifier, tokenInfo));
+      } catch (IOException ioe) {
+        LOG.error("Could not store token " + formatTokenId(identifier) + "!!", ioe);
+      }
+      return password;
+    } finally {
+      this.apiLock.writeLock().unlock();
     }
-    return password;
   }
 
 
@@ -526,7 +597,6 @@ extends AbstractDelegationTokenIdentifier>
    */
   protected DelegationTokenInformation checkToken(TokenIdent identifier)
       throws InvalidToken {
-    assert Thread.holdsLock(this);
     DelegationTokenInformation info = getTokenInfo(identifier);
     String err;
     if (info == null) {
@@ -546,9 +616,14 @@ extends AbstractDelegationTokenIdentifier>
   }
   
   @Override
-  public synchronized byte[] retrievePassword(TokenIdent identifier)
+  public byte[] retrievePassword(TokenIdent identifier)
       throws InvalidToken {
-    return checkToken(identifier).getPassword();
+    this.apiLock.readLock().lock();
+    try {
+      return checkToken(identifier).getPassword();
+    } finally {
+      this.apiLock.readLock().unlock();
+    }
   }
 
   protected String getTrackingIdIfEnabled(TokenIdent ident) {
@@ -558,12 +633,17 @@ extends AbstractDelegationTokenIdentifier>
     return null;
   }
 
-  public synchronized String getTokenTrackingId(TokenIdent identifier) {
-    DelegationTokenInformation info = getTokenInfo(identifier);
-    if (info == null) {
-      return null;
+  public String getTokenTrackingId(TokenIdent identifier) {
+    this.apiLock.readLock().lock();
+    try {
+      DelegationTokenInformation info = getTokenInfo(identifier);
+      if (info == null) {
+        return null;
+      }
+      return info.getTrackingId();
+    } finally {
+      this.apiLock.readLock().unlock();
     }
-    return info.getTrackingId();
   }
 
   /**
@@ -572,12 +652,17 @@ extends AbstractDelegationTokenIdentifier>
    * @param password Password in the token.
    * @throws InvalidToken InvalidToken.
    */
-  public synchronized void verifyToken(TokenIdent identifier, byte[] password)
+  public void verifyToken(TokenIdent identifier, byte[] password)
       throws InvalidToken {
-    byte[] storedPassword = retrievePassword(identifier);
-    if (!MessageDigest.isEqual(password, storedPassword)) {
-      throw new InvalidToken("token " + formatTokenId(identifier)
-          + " is invalid, password doesn't match");
+    this.apiLock.readLock().lock();
+    try {
+      byte[] storedPassword = retrievePassword(identifier);
+      if (!MessageDigest.isEqual(password, storedPassword)) {
+        throw new InvalidToken("token " + formatTokenId(identifier)
+            + " is invalid, password doesn't match");
+      }
+    } finally {
+      this.apiLock.readLock().unlock();
     }
   }
   
@@ -589,57 +674,55 @@ extends AbstractDelegationTokenIdentifier>
    * @throws InvalidToken if the token is invalid
    * @throws AccessControlException if the user can't renew token
    */
-  public synchronized long renewToken(Token<TokenIdent> token,
+  public long renewToken(Token<TokenIdent> token,
                          String renewer) throws InvalidToken, IOException {
-    ByteArrayInputStream buf = new ByteArrayInputStream(token.getIdentifier());
-    DataInputStream in = new DataInputStream(buf);
-    TokenIdent id = createIdentifier();
-    id.readFields(in);
-    LOG.info("Token renewal for identifier: " + formatTokenId(id)
-        + "; total currentTokens " +  currentTokens.size());
+    this.apiLock.writeLock().lock();
+    try {
+      ByteArrayInputStream buf = new ByteArrayInputStream(token.getIdentifier());
+      DataInputStream in = new DataInputStream(buf);
+      TokenIdent id = createIdentifier();
+      id.readFields(in);
+      LOG.info("Token renewal for identifier: " + formatTokenId(id) + "; total currentTokens "
+          + currentTokens.size());
 
-    long now = Time.now();
-    if (id.getMaxDate() < now) {
-      throw new InvalidToken(renewer + " tried to renew an expired token "
-          + formatTokenId(id) + " max expiration date: "
-          + Time.formatTime(id.getMaxDate())
-          + " currentTime: " + Time.formatTime(now));
-    }
-    if ((id.getRenewer() == null) || (id.getRenewer().toString().isEmpty())) {
-      throw new AccessControlException(renewer +
-          " tried to renew a token " + formatTokenId(id)
-          + " without a renewer");
-    }
-    if (!id.getRenewer().toString().equals(renewer)) {
-      throw new AccessControlException(renewer
-          + " tries to renew a token " + formatTokenId(id)
-          + " with non-matching renewer " + id.getRenewer());
-    }
-    DelegationKey key = getDelegationKey(id.getMasterKeyId());
-    if (key == null) {
-      throw new InvalidToken("Unable to find master key for keyId="
-          + id.getMasterKeyId()
-          + " from cache. Failed to renew an unexpired token "
-          + formatTokenId(id) + " with sequenceNumber="
-          + id.getSequenceNumber());
-    }
-    byte[] password = createPassword(token.getIdentifier(), key.getKey());
-    if (!MessageDigest.isEqual(password, token.getPassword())) {
-      throw new AccessControlException(renewer
-          + " is trying to renew a token "
-          + formatTokenId(id) + " with wrong password");
-    }
-    long renewTime = Math.min(id.getMaxDate(), now + tokenRenewInterval);
-    String trackingId = getTrackingIdIfEnabled(id);
-    DelegationTokenInformation info = new DelegationTokenInformation(renewTime,
-        password, trackingId);
+      long now = Time.now();
+      if (id.getMaxDate() < now) {
+        throw new InvalidToken(renewer + " tried to renew an expired token " + formatTokenId(id) +
+            " max expiration date: " + Time.formatTime(id.getMaxDate()) + " currentTime: " +
+            Time.formatTime(now));
+      }
+      if ((id.getRenewer() == null) || (id.getRenewer().toString().isEmpty())) {
+        throw new AccessControlException(renewer + " tried to renew a token " + formatTokenId(id) +
+            " without a renewer");
+      }
+      if (!id.getRenewer().toString().equals(renewer)) {
+        throw new AccessControlException(renewer + " tries to renew a token " + formatTokenId(id) +
+            " with non-matching renewer " + id.getRenewer());
+      }
+      DelegationKey key = getDelegationKey(id.getMasterKeyId());
+      if (key == null) {
+        throw new InvalidToken("Unable to find master key for keyId=" + id.getMasterKeyId() +
+            " from cache. Failed to renew an unexpired token " + formatTokenId(id) +
+            " with sequenceNumber=" + id.getSequenceNumber());
+      }
+      byte[] password = createPassword(token.getIdentifier(), key.getKey());
+      if (!MessageDigest.isEqual(password, token.getPassword())) {
+        throw new AccessControlException(
+            renewer + " is trying to renew a token " + formatTokenId(id) + " with wrong password");
+      }
+      long renewTime = Math.min(id.getMaxDate(), now + tokenRenewInterval);
+      String trackingId = getTrackingIdIfEnabled(id);
+      DelegationTokenInformation info =
+          new DelegationTokenInformation(renewTime, password, trackingId);
 
-    if (getTokenInfo(id) == null) {
-      throw new InvalidToken("Renewal request for unknown token "
-          + formatTokenId(id));
+      if (getTokenInfo(id) == null) {
+        throw new InvalidToken("Renewal request for unknown token " + formatTokenId(id));
+      }
+      METRICS.trackUpdateToken(() -> updateToken(id, info));
+      return renewTime;
+    } finally {
+      this.apiLock.writeLock().unlock();
     }
-    METRICS.trackUpdateToken(() -> updateToken(id, info));
-    return renewTime;
   }
   
   /**
@@ -651,37 +734,41 @@ extends AbstractDelegationTokenIdentifier>
    * @throws InvalidToken for invalid token
    * @throws AccessControlException if the user isn't allowed to cancel
    */
-  public synchronized TokenIdent cancelToken(Token<TokenIdent> token,
+  public TokenIdent cancelToken(Token<TokenIdent> token,
       String canceller) throws IOException {
-    ByteArrayInputStream buf = new ByteArrayInputStream(token.getIdentifier());
-    DataInputStream in = new DataInputStream(buf);
-    TokenIdent id = createIdentifier();
-    id.readFields(in);
-    LOG.info("Token cancellation requested for identifier: "
-        + formatTokenId(id));
-    
-    if (id.getUser() == null) {
-      throw new InvalidToken("Token with no owner " + formatTokenId(id));
+    this.apiLock.writeLock().lock();
+    try {
+      ByteArrayInputStream buf = new ByteArrayInputStream(token.getIdentifier());
+      DataInputStream in = new DataInputStream(buf);
+      TokenIdent id = createIdentifier();
+      id.readFields(in);
+      LOG.info("Token cancellation requested for identifier: " + formatTokenId(id));
+
+      if (id.getUser() == null) {
+        throw new InvalidToken("Token with no owner " + formatTokenId(id));
+      }
+      String owner = id.getUser().getUserName();
+      Text renewer = id.getRenewer();
+      HadoopKerberosName cancelerKrbName = new HadoopKerberosName(canceller);
+      String cancelerShortName = cancelerKrbName.getShortName();
+      if (!canceller.equals(owner) &&
+          (renewer == null || renewer.toString().isEmpty() ||
+              !cancelerShortName.equals(renewer.toString()))) {
+        throw new AccessControlException(canceller + " is not authorized to cancel the token " +
+            formatTokenId(id));
+      }
+      DelegationTokenInformation info = currentTokens.remove(id);
+      if (info == null) {
+        throw new InvalidToken("Token not found " + formatTokenId(id));
+      }
+      METRICS.trackRemoveToken(() -> {
+        removeTokenForOwnerStats(id);
+        removeStoredToken(id);
+      });
+      return id;
+    } finally {
+      this.apiLock.writeLock().unlock();
     }
-    String owner = id.getUser().getUserName();
-    Text renewer = id.getRenewer();
-    HadoopKerberosName cancelerKrbName = new HadoopKerberosName(canceller);
-    String cancelerShortName = cancelerKrbName.getShortName();
-    if (!canceller.equals(owner)
-        && (renewer == null || renewer.toString().isEmpty() || !cancelerShortName
-            .equals(renewer.toString()))) {
-      throw new AccessControlException(canceller
-          + " is not authorized to cancel the token " + formatTokenId(id));
-    }
-    DelegationTokenInformation info = currentTokens.remove(id);
-    if (info == null) {
-      throw new InvalidToken("Token not found " + formatTokenId(id));
-    }
-    METRICS.trackRemoveToken(() -> {
-      removeTokenForOwnerStats(id);
-      removeStoredToken(id);
-    });
-    return id;
   }
   
   /**
@@ -762,7 +849,8 @@ extends AbstractDelegationTokenIdentifier>
   private void removeExpiredToken() throws IOException {
     long now = Time.now();
     Set<TokenIdent> expiredTokens = new HashSet<>();
-    synchronized (this) {
+    this.apiLock.writeLock().lock();
+    try {
       Iterator<Map.Entry<TokenIdent, DelegationTokenInformation>> i =
           getCandidateTokensForCleanup().entrySet().iterator();
       while (i.hasNext()) {
@@ -774,6 +862,8 @@ extends AbstractDelegationTokenIdentifier>
           i.remove();
         }
       }
+    } finally {
+      this.apiLock.writeLock().unlock();
     }
     // don't hold lock on 'this' to avoid edit log updates blocking token ops
     logExpireTokens(expiredTokens);
@@ -818,10 +908,10 @@ extends AbstractDelegationTokenIdentifier>
    * is secretMgr running
    * @return true if secret mgr is running
    */
-  public synchronized boolean isRunning() {
+  public boolean isRunning() {
     return running;
   }
-  
+
   private class ExpiredTokenRemover extends Thread {
     private long lastMasterKeyUpdate;
     private long lastTokenCacheCleanup;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/ZKDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/ZKDelegationTokenSecretManager.java
@@ -25,7 +25,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
 
 import org.apache.curator.RetryPolicy;
@@ -153,7 +152,7 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
   private final int seqNumBatchSize;
   private int currentSeqNum;
   private int currentMaxSeqNum;
-  private final ReentrantLock currentSeqNumLock;
+
   private final boolean isTokenWatcherEnabled;
 
   public ZKDelegationTokenSecretManager(Configuration conf) {
@@ -169,8 +168,7 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
         ZK_DTSM_TOKEN_SEQNUM_BATCH_SIZE_DEFAULT);
     isTokenWatcherEnabled = conf.getBoolean(ZK_DTSM_TOKEN_WATCHER_ENABLED,
         ZK_DTSM_TOKEN_WATCHER_ENABLED_DEFAULT);
-    this.currentSeqNumLock = new ReentrantLock(true);
-
+    
     String workPath = conf.get(ZK_DTSM_ZNODE_WORKING_PATH, ZK_DTSM_ZNODE_WORKING_PATH_DEAFULT);
     String nameSpace = workPath + "/" + ZK_DTSM_NAMESPACE;
     if (CURATOR_TL.get() != null) {
@@ -506,28 +504,24 @@ public abstract class ZKDelegationTokenSecretManager<TokenIdent extends Abstract
     // The secret manager will keep a local range of seq num which won't be
     // seen by peers, so only when the range is exhausted it will ask zk for
     // another range again
-    try {
-      this.currentSeqNumLock.lock();
-      if (currentSeqNum >= currentMaxSeqNum) {
-        try {
-          // after a successful batch request, we can get the range starting point
-          currentSeqNum = incrSharedCount(delTokSeqCounter, seqNumBatchSize);
-          currentMaxSeqNum = currentSeqNum + seqNumBatchSize;
-          LOG.info("Fetched new range of seq num, from {} to {} ",
-              currentSeqNum+1, currentMaxSeqNum);
-        } catch (InterruptedException e) {
-          // The ExpirationThread is just finishing.. so dont do anything..
-          LOG.debug(
-                  "Thread interrupted while performing token counter increment", e);
-          Thread.currentThread().interrupt();
-        } catch (Exception e) {
-          throw new RuntimeException("Could not increment shared counter !!", e);
-        }
+    if (currentSeqNum >= currentMaxSeqNum) {
+      try {
+        // after a successful batch request, we can get the range starting point
+        currentSeqNum = incrSharedCount(delTokSeqCounter, seqNumBatchSize);
+        currentMaxSeqNum = currentSeqNum + seqNumBatchSize;
+        LOG.info("Fetched new range of seq num, from {} to {} ",
+            currentSeqNum+1, currentMaxSeqNum);
+      } catch (InterruptedException e) {
+        // The ExpirationThread is just finishing.. so dont do anything..
+        LOG.debug(
+            "Thread interrupted while performing token counter increment", e);
+        Thread.currentThread().interrupt();
+      } catch (Exception e) {
+        throw new RuntimeException("Could not increment shared counter !!", e);
       }
-      return ++currentSeqNum;
-    } finally {
-      this.currentSeqNumLock.unlock();
     }
+
+    return ++currentSeqNum;
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/StringUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/StringUtils.java
@@ -1149,6 +1149,19 @@ public class StringUtils {
   }
 
   /**
+   * Get stack trace from throwable exception.
+   * @param t Throwable.
+   * @return stack trace string.
+   */
+  public static String getStackTrace(Throwable t) {
+    StringBuilder str = new StringBuilder();
+    for (StackTraceElement e : t.getStackTrace()) {
+      str.append(e.toString() + "\n\t");
+    }
+    return str.toString();
+  }
+
+  /**
    * From a list of command-line arguments, remove both an option and the 
    * next argument.
    *

--- a/hadoop-common-project/hadoop-common/src/main/native/src/exception.c
+++ b/hadoop-common-project/hadoop-common/src/main/native/src/exception.c
@@ -110,9 +110,16 @@ jthrowable newIOException(JNIEnv* env, const char *fmt, ...)
 
 const char* terror(int errnum)
 {
-
-#if defined(__sun) || defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 32)
 // MT-Safe under Solaris or glibc >= 2.32 not supporting sys_errlist/sys_nerr
+#if defined(__sun)
+  #define USE_STR_ERROR
+#elif defined(__GLIBC_PREREQ)
+  #if __GLIBC_PREREQ(2, 32)
+    #define USE_STR_ERROR
+  #endif
+#endif
+
+#if defined(USE_STR_ERROR)
   return strerror(errnum); 
 #else
   if ((errnum < 0) || (errnum >= sys_nerr)) {
@@ -121,4 +128,3 @@ const char* terror(int errnum)
   return sys_errlist[errnum];
 #endif
 }
-

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -3623,6 +3623,21 @@ The switch to turn S3A auditing on or off.
   <value></value>
   <description>
     The JCE provider name used in CryptoCodec.
+    If this value is set, the corresponding provider must be added to the provider list.
+    The provider may be added statically in the java.security file, or
+    dynamically by calling the java.security.Security.addProvider(..) method, or
+    automatically (only for org.bouncycastle.jce.provider.BouncyCastleProvider)
+    by setting "hadoop.security.crypto.jce.provider.auto-add" to true
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.crypto.jce.provider.auto-add</name>
+  <value>true</value>
+  <description>
+    Automatically add the org.bouncycastle.jce.provider.BouncyCastleProvider
+    when the value in "hadoop.security.crypto.jce.provider" is set
+    to BouncyCastleProvider.PROVIDER_NAME.
   </description>
 </property>
 

--- a/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
@@ -532,6 +532,7 @@ Each metrics record contains tags such as SessionId and Hostname as additional i
 | `NumProcessedCommands` | Num of processed commands of all BPServiceActors |
 | `ProcessedCommandsOpNumOps` | Total number of processed commands operations |
 | `ProcessedCommandsOpAvgTime` | Average time of processed commands operations in milliseconds |
+| `NullStorageBlockReports` | Number of blocks in IBRs that failed due to null storage |
 
 FsVolume
 --------

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/TestCryptoUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/TestCryptoUtils.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.crypto;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.assertj.core.api.Assertions;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.event.Level;
+
+import java.security.Provider;
+import java.security.Security;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_AUTO_ADD_DEFAULT;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_AUTO_ADD_KEY;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_KEY;
+
+/** Test {@link CryptoUtils}. */
+public class TestCryptoUtils {
+  static {
+    GenericTestUtils.setLogLevel(CryptoUtils.LOG, Level.TRACE);
+  }
+
+  @Test(timeout = 1_000)
+  public void testProviderName() {
+    Assert.assertEquals(CryptoUtils.BOUNCY_CASTLE_PROVIDER_NAME, BouncyCastleProvider.PROVIDER_NAME);
+  }
+
+  static void assertRemoveProvider() {
+    Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
+    Assert.assertNull(Security.getProvider(BouncyCastleProvider.PROVIDER_NAME));
+  }
+
+  static void assertSetProvider(Configuration conf) {
+    conf.set(HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_KEY, CryptoUtils.BOUNCY_CASTLE_PROVIDER_NAME);
+    final String providerFromConf = CryptoUtils.getJceProvider(conf);
+    Assert.assertEquals(CryptoUtils.BOUNCY_CASTLE_PROVIDER_NAME, providerFromConf);
+  }
+
+  @Test(timeout = 5_000)
+  public void testAutoAddDisabled() {
+    assertRemoveProvider();
+
+    final Configuration conf = new Configuration();
+    conf.setBoolean(HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_AUTO_ADD_KEY, false);
+
+    assertSetProvider(conf);
+
+    Assert.assertNull(Security.getProvider(BouncyCastleProvider.PROVIDER_NAME));
+  }
+
+  @Test(timeout = 5_000)
+  public void testAutoAddEnabled() {
+    assertRemoveProvider();
+
+    final Configuration conf = new Configuration();
+    Assertions.assertThat(conf.get(HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_AUTO_ADD_KEY))
+        .describedAs("conf: " + HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_AUTO_ADD_KEY)
+        .isEqualToIgnoringCase("true");
+    Assert.assertTrue(HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_AUTO_ADD_DEFAULT);
+
+    conf.set(HADOOP_SECURITY_CRYPTO_JCE_PROVIDER_KEY, CryptoUtils.BOUNCY_CASTLE_PROVIDER_NAME);
+    final String providerFromConf = CryptoUtils.getJceProvider(conf);
+    Assert.assertEquals(CryptoUtils.BOUNCY_CASTLE_PROVIDER_NAME, providerFromConf);
+
+    final Provider provider = Security.getProvider(BouncyCastleProvider.PROVIDER_NAME);
+    Assertions.assertThat(provider)
+        .isInstanceOf(BouncyCastleProvider.class);
+
+    assertRemoveProvider();
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/TestCodecPool.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/TestCodecPool.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertEquals;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -32,7 +34,10 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.zlib.BuiltInGzipCompressor;
 import org.apache.hadoop.io.compress.zlib.BuiltInGzipDecompressor;
+import org.apache.hadoop.io.compress.zlib.ZlibCompressor.CompressionLevel;
+import org.apache.hadoop.io.compress.zlib.ZlibFactory;
 import org.apache.hadoop.test.LambdaTestUtils;
+import org.apache.hadoop.util.ReflectionUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -84,6 +89,36 @@ public class TestCodecPool {
     for (Compressor compressor : compressors) {
       CodecPool.returnCompressor(compressor);
     }
+  }
+
+  @Test(timeout = 10000)
+  public void testCompressorConf() throws Exception {
+    DefaultCodec codec1 = new DefaultCodec();
+    Configuration conf = new Configuration();
+    ZlibFactory.setCompressionLevel(conf, CompressionLevel.TWO);
+    codec1.setConf(conf);
+    Compressor comp1 = CodecPool.getCompressor(codec1);
+    CodecPool.returnCompressor(comp1);
+
+    DefaultCodec codec2 = new DefaultCodec();
+    Configuration conf2 = new Configuration();
+    CompressionLevel newCompressionLevel = CompressionLevel.THREE;
+    ZlibFactory.setCompressionLevel(conf2, newCompressionLevel);
+    codec2.setConf(conf2);
+    Compressor comp2 = CodecPool.getCompressor(codec2);
+    List<Field> fields = ReflectionUtils.getDeclaredFieldsIncludingInherited(comp2.getClass());
+    for (Field field : fields) {
+      if (field.getName().equals("level")) {
+        field.setAccessible(true);
+        Object levelValue = field.get(comp2);
+        if (levelValue instanceof CompressionLevel) {
+          assertEquals(newCompressionLevel, levelValue);
+        } else {
+          assertEquals(3, levelValue);
+        }
+      }
+    }
+    CodecPool.returnCompressor(comp2);
   }
 
   @Test(timeout = 10000)

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSaslRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSaslRPC.java
@@ -536,7 +536,7 @@ public class TestSaslRPC extends TestRpcBase {
   private static Pattern BadToken =
       Pattern.compile("^" + RemoteException.class.getName() +
           "\\("+ SaslException.class.getName() + "\\): " +
-          "DIGEST-MD5: digest response format violation.*");
+          SaslConstants.SASL_MECHANISM + ": digest response format violation.*");
   private static Pattern KrbFailed =
       Pattern.compile(".*Failed on local exception:.* " +
                       "Failed to specify server's Kerberos principal name.*");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestStringUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestStringUtils.java
@@ -624,6 +624,15 @@ public class TestStringUtils extends UnitTestcaseTimeLimit {
         () -> StringUtils.getTrimmedStringCollectionSplitByEquals(",="));
   }
 
+  @Test
+  public void testForGetStackTrace() {
+    Throwable throwable = new Throwable();
+    int stackLength = throwable.getStackTrace().length;
+    String stackTrace = StringUtils.getStackTrace(new Throwable());
+    String[] splitTrace = stackTrace.split("\n\t");
+    assertEquals(stackLength, splitTrace.length);
+  }
+
   // Benchmark for StringUtils split
   public static void main(String []args) {
     final String TO_SPLIT = "foo,bar,baz,blah,blah";

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/metrics/BlockReaderIoProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/metrics/BlockReaderIoProvider.java
@@ -65,7 +65,7 @@ public class BlockReaderIoProvider {
   public int read(FileChannel dataIn, ByteBuffer dst, long position)
       throws IOException{
     final int nRead;
-    if (isEnabled && (ThreadLocalRandom.current().nextInt() < sampleRangeMax)) {
+    if (isEnabled && (ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE) < sampleRangeMax)) {
       long begin = timer.monotonicNow();
       nRead = dataIn.read(dst, position);
       long latency = timer.monotonicNow() - begin;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslParticipant.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslParticipant.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.hdfs.protocol.datatransfer.IOStreamPair;
 import org.apache.hadoop.security.FastSaslClientFactory;
 import org.apache.hadoop.security.FastSaslServerFactory;
+import org.apache.hadoop.security.SaslConstants;
 import org.apache.hadoop.security.SaslInputStream;
 import org.apache.hadoop.security.SaslOutputStream;
 
@@ -50,7 +51,7 @@ class SaslParticipant {
   // a short string.
   private static final String SERVER_NAME = "0";
   private static final String PROTOCOL = "hdfs";
-  private static final String MECHANISM = "DIGEST-MD5";
+  private static final String[] MECHANISM_ARRAY = {SaslConstants.SASL_MECHANISM};
 
   // One of these will always be null.
   private final SaslServer saslServer;
@@ -81,7 +82,7 @@ class SaslParticipant {
       Map<String, String> saslProps, CallbackHandler callbackHandler)
       throws SaslException {
     initializeSaslServerFactory();
-    return new SaslParticipant(saslServerFactory.createSaslServer(MECHANISM,
+    return new SaslParticipant(saslServerFactory.createSaslServer(MECHANISM_ARRAY[0],
       PROTOCOL, SERVER_NAME, saslProps, callbackHandler));
   }
 
@@ -99,7 +100,7 @@ class SaslParticipant {
       throws SaslException {
     initializeSaslClientFactory();
     return new SaslParticipant(
-        saslClientFactory.createSaslClient(new String[] {MECHANISM}, userName,
+        saslClientFactory.createSaslClient(MECHANISM_ARRAY, userName,
             PROTOCOL, SERVER_NAME, saslProps, callbackHandler));
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/PoolAlignmentContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/PoolAlignmentContext.java
@@ -64,7 +64,12 @@ public class PoolAlignmentContext implements AlignmentContext {
    */
   @Override
   public void receiveResponseState(RpcHeaderProtos.RpcResponseHeaderProto header) {
-    sharedGlobalStateId.accumulate(header.getStateId());
+    if (header.getStateId() == 0 && sharedGlobalStateId.get() > 0) {
+      sharedGlobalStateId.reset();
+      poolLocalStateId.reset();
+    } else {
+      sharedGlobalStateId.accumulate(header.getStateId());
+    }
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -1698,42 +1698,6 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
   }
 
   /**
-   * Locate the location with the matching block pool id.
-   *
-   * @param path Path to check.
-   * @param failIfLocked Fail the request if locked (top mount point).
-   * @param blockPoolId The block pool ID of the namespace to search for.
-   * @return Prioritized list of locations in the federated cluster.
-   * @throws IOException if the location for this path cannot be determined.
-   */
-  protected RemoteLocation getLocationForPath(
-      String path, boolean failIfLocked, String blockPoolId)
-          throws IOException {
-
-    final List<RemoteLocation> locations =
-        getLocationsForPath(path, failIfLocked);
-
-    String nameserviceId = null;
-    Set<FederationNamespaceInfo> namespaces =
-        this.namenodeResolver.getNamespaces();
-    for (FederationNamespaceInfo namespace : namespaces) {
-      if (namespace.getBlockPoolId().equals(blockPoolId)) {
-        nameserviceId = namespace.getNameserviceId();
-        break;
-      }
-    }
-    if (nameserviceId != null) {
-      for (RemoteLocation location : locations) {
-        if (location.getNameserviceId().equals(nameserviceId)) {
-          return location;
-        }
-      }
-    }
-    throw new IOException(
-        "Cannot locate a nameservice for block pool " + blockPoolId);
-  }
-
-  /**
    * Get the possible locations of a path in the federated cluster.
    * During the get operation, it will do the quota verification.
    *

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/CachedRecordStore.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/CachedRecordStore.java
@@ -189,7 +189,7 @@ public abstract class CachedRecordStore<R extends BaseRecord>
           LOG.warn("Couldn't delete State Store record {}: {}", recordName,
               record);
         }
-      } else if (record.checkExpired(currentDriverTime)) {
+      } else if (!record.isExpired() && record.checkExpired(currentDriverTime)) {
         String recordName = StateStoreUtils.getRecordName(record.getClass());
         LOG.info("Override State Store record {}: {}", recordName, record);
         commitRecords.add(record);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
@@ -241,7 +241,7 @@ public class SaslDataTransferServer {
           continue; // realm is ignored
         } else {
           throw new UnsupportedCallbackException(callback,
-              "Unrecognized SASL DIGEST-MD5 Callback: " + callback);
+              "Unrecognized SASL Callback: " + callback);
         }
       }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeHttpServer.java
@@ -78,6 +78,16 @@ public class JournalNodeHttpServer {
         DFSConfigKeys.DFS_JOURNALNODE_KERBEROS_INTERNAL_SPNEGO_PRINCIPAL_KEY,
         DFSConfigKeys.DFS_JOURNALNODE_KEYTAB_FILE_KEY);
 
+    final boolean xFrameEnabled = conf.getBoolean(
+        DFSConfigKeys.DFS_XFRAME_OPTION_ENABLED,
+        DFSConfigKeys.DFS_XFRAME_OPTION_ENABLED_DEFAULT);
+
+    final String xFrameOptionValue = conf.getTrimmed(
+        DFSConfigKeys.DFS_XFRAME_OPTION_VALUE,
+        DFSConfigKeys.DFS_XFRAME_OPTION_VALUE_DEFAULT);
+
+    builder.configureXFrame(xFrameEnabled).setXFrameOption(xFrameOptionValue);
+
     httpServer = builder.build();
     httpServer.setAttribute(JN_ATTRIBUTE_KEY, localJournalNode);
     httpServer.setAttribute(JspHelper.CURRENT_CONF, conf);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
@@ -434,12 +434,12 @@ class BlockSender implements java.io.Closeable {
       blockIn = datanode.data.getBlockInputStream(block, offset); // seek to offset
       ris = new ReplicaInputStreams(
           blockIn, checksumIn, volumeRef, fileIoProvider);
-    } catch (IOException ioe) {
+    } catch (Throwable t) {
       IOUtils.cleanupWithLogger(null, volumeRef);
       IOUtils.closeStream(this);
       IOUtils.closeStream(blockIn);
       IOUtils.closeStream(checksumIn);
-      throw ioe;
+      throw t;
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -4057,7 +4057,8 @@ public class DataNode extends ReconfigurableBase
     }
   }
 
-  private void handleVolumeFailures(Set<FsVolumeSpi> unhealthyVolumes) {
+  @VisibleForTesting
+  public void handleVolumeFailures(Set<FsVolumeSpi> unhealthyVolumes) {
     if (unhealthyVolumes.isEmpty()) {
       LOG.debug("handleVolumeFailures done with empty " +
           "unhealthyVolumes");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeFaultInjector.java
@@ -172,4 +172,10 @@ public class DataNodeFaultInjector {
    * Just delay getMetaDataInputStream a while.
    */
   public void delayGetMetaDataInputStream() {}
+
+  /**
+   * Used in {@link DirectoryScanner#reconcile()} to wait until a storage is removed,
+   * leaving a stale copy of {@link DirectoryScanner#diffs}.
+   */
+  public void waitUntilStorageRemoved() {}
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DirectoryScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DirectoryScanner.java
@@ -466,7 +466,7 @@ public class DirectoryScanner implements Runnable {
   public void reconcile() throws IOException {
     LOG.debug("reconcile start DirectoryScanning");
     scan();
-
+    DataNodeFaultInjector.get().waitUntilStorageRemoved();
     // HDFS-14476: run checkAndUpdate with batch to avoid holding the lock too
     // long
     int loopCount = 0;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ProfilingFileIoEvents.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ProfilingFileIoEvents.java
@@ -80,7 +80,7 @@ class ProfilingFileIoEvents {
 
   public long beforeFileIo(@Nullable FsVolumeSpi volume,
       FileIoProvider.OPERATION op, long len) {
-    if (isEnabled && ThreadLocalRandom.current().nextInt() < sampleRangeMax) {
+    if (isEnabled && ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE) < sampleRangeMax) {
       DataNodeVolumeMetrics metrics = getVolumeMetrics(volume);
       if (metrics != null) {
         return Time.monotonicNow();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
@@ -1291,7 +1291,9 @@ public class FsVolumeImpl implements FsVolumeSpi {
 
     // rename meta file to rbw directory
     // rename block file to rbw directory
+    long oldReplicaLength = replicaInfo.getNumBytes() + replicaInfo.getMetadataLength();
     newReplicaInfo.moveReplicaFrom(replicaInfo, newBlkFile);
+    getBlockPoolSlice(bpid).decDfsUsed(oldReplicaLength);
 
     reserveSpaceForReplica(bytesReserved);
     return newReplicaInfo;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
@@ -185,6 +185,8 @@ public class DataNodeMetrics {
   private MutableCounterLong numProcessedCommands;
   @Metric("Rate of processed commands of all BPServiceActors")
   private MutableRate processedCommandsOp;
+  @Metric("Number of blocks in IBRs that failed due to null storage")
+  private MutableCounterLong nullStorageBlockReports;
 
   // FsDatasetImpl local file process metrics.
   @Metric private MutableRate createRbwOp;
@@ -812,4 +814,7 @@ public class DataNodeMetrics {
     replaceBlockOpToOtherHost.incr();
   }
 
+  public void incrNullStorageBlockReports() {
+    nullStorageBlockReports.incr();
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -2618,9 +2618,10 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
    * @throws  IOException
    */
   BlockStoragePolicy getStoragePolicy(String src) throws IOException {
+    final String operationName = "getStoragePolicy";
     checkOperation(OperationCategory.READ);
     final FSPermissionChecker pc = getPermissionChecker();
-    FSPermissionChecker.setOperationType(null);
+    FSPermissionChecker.setOperationType(operationName);
     readLock();
     try {
       checkOperation(OperationCategory.READ);
@@ -2646,9 +2647,10 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   }
 
   long getPreferredBlockSize(String src) throws IOException {
+    final String operationName = "getPreferredBlockSize";
     checkOperation(OperationCategory.READ);
     final FSPermissionChecker pc = getPermissionChecker();
-    FSPermissionChecker.setOperationType(null);
+    FSPermissionChecker.setOperationType(operationName);
     readLock();
     try {
       checkOperation(OperationCategory.READ);
@@ -2709,6 +2711,8 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       String storagePolicy, boolean logRetryCache) throws IOException {
 
     HdfsFileStatus status;
+    final String operationName = "create";
+    FSPermissionChecker.setOperationType(operationName);
     try {
       status = startFileInt(src, permissions, holder, clientMachine, flag,
           createParent, replication, blockSize, supportedVersions, ecPolicyName,
@@ -2764,7 +2768,6 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
 
     checkOperation(OperationCategory.WRITE);
     final FSPermissionChecker pc = getPermissionChecker();
-    FSPermissionChecker.setOperationType(null);
     writeLock();
     try {
       checkOperation(OperationCategory.WRITE);
@@ -2857,9 +2860,10 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   boolean recoverLease(String src, String holder, String clientMachine)
       throws IOException {
     boolean skipSync = false;
+    final String operationName = "recoverLease";
     checkOperation(OperationCategory.WRITE);
     final FSPermissionChecker pc = getPermissionChecker();
-    FSPermissionChecker.setOperationType(null);
+    FSPermissionChecker.setOperationType(operationName);
     writeLock();
     try {
       checkOperation(OperationCategory.WRITE);
@@ -3105,9 +3109,10 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     final byte storagePolicyID;
     final List<DatanodeStorageInfo> chosen;
     final BlockType blockType;
+    final String operationName = "getAdditionalDatanode";
     checkOperation(OperationCategory.WRITE);
     final FSPermissionChecker pc = getPermissionChecker();
-    FSPermissionChecker.setOperationType(null);
+    FSPermissionChecker.setOperationType(operationName);
     readLock();
     try {
       // Changing this operation category to WRITE instead of making getAdditionalDatanode as a
@@ -3155,10 +3160,11 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
    */
   void abandonBlock(ExtendedBlock b, long fileId, String src, String holder)
       throws IOException {
+    final String operationName = "abandonBlock";
     NameNode.stateChangeLog.debug("BLOCK* NameSystem.abandonBlock: {} of file {}", b, src);
     checkOperation(OperationCategory.WRITE);
     final FSPermissionChecker pc = getPermissionChecker();
-    FSPermissionChecker.setOperationType(null);
+    FSPermissionChecker.setOperationType(operationName);
     writeLock();
     try {
       checkOperation(OperationCategory.WRITE);
@@ -3222,9 +3228,10 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
                        ExtendedBlock last, long fileId)
     throws IOException {
     boolean success = false;
+    final String operationName = "completeFile";
     checkOperation(OperationCategory.WRITE);
     final FSPermissionChecker pc = getPermissionChecker();
-    FSPermissionChecker.setOperationType(null);
+    FSPermissionChecker.setOperationType(operationName);
     writeLock();
     try {
       checkOperation(OperationCategory.WRITE);
@@ -3666,10 +3673,11 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
    */
   void fsync(String src, long fileId, String clientName, long lastBlockLength)
       throws IOException {
+    final String operationName = "fsync";
     NameNode.stateChangeLog.info("BLOCK* fsync: " + src + " for " + clientName);
     checkOperation(OperationCategory.WRITE);
     final FSPermissionChecker pc = getPermissionChecker();
-    FSPermissionChecker.setOperationType(null);
+    FSPermissionChecker.setOperationType(operationName);
     writeLock();
     try {
       checkOperation(OperationCategory.WRITE);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -1531,10 +1531,10 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       if (dir != null && getFSImage() != null) {
         if (getFSImage().editLog != null) {
           getFSImage().editLog.close();
+          // Update the fsimage with the last txid that we wrote
+          // so that the tailer starts from the right spot.
+          getFSImage().updateLastAppliedTxIdFromWritten();
         }
-        // Update the fsimage with the last txid that we wrote
-        // so that the tailer starts from the right spot.
-        getFSImage().updateLastAppliedTxIdFromWritten();
       }
       if (dir != null) {
         dir.ezManager.stopReencryptThread();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
@@ -2095,22 +2095,20 @@ public class DFSAdmin extends FsShell {
     if (errMsg != null) {
       err.println(errMsg);
       return 1;
-    } else {
-      out.print(outMsg);
     }
 
     if (status != null) {
       if (!status.hasTask()) {
-        out.println("no task was found.");
+        out.println(outMsg + "no task was found.");
         return 0;
       }
-      out.print("started at " + new Date(status.getStartTime()));
+      String startMsg = outMsg + "started at " + new Date(status.getStartTime());
       if (!status.stopped()) {
-        out.println(" and is still running.");
+        out.println(startMsg + " and is still running.");
         return 0;
       }
 
-      out.println(" and finished at "
+      out.println(startMsg + " and finished at "
           + new Date(status.getEndTime()).toString() + ".");
       if (status.getStatus() == null) {
         // Nothing to report.
@@ -2133,6 +2131,7 @@ public class DFSAdmin extends FsShell {
         }
       }
     } else {
+      out.println(outMsg);
       return 1;
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeHttpServerXFrame.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeHttpServerXFrame.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdfs.qjournal.server;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.qjournal.MiniJournalCluster;
+import org.apache.hadoop.http.HttpServer2;
+
+/**
+ * Test that X-Frame-Options works correctly with JournalNodeHttpServer.
+ */
+public class TestJournalNodeHttpServerXFrame {
+
+  private static final int NUM_JN = 1;
+
+  private MiniJournalCluster cluster;
+
+  @Test
+  public void testJournalNodeXFrameOptionsEnabled() throws Exception {
+    boolean xFrameEnabled = true;
+    cluster = createCluster(xFrameEnabled);
+    HttpURLConnection conn = getConn(cluster);
+    String xfoHeader = conn.getHeaderField("X-FRAME-OPTIONS");
+    Assert.assertTrue("X-FRAME-OPTIONS is absent in the header", xfoHeader != null);
+    Assert.assertTrue(xfoHeader.endsWith(HttpServer2.XFrameOption.SAMEORIGIN.toString()));
+  }
+
+  @Test
+  public void testJournalNodeXFrameOptionsDisabled() throws Exception {
+    boolean xFrameEnabled = false;
+    cluster = createCluster(xFrameEnabled);
+    HttpURLConnection conn = getConn(cluster);
+    String xfoHeader = conn.getHeaderField("X-FRAME-OPTIONS");
+    System.out.println(xfoHeader);
+    Assert.assertTrue("unexpected X-FRAME-OPTION in header", xfoHeader == null);
+  }
+
+  @After
+  public void cleanup() throws IOException {
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
+    }
+  }
+
+  private static MiniJournalCluster createCluster(boolean enabled) throws IOException {
+    Configuration conf = new Configuration();
+    conf.setBoolean(DFSConfigKeys.DFS_XFRAME_OPTION_ENABLED, enabled);
+    MiniJournalCluster jCluster =
+        new MiniJournalCluster.Builder(conf).format(true).numJournalNodes(NUM_JN).build();
+    jCluster.waitActive();
+    return jCluster;
+  }
+
+  private static HttpURLConnection getConn(MiniJournalCluster journalCluster) throws IOException {
+    JournalNode journalNode = journalCluster.getJournalNode(0);
+    URL newURL = new URL(journalNode.getHttpServerURI());
+    HttpURLConnection conn = (HttpURLConnection) newURL.openConnection();
+    conn.connect();
+    return conn;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBPOfferService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBPOfferService.java
@@ -136,6 +136,7 @@ public class TestBPOfferService {
   private FsDatasetSpi<?> mockFSDataset;
   private DataSetLockManager dataSetLockManager = new DataSetLockManager();
   private boolean isSlownode;
+  private String mockStorageID;
 
   @Before
   public void setupMocks() throws Exception {
@@ -157,6 +158,7 @@ public class TestBPOfferService {
     // Set up a simulated dataset with our fake BP
     mockFSDataset = Mockito.spy(new SimulatedFSDataset(null, conf));
     mockFSDataset.addBlockPool(FAKE_BPID, conf);
+    mockStorageID = ((SimulatedFSDataset) mockFSDataset).getStorages().get(0).getStorageUuid();
 
     // Wire the dataset to the DN.
     Mockito.doReturn(mockFSDataset).when(mockDn).getFSDataset();
@@ -289,7 +291,7 @@ public class TestBPOfferService {
       waitForBlockReport(mockNN2);
 
       // When we receive a block, it should report it to both NNs
-      bpos.notifyNamenodeReceivedBlock(FAKE_BLOCK, null, "", false);
+      bpos.notifyNamenodeReceivedBlock(FAKE_BLOCK, null, mockStorageID, false);
 
       ReceivedDeletedBlockInfo[] ret = waitForBlockReceived(FAKE_BLOCK, mockNN1);
       assertEquals(1, ret.length);
@@ -1099,7 +1101,7 @@ public class TestBPOfferService {
       waitForBlockReport(mockNN2);
 
       // When we receive a block, it should report it to both NNs
-      bpos.notifyNamenodeReceivedBlock(FAKE_BLOCK, null, "", false);
+      bpos.notifyNamenodeReceivedBlock(FAKE_BLOCK, null, mockStorageID, false);
 
       ReceivedDeletedBlockInfo[] ret = waitForBlockReceived(FAKE_BLOCK,
           mockNN1);
@@ -1140,7 +1142,7 @@ public class TestBPOfferService {
       Mockito.verify(mockNN3).registerDatanode(Mockito.any());
 
       // When we receive a block, it should report it to both NNs
-      bpos.notifyNamenodeReceivedBlock(FAKE_BLOCK, null, "", false);
+      bpos.notifyNamenodeReceivedBlock(FAKE_BLOCK, null, mockStorageID, false);
 
       // veridfy new NN recieved block report
       ret = waitForBlockReceived(FAKE_BLOCK, mockNN3);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -2102,4 +2102,46 @@ public class TestFsDatasetImpl {
       DataNodeFaultInjector.set(oldDnInjector);
     }
   }
+
+  @Test(timeout = 30000)
+  public void testAppend() {
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf)
+          .numDataNodes(1)
+          .storageTypes(new StorageType[]{StorageType.DISK, StorageType.DISK})
+          .storagesPerDatanode(2)
+          .build();
+      FileSystem fs = cluster.getFileSystem();
+      DataNode dataNode = cluster.getDataNodes().get(0);
+
+      // Create test file
+      Path filePath = new Path("testData");
+      FsDatasetImpl fsDataSetImpl = (FsDatasetImpl) dataNode.getFSDataset();
+      DFSTestUtil.createFile(fs, filePath, 100, (short) 1, 0);
+      ExtendedBlock block = DFSTestUtil.getFirstBlock(fs, filePath);
+      ReplicaInfo replicaInfo = fsDataSetImpl.getReplicaInfo(block);
+      long oldMetaLength = replicaInfo.getMetadataLength();
+      long oldDfsUsed = fsDataSetImpl.getDfsUsed();
+
+      // Append to file
+      int appendLength = 100;
+      DFSTestUtil.appendFile(fs, filePath, appendLength);
+
+      block = DFSTestUtil.getFirstBlock(fs, filePath);
+      replicaInfo = fsDataSetImpl.getReplicaInfo(block);
+      long newMetaLength = replicaInfo.getMetadataLength();
+      long newDfsUsed = fsDataSetImpl.getDfsUsed();
+
+      assert newDfsUsed == oldDfsUsed + appendLength + (newMetaLength - oldMetaLength) :
+          "When appending a file, the dfsused statistics of datanode are incorrect.";
+    } catch (Exception ex) {
+      LOG.info("Exception in testAppend ", ex);
+      fail("Exception while testing testAppend ");
+    } finally {
+      if (cluster.isClusterUp()) {
+        cluster.shutdown();
+      }
+    }
+  }
 }

--- a/hadoop-mapreduce-project/bin/mapred
+++ b/hadoop-mapreduce-project/bin/mapred
@@ -37,6 +37,7 @@ function hadoop_usage
   hadoop_add_subcommand "frameworkuploader" admin "mapreduce framework upload"
   hadoop_add_subcommand "version" client "print the version"
   hadoop_add_subcommand "minicluster" client "CLI MiniCluster"
+  hadoop_add_subcommand "successfile" client "Print a _SUCCESS manifest from the manifest and S3A committers"
   hadoop_generate_usage "${HADOOP_SHELL_EXECNAME}" true
 }
 
@@ -101,6 +102,9 @@ function mapredcmd_case
     ;;
     version)
       HADOOP_CLASSNAME=org.apache.hadoop.util.VersionInfo
+    ;;
+    successfile)
+      HADOOP_CLASSNAME=org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.ManifestPrinter
     ;;
     minicluster)
       hadoop_add_classpath "${HADOOP_YARN_HOME}/${YARN_DIR}/timelineservice"'/*'

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterConstants.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterConstants.java
@@ -132,7 +132,9 @@ public final class ManifestCommitterConstants {
    * Should dir cleanup do parallel deletion of task attempt dirs
    * before trying to delete the toplevel dirs.
    * For GCS this may deliver speedup, while on ABFS it may avoid
-   * timeouts in certain deployments.
+   * timeouts in certain deployments, something
+   * {@link #OPT_CLEANUP_PARALLEL_DELETE_BASE_FIRST}
+   * can alleviate.
    * Value: {@value}.
    */
   public static final String OPT_CLEANUP_PARALLEL_DELETE =
@@ -142,6 +144,20 @@ public final class ManifestCommitterConstants {
    * Default value:  {@value}.
    */
   public static final boolean OPT_CLEANUP_PARALLEL_DELETE_DIRS_DEFAULT = true;
+
+  /**
+   * Should parallel cleanup try to delete the base first?
+   * Best for azure as it skips the task attempt deletions unless
+   * the toplevel delete fails.
+   * Value: {@value}.
+   */
+  public static final String OPT_CLEANUP_PARALLEL_DELETE_BASE_FIRST =
+      OPT_PREFIX + "cleanup.parallel.delete.base.first";
+
+  /**
+   * Default value of option {@link #OPT_CLEANUP_PARALLEL_DELETE_BASE_FIRST}:  {@value}.
+   */
+  public static final boolean OPT_CLEANUP_PARALLEL_DELETE_BASE_FIRST_DEFAULT = false;
 
   /**
    * Threads to use for IO.
@@ -259,6 +275,19 @@ public final class ManifestCommitterConstants {
    * Value {@value}.
    */
   public static final int DEFAULT_WRITER_QUEUE_CAPACITY = OPT_IO_PROCESSORS_DEFAULT;
+
+  /**
+   * How many attempts to save a task manifest by save and rename
+   * before giving up.
+   * Value: {@value}.
+   */
+  public static final String OPT_MANIFEST_SAVE_ATTEMPTS =
+      OPT_PREFIX + "manifest.save.attempts";
+
+  /**
+   * Default value of {@link #OPT_MANIFEST_SAVE_ATTEMPTS}: {@value}.
+   */
+  public static final int OPT_MANIFEST_SAVE_ATTEMPTS_DEFAULT = 5;
 
   private ManifestCommitterConstants() {
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterStatisticNames.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterStatisticNames.java
@@ -188,6 +188,12 @@ public final class ManifestCommitterStatisticNames {
       "task_stage_save_task_manifest";
 
   /**
+   * Save a summary file: {@value}.
+   */
+  public static final String OP_SAVE_SUMMARY_FILE =
+      "task_stage_save_summary_file";
+
+  /**
    * Task abort: {@value}.
    */
   public static final String OP_STAGE_TASK_ABORT_TASK
@@ -258,6 +264,9 @@ public final class ManifestCommitterStatisticNames {
   /** Task Scan directory Stage: {@value}. */
   public static final String OP_STAGE_TASK_SCAN_DIRECTORY
       = "task_stage_scan_directory";
+
+  /** Delete a directory: {@value}. */
+  public static final String OP_DELETE_DIR = "op_delete_dir";
 
   private ManifestCommitterStatisticNames() {
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/files/ManifestPrinter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/files/ManifestPrinter.java
@@ -36,7 +36,7 @@ import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsTo
  */
 public class ManifestPrinter extends Configured implements Tool {
 
-  private static final String USAGE = "ManifestPrinter <success-file>";
+  private static final String USAGE = "successfile <success-file>";
 
   /**
    * Output for printing.
@@ -88,7 +88,7 @@ public class ManifestPrinter extends Configured implements Tool {
     return success;
   }
 
-  private void printManifest(ManifestSuccessData success) {
+  public void printManifest(ManifestSuccessData success) {
     field("succeeded", success.getSuccess());
     field("created", success.getDate());
     field("committer", success.getCommitter());

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/InternalConstants.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/InternalConstants.java
@@ -73,6 +73,7 @@ public final class InternalConstants {
       OP_CREATE_ONE_DIRECTORY,
       OP_DIRECTORY_SCAN,
       OP_DELETE,
+      OP_DELETE_DIR,
       OP_DELETE_FILE_UNDER_DESTINATION,
       OP_GET_FILE_STATUS,
       OP_IS_DIRECTORY,
@@ -85,6 +86,7 @@ public final class InternalConstants {
       OP_MSYNC,
       OP_PREPARE_DIR_ANCESTORS,
       OP_RENAME_FILE,
+      OP_SAVE_SUMMARY_FILE,
       OP_SAVE_TASK_MANIFEST,
 
       OBJECT_LIST_REQUEST,
@@ -127,4 +129,11 @@ public final class InternalConstants {
   /** Schemas of filesystems we know to not work with this committer. */
   public static final Set<String> UNSUPPORTED_FS_SCHEMAS =
       ImmutableSet.of("s3a", "wasb");
+
+  /**
+   * Interval in milliseconds between save retries.
+   * Value {@value} milliseconds.
+   */
+  public static final int SAVE_SLEEP_INTERVAL = 500;
+
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/ManifestStoreOperations.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/ManifestStoreOperations.java
@@ -98,6 +98,35 @@ public abstract class ManifestStoreOperations implements Closeable {
       throws IOException;
 
   /**
+   * Forward to {@code delete(Path, true)}
+   * unless overridden.
+   * <p>
+   * If it returns without an error: there is no file at
+   * the end of the path.
+   * @param path path
+   * @return outcome
+   * @throws IOException failure.
+   */
+  public boolean deleteFile(Path path)
+      throws IOException {
+    return delete(path, false);
+  }
+
+  /**
+   * Call {@code FileSystem#delete(Path, true)} or equivalent.
+   * <p>
+   * If it returns without an error: there is nothing at
+   * the end of the path.
+   * @param path path
+   * @return outcome
+   * @throws IOException failure.
+   */
+  public boolean deleteRecursive(Path path)
+      throws IOException {
+    return delete(path, true);
+  }
+
+  /**
    * Forward to {@link FileSystem#mkdirs(Path)}.
    * Usual "what does 'false' mean" ambiguity.
    * @param path path

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/ManifestStoreOperationsThroughFileSystem.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/ManifestStoreOperationsThroughFileSystem.java
@@ -109,6 +109,11 @@ public class ManifestStoreOperationsThroughFileSystem extends ManifestStoreOpera
   }
 
   @Override
+  public boolean deleteRecursive(final Path path) throws IOException {
+    return fileSystem.delete(path, true);
+  }
+
+  @Override
   public boolean mkdirs(Path path)
       throws IOException {
     return fileSystem.mkdirs(path);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/AbortTaskStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/AbortTaskStage.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.fs.Path;
 
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_DELETE_DIR;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_STAGE_TASK_ABORT_TASK;
 
 /**
@@ -55,7 +56,11 @@ public class AbortTaskStage extends
     final Path dir = getTaskAttemptDir();
     if (dir != null) {
       LOG.info("{}: Deleting task attempt directory {}", getName(), dir);
-      deleteDir(dir, suppressExceptions);
+      if (suppressExceptions) {
+        deleteRecursiveSuppressingExceptions(dir, OP_DELETE_DIR);
+      } else {
+        deleteRecursive(dir, OP_DELETE_DIR);
+      }
     }
     return dir;
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CommitJobStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CommitJobStage.java
@@ -37,6 +37,7 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.COMMITTER_BYTES_COMMITTED_COUNT;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.COMMITTER_FILES_COMMITTED_COUNT;
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.COMMITTER_TASK_DIRECTORY_COUNT_MEAN;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_STAGE_JOB_COMMIT;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_STAGE_JOB_CREATE_TARGET_DIRS;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_STAGE_JOB_LOAD_MANIFESTS;
@@ -161,7 +162,12 @@ public class CommitJobStage extends
       }
 
       // optional cleanup
-      new CleanupJobStage(stageConfig).apply(arguments.getCleanupArguments());
+      final CleanupJobStage.Arguments cleanupArguments = arguments.getCleanupArguments();
+      // determine the directory count
+      cleanupArguments.setDirectoryCount(iostats.counters()
+          .getOrDefault(COMMITTER_TASK_DIRECTORY_COUNT_MEAN, 0L));
+
+      new CleanupJobStage(stageConfig).apply(cleanupArguments);
 
       // and then, after everything else: optionally validate.
       if (arguments.isValidateOutput()) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CommitTaskStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CommitTaskStage.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.statistics.IOStatisticsSnapshot;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.TaskManifest;
@@ -69,19 +70,21 @@ public class CommitTaskStage extends
     // the saving, but ...
     scanStage.addExecutionDurationToStatistics(getIOStatistics(), OP_STAGE_TASK_COMMIT);
 
-    // save a snapshot of the IO Statistics
-    final IOStatisticsSnapshot manifestStats = snapshotIOStatistics();
-    manifestStats.aggregate(getIOStatistics());
-    manifest.setIOStatistics(manifestStats);
-
-    // Now save with rename
-    Path manifestPath = new SaveTaskManifestStage(getStageConfig())
-        .apply(manifest);
-    return new CommitTaskStage.Result(manifestPath, manifest);
+    // Now save with retry, updating the statistics on every attempt.
+    Pair<Path, TaskManifest> p = new SaveTaskManifestStage(getStageConfig())
+        .apply(() -> {
+          /* save a snapshot of the IO Statistics */
+          final IOStatisticsSnapshot manifestStats = snapshotIOStatistics();
+          manifestStats.aggregate(getIOStatistics());
+          manifest.setIOStatistics(manifestStats);
+          return manifest;
+        });
+    return new CommitTaskStage.Result(p.getLeft(), p.getRight());
   }
 
   /**
-   * Result of the stage.
+   * Result of the stage: the path the manifest was saved to
+   * and the manifest which was successfully saved.
    */
   public static final class Result {
     /** The path the manifest was saved to. */
@@ -111,5 +114,9 @@ public class CommitTaskStage extends
       return taskManifest;
     }
 
+    @Override
+    public String toString() {
+      return "Result{path=" + path + '}';
+    }
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CreateOutputDirectoriesStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/CreateOutputDirectoriesStage.java
@@ -105,7 +105,7 @@ public class CreateOutputDirectoriesStage extends
       throws IOException {
 
     final List<Path> directories = createAllDirectories(manifestDirs);
-    LOG.debug("{}: Created {} directories", getName(), directories.size());
+    LOG.info("{}: Created {} directories", getName(), directories.size());
     return new Result(new HashSet<>(directories), dirMap);
   }
 
@@ -163,8 +163,9 @@ public class CreateOutputDirectoriesStage extends
 
     // Now the real work.
     final int createCount = leaves.size();
-    LOG.info("Preparing {} directory/directories; {} parent dirs implicitly created",
-        createCount, parents.size());
+    LOG.info("Preparing {} directory/directories; {} parent dirs implicitly created."
+            + " Files deleted: {}",
+        createCount, parents.size(), filesToDelete.size());
 
     // now probe for and create the leaf dirs, which are those at the
     // bottom level
@@ -232,7 +233,7 @@ public class CreateOutputDirectoriesStage extends
     // report progress back
     progress();
     LOG.info("{}: Deleting file {}", getName(), dir);
-    delete(dir, false, OP_DELETE);
+    deleteFile(dir, OP_DELETE);
     // note its final state
     addToDirectoryMap(dir, DirMapState.fileNowDeleted);
   }
@@ -323,7 +324,7 @@ public class CreateOutputDirectoriesStage extends
         // is bad: delete a file
         LOG.info("{}: Deleting file where a directory should go: {}",
             getName(), st);
-        delete(path, false, OP_DELETE_FILE_UNDER_DESTINATION);
+        deleteFile(path, OP_DELETE_FILE_UNDER_DESTINATION);
       } else {
         // is good.
         LOG.warn("{}: Even though mkdirs({}) failed, there is now a directory there",

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/SaveSuccessFileStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/SaveSuccessFileStage.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.ManifestS
 
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.SUCCESS_MARKER;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.TMP_SUFFIX;
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_SAVE_SUMMARY_FILE;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_STAGE_JOB_COMMIT;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_STAGE_JOB_SAVE_SUCCESS;
 
@@ -72,7 +73,7 @@ public class SaveSuccessFileStage extends
     LOG.debug("{}: Saving _SUCCESS file to {} via {}", successFile,
         getName(),
         successTempFile);
-    save(successData, successTempFile, successFile);
+    saveManifest(() -> successData, successTempFile, successFile, OP_SAVE_SUMMARY_FILE);
     return successFile;
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/SaveTaskManifestStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/SaveTaskManifestStage.java
@@ -19,13 +19,16 @@
 package org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.TaskManifest;
 
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_SAVE_TASK_MANIFEST;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_STAGE_TASK_SAVE_MANIFEST;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.ManifestCommitterSupport.manifestPathForTask;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.ManifestCommitterSupport.manifestTempPathForTaskAttempt;
@@ -38,16 +41,36 @@ import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.Man
  * Uses both the task ID and task attempt ID to determine the temp filename;
  * Before the rename of (temp, final-path), any file at the final path
  * is deleted.
+ * <p>
  * This is so that when this stage is invoked in a task commit, its output
  * overwrites any of the first commit.
  * When it succeeds, therefore, unless there is any subsequent commit of
  * another task, the task manifest at the final path is from this
  * operation.
- *
- * Returns the path where the manifest was saved.
+ * <p>
+ * If the save and rename fails, there are a limited number of retries, with no sleep
+ * interval.
+ * This is to briefly try recover from any transient rename() failure, including a
+ * race condition with any other task commit.
+ * <ol>
+ *   <li>If the previous task commit has already succeeded, this rename will overwrite it.
+ *        Both task attempts will report success.</li>
+ *   <li>If after, writing, another task attempt overwrites it, again, both
+ *        task attempts will report success.</li>
+ *   <li>If another task commits between the delete() and rename() operations, the retry will
+ *        attempt to recover by repeating the manifest write, and then report success.</li>
+ * </ol>
+ * This means that multiple task attempts may report success, but only one will have it actual
+ * manifest saved.
+ * The mapreduce and spark committers only schedule a second task commit attempt if the first
+ * task attempt's commit operation fails <i>or fails to report success in the allocated time</i>.
+ * The overwrite with retry loop is an attempt to ensure that the second attempt will report
+ * success, if a partitioned cluster means that the original TA commit is still in progress.
+ * <p>
+ * Returns (the path where the manifest was saved, the manifest).
  */
 public class SaveTaskManifestStage extends
-    AbstractJobOrTaskStage<TaskManifest, Path> {
+    AbstractJobOrTaskStage<Supplier<TaskManifest>, Pair<Path, TaskManifest>> {
 
   private static final Logger LOG = LoggerFactory.getLogger(
       SaveTaskManifestStage.class);
@@ -57,14 +80,16 @@ public class SaveTaskManifestStage extends
   }
 
   /**
-   * Save the manifest to a temp file and rename to the final
+   * Generate and save a manifest to a temp file and rename to the final
    * manifest destination.
-   * @param manifest manifest
+   * The manifest is generated on each retried attempt.
+   * @param manifestSource supplier the manifest/success file
+   *
    * @return the path to the final entry
    * @throws IOException IO failure.
    */
   @Override
-  protected Path executeStage(final TaskManifest manifest)
+  protected Pair<Path, TaskManifest> executeStage(Supplier<TaskManifest> manifestSource)
       throws IOException {
 
     final Path manifestDir = getTaskManifestDir();
@@ -74,8 +99,9 @@ public class SaveTaskManifestStage extends
     Path manifestTempFile = manifestTempPathForTaskAttempt(manifestDir,
         getRequiredTaskAttemptId());
     LOG.info("{}: Saving manifest file to {}", getName(), manifestFile);
-    save(manifest, manifestTempFile, manifestFile);
-    return manifestFile;
+    final TaskManifest manifest =
+        saveManifest(manifestSource, manifestTempFile, manifestFile, OP_SAVE_TASK_MANIFEST);
+    return Pair.of(manifestFile, manifest);
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/SetupJobStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/SetupJobStage.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.fs.Path;
 
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.OP_DELETE;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_STAGE_JOB_SETUP;
 
 /**
@@ -55,7 +56,7 @@ public class SetupJobStage extends
     createNewDirectory("Creating task manifest dir", getTaskManifestDir());
     // delete any success marker if so instructed.
     if (deleteMarker) {
-      delete(getStageConfig().getJobSuccessMarkerPath(), false);
+      deleteFile(getStageConfig().getJobSuccessMarkerPath(), OP_DELETE);
     }
     return path;
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/StageConfig.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/stages/StageConfig.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.util.functional.TaskPool;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.DEFAULT_WRITER_QUEUE_CAPACITY;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.SUCCESS_MARKER;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.SUCCESS_MARKER_FILE_LIMIT;
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.OPT_MANIFEST_SAVE_ATTEMPTS_DEFAULT;
 
 /**
  * Stage Config.
@@ -171,6 +172,12 @@ public class StageConfig {
    * Number of marker files to include in success file.
    */
   private int successMarkerFileLimit = SUCCESS_MARKER_FILE_LIMIT;
+
+  /**
+   * How many attempts to save a manifest by save and rename
+   * before giving up: {@value}.
+   */
+  private int manifestSaveAttempts = OPT_MANIFEST_SAVE_ATTEMPTS_DEFAULT;
 
   public StageConfig() {
   }
@@ -602,6 +609,21 @@ public class StageConfig {
 
   public int getSuccessMarkerFileLimit() {
     return successMarkerFileLimit;
+  }
+
+  public int getManifestSaveAttempts() {
+    return manifestSaveAttempts;
+  }
+
+  /**
+   * Set builder value.
+   * @param value new value
+   * @return the builder
+   */
+  public StageConfig withManifestSaveAttempts(final int value) {
+    checkOpen();
+    manifestSaveAttempts = value;
+    return this;
   }
 
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/MapredCommands.md
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/MapredCommands.md
@@ -134,6 +134,11 @@ Usage: `mapred envvars`
 
 Display computed Hadoop environment variables.
 
+# `successfile`
+
+Load and print a JSON `_SUCCESS` file from a [Manifest Committer](manifest_committer.html) or an S3A Committer,
+
+
 Administration Commands
 -----------------------
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/manifest_committer.md
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/manifest_committer.md
@@ -15,14 +15,16 @@
 
 # The Manifest Committer for Azure and Google Cloud Storage
 
-This document how to use the _Manifest Committer_.
+<!-- MACRO{toc|fromDepth=0|toDepth=2} -->
+
+This documents how to use the _Manifest Committer_.
 
 The _Manifest_ committer is a committer for work which provides
 performance on ABFS for "real world" queries,
 and performance and correctness on GCS.
 It also works with other filesystems, including HDFS.
 However, the design is optimized for object stores where
-listing operatons are slow and expensive.
+listing operations are slow and expensive.
 
 The architecture and implementation of the committer is covered in
 [Manifest Committer Architecture](manifest_committer_architecture.html).
@@ -31,10 +33,16 @@ The architecture and implementation of the committer is covered in
 The protocol and its correctness are covered in
 [Manifest Committer Protocol](manifest_committer_protocol.html).
 
-It was added in March 2022, and should be considered unstable
-in early releases.
+It was added in March 2022.
+As of April 2024, the problems which surfaced have been
+* Memory use at scale.
+* Directory deletion scalability.
+* Resilience to task commit to rename failures.
 
-<!-- MACRO{toc|fromDepth=0|toDepth=2} -->
+That is: the core algorithms is correct, but task commit
+robustness was insufficient to some failure conditions.
+And scale is always a challenge, even with components tested through
+large TPC-DS test runs.
 
 ## Problem:
 
@@ -70,10 +78,13 @@ This committer uses the extension point which came in for the S3A committers.
 Users can declare a new committer factory for abfs:// and gcs:// URLs.
 A suitably configured spark deployment will pick up the new committer.
 
-Directory performance issues in job cleanup can be addressed by two options
+Directory performance issues in job cleanup can be addressed by some options
 1. The committer will parallelize deletion of task attempt directories before
    deleting the `_temporary` directory.
-1. Cleanup can be disabled. .
+2. An initial attempt to delete the  `_temporary` directory before the parallel
+   attempt is made.
+3. Exceptions can be supressed, so that cleanup failures do not fail the job
+4. Cleanup can be disabled.
 
 The committer can be used with any filesystem client which has a "real" file rename()
 operation.
@@ -112,8 +123,8 @@ These can be done in `core-site.xml`, if it is not defined in the `mapred-defaul
 
 ## Binding to the manifest committer in Spark.
 
-In Apache Spark, the configuration can be done either with command line options (after the '--conf') or by using the `spark-defaults.conf` file. The following is an example of using `spark-defaults.conf` also including the configuration for Parquet with a subclass of the parquet
-committer which uses the factory mechansim internally.
+In Apache Spark, the configuration can be done either with command line options (after the `--conf`) or by using the `spark-defaults.conf` file.
+The following is an example of using `spark-defaults.conf` also including the configuration for Parquet with a subclass of the parquet committer which uses the factory mechanism internally.
 
 ```
 spark.hadoop.mapreduce.outputcommitter.factory.scheme.abfs org.apache.hadoop.fs.azurebfs.commit.AzureManifestCommitterFactory
@@ -184,6 +195,7 @@ Here are the main configuration options of the committer.
 | `mapreduce.manifest.committer.io.threads` | Thread count for parallel operations | `64` |
 | `mapreduce.manifest.committer.summary.report.directory` | directory to save reports. | `""` |
 | `mapreduce.manifest.committer.cleanup.parallel.delete` | Delete temporary directories in parallel | `true` |
+| `mapreduce.manifest.committer.cleanup.parallel.delete.base.first` | Attempt to delete the base directory before parallel task attempts | `false` |
 | `mapreduce.fileoutputcommitter.cleanup.skipped` | Skip cleanup of `_temporary` directory| `false` |
 | `mapreduce.fileoutputcommitter.cleanup-failures.ignored` | Ignore errors during cleanup | `false` |
 | `mapreduce.fileoutputcommitter.marksuccessfuljobs` | Create a `_SUCCESS` marker file on successful completion. (and delete any existing one in job setup) | `true` |
@@ -237,37 +249,6 @@ Caveats
 * Azure rate throttling may be triggered if too many IO requests
   are made against the store. The rate throttling option
   `mapreduce.manifest.committer.io.rate` can help avoid this.
-
-
-### `mapreduce.manifest.committer.writer.queue.capacity`
-
-This is a secondary scale option.
-It controls the size of the queue for storing lists of files to rename from
-the manifests loaded from the target filesystem, manifests loaded
-from a pool of worker threads, and the single thread which saves
-the entries from each manifest to an intermediate file in the local filesystem.
-
-Once the queue is full, all manifest loading threads will block.
-
-```xml
-<property>
-  <name>mapreduce.manifest.committer.writer.queue.capacity</name>
-  <value>32</value>
-</property>
-```
-
-As the local filesystem is usually much faster to write to than any cloud store,
-this queue size should not be a limit on manifest load performance.
-
-It can help limit the amount of memory consumed during manifest load during
-job commit.
-The maximum number of loaded manifests will be:
-
-```
-mapreduce.manifest.committer.writer.queue.capacity + mapreduce.manifest.committer.io.threads
-```
-
-
 
 ## <a name="deleting"></a> Optional: deleting target files in Job Commit
 
@@ -403,6 +384,153 @@ hadoop org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.ManifestP
 This works for the files saved at the base of an output directory, and
 any reports saved to a report directory.
 
+Example from a run of the `ITestAbfsTerasort` MapReduce terasort.
+
+```
+bin/mapred successfile abfs://testing@ukwest.dfs.core.windows.net/terasort/_SUCCESS
+
+Manifest file: abfs://testing@ukwest.dfs.core.windows.net/terasort/_SUCCESS
+succeeded: true
+created: 2024-04-18T18:34:34.003+01:00[Europe/London]
+committer: org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitter
+hostname: pi5
+jobId: job_1713461587013_0003
+jobIdSource: JobID
+Diagnostics
+  mapreduce.manifest.committer.io.threads = 192
+  principal = alice
+  stage = committer_commit_job
+
+Statistics:
+counters=((commit_file_rename=1)
+(committer_bytes_committed=21)
+(committer_commit_job=1)
+(committer_files_committed=1)
+(committer_task_directory_depth=2)
+(committer_task_file_count=2)
+(committer_task_file_size=21)
+(committer_task_manifest_file_size=37157)
+(job_stage_cleanup=1)
+(job_stage_create_target_dirs=1)
+(job_stage_load_manifests=1)
+(job_stage_optional_validate_output=1)
+(job_stage_rename_files=1)
+(job_stage_save_success_marker=1)
+(job_stage_setup=1)
+(op_create_directories=1)
+(op_delete=3)
+(op_delete_dir=1)
+(op_get_file_status=9)
+(op_get_file_status.failures=6)
+(op_list_status=3)
+(op_load_all_manifests=1)
+(op_load_manifest=2)
+(op_mkdirs=4)
+(op_msync=1)
+(op_rename=2)
+(op_rename.failures=1)
+(task_stage_commit=2)
+(task_stage_save_task_manifest=1)
+(task_stage_scan_directory=2)
+(task_stage_setup=2));
+
+gauges=();
+
+minimums=((commit_file_rename.min=141)
+(committer_commit_job.min=2306)
+(committer_task_directory_count=0)
+(committer_task_directory_depth=1)
+(committer_task_file_count=0)
+(committer_task_file_size=0)
+(committer_task_manifest_file_size=18402)
+(job_stage_cleanup.min=196)
+(job_stage_create_target_dirs.min=2)
+(job_stage_load_manifests.min=687)
+(job_stage_optional_validate_output.min=66)
+(job_stage_rename_files.min=161)
+(job_stage_save_success_marker.min=653)
+(job_stage_setup.min=571)
+(op_create_directories.min=1)
+(op_delete.min=57)
+(op_delete_dir.min=129)
+(op_get_file_status.failures.min=57)
+(op_get_file_status.min=55)
+(op_list_status.min=202)
+(op_load_all_manifests.min=445)
+(op_load_manifest.min=171)
+(op_mkdirs.min=67)
+(op_msync.min=0)
+(op_rename.failures.min=266)
+(op_rename.min=139)
+(task_stage_commit.min=206)
+(task_stage_save_task_manifest.min=651)
+(task_stage_scan_directory.min=206)
+(task_stage_setup.min=127));
+
+maximums=((commit_file_rename.max=141)
+(committer_commit_job.max=2306)
+(committer_task_directory_count=0)
+(committer_task_directory_depth=1)
+(committer_task_file_count=1)
+(committer_task_file_size=21)
+(committer_task_manifest_file_size=18755)
+(job_stage_cleanup.max=196)
+(job_stage_create_target_dirs.max=2)
+(job_stage_load_manifests.max=687)
+(job_stage_optional_validate_output.max=66)
+(job_stage_rename_files.max=161)
+(job_stage_save_success_marker.max=653)
+(job_stage_setup.max=571)
+(op_create_directories.max=1)
+(op_delete.max=113)
+(op_delete_dir.max=129)
+(op_get_file_status.failures.max=231)
+(op_get_file_status.max=61)
+(op_list_status.max=300)
+(op_load_all_manifests.max=445)
+(op_load_manifest.max=436)
+(op_mkdirs.max=123)
+(op_msync.max=0)
+(op_rename.failures.max=266)
+(op_rename.max=139)
+(task_stage_commit.max=302)
+(task_stage_save_task_manifest.max=651)
+(task_stage_scan_directory.max=302)
+(task_stage_setup.max=157));
+
+means=((commit_file_rename.mean=(samples=1, sum=141, mean=141.0000))
+(committer_commit_job.mean=(samples=1, sum=2306, mean=2306.0000))
+(committer_task_directory_count=(samples=4, sum=0, mean=0.0000))
+(committer_task_directory_depth=(samples=2, sum=2, mean=1.0000))
+(committer_task_file_count=(samples=4, sum=2, mean=0.5000))
+(committer_task_file_size=(samples=2, sum=21, mean=10.5000))
+(committer_task_manifest_file_size=(samples=2, sum=37157, mean=18578.5000))
+(job_stage_cleanup.mean=(samples=1, sum=196, mean=196.0000))
+(job_stage_create_target_dirs.mean=(samples=1, sum=2, mean=2.0000))
+(job_stage_load_manifests.mean=(samples=1, sum=687, mean=687.0000))
+(job_stage_optional_validate_output.mean=(samples=1, sum=66, mean=66.0000))
+(job_stage_rename_files.mean=(samples=1, sum=161, mean=161.0000))
+(job_stage_save_success_marker.mean=(samples=1, sum=653, mean=653.0000))
+(job_stage_setup.mean=(samples=1, sum=571, mean=571.0000))
+(op_create_directories.mean=(samples=1, sum=1, mean=1.0000))
+(op_delete.mean=(samples=3, sum=240, mean=80.0000))
+(op_delete_dir.mean=(samples=1, sum=129, mean=129.0000))
+(op_get_file_status.failures.mean=(samples=6, sum=614, mean=102.3333))
+(op_get_file_status.mean=(samples=3, sum=175, mean=58.3333))
+(op_list_status.mean=(samples=3, sum=671, mean=223.6667))
+(op_load_all_manifests.mean=(samples=1, sum=445, mean=445.0000))
+(op_load_manifest.mean=(samples=2, sum=607, mean=303.5000))
+(op_mkdirs.mean=(samples=4, sum=361, mean=90.2500))
+(op_msync.mean=(samples=1, sum=0, mean=0.0000))
+(op_rename.failures.mean=(samples=1, sum=266, mean=266.0000))
+(op_rename.mean=(samples=1, sum=139, mean=139.0000))
+(task_stage_commit.mean=(samples=2, sum=508, mean=254.0000))
+(task_stage_save_task_manifest.mean=(samples=1, sum=651, mean=651.0000))
+(task_stage_scan_directory.mean=(samples=2, sum=508, mean=254.0000))
+(task_stage_setup.mean=(samples=2, sum=284, mean=142.0000)));
+
+```
+
 ## <a name="summaries"></a> Collecting Job Summaries `mapreduce.manifest.committer.summary.report.directory`
 
 The committer can be configured to save the `_SUCCESS` summary files to a report directory,
@@ -431,46 +559,62 @@ This allows for the statistics of jobs to be collected irrespective of their out
 saving the `_SUCCESS` marker is enabled, and without problems caused by a chain of queries
 overwriting the markers.
 
+The `mapred successfile` operation can be used to print these reports.
 
 # <a name="cleanup"></a> Cleanup
 
 Job cleanup is convoluted as it is designed to address a number of issues which
 may surface in cloud storage.
 
-* Slow performance for deletion of directories.
-* Timeout when deleting very deep and wide directory trees.
+* Slow performance for deletion of directories (GCS).
+* Timeout when deleting very deep and wide directory trees (Azure).
 * General resilience to cleanup issues escalating to job failures.
 
 
-| Option | Meaning | Default Value |
-|--------|---------|---------------|
-| `mapreduce.fileoutputcommitter.cleanup.skipped` | Skip cleanup of `_temporary` directory| `false` |
-| `mapreduce.fileoutputcommitter.cleanup-failures.ignored` | Ignore errors during cleanup | `false` |
-| `mapreduce.manifest.committer.cleanup.parallel.delete` | Delete task attempt directories in parallel | `true` |
+| Option                                                            | Meaning                                                            | Default Value |
+|-------------------------------------------------------------------|--------------------------------------------------------------------|---------------|
+| `mapreduce.fileoutputcommitter.cleanup.skipped`                   | Skip cleanup of `_temporary` directory                             | `false`       |
+| `mapreduce.fileoutputcommitter.cleanup-failures.ignored`          | Ignore errors during cleanup                                       | `false`       |
+| `mapreduce.manifest.committer.cleanup.parallel.delete`            | Delete task attempt directories in parallel                        | `true`        |
+| `mapreduce.manifest.committer.cleanup.parallel.delete.base.first` | Attempt to delete the base directory before parallel task attempts | `false`       |
 
 The algorithm is:
 
-```
-if `mapreduce.fileoutputcommitter.cleanup.skipped`:
+```python
+if "mapreduce.fileoutputcommitter.cleanup.skipped":
   return
-if `mapreduce.manifest.committer.cleanup.parallel.delete`:
-  attempt parallel delete of task directories; catch any exception
-if not `mapreduce.fileoutputcommitter.cleanup.skipped`:
-  delete(`_temporary`); catch any exception
-if caught-exception and not `mapreduce.fileoutputcommitter.cleanup-failures.ignored`:
-  throw caught-exception
+if "mapreduce.manifest.committer.cleanup.parallel.delete":
+  if "mapreduce.manifest.committer.cleanup.parallel.delete.base.first" :
+    if delete("_temporary"):
+      return
+  delete(list("$task-directories")) catch any exception
+if not "mapreduce.fileoutputcommitter.cleanup.skipped":
+  delete("_temporary"); catch any exception
+if caught-exception and not "mapreduce.fileoutputcommitter.cleanup-failures.ignored":
+  raise caught-exception
 ```
 
 It's a bit complicated, but the goal is to perform a fast/scalable delete and
 throw a meaningful exception if that didn't work.
 
-When working with ABFS and GCS, these settings should normally be left alone.
-If somehow errors surface during cleanup, enabling the option to
-ignore failures will ensure the job still completes.
+For ABFS set `mapreduce.manifest.committer.cleanup.parallel.delete.base.first` to `true`
+which should normally result in less network IO and a faster cleanup.
+
+```
+spark.hadoop.mapreduce.manifest.committer.cleanup.parallel.delete.base.first true
+```
+
+For GCS, setting `mapreduce.manifest.committer.cleanup.parallel.delete.base.first`
+to `false` may speed up cleanup.
+
+If somehow errors surface during cleanup, ignoring failures will ensure the job
+is still considered a success.
+`mapreduce.fileoutputcommitter.cleanup-failures.ignored = true`
+
 Disabling cleanup even avoids the overhead of cleanup, but
 requires a workflow or manual operation to clean up all
-`_temporary` directories on a regular basis.
-
+`_temporary` directories on a regular basis:
+`mapreduce.fileoutputcommitter.cleanup.skipped = true`.
 
 # <a name="abfs"></a> Working with Azure ADLS Gen2 Storage
 
@@ -504,9 +648,15 @@ The core set of Azure-optimized options becomes
 </property>
 
 <property>
-  <name>spark.hadoop.fs.azure.io.rate.limit</name>
-  <value>10000</value>
+  <name>fs.azure.io.rate.limit</name>
+  <value>1000</value>
 </property>
+
+<property>
+  <name>mapreduce.manifest.committer.cleanup.parallel.delete.base.first</name>
+  <value>true</value>
+</property>
+
 ```
 
 And optional settings for debugging/performance analysis
@@ -514,7 +664,7 @@ And optional settings for debugging/performance analysis
 ```xml
 <property>
   <name>mapreduce.manifest.committer.summary.report.directory</name>
-  <value>abfs:// Path within same store/separate store</value>
+  <value>Path within same store/separate store</value>
   <description>Optional: path to where job summaries are saved</description>
 </property>
 ```
@@ -523,14 +673,15 @@ And optional settings for debugging/performance analysis
 
 ```
 spark.hadoop.mapreduce.outputcommitter.factory.scheme.abfs org.apache.hadoop.fs.azurebfs.commit.AzureManifestCommitterFactory
-spark.hadoop.fs.azure.io.rate.limit 10000
+spark.hadoop.fs.azure.io.rate.limit 1000
+spark.hadoop.mapreduce.manifest.committer.cleanup.parallel.delete.base.first true
 spark.sql.parquet.output.committer.class org.apache.spark.internal.io.cloud.BindingParquetOutputCommitter
 spark.sql.sources.commitProtocolClass org.apache.spark.internal.io.cloud.PathOutputCommitProtocol
 
 spark.hadoop.mapreduce.manifest.committer.summary.report.directory  (optional: URI of a directory for job summaries)
 ```
 
-## Experimental: ABFS Rename Rate Limiting `fs.azure.io.rate.limit`
+## <a name="abfs-rate-limit"></a> ABFS Rename Rate Limiting `fs.azure.io.rate.limit`
 
 To avoid triggering store throttling and backoff delays, as well as other
 throttling-related failure conditions file renames during job commit
@@ -544,13 +695,12 @@ may issue.
 
 Set the option to `0` remove all rate limiting.
 
-The default value of this is set to 10000, which is the default IO capacity for
-an ADLS storage account.
+The default value of this is set to 1000.
 
 ```xml
 <property>
   <name>fs.azure.io.rate.limit</name>
-  <value>10000</value>
+  <value>1000</value>
   <description>maximum number of renames attempted per second</description>
 </property>
 ```
@@ -569,7 +719,7 @@ If server-side throttling took place, signs of this can be seen in
 * The store service's logs and their throttling status codes (usually 503 or 500).
 * The job statistic `commit_file_rename_recovered`. This statistic indicates that
   ADLS throttling manifested as failures in renames, failures which were recovered
-  from in the comitter.
+  from in the committer.
 
 If these are seen -or other applications running at the same time experience
 throttling/throttling-triggered problems, consider reducing the value of
@@ -598,13 +748,14 @@ The Spark settings to switch to this committer are
 spark.hadoop.mapreduce.outputcommitter.factory.scheme.gs org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterFactory
 spark.sql.parquet.output.committer.class org.apache.spark.internal.io.cloud.BindingParquetOutputCommitter
 spark.sql.sources.commitProtocolClass org.apache.spark.internal.io.cloud.PathOutputCommitProtocol
-
+spark.hadoop.mapreduce.manifest.committer.cleanup.parallel.delete.base.first false
 spark.hadoop.mapreduce.manifest.committer.summary.report.directory  (optional: URI of a directory for job summaries)
 ```
 
 The store's directory delete operations are `O(files)` so the value
 of `mapreduce.manifest.committer.cleanup.parallel.delete`
-SHOULD be left at the default of `true`.
+SHOULD be left at the default of `true`, but
+`mapreduce.manifest.committer.cleanup.parallel.delete.base.first` changed to `false`
 
 For mapreduce, declare the binding in `core-site.xml`or `mapred-site.xml`
 ```xml
@@ -639,19 +790,33 @@ spark.sql.sources.commitProtocolClass org.apache.spark.internal.io.cloud.PathOut
 spark.hadoop.mapreduce.manifest.committer.summary.report.directory  (optional: URI of a directory for job summaries)
 ```
 
-# <a name="advanced"></a> Advanced Topics
-
-## Advanced Configuration options
+# <a name="advanced"></a> Advanced Configuration options
 
 There are some advanced options which are intended for development and testing,
 rather than production use.
 
-| Option | Meaning                                      | Default Value |
-|--------|----------------------------------------------|---------------|
-| `mapreduce.manifest.committer.store.operations.classname` | Classname for Manifest Store Operations      | `""`          |
-| `mapreduce.manifest.committer.validate.output` | Perform output validation?                   | `false`       |
-| `mapreduce.manifest.committer.writer.queue.capacity` | Queue capacity for writing intermediate file | `32`          |
+| Option                                                    | Meaning                                                     | Default Value |
+|-----------------------------------------------------------|-------------------------------------------------------------|---------------|
+| `mapreduce.manifest.committer.manifest.save.attempts`     | How many attempts should be made to commit a task manifest? | `5`           |
+| `mapreduce.manifest.committer.store.operations.classname` | Classname for Manifest Store Operations                     | `""`          |
+| `mapreduce.manifest.committer.validate.output`            | Perform output validation?                                  | `false`       |
+| `mapreduce.manifest.committer.writer.queue.capacity`      | Queue capacity for writing intermediate file                | `32`          |
 
+### `mapreduce.manifest.committer.manifest.save.attempts`
+
+The number of attempts which should be made to save a task attempt manifest, which is done by
+1. Writing the file to a temporary file in the job attempt directory.
+2. Deleting any existing task manifest
+3. Renaming the temporary file to the final filename.
+
+This may fail for unrecoverable reasons (permissions, permanent loss of network, service down,...) or it may be
+a transient problem which may not reoccur if another attempt is made to write the data.
+
+The number of attempts to make is set by `mapreduce.manifest.committer.manifest.save.attempts`;
+the sleep time increases with each attempt.
+
+Consider increasing the default value if task attempts fail to commit their work
+and fail to recover from network problems.
 
 ### Validating output  `mapreduce.manifest.committer.validate.output`
 
@@ -690,6 +855,34 @@ The default implementation may also be configured.
 There is no need to alter these values, except when writing new implementations for other stores,
 something which is only needed if the store provides extra integration support for the
 committer.
+
+### `mapreduce.manifest.committer.writer.queue.capacity`
+
+This is a secondary scale option.
+It controls the size of the queue for storing lists of files to rename from
+the manifests loaded from the target filesystem, manifests loaded
+from a pool of worker threads, and the single thread which saves
+the entries from each manifest to an intermediate file in the local filesystem.
+
+Once the queue is full, all manifest loading threads will block.
+
+```xml
+<property>
+  <name>mapreduce.manifest.committer.writer.queue.capacity</name>
+  <value>32</value>
+</property>
+```
+
+As the local filesystem is usually much faster to write to than any cloud store,
+this queue size should not be a limit on manifest load performance.
+
+It can help limit the amount of memory consumed during manifest load during
+job commit.
+The maximum number of loaded manifests will be:
+
+```
+mapreduce.manifest.committer.writer.queue.capacity + mapreduce.manifest.committer.io.threads
+```
 
 ## <a name="concurrent"></a> Support for concurrent jobs to the same directory
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/manifest_committer_architecture.md
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/manifest_committer_architecture.md
@@ -19,6 +19,7 @@ This document describes the architecture and other implementation/correctness
 aspects of the [Manifest Committer](manifest_committer.html)
 
 The protocol and its correctness are covered in [Manifest Committer Protocol](manifest_committer_protocol.html).
+
 <!-- MACRO{toc|fromDepth=0|toDepth=2} -->
 
 The _Manifest_ committer is a committer for work which provides performance on ABFS for "real world"
@@ -278,6 +279,11 @@ The manifest committer assumes that the amount of data being stored in memory is
 because there is no longer the need to store an etag for every block of every
 file being committed.
 
+This assumption turned out not to hold for some jobs:
+[MAPREDUCE-7435. ManifestCommitter OOM on azure job](https://issues.apache.org/jira/browse/MAPREDUCE-7435)
+
+The strategy here was to read in all manifests and stream their entries to a local file, as Hadoop
+Writable objects -hence with lower marshalling overhead than JSON.
 
 #### Duplicate creation of directories in the dest dir
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterTestSupport.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/ManifestCommitterTestSupport.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.mapreduce.JobID;
 import org.apache.hadoop.mapreduce.RecordWriter;
@@ -312,6 +313,21 @@ public final class ManifestCommitterTestSupport {
     assertThat(fileOrDir.getType())
         .describedAs("type of " + entry)
         .isEqualTo(type);
+  }
+
+  /**
+   * Assert that none of the named statistics have any failure counts,
+   * which may be from being null or 0.
+   * @param iostats statistics
+   * @param names base name of the statistics (i.e. without ".failures" suffix)
+   */
+  public static void assertNoFailureStatistics(IOStatistics iostats, String... names) {
+    final Map<String, Long> counters = iostats.counters();
+    for (String name : names) {
+      Assertions.assertThat(counters.get(name + ".failures"))
+          .describedAs("Failure count of %s", name)
+          .matches(f -> f == null || f == 0);
+    }
   }
 
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestCommitTaskStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestCommitTaskStage.java
@@ -19,13 +19,21 @@
 package org.apache.hadoop.mapreduce.lib.output.committer.manifest;
 
 import java.io.FileNotFoundException;
+import java.net.SocketTimeoutException;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathIOException;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.statistics.IOStatisticsSnapshot;
+import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.ManifestSuccessData;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.TaskManifest;
+import org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.ManifestStoreOperations;
+import org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.UnreliableManifestStoreOperations;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages.CleanupJobStage;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages.CommitJobStage;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages.CommitTaskStage;
@@ -33,13 +41,26 @@ import org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages.SetupJob
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages.SetupTaskStage;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.stages.StageConfig;
 
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertThatStatisticCounter;
+import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsToPrettyString;
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_SAVE_TASK_MANIFEST;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterStatisticNames.OP_STAGE_JOB_CLEANUP;
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.ManifestCommitterSupport.manifestPathForTask;
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.ManifestCommitterSupport.manifestTempPathForTaskAttempt;
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.UnreliableManifestStoreOperations.E_TIMEOUT;
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.UnreliableManifestStoreOperations.generatedErrorMessage;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
- * Test committing a task.
+ * Test committing a task, with lots of fault injection to validate
+ * resilience to transient failures.
  */
 public class TestCommitTaskStage extends AbstractManifestCommitterTest {
+
+  public static final String TASK1 = String.format("task_%03d", 1);
+
+  public static final String TASK1_ATTEMPT1 = String.format("%s_%02d",
+      TASK1, 1);
 
   @Override
   public void setup() throws Exception {
@@ -49,6 +70,15 @@ public class TestCommitTaskStage extends AbstractManifestCommitterTest {
     StageConfig stageConfig = createStageConfigForJob(JOB1, destDir);
     setJobStageConfig(stageConfig);
     new SetupJobStage(stageConfig).apply(true);
+  }
+
+
+  /**
+   * Create a stage config for job 1 task1 attempt 1.
+   * @return a task stage configuration.
+   */
+  private StageConfig createStageConfig() {
+    return createTaskStageConfig(JOB1, TASK1, TASK1_ATTEMPT1);
   }
 
   @Test
@@ -108,8 +138,9 @@ public class TestCommitTaskStage extends AbstractManifestCommitterTest {
                 OP_STAGE_JOB_CLEANUP,
                 true,
                 true,
-                false
-            )));
+                false,
+                false,
+                0)));
 
     // review success file
     final Path successPath = outcome.getSuccessPath();
@@ -121,6 +152,285 @@ public class TestCommitTaskStage extends AbstractManifestCommitterTest {
     Assertions.assertThat(successData.getFilenames())
         .as("Filenames in _SUCCESS")
         .isEmpty();
+  }
+
+
+  @Test
+  public void testManifestSaveFailures() throws Throwable {
+    describe("Test recovery of manifest save/rename failures");
+
+    UnreliableManifestStoreOperations failures = makeStoreOperationsUnreliable();
+
+    StageConfig stageConfig = createStageConfig();
+
+    new SetupTaskStage(stageConfig).apply("setup");
+
+    final Path manifestDir = stageConfig.getTaskManifestDir();
+    // final manifest file is by task ID
+    Path manifestFile = manifestPathForTask(manifestDir,
+        stageConfig.getTaskId());
+    Path manifestTempFile = manifestTempPathForTaskAttempt(manifestDir,
+        stageConfig.getTaskAttemptId());
+
+    // manifest save will fail but recover before the task gives up.
+    failures.addSaveToFail(manifestTempFile);
+
+    // will fail because too many attempts failed.
+    failures.setFailureLimit(SAVE_ATTEMPTS + 1);
+    intercept(PathIOException.class, generatedErrorMessage("save"), () ->
+        new CommitTaskStage(stageConfig).apply(null));
+
+    // will succeed because the failure limit is set lower
+    failures.setFailureLimit(SAVE_ATTEMPTS - 1);
+    new CommitTaskStage(stageConfig).apply(null);
+
+    describe("Testing timeouts on rename operations.");
+    // now do it for the renames, which will fail after the rename
+    failures.reset();
+    failures.addTimeoutBeforeRename(manifestTempFile);
+
+    // first verify that if too many attempts fail, the task will fail
+    failures.setFailureLimit(SAVE_ATTEMPTS + 1);
+    intercept(SocketTimeoutException.class, E_TIMEOUT, () ->
+        new CommitTaskStage(stageConfig).apply(null));
+
+    // reduce the limit and expect the stage to succeed.
+    failures.setFailureLimit(SAVE_ATTEMPTS - 1);
+    new CommitTaskStage(stageConfig).apply(null);
+  }
+
+  /**
+   * Save with renaming failing before the rename; the source file
+   * will be present on the next attempt.
+   * The successfully saved manifest file is loaded and its statistics
+   * examined to verify that the failure count is updated.
+   */
+  @Test
+  public void testManifestRenameEarlyTimeouts() throws Throwable {
+    describe("Testing timeouts on rename operations.");
+
+    UnreliableManifestStoreOperations failures = makeStoreOperationsUnreliable();
+    StageConfig stageConfig = createStageConfig();
+
+    new SetupTaskStage(stageConfig).apply("setup");
+
+    final Path manifestDir = stageConfig.getTaskManifestDir();
+    // final manifest file is by task ID
+    Path manifestFile = manifestPathForTask(manifestDir,
+        stageConfig.getTaskId());
+    Path manifestTempFile = manifestTempPathForTaskAttempt(manifestDir,
+        stageConfig.getTaskAttemptId());
+
+
+    // configure for which will fail after the rename
+    failures.addTimeoutBeforeRename(manifestTempFile);
+
+    // first verify that if too many attempts fail, the task will fail
+    failures.setFailureLimit(SAVE_ATTEMPTS + 1);
+    intercept(SocketTimeoutException.class, E_TIMEOUT, () ->
+        new CommitTaskStage(stageConfig).apply(null));
+    // and that the IO stats are updated
+    final IOStatisticsStore iostats = stageConfig.getIOStatistics();
+    assertThatStatisticCounter(iostats, OP_SAVE_TASK_MANIFEST + ".failures")
+        .isEqualTo(SAVE_ATTEMPTS);
+
+    // reduce the limit and expect the stage to succeed.
+    iostats.reset();
+    failures.setFailureLimit(SAVE_ATTEMPTS);
+    final CommitTaskStage.Result r = new CommitTaskStage(stageConfig).apply(null);
+
+    // load in the manifest
+    final TaskManifest loadedManifest = TaskManifest.load(getFileSystem(), r.getPath());
+    final IOStatisticsSnapshot loadedIOStats = loadedManifest.getIOStatistics();
+    LOG.info("Statistics of file successfully saved:\nD {}",
+        ioStatisticsToPrettyString(loadedIOStats));
+    assertThatStatisticCounter(loadedIOStats, OP_SAVE_TASK_MANIFEST + ".failures")
+        .isEqualTo(SAVE_ATTEMPTS - 1);
+  }
+
+  @Test
+  public void testManifestRenameLateTimeoutsFailure() throws Throwable {
+    describe("Testing timeouts on rename operations.");
+
+    UnreliableManifestStoreOperations failures = makeStoreOperationsUnreliable();
+    StageConfig stageConfig = createStageConfig();
+
+    new SetupTaskStage(stageConfig).apply("setup");
+
+    final Path manifestDir = stageConfig.getTaskManifestDir();
+
+    Path manifestTempFile = manifestTempPathForTaskAttempt(manifestDir,
+        stageConfig.getTaskAttemptId());
+
+    failures.addTimeoutAfterRename(manifestTempFile);
+
+    // if too many attempts fail, the task will fail
+    failures.setFailureLimit(SAVE_ATTEMPTS + 1);
+    intercept(SocketTimeoutException.class, E_TIMEOUT, () ->
+        new CommitTaskStage(stageConfig).apply(null));
+
+  }
+
+  @Test
+  public void testManifestRenameLateTimeoutsRecovery() throws Throwable {
+    describe("Testing recovery from late timeouts on rename operations.");
+
+    UnreliableManifestStoreOperations failures = makeStoreOperationsUnreliable();
+    StageConfig stageConfig = createStageConfig();
+
+    new SetupTaskStage(stageConfig).apply("setup");
+
+    final Path manifestDir = stageConfig.getTaskManifestDir();
+
+    Path manifestTempFile = manifestTempPathForTaskAttempt(manifestDir,
+        stageConfig.getTaskAttemptId());
+
+    failures.addTimeoutAfterRename(manifestTempFile);
+
+    // reduce the limit and expect the stage to succeed.
+    failures.setFailureLimit(SAVE_ATTEMPTS);
+    stageConfig.getIOStatistics().reset();
+    new CommitTaskStage(stageConfig).apply(null);
+    final CommitTaskStage.Result r = new CommitTaskStage(stageConfig).apply(null);
+
+    // load in the manifest
+    final TaskManifest loadedManifest = TaskManifest.load(getFileSystem(), r.getPath());
+    final IOStatisticsSnapshot loadedIOStats = loadedManifest.getIOStatistics();
+    LOG.info("Statistics of file successfully saved:\n{}",
+        ioStatisticsToPrettyString(loadedIOStats));
+    // the failure event is one less than the limit.
+    assertThatStatisticCounter(loadedIOStats, OP_SAVE_TASK_MANIFEST + ".failures")
+        .isEqualTo(SAVE_ATTEMPTS - 1);
+  }
+
+  @Test
+  public void testFailureToDeleteManifestPath() throws Throwable {
+    describe("Testing failure in the delete call made before renaming the manifest");
+
+    UnreliableManifestStoreOperations failures = makeStoreOperationsUnreliable();
+    StageConfig stageConfig = createStageConfig();
+
+    new SetupTaskStage(stageConfig).apply("setup");
+
+    final Path manifestDir = stageConfig.getTaskManifestDir();
+    // final manifest file is by task ID
+    Path manifestFile = manifestPathForTask(manifestDir,
+        stageConfig.getTaskId());
+    // put a file in as there is a check for it before the delete
+    ContractTestUtils.touch(getFileSystem(), manifestFile);
+    /* and the delete shall fail */
+    failures.addDeletePathToFail(manifestFile);
+    Path manifestTempFile = manifestTempPathForTaskAttempt(manifestDir,
+        stageConfig.getTaskAttemptId());
+
+
+    // first verify that if too many attempts fail, the task will fail
+    failures.setFailureLimit(SAVE_ATTEMPTS + 1);
+    intercept(PathIOException.class, () ->
+        new CommitTaskStage(stageConfig).apply(null));
+
+    // reduce the limit and expect the stage to succeed.
+    failures.setFailureLimit(SAVE_ATTEMPTS - 1);
+    new CommitTaskStage(stageConfig).apply(null);
+  }
+
+
+  /**
+   * Failure of delete before saving the manifest to a temporary path.
+   */
+  @Test
+  public void testFailureOfDeleteBeforeSavingTemporaryFile() throws Throwable {
+    describe("Testing failure in the delete call made before rename");
+
+    UnreliableManifestStoreOperations failures = makeStoreOperationsUnreliable();
+    StageConfig stageConfig = createStageConfig();
+
+    new SetupTaskStage(stageConfig).apply("setup");
+
+    final Path manifestDir = stageConfig.getTaskManifestDir();
+    Path manifestTempFile = manifestTempPathForTaskAttempt(manifestDir,
+        stageConfig.getTaskAttemptId());
+
+    // delete will fail
+    failures.addDeletePathToFail(manifestTempFile);
+
+    // first verify that if too many attempts fail, the task will fail
+    failures.setFailureLimit(SAVE_ATTEMPTS + 1);
+    intercept(PathIOException.class, () ->
+        new CommitTaskStage(stageConfig).apply(null));
+
+    // reduce the limit and expect the stage to succeed.
+    failures.setFailureLimit(SAVE_ATTEMPTS - 1);
+    new CommitTaskStage(stageConfig).apply(null);
+
+  }
+  /**
+   * Rename target is a directory.
+   */
+  @Test
+  public void testRenameTargetIsDir() throws Throwable {
+    describe("Rename target is a directory");
+
+    final ManifestStoreOperations operations = getStoreOperations();
+    StageConfig stageConfig = createStageConfig();
+
+    final SetupTaskStage setup = new SetupTaskStage(stageConfig);
+    setup.apply("setup");
+
+    final Path manifestDir = stageConfig.getTaskManifestDir();
+    // final manifest file is by task ID
+    Path manifestFile = manifestPathForTask(manifestDir,
+        stageConfig.getTaskId());
+    Path manifestTempFile = manifestTempPathForTaskAttempt(manifestDir,
+        stageConfig.getTaskAttemptId());
+
+    // add a directory where the manifest file is to go
+    setup.mkdirs(manifestFile, true);
+    ContractTestUtils.assertIsDirectory(getFileSystem(), manifestFile);
+    new CommitTaskStage(stageConfig).apply(null);
+
+    // this must be a file.
+    final FileStatus st = operations.getFileStatus(manifestFile);
+    Assertions.assertThat(st)
+        .describedAs("File status of %s", manifestFile)
+        .matches(FileStatus::isFile, "is a file");
+
+    // and it must load.
+    final TaskManifest manifest = setup.loadManifest(st);
+    Assertions.assertThat(manifest)
+        .matches(m -> m.getTaskID().equals(TASK1))
+        .matches(m -> m.getTaskAttemptID().equals(TASK1_ATTEMPT1));
+  }
+
+  /**
+   * Manifest temp file path is a directory.
+   */
+  @Test
+  public void testManifestTempFileIsDir() throws Throwable {
+    describe("Manifest temp file path is a directory");
+
+    final ManifestStoreOperations operations = getStoreOperations();
+    StageConfig stageConfig = createStageConfig();
+
+    final SetupTaskStage setup = new SetupTaskStage(stageConfig);
+    setup.apply("setup");
+
+    final Path manifestDir = stageConfig.getTaskManifestDir();
+    // final manifest file is by task ID
+    Path manifestFile = manifestPathForTask(manifestDir,
+        stageConfig.getTaskId());
+    Path manifestTempFile = manifestTempPathForTaskAttempt(manifestDir,
+        stageConfig.getTaskAttemptId());
+
+    // add a directory where the manifest file is to go
+    setup.mkdirs(manifestTempFile, true);
+    new CommitTaskStage(stageConfig).apply(null);
+
+    final TaskManifest manifest = setup.loadManifest(
+        operations.getFileStatus(manifestFile));
+    Assertions.assertThat(manifest)
+        .matches(m -> m.getTaskID().equals(TASK1))
+        .matches(m -> m.getTaskAttemptID().equals(TASK1_ATTEMPT1));
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestCreateOutputDirectoriesStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestCreateOutputDirectoriesStage.java
@@ -247,7 +247,7 @@ public class TestCreateOutputDirectoriesStage extends AbstractManifestCommitterT
     CreateOutputDirectoriesStage attempt2 =
         new CreateOutputDirectoriesStage(
             createStageConfigForJob(JOB1, destDir)
-                .withDeleteTargetPaths(true));
+                .withDeleteTargetPaths(false));
     // attempt will fail because one of the entries marked as
     // a file to delete is now a non-empty directory
     LOG.info("Executing failing attempt to create the directories");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestJobThroughManifestCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestJobThroughManifestCommitter.java
@@ -598,7 +598,8 @@ public class TestJobThroughManifestCommitter
   public void test_0900_cleanupJob() throws Throwable {
     describe("Cleanup job");
     CleanupJobStage.Arguments arguments = new CleanupJobStage.Arguments(
-        OP_STAGE_JOB_CLEANUP, true, true, false);
+        OP_STAGE_JOB_CLEANUP, true, true,
+        false, false, 0);
     // the first run will list the three task attempt dirs and delete each
     // one before the toplevel dir.
     CleanupJobStage.Result result = new CleanupJobStage(
@@ -615,7 +616,7 @@ public class TestJobThroughManifestCommitter
    * Needed to clean up the shared test root, as test case teardown
    * does not do it.
    */
-  //@Test
+  @Test
   public void test_9999_cleanupTestDir() throws Throwable {
     if (shouldDeleteTestRootAtEndOfTestRun()) {
       deleteSharedTestRoot();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestLoadManifestsStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestLoadManifestsStage.java
@@ -176,7 +176,7 @@ public class TestLoadManifestsStage extends AbstractManifestCommitterTest {
     // and skipping the rename stage (which is going to fail),
     // go straight to cleanup
     new CleanupJobStage(stageConfig).apply(
-        new CleanupJobStage.Arguments("", true, true, false));
+        new CleanupJobStage.Arguments("", true, true, false, false, 0));
     heapinfo(heapInfo, "cleanup");
 
     ManifestSuccessData success = createManifestOutcome(stageConfig, OP_STAGE_JOB_COMMIT);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/UnreliableManifestStoreOperations.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/impl/UnreliableManifestStoreOperations.java
@@ -21,8 +21,10 @@ package org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.net.SocketTimeoutException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,8 +49,7 @@ import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.impl.Int
  * This is for testing. It could be implemented via
  * Mockito 2 spy code but is not so that:
  * 1. It can be backported to Hadoop versions using Mockito 1.x.
- * 2. It can be extended to use in production. This is why it is in
- * the production module -to allow for downstream tests to adopt it.
+ * 2. It can be extended to use in production.
  * 3. You can actually debug what's going on.
  */
 @InterfaceAudience.Private
@@ -68,6 +69,12 @@ public class UnreliableManifestStoreOperations extends ManifestStoreOperations {
    * Text to use in simulated failure exceptions.
    */
   public static final String SIMULATED_FAILURE = "Simulated failure";
+
+  /**
+   * Default failure limit.
+   * Set to a large enough value that most tests don't hit it.
+   */
+  private static final int DEFAULT_FAILURE_LIMIT = Integer.MAX_VALUE;
 
   /**
    * Underlying store operations to wrap.
@@ -111,6 +118,16 @@ public class UnreliableManifestStoreOperations extends ManifestStoreOperations {
   private final Set<Path> renameDestDirsToFail = new HashSet<>();
 
   /**
+   * Source paths of rename operations to time out before the rename request is issued.
+   */
+  private final Set<Path> renamePathsToTimeoutBeforeRename = new HashSet<>();
+
+  /**
+   * Source paths of rename operations to time out after the rename request has succeeded.
+   */
+  private final Set<Path> renamePathsToTimeoutAfterRename = new HashSet<>();
+
+  /**
    * Path of save() to fail.
    */
   private final Set<Path> saveToFail = new HashSet<>();
@@ -126,6 +143,11 @@ public class UnreliableManifestStoreOperations extends ManifestStoreOperations {
   private boolean renameToFailWithException = true;
 
   /**
+   * How many failures before an operation is passed through.
+   */
+  private final AtomicInteger failureLimit = new AtomicInteger(DEFAULT_FAILURE_LIMIT);
+
+  /**
    * Constructor.
    * @param wrappedOperations operations to wrap.
    */
@@ -133,16 +155,19 @@ public class UnreliableManifestStoreOperations extends ManifestStoreOperations {
     this.wrappedOperations = wrappedOperations;
   }
 
-
   /**
    * Reset everything.
    */
   public void reset() {
     deletePathsToFail.clear();
     deletePathsToTimeOut.clear();
+    failureLimit.set(DEFAULT_FAILURE_LIMIT);
     pathNotFound.clear();
     renameSourceFilesToFail.clear();
     renameDestDirsToFail.clear();
+    renamePathsToTimeoutBeforeRename.clear();
+    renamePathsToTimeoutAfterRename.clear();
+    saveToFail.clear();
     timeoutSleepTimeMillis = 0;
   }
 
@@ -220,6 +245,21 @@ public class UnreliableManifestStoreOperations extends ManifestStoreOperations {
   }
 
   /**
+   * Add a source path to timeout before the rename.
+   * @param path path to add.
+   */
+  public void addTimeoutBeforeRename(Path path) {
+    renamePathsToTimeoutBeforeRename.add(requireNonNull(path));
+  }
+  /**
+   * Add a source path to timeout after the rename.
+   * @param path path to add.
+   */
+  public void addTimeoutAfterRename(Path path) {
+    renamePathsToTimeoutAfterRename.add(requireNonNull(path));
+  }
+
+  /**
    * Add a path to the list of paths where save will fail.
    * @param path path to add.
    */
@@ -228,7 +268,16 @@ public class UnreliableManifestStoreOperations extends ManifestStoreOperations {
   }
 
   /**
-   * Raise an exception if the path is in the set of target paths.
+   * Set the failure limit.
+   * @param limit limit
+   */
+  public void setFailureLimit(int limit) {
+    failureLimit.set(limit);
+  }
+
+  /**
+   * Raise an exception if the path is in the set of target paths
+   * and the failure limit is not exceeded.
    * @param operation operation which failed.
    * @param path path to check
    * @param paths paths to probe for {@code path} being in.
@@ -236,11 +285,47 @@ public class UnreliableManifestStoreOperations extends ManifestStoreOperations {
    */
   private void maybeRaiseIOE(String operation, Path path, Set<Path> paths)
       throws IOException {
+    if (paths.contains(path) && decrementAndCheckFailureLimit()) {
+      // hand off to the inner check.
+      maybeRaiseIOENoFailureLimitCheck(operation, path, paths);
+    }
+  }
+
+  /**
+   * Raise an exception if the path is in the set of target paths.
+   * No checks on failure count are performed.
+   * @param operation operation which failed.
+   * @param path path to check
+   * @param paths paths to probe for {@code path} being in.
+   * @throws IOException simulated failure
+   */
+  private void maybeRaiseIOENoFailureLimitCheck(String operation, Path path, Set<Path> paths)
+      throws IOException {
     if (paths.contains(path)) {
       LOG.info("Simulating failure of {} with {}", operation, path);
       throw new PathIOException(path.toString(),
-          SIMULATED_FAILURE + " of " + operation);
+          generatedErrorMessage(operation));
     }
+  }
+
+  /**
+   * Given an operation, return the error message which is used for the simulated
+   * {@link PathIOException}.
+   * @param operation operation name
+   * @return error text
+   */
+  public static String generatedErrorMessage(final String operation) {
+    return SIMULATED_FAILURE + " of " + operation;
+  }
+
+  /**
+   * Check if the failure limit is exceeded.
+   * Call this after any other trigger checks, as it decrements the counter.
+   *
+   * @return true if the limit is not exceeded.
+   */
+  private boolean decrementAndCheckFailureLimit() {
+    return failureLimit.decrementAndGet() > 0;
   }
 
   /**
@@ -249,7 +334,7 @@ public class UnreliableManifestStoreOperations extends ManifestStoreOperations {
    * @throws FileNotFoundException if configured to fail.
    */
   private void verifyExists(Path path) throws FileNotFoundException {
-    if (pathNotFound.contains(path)) {
+    if (pathNotFound.contains(path) && decrementAndCheckFailureLimit()) {
       throw new FileNotFoundException(path.toString());
     }
   }
@@ -260,11 +345,12 @@ public class UnreliableManifestStoreOperations extends ManifestStoreOperations {
    * @param operation operation which failed.
    * @param path path to check
    * @param paths paths to probe for {@code path} being in.
-   * @throws IOException simulated timeout
+   * @throws SocketTimeoutException simulated timeout
+   * @throws InterruptedIOException if the sleep is interrupted.
    */
   private void maybeTimeout(String operation, Path path, Set<Path> paths)
-      throws IOException {
-    if (paths.contains(path)) {
+      throws SocketTimeoutException, InterruptedIOException  {
+    if (paths.contains(path) && decrementAndCheckFailureLimit()) {
       LOG.info("Simulating timeout of {} with {}", operation, path);
       try {
         if (timeoutSleepTimeMillis > 0) {
@@ -273,14 +359,16 @@ public class UnreliableManifestStoreOperations extends ManifestStoreOperations {
       } catch (InterruptedException e) {
         throw new InterruptedIOException(e.toString());
       }
-      throw new PathIOException(path.toString(),
-          "ErrorCode=" + OPERATION_TIMED_OUT
+      throw new SocketTimeoutException(
+          path.toString() + ": " + operation
+              + " ErrorCode=" + OPERATION_TIMED_OUT
               + " ErrorMessage=" + E_TIMEOUT);
     }
   }
 
   @Override
   public FileStatus getFileStatus(final Path path) throws IOException {
+    maybeTimeout("getFileStatus()", path, pathNotFound);
     verifyExists(path);
     return wrappedOperations.getFileStatus(path);
   }
@@ -304,17 +392,23 @@ public class UnreliableManifestStoreOperations extends ManifestStoreOperations {
   public boolean renameFile(final Path source, final Path dest)
       throws IOException {
     String op = "rename";
+    maybeTimeout(op, source, renamePathsToTimeoutBeforeRename);
     if (renameToFailWithException) {
       maybeRaiseIOE(op, source, renameSourceFilesToFail);
       maybeRaiseIOE(op, dest.getParent(), renameDestDirsToFail);
     } else {
-      if (renameSourceFilesToFail.contains(source)
-          || renameDestDirsToFail.contains(dest.getParent())) {
+      // logic to determine whether rename should just return false.
+      if ((renameSourceFilesToFail.contains(source)
+          || renameDestDirsToFail.contains(dest.getParent())
+          && decrementAndCheckFailureLimit())) {
         LOG.info("Failing rename({}, {})", source, dest);
         return false;
       }
     }
-    return wrappedOperations.renameFile(source, dest);
+    final boolean b = wrappedOperations.renameFile(source, dest);
+    // post rename timeout.
+    maybeTimeout(op, source, renamePathsToTimeoutAfterRename);
+    return b;
   }
 
   @Override
@@ -358,13 +452,19 @@ public class UnreliableManifestStoreOperations extends ManifestStoreOperations {
   @Override
   public CommitFileResult commitFile(final FileEntry entry)
       throws IOException {
+    final String op = "commitFile";
+    final Path source = entry.getSourcePath();
+    maybeTimeout(op, source, renamePathsToTimeoutBeforeRename);
     if (renameToFailWithException) {
-      maybeRaiseIOE("commitFile",
-          entry.getSourcePath(), renameSourceFilesToFail);
-      maybeRaiseIOE("commitFile",
+      maybeRaiseIOE(op,
+          source, renameSourceFilesToFail);
+      maybeRaiseIOE(op,
           entry.getDestPath().getParent(), renameDestDirsToFail);
     }
-    return wrappedOperations.commitFile(entry);
+    final CommitFileResult result = wrappedOperations.commitFile(entry);
+    // post rename timeout.
+    maybeTimeout(op, source, renamePathsToTimeoutAfterRename);
+    return result;
   }
 
   @Override

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/resources/log4j.properties
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/resources/log4j.properties
@@ -17,3 +17,5 @@ log4j.threshold=ALL
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2} (%F:%M(%L)) - %m%n
+
+log4j.logger.org.apache.hadoop.mapreduce.lib.output.committer.manifest=DEBUG

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -186,7 +186,7 @@
     <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <surefire.fork.timeout>900</surefire.fork.timeout>
-    <aws-java-sdk.version>1.12.599</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.720</aws-java-sdk.version>
     <aws-java-sdk-v2.version>2.24.6</aws-java-sdk-v2.version>
     <aws.eventstream.version>1.0.1</aws.eventstream.version>
     <hsqldb.version>2.7.1</hsqldb.version>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -111,7 +111,7 @@
     <guava.version>27.0-jre</guava.version>
     <guice.version>4.2.3</guice.version>
 
-    <bouncycastle.version>1.77</bouncycastle.version>
+    <bouncycastle.version>1.78</bouncycastle.version>
 
     <!-- Required for testing LDAP integration -->
     <apacheds.version>2.0.0.AM26</apacheds.version>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1960,6 +1960,11 @@
           <version>${kerby.version}</version>
         </dependency>
         <dependency>
+          <groupId>org.apache.kerby</groupId>
+          <artifactId>kerb-util</artifactId>
+          <version>${kerby.version}</version>
+        </dependency>
+        <dependency>
           <groupId>org.ehcache</groupId>
           <artifactId>ehcache</artifactId>
           <version>${ehcache.version}</version>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -135,7 +135,7 @@
     <ehcache.version>3.8.2</ehcache.version>
     <cache.api.version>1.1.1</cache.api.version>
     <hikari.version>4.0.3</hikari.version>
-    <derby.version>10.14.2.0</derby.version>
+    <derby.version>10.17.1.0</derby.version>
     <mssql.version>6.2.1.jre7</mssql.version>
     <okhttp3.version>4.11.0</okhttp3.version>
     <kotlin-stdlib.version>1.6.20</kotlin-stdlib.version>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSHeaders.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSHeaders.java
@@ -55,6 +55,9 @@ public interface AWSHeaders {
   /** Header for optional server-side encryption algorithm. */
   String SERVER_SIDE_ENCRYPTION = "x-amz-server-side-encryption";
 
+  /** Header for optional server-side encryption algorithm. */
+  String SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID = "x-amz-server-side-encryption-aws-kms-key-id";
+
   /** Range header for the get object request. */
   String RANGE = "Range";
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/HeaderProcessing.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/HeaderProcessing.java
@@ -47,6 +47,7 @@ import static org.apache.hadoop.fs.s3a.Statistic.INVOCATION_XATTR_GET_MAP;
 import static org.apache.hadoop.fs.s3a.Statistic.INVOCATION_XATTR_GET_NAMED;
 import static org.apache.hadoop.fs.s3a.Statistic.INVOCATION_XATTR_GET_NAMED_MAP;
 import static org.apache.hadoop.fs.s3a.commit.CommitConstants.X_HEADER_MAGIC_MARKER;
+import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.trackDuration;
 
 /**
@@ -184,6 +185,9 @@ public class HeaderProcessing extends AbstractStoreOperation {
    */
   public static final String XA_SERVER_SIDE_ENCRYPTION =
       XA_HEADER_PREFIX + AWSHeaders.SERVER_SIDE_ENCRYPTION;
+
+  public static final String XA_ENCRYPTION_KEY_ID =
+      XA_HEADER_PREFIX + SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID;
 
   /**
    * Storage Class XAttr: {@value}.
@@ -363,6 +367,8 @@ public class HeaderProcessing extends AbstractStoreOperation {
         md.versionId());
     maybeSetHeader(headers, XA_SERVER_SIDE_ENCRYPTION,
         md.serverSideEncryptionAsString());
+    maybeSetHeader(headers, XA_ENCRYPTION_KEY_ID,
+            md.ssekmsKeyId());
     maybeSetHeader(headers, XA_STORAGE_CLASS,
         md.storageClassAsString());
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/committers.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/committers.md
@@ -720,7 +720,7 @@ such use case, The "MAGIC PATH" for each job is unique of the format `__magic_jo
 multiple job running simultaneously do not step into each other.
 
 Before attempting this, the committers must be set to not delete all incomplete uploads on job commit,
-by setting `fs.s3a.committer.abort.pending.uploads` to `false`. This is set to `false`by default
+by setting `fs.s3a.committer.abort.pending.uploads` to `false`. This is set to `true` by default.
 
 ```xml
 <property>

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/EncryptionTestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/EncryptionTestUtils.java
@@ -19,7 +19,11 @@
 package org.apache.hadoop.fs.s3a;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
 
+import org.apache.hadoop.fs.s3a.impl.HeaderProcessing;
+import org.assertj.core.api.Assertions;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 import org.apache.commons.codec.digest.DigestUtils;
@@ -28,6 +32,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 import static org.apache.hadoop.fs.s3a.Constants.S3_ENCRYPTION_KEY;
+import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.XA_ENCRYPTION_KEY_ID;
+import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.XA_SERVER_SIDE_ENCRYPTION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public final class EncryptionTestUtils {
@@ -111,4 +117,31 @@ public final class EncryptionTestUtils {
     }
   }
 
+  /**
+   * Assert that a path is encrypted with right encryption settings.
+   * @param fs filesystem.
+   * @param path path
+   * @param algorithm encryption algorithm.
+   * @param kmsKey full kms key if present.
+   * @throws IOException any IOE.
+   */
+  public static void validateEncryptionFileAttributes(S3AFileSystem fs,
+                                                Path path,
+                                                String algorithm,
+                                                Optional<String> kmsKey) throws IOException {
+    Map<String, byte[]> xAttrs = fs.getXAttrs(path);
+    Assertions.assertThat(xAttrs.get(XA_SERVER_SIDE_ENCRYPTION))
+            .describedAs("Server side encryption must not be null")
+            .isNotNull();
+    Assertions.assertThat(HeaderProcessing.decodeBytes(xAttrs.get(XA_SERVER_SIDE_ENCRYPTION)))
+                    .describedAs("Server side encryption algorithm must match")
+                    .isEqualTo(algorithm);
+    Assertions.assertThat(xAttrs)
+            .describedAs("Encryption key id should be present")
+            .containsKey(XA_ENCRYPTION_KEY_ID);
+    kmsKey.ifPresent(s -> Assertions
+            .assertThat(HeaderProcessing.decodeBytes(xAttrs.get(XA_ENCRYPTION_KEY_ID)))
+              .describedAs("Encryption key id should match with the kms key")
+              .isEqualTo(s));
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAWSCredentialsProvider.java
@@ -44,6 +44,7 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.DELEGATION_TOKEN_BINDING;
 import static org.apache.hadoop.fs.s3a.impl.InstantiationIOException.CONSTRUCTOR_EXCEPTION;
 import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.getExternalData;
+import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.isUsingDefaultExternalDataFile;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.junit.Assert.*;
 
@@ -207,6 +208,11 @@ public class ITestS3AAWSCredentialsProvider {
   @Test
   public void testAnonymousProvider() throws Exception {
     Configuration conf = createConf(AnonymousAWSCredentialsProvider.class);
+    if (isUsingDefaultExternalDataFile(conf)) {
+      removeBaseAndBucketOverrides(conf,
+          ENDPOINT);
+      conf.set(ENDPOINT, CENTRAL_ENDPOINT);
+    }
     Path testFile = getExternalData(conf);
     try (FileSystem fs = FileSystem.newInstance(testFile.toUri(), conf)) {
       Assertions.assertThat(fs)

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEKMSDefaultKey.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEKMSDefaultKey.java
@@ -19,12 +19,18 @@
 package org.apache.hadoop.fs.s3a;
 
 import java.io.IOException;
+import java.util.Optional;
 
+import org.junit.Test;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
 
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
+import static org.apache.hadoop.fs.s3a.EncryptionTestUtils.validateEncryptionFileAttributes;
 import static org.hamcrest.CoreMatchers.containsString;
 
 /**
@@ -55,5 +61,20 @@ public class ITestS3AEncryptionSSEKMSDefaultKey
     assertEquals("SSE Algorithm", EncryptionTestUtils.AWS_KMS_SSE_ALGORITHM,
             md.serverSideEncryptionAsString());
     assertThat(md.ssekmsKeyId(), containsString("arn:aws:kms:"));
+  }
+
+  @Test
+  public void testEncryptionFileAttributes() throws Exception {
+    describe("Test for correct encryption file attributes for SSE-KMS with server default key.");
+    Path path = path(createFilename(1024));
+    byte[] data = dataset(1024, 'a', 'z');
+    S3AFileSystem fs = getFileSystem();
+    writeDataset(fs, path, data, data.length, 1024 * 1024, true);
+    ContractTestUtils.verifyFileContents(fs, path, data);
+    // we don't know the KMS key in case of server default option.
+    validateEncryptionFileAttributes(fs,
+            path,
+            EncryptionTestUtils.AWS_KMS_SSE_ALGORITHM,
+            Optional.empty());
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.fs.s3a;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -36,6 +37,7 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
 import static org.apache.hadoop.fs.s3a.Constants.S3_ENCRYPTION_ALGORITHM;
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_ALGORITHM;
 import static org.apache.hadoop.fs.s3a.EncryptionTestUtils.AWS_KMS_SSE_ALGORITHM;
+import static org.apache.hadoop.fs.s3a.EncryptionTestUtils.validateEncryptionFileAttributes;
 import static org.apache.hadoop.fs.s3a.S3AEncryptionMethods.SSE_KMS;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestBucketName;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
@@ -96,6 +98,22 @@ public class ITestS3AEncryptionWithDefaultS3Settings extends
     String kmsKey = getS3EncryptionKey(getTestBucketName(c), c);
     EncryptionTestUtils.assertEncrypted(fs, path, SSE_KMS, kmsKey);
   }
+
+  @Test
+  public void testEncryptionFileAttributes() throws Exception {
+    describe("Test for correct encryption file attributes for SSE-KMS with user default setting.");
+    Path path = path(createFilename(1024));
+    byte[] data = dataset(1024, 'a', 'z');
+    S3AFileSystem fs = getFileSystem();
+    writeDataset(fs, path, data, data.length, 1024 * 1024, true);
+    ContractTestUtils.verifyFileContents(fs, path, data);
+    Configuration c = fs.getConf();
+    String kmsKey = getS3EncryptionKey(getTestBucketName(c), c);
+    validateEncryptionFileAttributes(fs, path, AWS_KMS_SSE_ALGORITHM, Optional.of(kmsKey));
+  }
+
+
+
 
   @Override
   @Ignore

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFailureHandling.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFailureHandling.java
@@ -32,9 +32,6 @@ import org.apache.hadoop.fs.statistics.StoreStatisticNames;
 import org.apache.hadoop.fs.store.audit.AuditSpan;
 
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,7 +42,9 @@ import java.util.stream.Collectors;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.createFiles;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.isBulkDeleteEnabled;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.test.ExtraAssertions.failIf;
+import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.isUsingDefaultExternalDataFile;
 import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.requireDefaultExternalData;
 import static org.apache.hadoop.test.LambdaTestUtils.*;
 import static org.apache.hadoop.util.functional.RemoteIterators.mappingRemoteIterator;
@@ -55,14 +54,15 @@ import static org.apache.hadoop.util.functional.RemoteIterators.toList;
  * ITest for failure handling, primarily multipart deletion.
  */
 public class ITestS3AFailureHandling extends AbstractS3ATestBase {
-  private static final Logger LOG =
-      LoggerFactory.getLogger(ITestS3AFailureHandling.class);
 
   @Override
   protected Configuration createConfiguration() {
     Configuration conf = super.createConfiguration();
     S3ATestUtils.disableFilesystemCaching(conf);
     conf.setBoolean(Constants.ENABLE_MULTI_DELETE, true);
+    if (isUsingDefaultExternalDataFile(conf)) {
+      removeBaseAndBucketOverrides(conf, Constants.ENDPOINT);
+    }
     return conf;
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3APrefetchingCacheFiles.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3APrefetchingCacheFiles.java
@@ -38,9 +38,11 @@ import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.s3a.performance.AbstractS3ACostTest;
 
 import static org.apache.hadoop.fs.s3a.Constants.BUFFER_DIR;
+import static org.apache.hadoop.fs.s3a.Constants.ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.PREFETCH_BLOCK_SIZE_KEY;
 import static org.apache.hadoop.fs.s3a.Constants.PREFETCH_ENABLED_KEY;
 import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.getExternalData;
+import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.isUsingDefaultExternalDataFile;
 import static org.apache.hadoop.io.IOUtils.cleanupWithLogger;
 
 /**
@@ -84,7 +86,11 @@ public class ITestS3APrefetchingCacheFiles extends AbstractS3ACostTest {
   @Override
   public Configuration createConfiguration() {
     Configuration configuration = super.createConfiguration();
-    S3ATestUtils.removeBaseAndBucketOverrides(configuration, PREFETCH_ENABLED_KEY);
+    if (isUsingDefaultExternalDataFile(configuration)) {
+      S3ATestUtils.removeBaseAndBucketOverrides(configuration,
+          PREFETCH_ENABLED_KEY,
+          ENDPOINT);
+    }
     configuration.setBoolean(PREFETCH_ENABLED_KEY, true);
     // use a small block size unless explicitly set in the test config.
     configuration.setInt(PREFETCH_BLOCK_SIZE_KEY, BLOCK_SIZE);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestDelegatedMRJob.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestDelegatedMRJob.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.examples.WordCount;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.Text;
@@ -53,12 +54,14 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeSessionTestsEnabled;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.deployService;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestPropertyInt;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.terminateService;
 import static org.apache.hadoop.fs.s3a.auth.RoleTestUtils.probeForAssumedRoleARN;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.*;
 import static org.apache.hadoop.fs.s3a.auth.delegation.MiniKerberizedHadoopCluster.assertSecurityEnabled;
 import static org.apache.hadoop.fs.s3a.auth.delegation.MiniKerberizedHadoopCluster.closeUserFileSystems;
 import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.getOrcData;
+import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.isUsingDefaultExternalDataFile;
 import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.requireAnonymousDataPath;
 
 /**
@@ -251,6 +254,10 @@ public class ITestDelegatedMRJob extends AbstractDelegationIT {
   public void testJobSubmissionCollectsTokens() throws Exception {
     describe("Mock Job test");
     JobConf conf = new JobConf(getConfiguration());
+    if (isUsingDefaultExternalDataFile(conf)) {
+      removeBaseAndBucketOverrides(conf,
+          Constants.ENDPOINT);
+    }
 
     // the input here is the external file; which lets
     // us differentiate source URI from dest URI

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/AbstractS3GuardToolTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/AbstractS3GuardToolTestBase.java
@@ -118,12 +118,12 @@ public abstract class AbstractS3GuardToolTestBase extends AbstractS3ATestBase {
    * Run a S3GuardTool command from a varags list, catch any raised
    * ExitException and verify the status code matches that expected.
    * @param status expected status code of the exception
+   * @param conf configuration object.
    * @param args argument list
    * @throws Exception any exception
    */
-  protected void runToFailure(int status, Object... args)
+  protected void runToFailure(int status, Configuration conf, Object... args)
       throws Exception {
-    final Configuration conf = getConfiguration();
     ExitUtil.ExitException ex =
         intercept(ExitUtil.ExitException.class, () ->
             runS3GuardCommand(conf, args));
@@ -247,7 +247,7 @@ public abstract class AbstractS3GuardToolTestBase extends AbstractS3ATestBase {
     describe("Verify the unsupported tools are rejected");
     for (String tool : UNSUPPORTED_COMMANDS) {
       describe("Probing %s", tool);
-      runToFailure(E_S3GUARD_UNSUPPORTED, tool);
+      runToFailure(E_S3GUARD_UNSUPPORTED, getConfiguration(), tool);
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardTool.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardTool.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.StringUtils;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
+import static org.apache.hadoop.fs.s3a.Constants.ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.FIPS_ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.S3_ENCRYPTION_ALGORITHM;
 import static org.apache.hadoop.fs.s3a.MultipartTestUtils.assertNoUploadsAt;
@@ -48,6 +49,7 @@ import static org.apache.hadoop.fs.s3a.s3guard.S3GuardTool.BucketInfo;
 import static org.apache.hadoop.fs.s3a.s3guard.S3GuardTool.E_BAD_STATE;
 import static org.apache.hadoop.fs.s3a.s3guard.S3GuardTool.Uploads;
 import static org.apache.hadoop.fs.s3a.s3guard.S3GuardToolTestHelper.exec;
+import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.isUsingDefaultExternalDataFile;
 
 /**
  * Test S3Guard Tool CLI commands.
@@ -60,8 +62,13 @@ public class ITestS3GuardTool extends AbstractS3GuardToolTestBase {
 
   @Test
   public void testExternalBucketRequireUnencrypted() throws Throwable {
-    removeBaseAndBucketOverrides(getConfiguration(), S3_ENCRYPTION_ALGORITHM);
-    run(BucketInfo.NAME,
+    Configuration conf = getConfiguration();
+    if (isUsingDefaultExternalDataFile(conf)) {
+      removeBaseAndBucketOverrides(conf,
+          S3_ENCRYPTION_ALGORITHM,
+          ENDPOINT);
+    }
+    run(conf, BucketInfo.NAME,
         "-" + BucketInfo.ENCRYPTION_FLAG, "none",
         externalBucket());
   }
@@ -81,10 +88,17 @@ public class ITestS3GuardTool extends AbstractS3GuardToolTestBase {
 
   @Test
   public void testExternalBucketRequireEncrypted() throws Throwable {
+    Configuration conf = getConfiguration();
+    if (isUsingDefaultExternalDataFile(conf)) {
+      removeBaseAndBucketOverrides(conf,
+          ENDPOINT);
+    }
     runToFailure(E_BAD_STATE,
+        conf,
         BucketInfo.NAME,
         "-" + BucketInfo.ENCRYPTION_FLAG,
-        "AES256", externalBucket());
+        "AES256",
+        externalBucket());
   }
 
   @Test
@@ -212,9 +226,13 @@ public class ITestS3GuardTool extends AbstractS3GuardToolTestBase {
 
   @Test
   public void testUploadNegativeExpect() throws Throwable {
-    runToFailure(E_BAD_STATE, Uploads.NAME, "-expect", "1",
-        path("/we/are/almost/postive/this/doesnt/exist/fhfsadfoijew")
-            .toString());
+    Configuration conf = getConfiguration();
+    runToFailure(E_BAD_STATE,
+        conf,
+        Uploads.NAME,
+        "-expect",
+        "1",
+        path("/we/are/almost/postive/this/doesnt/exist/fhfsadfoijew").toString());
   }
 
   private void assertNumUploads(Path path, int numUploads) throws Exception {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AInputStreamPerformance.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AInputStreamPerformance.java
@@ -60,6 +60,7 @@ import static org.apache.hadoop.fs.s3a.Constants.*;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assume;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getInputStreamStatistics;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getS3AInputStream;
+import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.isUsingDefaultExternalDataFile;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertThatStatisticMinimum;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.lookupMaximumStatistic;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.lookupMeanStatistic;
@@ -99,7 +100,13 @@ public class ITestS3AInputStreamPerformance extends S3AScaleTestBase {
   @Override
   protected Configuration createScaleConfiguration() {
     Configuration conf = super.createScaleConfiguration();
-    S3ATestUtils.removeBaseAndBucketOverrides(conf, PREFETCH_ENABLED_KEY);
+    S3ATestUtils.removeBaseAndBucketOverrides(conf,
+        PREFETCH_ENABLED_KEY);
+    if (isUsingDefaultExternalDataFile(conf)) {
+      S3ATestUtils.removeBaseAndBucketOverrides(
+          conf,
+          ENDPOINT);
+    }
     conf.setBoolean(PREFETCH_ENABLED_KEY, false);
     return conf;
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/PublicDatasetTestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/PublicDatasetTestUtils.java
@@ -134,6 +134,18 @@ public final class PublicDatasetTestUtils {
   }
 
   /**
+   * To determine whether {@value S3ATestConstants#KEY_CSVTEST_FILE} is configured to be
+   * different from the default external file.
+   *
+   * @param conf Configuration object.
+   * @return True if the default external data file is being used.
+   */
+  public static boolean isUsingDefaultExternalDataFile(final Configuration conf) {
+    final String filename = getExternalData(conf).toUri().toString();
+    return DEFAULT_EXTERNAL_FILE.equals(filename);
+  }
+
+  /**
    * Get the test external file; assume() that it is not modified (i.e. we haven't
    * switched to a new storage infrastructure where the bucket is no longer
    * read only).

--- a/hadoop-tools/hadoop-azure/pom.xml
+++ b/hadoop-tools/hadoop-azure/pom.xml
@@ -45,6 +45,8 @@
     <fs.azure.scale.test.timeout>7200</fs.azure.scale.test.timeout>
     <fs.azure.scale.test.list.performance.threads>10</fs.azure.scale.test.list.performance.threads>
     <fs.azure.scale.test.list.performance.files>1000</fs.azure.scale.test.list.performance.files>
+    <!-- http connection pool size; passed down as a system property -->
+    <http.maxConnections>100</http.maxConnections>
   </properties>
 
   <build>
@@ -400,7 +402,8 @@
                     <fs.azure.scale.test.timeout>${fs.azure.scale.test.timeout}</fs.azure.scale.test.timeout>
                     <fs.azure.scale.test.list.performance.threads>${fs.azure.scale.test.list.performance.threads}</fs.azure.scale.test.list.performance.threads>
                     <fs.azure.scale.test.list.performance.files>${fs.azure.scale.test.list.performance.files}</fs.azure.scale.test.list.performance.files>
-                  </systemPropertyVariables>
+                    <!-- http connection pool size -->
+                    <http.maxConnections>${http.maxConnections}</http.maxConnections>                  </systemPropertyVariables>
                   <includes>
                     <include>**/azure/Test*.java</include>
                     <include>**/azure/**/Test*.java</include>
@@ -431,6 +434,8 @@
                     <fs.azure.scale.test.timeout>${fs.azure.scale.test.timeout}</fs.azure.scale.test.timeout>
                     <fs.azure.scale.test.list.performance.threads>${fs.azure.scale.test.list.performance.threads}</fs.azure.scale.test.list.performance.threads>
                     <fs.azure.scale.test.list.performance.files>${fs.azure.scale.test.list.performance.files}</fs.azure.scale.test.list.performance.files>
+                    <!-- http connection pool size -->
+                    <http.maxConnections>${http.maxConnections}</http.maxConnections>
                   </systemPropertyVariables>
                   <includes>
                     <include>**/azure/**/TestRollingWindowAverage*.java</include>
@@ -604,6 +609,8 @@
                     <!-- Propagate scale parameters -->
                     <fs.azure.scale.test.enabled>${fs.azure.scale.test.enabled}</fs.azure.scale.test.enabled>
                     <fs.azure.scale.test.timeout>${fs.azure.scale.test.timeout}</fs.azure.scale.test.timeout>
+                    <!-- http connection pool size -->
+                    <http.maxConnections>${http.maxConnections}</http.maxConnections>
                   </systemPropertyVariables>
 
                   <includes>
@@ -792,6 +799,8 @@
                     <fs.azure.scale.test.timeout>${fs.azure.scale.test.timeout}</fs.azure.scale.test.timeout>
                     <fs.azure.scale.test.list.performance.threads>${fs.azure.scale.test.list.performance.threads}</fs.azure.scale.test.list.performance.threads>
                     <fs.azure.scale.test.list.performance.files>${fs.azure.scale.test.list.performance.files}</fs.azure.scale.test.list.performance.files>
+                    <!-- http connection pool size -->
+                    <http.maxConnections>${http.maxConnections}</http.maxConnections>
                   </systemPropertyVariables>
                   <!-- Some tests cannot run in parallel.  Tests that cover -->
                   <!-- access to the root directory must run in isolation -->
@@ -842,7 +851,8 @@
                     <fs.azure.scale.test.timeout>${fs.azure.scale.test.timeout}</fs.azure.scale.test.timeout>
                     <fs.azure.scale.test.list.performance.threads>${fs.azure.scale.test.list.performance.threads}</fs.azure.scale.test.list.performance.threads>
                     <fs.azure.scale.test.list.performance.files>${fs.azure.scale.test.list.performance.files}</fs.azure.scale.test.list.performance.files>
-                  </systemPropertyVariables>
+                    <!-- http connection pool size -->
+                    <http.maxConnections>${http.maxConnections}</http.maxConnections>                  </systemPropertyVariables>
                   <includes>
                     <include>**/ITestWasbAbfsCompatibility.java</include>
                     <include>**/ITestFileSystemOperationsExceptionHandlingMultiThreaded.java</include>
@@ -891,6 +901,8 @@
                     <fs.azure.scale.test.timeout>${fs.azure.scale.test.timeout}</fs.azure.scale.test.timeout>
                     <fs.azure.scale.test.list.performance.threads>${fs.azure.scale.test.list.performance.threads}</fs.azure.scale.test.list.performance.threads>
                     <fs.azure.scale.test.list.performance.files>${fs.azure.scale.test.list.performance.files}</fs.azure.scale.test.list.performance.files>
+                    <!-- http connection pool size -->
+                    <http.maxConnections>${http.maxConnections}</http.maxConnections>
                   </systemPropertyVariables>
                   <forkedProcessTimeoutInSeconds>${fs.azure.scale.test.timeout}</forkedProcessTimeoutInSeconds>
                   <trimStackTrace>false</trimStackTrace>

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
@@ -160,9 +160,12 @@ public class NativeAzureFileSystem extends FileSystem {
 
       // open redo file
       Path f = redoFile;
-      FSDataInputStream input = fs.open(f);
-      byte[] bytes = new byte[MAX_RENAME_PENDING_FILE_SIZE];
-      int l = input.read(bytes);
+      int l;
+      byte[] bytes;
+      try (FSDataInputStream input = fs.open(f)) {
+        bytes = new byte[MAX_RENAME_PENDING_FILE_SIZE];
+        l = input.read(bytes);
+      }
       if (l <= 0) {
         // Jira HADOOP-12678 -Handle empty rename pending metadata file during
         // atomic rename in redo path. If during renamepending file is created

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -159,7 +159,7 @@ public final class FileSystemConfigurations {
   /**
    * IO rate limit. Value: {@value}
    */
-  public static final int RATE_LIMIT_DEFAULT = 10_000;
+  public static final int RATE_LIMIT_DEFAULT = 1_000;
 
   private FileSystemConfigurations() {}
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
@@ -187,21 +187,18 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
     config.set(AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION, "false");
 
     final AzureBlobFileSystem fs = getFileSystem(config);
-    try {
-      intercept(Exception.class,
-              () -> {
-                fs.getFileStatus(new Path("/"));
-              });
-    } catch (AbfsRestOperationException e) {
-      String errorDesc = "Should throw RestOp exception on AAD failure";
-      Assertions.assertThat(e.getStatusCode())
-          .describedAs("Incorrect status code. " + errorDesc).isEqualTo(-1);
-      Assertions.assertThat(e.getErrorCode())
-          .describedAs("Incorrect error code. " + errorDesc)
-          .isEqualTo(AzureServiceErrorCode.UNKNOWN);
-      Assertions.assertThat(e.getErrorMessage())
-          .describedAs("Incorrect error message. " + errorDesc)
-          .contains("Auth failure: ");
-    }
+    AbfsRestOperationException e = intercept(AbfsRestOperationException.class, () -> {
+      fs.getFileStatus(new Path("/"));
+    });
+
+    String errorDesc = "Should throw RestOp exception on AAD failure";
+    Assertions.assertThat(e.getStatusCode())
+        .describedAs("Incorrect status code: " + errorDesc).isEqualTo(-1);
+    Assertions.assertThat(e.getErrorCode())
+        .describedAs("Incorrect error code: " + errorDesc)
+        .isEqualTo(AzureServiceErrorCode.UNKNOWN);
+    Assertions.assertThat(e.getErrorMessage())
+        .describedAs("Incorrect error message: " + errorDesc)
+        .contains("Auth failure: ");
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/AbfsCommitTestHelper.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/AbfsCommitTestHelper.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.azurebfs.contract.ABFSContractTestBinding;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants;
 
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_READ_SMALL_FILES_COMPLETELY;
+import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.OPT_CLEANUP_PARALLEL_DELETE_BASE_FIRST;
 import static org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterConstants.OPT_STORE_OPERATIONS_CLASS;
 
 /**
@@ -51,9 +52,10 @@ final class AbfsCommitTestHelper {
     final String size = Integer.toString(192);
     conf.setIfUnset(ManifestCommitterConstants.OPT_IO_PROCESSORS, size);
     conf.setIfUnset(ManifestCommitterConstants.OPT_WRITER_QUEUE_CAPACITY, size);
-    // no need for parallel delete here as we aren't at the scale where unified delete
-    // is going to time out
-    conf.setBooleanIfUnset(ManifestCommitterConstants.OPT_CLEANUP_PARALLEL_DELETE, false);
+    // enable parallel delete but ask for base deletion first,
+    // which is now our recommended azure option
+    conf.setBoolean(ManifestCommitterConstants.OPT_CLEANUP_PARALLEL_DELETE, true);
+    conf.setBoolean(OPT_CLEANUP_PARALLEL_DELETE_BASE_FIRST, true);
 
     return conf;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2805,6 +2805,14 @@ public class YarnConfiguration extends Configuration {
       20;
 
   /**
+   * Boolean indicating whether cgroup v2 is enabled.
+   */
+  public static final String NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED =
+      NM_PREFIX + "linux-container-executor.cgroups.v2.enabled";
+
+  public static final boolean DEFAULT_NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED = false;
+
+  /**
    * Indicates if memory and CPU limits will be set for the Windows Job
    * Object for the containers launched by the default container executor.
    */

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2733,6 +2733,10 @@ public class YarnConfiguration extends Configuration {
   public static final String NM_LINUX_CONTAINER_CGROUPS_MOUNT_PATH =
     NM_PREFIX + "linux-container-executor.cgroups.mount-path";
 
+  /** Where the linux container executor should mount cgroups v2 if not found. */
+  public static final String NM_LINUX_CONTAINER_CGROUPS_V2_MOUNT_PATH =
+      NM_PREFIX + "linux-container-executor.cgroups.v2.mount-path";
+
   /**
    * Whether the apps should run in strict resource usage mode(not allowed to
    * use spare CPU)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-docker/Dockerfile
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-docker/Dockerfile
@@ -19,7 +19,7 @@ FROM centos:7
 RUN yum -y install tomcat lsof krb5-workstation sssd-client curl
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mkdir -p /opt/apache/solr && \
-    curl -SL http://archive.apache.org/dist/lucene/solr/7.7.0/solr-7.7.0.tgz | \
+    curl -SL https://downloads.apache.org/lucene/solr/8.11.2/solr-8.11.2.tgz | \
     tar -xzC /opt/apache/solr --strip 1
 COPY src/main/scripts/setup-image.sh /setup-image.sh
 COPY src/main/resources/samples.xml /tmp/samples.xml

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -2465,6 +2465,12 @@
   </property>
 
   <property>
+    <name>yarn.nodemanager.linux-container-executor.cgroups.v2.enabled</name>
+    <value>false</value>
+    <description>Boolean indicating whether cgroup v2 is enabled.</description>
+  </property>
+
+  <property>
     <description>T-file compression types used to compress aggregated logs.</description>
     <name>yarn.nodemanager.log-aggregation.compression-type</name>
     <value>none</value>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -2088,6 +2088,20 @@
   </property>
 
   <property>
+    <description>This property sets the mount path for CGroups v2.
+      This parameter is optional, and needed to be set only in mixed mode,
+      when CGroups v2 is mounted alongside with Cgroups v1.
+      For example, in hybrid mode, CGroups v1 controllers can be mounted under /sys/fs/cgroup/
+      (for example /sys/fs/cgroup/cpu,cpuacct), while v2 can be mounted in /sys/fs/cgroup/unified folder.
+
+      If this value is not set, the value of
+      yarn.nodemanager.linux-container-executor.cgroups.mount-path
+      will be used for CGroups v2 as well.
+    </description>
+    <name>yarn.nodemanager.linux-container-executor.cgroups.v2.mount-path</name>
+  </property>
+
+  <property>
     <description>Delay in ms between attempts to remove linux cgroup</description>
     <name>yarn.nodemanager.linux-container-executor.cgroups.delete-delay-ms</name>
     <value>20</value>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/AbstractCGroupsHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/AbstractCGroupsHandler.java
@@ -358,14 +358,14 @@ public abstract class AbstractCGroupsHandler implements CGroupsHandler {
         } else {
           // Unexpected: we just checked that it was missing
           throw new ResourceHandlerException(getErrorWithDetails(
-              "Unexpected: Cannot create yarn cgroup",
+              "Unexpected: Cannot create yarn cgroup hierarchy",
               subsystemName,
               yarnHierarchy.getAbsolutePath()
           ));
         }
       } catch (SecurityException e) {
         throw new ResourceHandlerException(getErrorWithDetails(
-            "No permissions to create yarn cgroup",
+            "No permissions to create yarn cgroup hierarchy",
             subsystemName,
             yarnHierarchy.getAbsolutePath()
         ), e);
@@ -378,15 +378,7 @@ public abstract class AbstractCGroupsHandler implements CGroupsHandler {
       ));
     }
 
-    try {
-      updateEnabledControllersInHierarchy(yarnHierarchy, controller);
-    } catch (ResourceHandlerException e) {
-      throw new ResourceHandlerException(getErrorWithDetails(
-          "Failed to update cgroup.subtree_control in yarn hierarchy",
-          subsystemName,
-          yarnHierarchy.getAbsolutePath()
-      ));
-    }
+    updateEnabledControllersInHierarchy(yarnHierarchy, controller);
   }
 
   protected abstract void updateEnabledControllersInHierarchy(
@@ -401,7 +393,7 @@ public abstract class AbstractCGroupsHandler implements CGroupsHandler {
    * @param yarnCgroupPath cgroup path that failed
    * @return a string builder that can be appended by the caller
    */
-  private String getErrorWithDetails(
+  protected String getErrorWithDetails(
       String errorMessage,
       String subsystemName,
       String yarnCgroupPath) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/AbstractCGroupsMemoryResourceHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/AbstractCGroupsMemoryResourceHandler.java
@@ -1,0 +1,158 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.ExecutionType;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.security.ContainerTokenIdentifier;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+@InterfaceStability.Unstable
+@InterfaceAudience.Private
+public abstract class AbstractCGroupsMemoryResourceHandler implements MemoryResourceHandler {
+
+  static final Logger LOG =
+      LoggerFactory.getLogger(CGroupsMemoryResourceHandlerImpl.class);
+  protected static final CGroupsHandler.CGroupController MEMORY =
+      CGroupsHandler.CGroupController.MEMORY;
+
+  private CGroupsHandler cGroupsHandler;
+
+  protected static final int OPPORTUNISTIC_SOFT_LIMIT = 0;
+  // multiplier to set the soft limit - value should be between 0 and 1
+  private float softLimit = 0.0f;
+  private boolean enforce = true;
+
+  public AbstractCGroupsMemoryResourceHandler(CGroupsHandler cGroupsHandler) {
+    this.cGroupsHandler = cGroupsHandler;
+  }
+
+  protected CGroupsHandler getCGroupsHandler() {
+    return cGroupsHandler;
+  }
+
+  @Override
+  public List<PrivilegedOperation> bootstrap(Configuration conf)
+      throws ResourceHandlerException {
+    this.cGroupsHandler.initializeCGroupController(MEMORY);
+    enforce = conf.getBoolean(
+        YarnConfiguration.NM_MEMORY_RESOURCE_ENFORCED,
+        YarnConfiguration.DEFAULT_NM_MEMORY_RESOURCE_ENFORCED);
+    float softLimitPerc = conf.getFloat(
+        YarnConfiguration.NM_MEMORY_RESOURCE_CGROUPS_SOFT_LIMIT_PERCENTAGE,
+        YarnConfiguration.
+            DEFAULT_NM_MEMORY_RESOURCE_CGROUPS_SOFT_LIMIT_PERCENTAGE);
+    softLimit = softLimitPerc / 100.0f;
+    if (softLimitPerc < 0.0f || softLimitPerc > 100.0f) {
+      throw new ResourceHandlerException(
+          "Illegal value '" + softLimitPerc + "' "
+              + YarnConfiguration.
+              NM_MEMORY_RESOURCE_CGROUPS_SOFT_LIMIT_PERCENTAGE
+              + ". Value must be between 0 and 100.");
+    }
+    return null;
+  }
+
+  @Override
+  public List<PrivilegedOperation> updateContainer(Container container)
+      throws ResourceHandlerException {
+    String cgroupId = container.getContainerId().toString();
+    File cgroup = new File(cGroupsHandler.getPathForCGroup(MEMORY, cgroupId));
+    if (cgroup.exists()) {
+      //memory is in MB
+      long containerSoftLimit =
+          (long) (container.getResource().getMemorySize() * this.softLimit);
+      long containerHardLimit = container.getResource().getMemorySize();
+      if (enforce) {
+        try {
+          updateMemoryHardLimit(cgroupId, containerHardLimit);
+          ContainerTokenIdentifier id = container.getContainerTokenIdentifier();
+          if (id != null && id.getExecutionType() ==
+              ExecutionType.OPPORTUNISTIC) {
+            updateOpportunisticMemoryLimits(cgroupId);
+          } else {
+            updateGuaranteedMemoryLimits(cgroupId, containerSoftLimit);
+          }
+        } catch (ResourceHandlerException re) {
+          cGroupsHandler.deleteCGroup(MEMORY, cgroupId);
+          LOG.warn("Could not update cgroup for container", re);
+          throw re;
+        }
+      }
+    }
+    return null;
+  }
+
+  protected abstract void updateMemoryHardLimit(String cgroupId, long containerHardLimit)
+      throws ResourceHandlerException;
+
+  protected abstract void updateOpportunisticMemoryLimits(String cgroupId)
+      throws ResourceHandlerException;
+
+  protected abstract void updateGuaranteedMemoryLimits(String cgroupId, long containerSoftLimit)
+      throws ResourceHandlerException;
+
+  @Override
+  public List<PrivilegedOperation> reacquireContainer(ContainerId containerId)
+      throws ResourceHandlerException {
+    return null;
+  }
+
+  @Override
+  public List<PrivilegedOperation> preStart(Container container)
+      throws ResourceHandlerException {
+    String cgroupId = container.getContainerId().toString();
+    cGroupsHandler.createCGroup(MEMORY, cgroupId);
+    updateContainer(container);
+    List<PrivilegedOperation> ret = new ArrayList<>();
+    ret.add(new PrivilegedOperation(
+        PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
+        PrivilegedOperation.CGROUP_ARG_PREFIX
+            + cGroupsHandler.getPathForCGroupTasks(MEMORY, cgroupId)));
+    return ret;
+  }
+
+  @Override
+  public List<PrivilegedOperation> postComplete(ContainerId containerId)
+      throws ResourceHandlerException {
+    cGroupsHandler.deleteCGroup(MEMORY, containerId.toString());
+    return null;
+  }
+
+  @Override
+  public List<PrivilegedOperation> teardown() throws ResourceHandlerException {
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return AbstractCGroupsMemoryResourceHandler.class.getName();
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsHandler.java
@@ -123,6 +123,8 @@ public interface CGroupsHandler {
   String CGROUP_CONTROLLERS_FILE = "cgroup.controllers";
   String CGROUP_SUBTREE_CONTROL_FILE = "cgroup.subtree_control";
   String CGROUP_CPU_MAX = "max";
+  String CGROUP_MEMORY_MAX = "max";
+  String CGROUP_MEMORY_LOW = "low";
 
   // present in v1 and v2
   String CGROUP_PROCS_FILE = "cgroup.procs";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsMemoryResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsMemoryResourceHandlerImpl.java
@@ -19,20 +19,12 @@
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources;
 
 import org.apache.hadoop.classification.VisibleForTesting;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.yarn.api.records.ContainerId;
-import org.apache.hadoop.yarn.api.records.ExecutionType;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.apache.hadoop.yarn.security.ContainerTokenIdentifier;
-import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperation;
 
-import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -43,32 +35,19 @@ import java.util.List;
  */
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
-public class CGroupsMemoryResourceHandlerImpl implements MemoryResourceHandler {
+public class CGroupsMemoryResourceHandlerImpl extends AbstractCGroupsMemoryResourceHandler {
 
-  static final Logger LOG =
-       LoggerFactory.getLogger(CGroupsMemoryResourceHandlerImpl.class);
-  private static final CGroupsHandler.CGroupController MEMORY =
-      CGroupsHandler.CGroupController.MEMORY;
   private static final int OPPORTUNISTIC_SWAPPINESS = 100;
-  private static final int OPPORTUNISTIC_SOFT_LIMIT = 0;
-
-  private CGroupsHandler cGroupsHandler;
-  private boolean enforce = true;
   private int swappiness = 0;
-  // multiplier to set the soft limit - value should be between 0 and 1
-  private float softLimit = 0.0f;
 
   CGroupsMemoryResourceHandlerImpl(CGroupsHandler cGroupsHandler) {
-    this.cGroupsHandler = cGroupsHandler;
+    super(cGroupsHandler);
   }
 
   @Override
   public List<PrivilegedOperation> bootstrap(Configuration conf)
       throws ResourceHandlerException {
-    this.cGroupsHandler.initializeCGroupController(MEMORY);
-    enforce = conf.getBoolean(
-        YarnConfiguration.NM_MEMORY_RESOURCE_ENFORCED,
-        YarnConfiguration.DEFAULT_NM_MEMORY_RESOURCE_ENFORCED);
+    super.bootstrap(conf);
     swappiness = conf
         .getInt(YarnConfiguration.NM_MEMORY_RESOURCE_CGROUPS_SWAPPINESS,
             YarnConfiguration.DEFAULT_NM_MEMORY_RESOURCE_CGROUPS_SWAPPINESS);
@@ -76,18 +55,6 @@ public class CGroupsMemoryResourceHandlerImpl implements MemoryResourceHandler {
       throw new ResourceHandlerException(
           "Illegal value '" + swappiness + "' for "
               + YarnConfiguration.NM_MEMORY_RESOURCE_CGROUPS_SWAPPINESS
-              + ". Value must be between 0 and 100.");
-    }
-    float softLimitPerc = conf.getFloat(
-        YarnConfiguration.NM_MEMORY_RESOURCE_CGROUPS_SOFT_LIMIT_PERCENTAGE,
-        YarnConfiguration.
-            DEFAULT_NM_MEMORY_RESOURCE_CGROUPS_SOFT_LIMIT_PERCENTAGE);
-    softLimit = softLimitPerc / 100.0f;
-    if (softLimitPerc < 0.0f || softLimitPerc > 100.0f) {
-      throw new ResourceHandlerException(
-          "Illegal value '" + softLimitPerc + "' "
-              + YarnConfiguration.
-                NM_MEMORY_RESOURCE_CGROUPS_SOFT_LIMIT_PERCENTAGE
               + ". Value must be between 0 and 100.");
     }
     return null;
@@ -99,81 +66,31 @@ public class CGroupsMemoryResourceHandlerImpl implements MemoryResourceHandler {
   }
 
   @Override
-  public List<PrivilegedOperation> reacquireContainer(ContainerId containerId)
+  protected void updateMemoryHardLimit(String cgroupId, long containerHardLimit)
       throws ResourceHandlerException {
-    return null;
+    getCGroupsHandler().updateCGroupParam(MEMORY, cgroupId,
+        CGroupsHandler.CGROUP_PARAM_MEMORY_HARD_LIMIT_BYTES,
+        String.valueOf(containerHardLimit) + "M");
   }
 
   @Override
-  public List<PrivilegedOperation> updateContainer(Container container)
+  protected void updateOpportunisticMemoryLimits(String cgroupId) throws ResourceHandlerException {
+    getCGroupsHandler().updateCGroupParam(MEMORY, cgroupId,
+        CGroupsHandler.CGROUP_PARAM_MEMORY_SOFT_LIMIT_BYTES,
+        String.valueOf(OPPORTUNISTIC_SOFT_LIMIT) + "M");
+    getCGroupsHandler().updateCGroupParam(MEMORY, cgroupId,
+        CGroupsHandler.CGROUP_PARAM_MEMORY_SWAPPINESS,
+        String.valueOf(OPPORTUNISTIC_SWAPPINESS));
+  }
+
+  @Override
+  protected void updateGuaranteedMemoryLimits(String cgroupId, long containerSoftLimit)
       throws ResourceHandlerException {
-    String cgroupId = container.getContainerId().toString();
-    File cgroup = new File(cGroupsHandler.getPathForCGroup(MEMORY, cgroupId));
-    if (cgroup.exists()) {
-      //memory is in MB
-      long containerSoftLimit =
-          (long) (container.getResource().getMemorySize() * this.softLimit);
-      long containerHardLimit = container.getResource().getMemorySize();
-      if (enforce) {
-        try {
-          cGroupsHandler.updateCGroupParam(MEMORY, cgroupId,
-              CGroupsHandler.CGROUP_PARAM_MEMORY_HARD_LIMIT_BYTES,
-              String.valueOf(containerHardLimit) + "M");
-          ContainerTokenIdentifier id = container.getContainerTokenIdentifier();
-          if (id != null && id.getExecutionType() ==
-              ExecutionType.OPPORTUNISTIC) {
-            cGroupsHandler.updateCGroupParam(MEMORY, cgroupId,
-                CGroupsHandler.CGROUP_PARAM_MEMORY_SOFT_LIMIT_BYTES,
-                String.valueOf(OPPORTUNISTIC_SOFT_LIMIT) + "M");
-            cGroupsHandler.updateCGroupParam(MEMORY, cgroupId,
-                CGroupsHandler.CGROUP_PARAM_MEMORY_SWAPPINESS,
-                String.valueOf(OPPORTUNISTIC_SWAPPINESS));
-          } else {
-            cGroupsHandler.updateCGroupParam(MEMORY, cgroupId,
-                CGroupsHandler.CGROUP_PARAM_MEMORY_SOFT_LIMIT_BYTES,
-                String.valueOf(containerSoftLimit) + "M");
-            cGroupsHandler.updateCGroupParam(MEMORY, cgroupId,
-                CGroupsHandler.CGROUP_PARAM_MEMORY_SWAPPINESS,
-                String.valueOf(swappiness));
-          }
-        } catch (ResourceHandlerException re) {
-          cGroupsHandler.deleteCGroup(MEMORY, cgroupId);
-          LOG.warn("Could not update cgroup for container", re);
-          throw re;
-        }
-      }
-    }
-    return null;
-  }
-
-  @Override
-  public List<PrivilegedOperation> preStart(Container container)
-      throws ResourceHandlerException {
-    String cgroupId = container.getContainerId().toString();
-    cGroupsHandler.createCGroup(MEMORY, cgroupId);
-    updateContainer(container);
-    List<PrivilegedOperation> ret = new ArrayList<>();
-    ret.add(new PrivilegedOperation(
-        PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
-        PrivilegedOperation.CGROUP_ARG_PREFIX
-            + cGroupsHandler.getPathForCGroupTasks(MEMORY, cgroupId)));
-    return ret;
-  }
-
-  @Override
-  public List<PrivilegedOperation> postComplete(ContainerId containerId)
-      throws ResourceHandlerException {
-    cGroupsHandler.deleteCGroup(MEMORY, containerId.toString());
-    return null;
-  }
-
-  @Override
-  public List<PrivilegedOperation> teardown() throws ResourceHandlerException {
-    return null;
-  }
-
-  @Override
-  public String toString() {
-    return CGroupsMemoryResourceHandlerImpl.class.getName();
+    getCGroupsHandler().updateCGroupParam(MEMORY, cgroupId,
+        CGroupsHandler.CGROUP_PARAM_MEMORY_SOFT_LIMIT_BYTES,
+        String.valueOf(containerSoftLimit) + "M");
+    getCGroupsHandler().updateCGroupParam(MEMORY, cgroupId,
+        CGroupsHandler.CGROUP_PARAM_MEMORY_SWAPPINESS,
+        String.valueOf(swappiness));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsMountConfig.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsMountConfig.java
@@ -26,11 +26,17 @@ public class CGroupsMountConfig {
   private final boolean enableMount;
   private final String mountPath;
 
+  // CGroups v2 mount path is only relevant in mixed CGroups v1/v2 mode,
+  // where v2 is mounted alongside with v1.
+  private final String v2MountPath;
+
   public CGroupsMountConfig(Configuration conf) {
     this.enableMount = conf.getBoolean(YarnConfiguration.
         NM_LINUX_CONTAINER_CGROUPS_MOUNT, false);
     this.mountPath = conf.get(YarnConfiguration.
         NM_LINUX_CONTAINER_CGROUPS_MOUNT_PATH, null);
+    this.v2MountPath = conf.get(YarnConfiguration.
+        NM_LINUX_CONTAINER_CGROUPS_V2_MOUNT_PATH, mountPath);
   }
 
   public boolean ensureMountPathIsDefined() throws ResourceHandlerException {
@@ -62,11 +68,16 @@ public class CGroupsMountConfig {
     return mountPath;
   }
 
+  public String getV2MountPath() {
+    return v2MountPath;
+  }
+
   @Override
   public String toString() {
     return "CGroupsMountConfig{" +
         "enableMount=" + enableMount +
-        ", mountPath='" + mountPath + '\'' +
+        ", mountPath='" + mountPath +
+        ", v2MountPath='" + v2MountPath + '\'' +
         '}';
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsV2HandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsV2HandlerImpl.java
@@ -97,8 +97,8 @@ class CGroupsV2HandlerImpl extends AbstractCGroupsHandler {
   @Override
   protected Map<String, Set<String>> parsePreConfiguredMountPath() throws IOException {
     Map<String, Set<String>> controllerMappings = new HashMap<>();
-    controllerMappings.put(this.cGroupsMountConfig.getMountPath(),
-        readControllersFile(this.cGroupsMountConfig.getMountPath()));
+    controllerMappings.put(this.cGroupsMountConfig.getV2MountPath(),
+        readControllersFile(this.cGroupsMountConfig.getV2MountPath()));
     return controllerMappings;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsV2MemoryResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsV2MemoryResourceHandlerImpl.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources;
+
+/**
+ * Handler class to handle the memory controller. YARN already ships a
+ * physical memory monitor in Java but it isn't as
+ * good as CGroups. This handler sets the soft and hard memory limits. The soft
+ * limit is set to 90% of the hard limit.
+ */
+public class CGroupsV2MemoryResourceHandlerImpl extends AbstractCGroupsMemoryResourceHandler {
+
+  CGroupsV2MemoryResourceHandlerImpl(CGroupsHandler cGroupsHandler) {
+    super(cGroupsHandler);
+  }
+
+  @Override
+  protected void updateMemoryHardLimit(String cgroupId, long containerHardLimit)
+      throws ResourceHandlerException {
+    getCGroupsHandler().updateCGroupParam(MEMORY, cgroupId,
+        CGroupsHandler.CGROUP_MEMORY_MAX, String.valueOf(containerHardLimit) + "M");
+  }
+
+  @Override
+  protected void updateOpportunisticMemoryLimits(String cgroupId) throws ResourceHandlerException {
+    updateGuaranteedMemoryLimits(cgroupId, OPPORTUNISTIC_SOFT_LIMIT);
+  }
+
+  @Override
+  protected void updateGuaranteedMemoryLimits(String cgroupId, long containerSoftLimit)
+      throws ResourceHandlerException {
+    getCGroupsHandler().updateCGroupParam(MEMORY, cgroupId,
+        CGroupsHandler.CGROUP_MEMORY_LOW, String.valueOf(containerSoftLimit) + "M");
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/ResourceHandlerModule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/ResourceHandlerModule.java
@@ -55,6 +55,7 @@ import java.util.Set;
 public class ResourceHandlerModule {
   static final Logger LOG =
        LoggerFactory.getLogger(ResourceHandlerModule.class);
+  private static boolean cgroupsV2Enabled;
   private static volatile ResourceHandlerChain resourceHandlerChain;
 
   /**
@@ -69,9 +70,9 @@ public class ResourceHandlerModule {
   private static volatile CGroupsHandler cGroupsHandler;
   private static volatile CGroupsBlkioResourceHandlerImpl
       cGroupsBlkioResourceHandler;
-  private static volatile CGroupsMemoryResourceHandlerImpl
+  private static volatile MemoryResourceHandler
       cGroupsMemoryResourceHandler;
-  private static volatile CGroupsCpuResourceHandlerImpl
+  private static volatile CpuResourceHandler
       cGroupsCpuResourceHandler;
 
   /**
@@ -82,9 +83,9 @@ public class ResourceHandlerModule {
     if (cGroupsHandler == null) {
       synchronized (CGroupsHandler.class) {
         if (cGroupsHandler == null) {
-          // TODO determine cgroup version
-          cGroupsHandler = new CGroupsHandlerImpl(conf,
-              PrivilegedOperationExecutor.getInstance(conf));
+          cGroupsHandler = cgroupsV2Enabled
+              ? new CGroupsV2HandlerImpl(conf, PrivilegedOperationExecutor.getInstance(conf))
+              : new CGroupsHandlerImpl(conf, PrivilegedOperationExecutor.getInstance(conf));
           LOG.debug("Value of CGroupsHandler is: {}", cGroupsHandler);
         }
       }
@@ -138,7 +139,7 @@ public class ResourceHandlerModule {
     return cGroupsCpuResourceHandler;
   }
 
-  private static CGroupsCpuResourceHandlerImpl initCGroupsCpuResourceHandler(
+  private static CpuResourceHandler initCGroupsCpuResourceHandler(
       Configuration conf) throws ResourceHandlerException {
     boolean cgroupsCpuEnabled =
         conf.getBoolean(YarnConfiguration.NM_CPU_RESOURCE_ENABLED,
@@ -152,9 +153,9 @@ public class ResourceHandlerModule {
         synchronized (CpuResourceHandler.class) {
           if (cGroupsCpuResourceHandler == null) {
             LOG.debug("Creating new cgroups cpu handler");
-            cGroupsCpuResourceHandler =
-                new CGroupsCpuResourceHandlerImpl(
-                    getInitializedCGroupsHandler(conf));
+            cGroupsCpuResourceHandler = cgroupsV2Enabled
+                ? new CGroupsV2CpuResourceHandlerImpl(getInitializedCGroupsHandler(conf))
+                : new CGroupsCpuResourceHandlerImpl(getInitializedCGroupsHandler(conf));
             return cGroupsCpuResourceHandler;
           }
         }
@@ -256,15 +257,15 @@ public class ResourceHandlerModule {
     return null;
   }
 
-  private static CGroupsMemoryResourceHandlerImpl
+  private static MemoryResourceHandler
       getCgroupsMemoryResourceHandler(
       Configuration conf) throws ResourceHandlerException {
     if (cGroupsMemoryResourceHandler == null) {
       synchronized (MemoryResourceHandler.class) {
         if (cGroupsMemoryResourceHandler == null) {
-          cGroupsMemoryResourceHandler =
-              new CGroupsMemoryResourceHandlerImpl(
-                  getInitializedCGroupsHandler(conf));
+          cGroupsMemoryResourceHandler = cgroupsV2Enabled
+              ? new CGroupsV2MemoryResourceHandlerImpl(getInitializedCGroupsHandler(conf))
+              : new CGroupsMemoryResourceHandlerImpl(getInitializedCGroupsHandler(conf));
         }
       }
     }
@@ -335,6 +336,10 @@ public class ResourceHandlerModule {
 
   public static ResourceHandlerChain getConfiguredResourceHandlerChain(
       Configuration conf, Context nmContext) throws ResourceHandlerException {
+    cgroupsV2Enabled =
+        conf.getBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED,
+            YarnConfiguration.DEFAULT_NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED);
+
     if (resourceHandlerChain == null) {
       synchronized (ResourceHandlerModule.class) {
         if (resourceHandlerChain == null) {
@@ -353,6 +358,21 @@ public class ResourceHandlerModule {
   @VisibleForTesting
   static void nullifyResourceHandlerChain() throws ResourceHandlerException {
     resourceHandlerChain = null;
+  }
+
+  @VisibleForTesting
+  static void resetCgroupsHandler() {
+    cGroupsHandler = null;
+  }
+
+  @VisibleForTesting
+  static void resetCpuResourceHandler() {
+    cGroupsCpuResourceHandler = null;
+  }
+
+  @VisibleForTesting
+  static void resetMemoryResourceHandler() {
+    cGroupsMemoryResourceHandler = null;
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2HandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2HandlerImpl.java
@@ -217,11 +217,13 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
     conf.set(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_HIERARCHY,
         "/hadoop-yarn");
 
+    File baseCgroup = new File(tmpPath);
     File subCgroup = new File(tmpPath, "/hadoop-yarn");
     Assert.assertTrue("temp dir should be created", subCgroup.mkdirs());
     subCgroup.deleteOnExit();
 
     String enabledControllers = "cpuset cpu io memory hugetlb pids rdma misc\n";
+    createFileWithContent(baseCgroup, CGroupsHandler.CGROUP_CONTROLLERS_FILE, enabledControllers);
     createFileWithContent(subCgroup, CGroupsHandler.CGROUP_CONTROLLERS_FILE, enabledControllers);
 
     File subtreeControlFile = new File(subCgroup.getAbsolutePath(),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2HandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2HandlerImpl.java
@@ -210,6 +210,111 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
     Assert.assertEquals(parentDir.getAbsolutePath(), memoryDir);
   }
 
+  /*
+   * Create a mock mtab file with the following content for hybrid v1/v2:
+   * cgroup2 /path/to/parentV2Dir cgroup2 rw,nosuid,nodev,noexec,relatime,memory_recursiveprot 0 0
+   * cgroup /path/to/parentDir/memory cgroup rw,nosuid,nodev,noexec,relatime,memory 0 0
+   *
+   * Create the following cgroup hierarchy:
+   *
+   *                                           parentDir
+   *                              __________________________________
+   *                             /                                  \
+   *                          unified                             memory
+   *       _________________________________________________
+   *      /                     \                           \
+   *  cgroup.controllers     cgroup.subtree_control   test-hadoop-yarn (hierarchyDir)
+   *                                                        _________________
+   *                                                       /                 \
+   *                                              cgroup.controllers   cgroup.subtree_control
+   */
+  public File createPremountedHybridCgroups(File v1ParentDir)
+      throws IOException {
+    File v2ParentDir = new File(v1ParentDir, "unified");
+
+    String mtabContent =
+        "cgroup " + v1ParentDir.getAbsolutePath() + "/memory"
+            + " cgroup rw,nosuid,nodev,noexec,relatime,memory 0 0\n"
+        + "cgroup2 " + v2ParentDir.getAbsolutePath()
+            + " cgroup2 rw,nosuid,nodev,noexec,relatime,memory_recursiveprot 0 0\n";
+
+    File mockMtab = createFileWithContent(v1ParentDir, UUID.randomUUID().toString(), mtabContent);
+
+    String enabledV2Controllers = "cpuset cpu io hugetlb pids rdma misc\n";
+    File controllersFile = createFileWithContent(v2ParentDir,
+        CGroupsHandler.CGROUP_CONTROLLERS_FILE, enabledV2Controllers);
+
+    File subtreeControlFile = new File(v2ParentDir, CGroupsHandler.CGROUP_SUBTREE_CONTROL_FILE);
+    Assert.assertTrue("empty subtree_control file should be created",
+        subtreeControlFile.createNewFile());
+
+    File hierarchyDir = new File(v2ParentDir, hierarchy);
+    if (!hierarchyDir.mkdirs()) {
+      String message = "Could not create directory " + hierarchyDir.getAbsolutePath();
+      throw new IOException(message);
+    }
+    hierarchyDir.deleteOnExit();
+
+    FileUtils.copyFile(controllersFile, new File(hierarchyDir,
+        CGroupsHandler.CGROUP_CONTROLLERS_FILE));
+    FileUtils.copyFile(subtreeControlFile, new File(hierarchyDir,
+        CGroupsHandler.CGROUP_SUBTREE_CONTROL_FILE));
+
+    return mockMtab;
+  }
+
+  @Test
+  public void testHybridMtabParsing() throws Exception {
+    // Initialize mtab and cgroup dir
+    File v1ParentDir = new File(tmpPath);
+
+    File v2ParentDir = new File(v1ParentDir, "unified");
+    Assert.assertTrue("temp dir should be created", v2ParentDir.mkdirs());
+    v2ParentDir.deleteOnExit();
+
+    // create mock cgroup
+    File mockMtabFile = createPremountedHybridCgroups(v1ParentDir);
+
+    // create memory cgroup for v1
+    File memoryCgroup = new File(v1ParentDir, "memory");
+    assertTrue("Directory should be created", memoryCgroup.mkdirs());
+
+    // init v1 and v2 handlers
+    CGroupsHandlerImpl cGroupsHandler = new CGroupsHandlerImpl(
+        createMountConfiguration(),
+        privilegedOperationExecutorMock, mockMtabFile.getAbsolutePath());
+    CGroupsV2HandlerImpl cGroupsV2Handler = new CGroupsV2HandlerImpl(
+        createMountConfiguration(),
+        privilegedOperationExecutorMock, mockMtabFile.getAbsolutePath());
+
+    // Verify resource handlers that are enabled in v1
+    Map<String, Set<String>> newMtab =
+        cGroupsHandler.parseMtab(mockMtabFile.getAbsolutePath());
+    Map<CGroupsHandler.CGroupController, String> controllerv1Paths =
+        cGroupsHandler.initializeControllerPathsFromMtab(
+            newMtab);
+
+    Assert.assertEquals(1, controllerv1Paths.size());
+    assertTrue(controllerv1Paths
+        .containsKey(CGroupsHandler.CGroupController.MEMORY));
+    String memoryDir =
+        controllerv1Paths.get(CGroupsHandler.CGroupController.MEMORY);
+    Assert.assertEquals(memoryCgroup.getAbsolutePath(), memoryDir);
+
+    // Verify resource handlers that are enabled in v2
+    newMtab =
+        cGroupsV2Handler.parseMtab(mockMtabFile.getAbsolutePath());
+    Map<CGroupsHandler.CGroupController, String> controllerPaths =
+        cGroupsV2Handler.initializeControllerPathsFromMtab(
+            newMtab);
+
+    Assert.assertEquals(3, controllerPaths.size());
+    assertTrue(controllerPaths
+        .containsKey(CGroupsHandler.CGroupController.CPU));
+    String cpuDir = controllerPaths.get(CGroupsHandler.CGroupController.CPU);
+    Assert.assertEquals(v2ParentDir.getAbsolutePath(), cpuDir);
+  }
+
   @Test
   public void testManualCgroupSetting() throws Exception {
     YarnConfiguration conf = new YarnConfiguration();
@@ -217,8 +322,27 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
     conf.set(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_HIERARCHY,
         "/hadoop-yarn");
 
-    File baseCgroup = new File(tmpPath);
-    File subCgroup = new File(tmpPath, "/hadoop-yarn");
+    validateCgroupV2Controllers(conf, tmpPath);
+  }
+
+  @Test
+  public void testManualHybridCgroupSetting() throws Exception {
+    String unifiedPath = tmpPath + "/unified";
+
+    YarnConfiguration conf = new YarnConfiguration();
+    conf.set(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_MOUNT_PATH, tmpPath);
+    conf.set(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_MOUNT_PATH, unifiedPath);
+    conf.set(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_HIERARCHY,
+        "/hadoop-yarn");
+
+    validateCgroupV1Controllers(conf, tmpPath);
+    validateCgroupV2Controllers(conf, unifiedPath);
+  }
+
+  private void validateCgroupV2Controllers(YarnConfiguration conf, String mountPath)
+      throws Exception {
+    File baseCgroup = new File(mountPath);
+    File subCgroup = new File(mountPath, "/hadoop-yarn");
     Assert.assertTrue("temp dir should be created", subCgroup.mkdirs());
     subCgroup.deleteOnExit();
 
@@ -235,8 +359,8 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
     cGroupsHandler.initializeCGroupController(CGroupsHandler.CGroupController.CPU);
 
     Assert.assertEquals("CPU cgroup path was not set", subCgroup.getAbsolutePath(),
-            new File(cGroupsHandler.getPathForCGroup(
-                CGroupsHandler.CGroupController.CPU, "")).getAbsolutePath());
+        new File(cGroupsHandler.getPathForCGroup(
+            CGroupsHandler.CGroupController.CPU, "")).getAbsolutePath());
 
     // Verify that the subtree control file was updated
     String subtreeControllersEnabledString = FileUtils.readFileToString(subtreeControlFile,
@@ -275,5 +399,22 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
     Assert.assertEquals(3, subtreeControllersEnabled.size());
     Assert.assertTrue("Controllers not enabled in subtree control file",
         cGroupsHandler.getValidCGroups().containsAll(subtreeControllersEnabled));
+  }
+
+  private void validateCgroupV1Controllers(YarnConfiguration conf, String mountPath)
+      throws ResourceHandlerException {
+    File blkio = new File(new File(mountPath, "blkio"), "/hadoop-yarn");
+
+    Assert.assertTrue("temp dir should be created", blkio.mkdirs());
+
+    CGroupsHandlerImpl cGroupsv1Handler = new CGroupsHandlerImpl(conf, null);
+    cGroupsv1Handler.initializeCGroupController(
+        CGroupsHandler.CGroupController.BLKIO);
+
+    Assert.assertEquals("BLKIO CGRoup path was not set", blkio.getAbsolutePath(),
+        new File(cGroupsv1Handler.getPathForCGroup(
+            CGroupsHandler.CGroupController.BLKIO, "")).getAbsolutePath());
+
+    FileUtils.deleteQuietly(blkio);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCgroupsV2MemoryResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCgroupsV2MemoryResourceHandlerImpl.java
@@ -1,0 +1,209 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.ExecutionType;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.security.ContainerTokenIdentifier;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperation;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestCgroupsV2MemoryResourceHandlerImpl {
+
+  private CGroupsHandler mockCGroupsHandler;
+  private CGroupsV2MemoryResourceHandlerImpl cGroupsMemoryResourceHandler;
+
+  @Before
+  public void setup() {
+    mockCGroupsHandler = mock(CGroupsHandler.class);
+    when(mockCGroupsHandler.getPathForCGroup(any(), any())).thenReturn(".");
+    cGroupsMemoryResourceHandler =
+        new CGroupsV2MemoryResourceHandlerImpl(mockCGroupsHandler);
+  }
+
+  @Test
+  public void testBootstrap() throws Exception {
+    Configuration conf = new YarnConfiguration();
+    conf.setBoolean(YarnConfiguration.NM_PMEM_CHECK_ENABLED, false);
+    conf.setBoolean(YarnConfiguration.NM_VMEM_CHECK_ENABLED, false);
+    List<PrivilegedOperation> ret =
+        cGroupsMemoryResourceHandler.bootstrap(conf);
+    verify(mockCGroupsHandler, times(1))
+        .initializeCGroupController(CGroupsHandler.CGroupController.MEMORY);
+    Assert.assertNull(ret);
+    conf.setBoolean(YarnConfiguration.NM_PMEM_CHECK_ENABLED, true);
+    try {
+      cGroupsMemoryResourceHandler.bootstrap(conf);
+    } catch (ResourceHandlerException re) {
+      Assert.fail("Pmem check should be allowed to run with cgroups");
+    }
+    conf.setBoolean(YarnConfiguration.NM_PMEM_CHECK_ENABLED, false);
+    conf.setBoolean(YarnConfiguration.NM_VMEM_CHECK_ENABLED, true);
+    try {
+      cGroupsMemoryResourceHandler.bootstrap(conf);
+    } catch (ResourceHandlerException re) {
+      Assert.fail("Vmem check should be allowed to run with cgroups");
+    }
+  }
+
+  @Test
+  public void testPreStart() throws Exception {
+    Configuration conf = new Configuration();
+    conf.setBoolean(YarnConfiguration.NM_PMEM_CHECK_ENABLED, false);
+    conf.setBoolean(YarnConfiguration.NM_VMEM_CHECK_ENABLED, false);
+    cGroupsMemoryResourceHandler.bootstrap(conf);
+    String id = "container_01_01";
+    String path = "test-path/" + id;
+    ContainerId mockContainerId = mock(ContainerId.class);
+    when(mockContainerId.toString()).thenReturn(id);
+    Container mockContainer = mock(Container.class);
+    when(mockContainer.getContainerId()).thenReturn(mockContainerId);
+    when(mockCGroupsHandler
+        .getPathForCGroupTasks(CGroupsHandler.CGroupController.MEMORY, id))
+        .thenReturn(path);
+    int memory = 1024;
+    when(mockContainer.getResource())
+        .thenReturn(Resource.newInstance(memory, 1));
+    List<PrivilegedOperation> ret =
+        cGroupsMemoryResourceHandler.preStart(mockContainer);
+    verify(mockCGroupsHandler, times(1))
+        .createCGroup(CGroupsHandler.CGroupController.MEMORY, id);
+    verify(mockCGroupsHandler, times(1))
+        .updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, id,
+            CGroupsHandler.CGROUP_MEMORY_MAX,
+            String.valueOf(memory) + "M");
+    verify(mockCGroupsHandler, times(1))
+        .updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, id,
+            CGroupsHandler.CGROUP_MEMORY_LOW,
+            String.valueOf((int) (memory * 0.9)) + "M");
+    Assert.assertNotNull(ret);
+    Assert.assertEquals(1, ret.size());
+    PrivilegedOperation op = ret.get(0);
+    Assert.assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
+        op.getOperationType());
+    List<String> args = op.getArguments();
+    Assert.assertEquals(1, args.size());
+    Assert.assertEquals(PrivilegedOperation.CGROUP_ARG_PREFIX + path,
+        args.get(0));
+  }
+
+  @Test
+  public void testPreStartNonEnforced() throws Exception {
+    Configuration conf = new Configuration();
+    conf.setBoolean(YarnConfiguration.NM_PMEM_CHECK_ENABLED, false);
+    conf.setBoolean(YarnConfiguration.NM_VMEM_CHECK_ENABLED, false);
+    conf.setBoolean(YarnConfiguration.NM_MEMORY_RESOURCE_ENFORCED, false);
+    cGroupsMemoryResourceHandler.bootstrap(conf);
+    String id = "container_01_01";
+    String path = "test-path/" + id;
+    ContainerId mockContainerId = mock(ContainerId.class);
+    when(mockContainerId.toString()).thenReturn(id);
+    Container mockContainer = mock(Container.class);
+    when(mockContainer.getContainerId()).thenReturn(mockContainerId);
+    when(mockCGroupsHandler
+        .getPathForCGroupTasks(CGroupsHandler.CGroupController.MEMORY, id))
+        .thenReturn(path);
+    int memory = 1024;
+    when(mockContainer.getResource())
+        .thenReturn(Resource.newInstance(memory, 1));
+    List<PrivilegedOperation> ret =
+        cGroupsMemoryResourceHandler.preStart(mockContainer);
+    verify(mockCGroupsHandler, times(1))
+        .createCGroup(CGroupsHandler.CGroupController.MEMORY, id);
+    verify(mockCGroupsHandler, times(0))
+        .updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, id,
+            CGroupsHandler.CGROUP_MEMORY_MAX,
+            String.valueOf(memory) + "M");
+    verify(mockCGroupsHandler, times(0))
+        .updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, id,
+            CGroupsHandler.CGROUP_MEMORY_LOW,
+            String.valueOf((int) (memory * 0.9)) + "M");
+    Assert.assertNotNull(ret);
+    Assert.assertEquals(1, ret.size());
+    PrivilegedOperation op = ret.get(0);
+    Assert.assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
+        op.getOperationType());
+    List<String> args = op.getArguments();
+    Assert.assertEquals(1, args.size());
+    Assert.assertEquals(PrivilegedOperation.CGROUP_ARG_PREFIX + path,
+        args.get(0));
+  }
+
+  @Test
+  public void testReacquireContainer() throws Exception {
+    ContainerId containerIdMock = mock(ContainerId.class);
+    Assert.assertNull(
+        cGroupsMemoryResourceHandler.reacquireContainer(containerIdMock));
+  }
+
+  @Test
+  public void testPostComplete() throws Exception {
+    String id = "container_01_01";
+    ContainerId mockContainerId = mock(ContainerId.class);
+    when(mockContainerId.toString()).thenReturn(id);
+    Assert
+        .assertNull(cGroupsMemoryResourceHandler.postComplete(mockContainerId));
+    verify(mockCGroupsHandler, times(1))
+        .deleteCGroup(CGroupsHandler.CGroupController.MEMORY, id);
+  }
+
+  @Test
+  public void testTeardown() throws Exception {
+    Assert.assertNull(cGroupsMemoryResourceHandler.teardown());
+  }
+
+  @Test
+  public void testOpportunistic() throws Exception {
+    Configuration conf = new YarnConfiguration();
+    conf.setBoolean(YarnConfiguration.NM_PMEM_CHECK_ENABLED, false);
+    conf.setBoolean(YarnConfiguration.NM_VMEM_CHECK_ENABLED, false);
+
+    cGroupsMemoryResourceHandler.bootstrap(conf);
+    ContainerTokenIdentifier tokenId = mock(ContainerTokenIdentifier.class);
+    when(tokenId.getExecutionType()).thenReturn(ExecutionType.OPPORTUNISTIC);
+    Container container = mock(Container.class);
+    String id = "container_01_01";
+    ContainerId mockContainerId = mock(ContainerId.class);
+    when(mockContainerId.toString()).thenReturn(id);
+    when(container.getContainerId()).thenReturn(mockContainerId);
+    when(container.getContainerTokenIdentifier()).thenReturn(tokenId);
+    when(container.getResource()).thenReturn(Resource.newInstance(1024, 2));
+    cGroupsMemoryResourceHandler.preStart(container);
+    verify(mockCGroupsHandler, times(1))
+        .updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, id,
+            CGroupsHandler.CGROUP_MEMORY_LOW, "0M");
+    verify(mockCGroupsHandler, times(1))
+        .updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, id,
+            CGroupsHandler.CGROUP_MEMORY_MAX, "1024M");
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestResourceHandlerModule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestResourceHandlerModule.java
@@ -49,6 +49,9 @@ public class TestResourceHandlerModule {
     networkEnabledConf.setBoolean(YarnConfiguration.NM_NETWORK_RESOURCE_ENABLED,
         true);
     ResourceHandlerModule.nullifyResourceHandlerChain();
+    ResourceHandlerModule.resetCgroupsHandler();
+    ResourceHandlerModule.resetCpuResourceHandler();
+    ResourceHandlerModule.resetMemoryResourceHandler();
   }
 
   @Test
@@ -109,6 +112,71 @@ public class TestResourceHandlerModule {
       Assert.assertTrue(resourceHandlers.get(0) == handler);
     } else {
       Assert.fail("Null returned");
+    }
+  }
+
+  @Test
+  public void testCpuResourceHandlerClassForCgroupV1() throws ResourceHandlerException {
+    Configuration conf = new YarnConfiguration();
+    conf.setBoolean(YarnConfiguration.NM_CPU_RESOURCE_ENABLED, true);
+    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, false);
+
+    initResourceHandlerChain(conf);
+
+    Assert.assertTrue(ResourceHandlerModule.getCpuResourceHandler()
+        instanceof CGroupsCpuResourceHandlerImpl);
+    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
+        instanceof CGroupsHandlerImpl);
+  }
+
+  @Test
+  public void testCpuResourceHandlerClassForCgroupV2() throws ResourceHandlerException {
+    Configuration conf = new YarnConfiguration();
+    conf.setBoolean(YarnConfiguration.NM_CPU_RESOURCE_ENABLED, true);
+    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, true);
+
+    initResourceHandlerChain(conf);
+
+    Assert.assertTrue(ResourceHandlerModule.getCpuResourceHandler()
+        instanceof CGroupsV2CpuResourceHandlerImpl);
+    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
+        instanceof CGroupsV2HandlerImpl);
+  }
+
+  @Test
+  public void testMemoryResourceHandlerClassForCgroupV1() throws ResourceHandlerException {
+    Configuration conf = new YarnConfiguration();
+    conf.setBoolean(YarnConfiguration.NM_MEMORY_RESOURCE_ENABLED, true);
+    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, false);
+
+    initResourceHandlerChain(conf);
+
+    Assert.assertTrue(ResourceHandlerModule.getMemoryResourceHandler()
+        instanceof CGroupsMemoryResourceHandlerImpl);
+    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
+        instanceof CGroupsHandlerImpl);
+  }
+
+  @Test
+  public void testMemoryResourceHandlerClassForCgroupV2() throws ResourceHandlerException {
+    Configuration conf = new YarnConfiguration();
+    conf.setBoolean(YarnConfiguration.NM_MEMORY_RESOURCE_ENABLED, true);
+    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, true);
+
+    initResourceHandlerChain(conf);
+
+    Assert.assertTrue(ResourceHandlerModule.getMemoryResourceHandler()
+        instanceof CGroupsV2MemoryResourceHandlerImpl);
+    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
+        instanceof CGroupsV2HandlerImpl);
+  }
+
+  private void initResourceHandlerChain(Configuration conf) throws ResourceHandlerException {
+    ResourceHandlerChain resourceHandlerChain =
+        ResourceHandlerModule.getConfiguredResourceHandlerChain(conf,
+            mock(Context.class));
+    if (resourceHandlerChain == null) {
+      Assert.fail("Could not initialize resource handler chain");
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestResourceHandlerModule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestResourceHandlerModule.java
@@ -49,9 +49,6 @@ public class TestResourceHandlerModule {
     networkEnabledConf.setBoolean(YarnConfiguration.NM_NETWORK_RESOURCE_ENABLED,
         true);
     ResourceHandlerModule.nullifyResourceHandlerChain();
-    ResourceHandlerModule.resetCgroupsHandler();
-    ResourceHandlerModule.resetCpuResourceHandler();
-    ResourceHandlerModule.resetMemoryResourceHandler();
   }
 
   @Test
@@ -112,71 +109,6 @@ public class TestResourceHandlerModule {
       Assert.assertTrue(resourceHandlers.get(0) == handler);
     } else {
       Assert.fail("Null returned");
-    }
-  }
-
-  @Test
-  public void testCpuResourceHandlerClassForCgroupV1() throws ResourceHandlerException {
-    Configuration conf = new YarnConfiguration();
-    conf.setBoolean(YarnConfiguration.NM_CPU_RESOURCE_ENABLED, true);
-    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, false);
-
-    initResourceHandlerChain(conf);
-
-    Assert.assertTrue(ResourceHandlerModule.getCpuResourceHandler()
-        instanceof CGroupsCpuResourceHandlerImpl);
-    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
-        instanceof CGroupsHandlerImpl);
-  }
-
-  @Test
-  public void testCpuResourceHandlerClassForCgroupV2() throws ResourceHandlerException {
-    Configuration conf = new YarnConfiguration();
-    conf.setBoolean(YarnConfiguration.NM_CPU_RESOURCE_ENABLED, true);
-    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, true);
-
-    initResourceHandlerChain(conf);
-
-    Assert.assertTrue(ResourceHandlerModule.getCpuResourceHandler()
-        instanceof CGroupsV2CpuResourceHandlerImpl);
-    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
-        instanceof CGroupsV2HandlerImpl);
-  }
-
-  @Test
-  public void testMemoryResourceHandlerClassForCgroupV1() throws ResourceHandlerException {
-    Configuration conf = new YarnConfiguration();
-    conf.setBoolean(YarnConfiguration.NM_MEMORY_RESOURCE_ENABLED, true);
-    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, false);
-
-    initResourceHandlerChain(conf);
-
-    Assert.assertTrue(ResourceHandlerModule.getMemoryResourceHandler()
-        instanceof CGroupsMemoryResourceHandlerImpl);
-    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
-        instanceof CGroupsHandlerImpl);
-  }
-
-  @Test
-  public void testMemoryResourceHandlerClassForCgroupV2() throws ResourceHandlerException {
-    Configuration conf = new YarnConfiguration();
-    conf.setBoolean(YarnConfiguration.NM_MEMORY_RESOURCE_ENABLED, true);
-    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, true);
-
-    initResourceHandlerChain(conf);
-
-    Assert.assertTrue(ResourceHandlerModule.getMemoryResourceHandler()
-        instanceof CGroupsV2MemoryResourceHandlerImpl);
-    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
-        instanceof CGroupsV2HandlerImpl);
-  }
-
-  private void initResourceHandlerChain(Configuration conf) throws ResourceHandlerException {
-    ResourceHandlerChain resourceHandlerChain =
-        ResourceHandlerModule.getConfiguredResourceHandlerChain(conf,
-            mock(Context.class));
-    if (resourceHandlerChain == null) {
-      Assert.fail("Could not initialize resource handler chain");
     }
   }
 }


### PR DESCRIPTION
### Description of PR

Port the functionality CGroupsResourceCalculator to CgroupV2
This (and  CGroupsResourceCalculator) can only be turned on if  **mapreduce.job.process-tree.class** is set to one of them (or to CombinedResourceCalculator).

### How was this patch tested?
- Unit test 

