### PR TITLE
HDFS-17509. RBF: Fix ClientProtocol.concat will throw NPE if tgr is a empty file.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -670,9 +670,6 @@ public class RouterClientProtocol implements ClientProtocol {
     // Concat only effects when all files in same namespace. And in router view, a file only exists in one RemoteLocation.
     final List<RemoteLocation> locations =
         rpcServer.getLocationsForPath(trg, true);
-    if (locations == null) {
-      throw new IOException("Cannot find target file - " + trg);
-    }
 
     final RemoteLocation targetDestination = locations.get(0);
     String targetNameService = targetDestination.getNameserviceId();
@@ -682,10 +679,6 @@ public class RouterClientProtocol implements ClientProtocol {
       String sourceFile = src[i];
       List<RemoteLocation> srcLocations =
           rpcServer.getLocationsForPath(sourceFile, true);
-      if (srcLocations == null) {
-        throw new IOException(
-            "Cannot find source file " + sourceFile);
-      }
       RemoteLocation srcLocation = srcLocations.get(0);
       sourceDestinations[i] = srcLocation.getDest();
       if (!targetNameService.equals(srcLocation.getNameserviceId())) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -667,7 +667,8 @@ public class RouterClientProtocol implements ClientProtocol {
   public void concat(String trg, String[] src) throws IOException {
     rpcServer.checkOperation(NameNode.OperationCategory.WRITE);
 
-    // Concat only effects when all files in same namespace. And in router view, a file only exists in one RemoteLocation.
+    // Concat only effects when all files in same namespace.
+    // And in router view, a file only exists in one RemoteLocation.
     final List<RemoteLocation> locations =
         rpcServer.getLocationsForPath(trg, true);
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -1003,8 +1003,9 @@ public class RouterClientProtocol implements ClientProtocol {
     rpcServer.checkOperation(NameNode.OperationCategory.READ);
 
     final List<RemoteLocation> locations = rpcServer.getLocationsForPath(path, false, false);
-    if (locations.size() == 1)
+    if (locations.size() == 1) {
       return locations.get(0);
+    }
     RemoteLocation remoteLocation = null;
     for (RemoteLocation location : locations) {
       RemoteMethod method =

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -1698,42 +1698,6 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
   }
 
   /**
-   * Locate the location with the matching block pool id.
-   *
-   * @param path Path to check.
-   * @param failIfLocked Fail the request if locked (top mount point).
-   * @param blockPoolId The block pool ID of the namespace to search for.
-   * @return Prioritized list of locations in the federated cluster.
-   * @throws IOException if the location for this path cannot be determined.
-   */
-  protected RemoteLocation getLocationForPath(
-      String path, boolean failIfLocked, String blockPoolId)
-          throws IOException {
-
-    final List<RemoteLocation> locations =
-        getLocationsForPath(path, failIfLocked);
-
-    String nameserviceId = null;
-    Set<FederationNamespaceInfo> namespaces =
-        this.namenodeResolver.getNamespaces();
-    for (FederationNamespaceInfo namespace : namespaces) {
-      if (namespace.getBlockPoolId().equals(blockPoolId)) {
-        nameserviceId = namespace.getNameserviceId();
-        break;
-      }
-    }
-    if (nameserviceId != null) {
-      for (RemoteLocation location : locations) {
-        if (location.getNameserviceId().equals(nameserviceId)) {
-          return location;
-        }
-      }
-    }
-    throw new IOException(
-        "Cannot locate a nameservice for block pool " + blockPoolId);
-  }
-
-  /**
    * Get the possible locations of a path in the federated cluster.
    * During the get operation, it will do the quota verification.
    *

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
@@ -1224,6 +1224,17 @@ public class TestRouterRpc {
     String badPath = "/unknownlocation/unknowndir";
     compareResponses(routerProtocol, nnProtocol, m,
         new Object[] {badPath, new String[] {routerFile}});
+
+    // Test when concat trg is a empty file
+    createFile(routerFS, existingFile, existingFileSize);
+    String sameRouterEmptyFile =
+        cluster.getFederatedTestDirectoryForNS(sameNameservice) +
+            "_newemptyfile";
+    createFile(routerFS, sameRouterEmptyFile, 0);
+    // Concat in same namespaces, succeeds
+    testConcat(existingFile, sameRouterEmptyFile, false);
+    FileStatus mergedStatus = getFileStatus(routerFS, sameRouterEmptyFile);
+    assertEquals(existingFileSize, mergedStatus.getLen());
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
@@ -1164,6 +1164,21 @@ public class TestRouterRpc {
   }
 
   private void testConcat(
+      String source, String target, boolean failureExpected, boolean verfiyException, String msg) {
+    boolean failure = false;
+    try {
+      // Concat test file with fill block length file via router
+      routerProtocol.concat(target, new String[] {source});
+    } catch (IOException ex) {
+      failure = true;
+      if (verfiyException) {
+        assertExceptionContains(msg, ex);
+      }
+    }
+    assertEquals(failureExpected, failure);
+  }
+
+  private void testConcat(
       String source, String target, boolean failureExpected) {
     boolean failure = false;
     try {
@@ -1242,7 +1257,8 @@ public class TestRouterRpc {
     String targetFile = cluster.getFederatedTestDirectoryForNS(sameNameservice) + "_targetFile";
     createFile(routerFS, targetFile, existingFileSize);
     // Concat in same namespaces, succeeds
-    testConcat(srcEmptyFile, targetFile, true);
+    testConcat(srcEmptyFile, targetFile, true, true,
+        "concat: source file " + srcEmptyFile + " is invalid or empty or underConstruction");
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
@@ -1235,6 +1235,14 @@ public class TestRouterRpc {
     testConcat(existingFile, sameRouterEmptyFile, false);
     FileStatus mergedStatus = getFileStatus(routerFS, sameRouterEmptyFile);
     assertEquals(existingFileSize, mergedStatus.getLen());
+
+    // Test when concat srclist has some empty file, namenode will throw IOException.
+    String srcEmptyFile = cluster.getFederatedTestDirectoryForNS(sameNameservice) + "_srcEmptyFile";
+    createFile(routerFS, srcEmptyFile, 0);
+    String targetFile = cluster.getFederatedTestDirectoryForNS(sameNameservice) + "_targetFile";
+    createFile(routerFS, targetFile, existingFileSize);
+    // Concat in same namespaces, succeeds
+    testConcat(srcEmptyFile, targetFile, true);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
@@ -1258,7 +1258,8 @@ public class TestRouterRpc {
     createFile(routerFS, targetFile, existingFileSize);
     // Concat in same namespaces, succeeds
     testConcat(srcEmptyFile, targetFile, true, true,
-        "concat: source file " + srcEmptyFile + " is invalid or empty or underConstruction");
+        "org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.HadoopIllegalArgumentException): concat: source file "
+            + srcEmptyFile + " is invalid or empty or underConstruction");
   }
 
   @Test


### PR DESCRIPTION

### Description of PR
As described    [HDFS-17509](https://issues.apache.org/jira/browse/HDFS-17509)

hdfs dfs -concat  /tmp/merge /tmp/t1 /tmp/t2
When /tmp/merge is a empty file, this command will throw NPE via DFSRouter. 


Because a file via DFSRouter only can be exists in one namespace, so this RP can implement in this way.