### PR TITLE
YARN-11691. Add HTTP POST method to yarn web proxy servlet

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
@@ -69,6 +69,7 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -295,6 +296,19 @@ public class WebAppProxyServlet extends HttpServlet {
       }
 
       ((HttpPut) base).setEntity(new StringEntity(sb.toString()));
+    } else if (method.equals(HTTP.POST)){
+      base = new HttpPost(link);
+
+      StringBuilder sb = new StringBuilder();
+      BufferedReader reader =
+              new BufferedReader(
+                      new InputStreamReader(req.getInputStream(), "UTF-8"));
+      String line;
+      while ((line = reader.readLine()) != null) {
+        sb.append(line);
+      }
+
+      ((HttpPost) base).setEntity(new StringEntity(sb.toString()));
     } else {
       resp.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
       return;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The flink front-end tried to use the POST method to call the yarn server rest api, but it returned a 405 error. see [FLINK-35039
](https://issues.apache.org/jira/browse/FLINK-35039) ,I think that flink should not be modified, but it is more reasonable to support the POST method in yarn web proxy.
### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

