### PR TITLE
HDFS-17503. Unreleased volume references because of OOM.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
@@ -434,12 +434,12 @@ class BlockSender implements java.io.Closeable {
       blockIn = datanode.data.getBlockInputStream(block, offset); // seek to offset
       ris = new ReplicaInputStreams(
           blockIn, checksumIn, volumeRef, fileIoProvider);
-    } catch (IOException ioe) {
+    } catch (Throwable t) {
       IOUtils.cleanupWithLogger(null, volumeRef);
       IOUtils.closeStream(this);
       IOUtils.closeStream(blockIn);
       IOUtils.closeStream(checksumIn);
-      throw ioe;
+      throw t;
     }
   }
 


### PR DESCRIPTION
### Description of PR
Refer to HDFS-17503.
When BlockSender throws an error because of OOM，the volume reference obtained by the thread is not released，which causes the thread trying to remove the volume to wait and fall into an infinite loop.
I found [HDFS-15963](https://issues.apache.org/jira/browse/HDFS-15963) catched exception and release volume reference. But it did not handle the case of throwing errors. I think "catch (Throwable t)" should be used instead of "catch (IOException ioe)".

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

