### PR TITLE
MAPREDUCE-7475. Fixed non-idempotent unit tests

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAppController.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAppController.java
@@ -319,6 +319,8 @@ public class TestAppController {
     appController.attempts();
 
     assertEquals(AttemptsPage.class, appController.getClazz());
+
+    appController.getProperty().remove(AMParams.ATTEMPT_STATE);
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMapTask.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMapTask.java
@@ -58,8 +58,8 @@ public class TestMapTask {
     if(!TEST_ROOT_DIR.exists()) {
       TEST_ROOT_DIR.mkdirs();
     }
-  } 
- 
+  }
+
   @After
   public void cleanup() throws Exception {
     FileUtil.fullyDelete(TEST_ROOT_DIR);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMapTask.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMapTask.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.mapreduce.TaskCounter;
 import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.util.Progress;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,6 +53,13 @@ public class TestMapTask {
           System.getProperty("java.io.tmpdir", "/tmp")),
       TestMapTask.class.getName());
 
+  @Before
+  public void setup() throws Exception {
+    if(!TEST_ROOT_DIR.exists()) {
+      TEST_ROOT_DIR.mkdirs();
+    }
+  } 
+ 
   @After
   public void cleanup() throws Exception {
     FileUtil.fullyDelete(TEST_ROOT_DIR);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMapTask.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMapTask.java
@@ -48,21 +48,21 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 public class TestMapTask {
-  private static File TEST_ROOT_DIR = new File(
+  private static File testRootDir = new File(
       System.getProperty("test.build.data",
           System.getProperty("java.io.tmpdir", "/tmp")),
       TestMapTask.class.getName());
 
   @Before
   public void setup() throws Exception {
-    if(!TEST_ROOT_DIR.exists()) {
-      TEST_ROOT_DIR.mkdirs();
+    if(!testRootDir.exists()) {
+      testRootDir.mkdirs();
     }
   }
 
   @After
   public void cleanup() throws Exception {
-    FileUtil.fullyDelete(TEST_ROOT_DIR);
+    FileUtil.fullyDelete(testRootDir);
   }
 
   @Rule
@@ -74,7 +74,7 @@ public class TestMapTask {
   public void testShufflePermissions() throws Exception {
     JobConf conf = new JobConf();
     conf.set(CommonConfigurationKeys.FS_PERMISSIONS_UMASK_KEY, "077");
-    conf.set(MRConfig.LOCAL_DIR, TEST_ROOT_DIR.getAbsolutePath());
+    conf.set(MRConfig.LOCAL_DIR, testRootDir.getAbsolutePath());
     MapOutputFile mof = new MROutputFiles();
     mof.setConf(conf);
     TaskAttemptID attemptId = new TaskAttemptID("12345", 1, TaskType.MAP, 1, 1);
@@ -106,7 +106,7 @@ public class TestMapTask {
   public void testSpillFilesCountLimitInvalidValue() throws Exception {
     JobConf conf = new JobConf();
     conf.set(CommonConfigurationKeys.FS_PERMISSIONS_UMASK_KEY, "077");
-    conf.set(MRConfig.LOCAL_DIR, TEST_ROOT_DIR.getAbsolutePath());
+    conf.set(MRConfig.LOCAL_DIR, testRootDir.getAbsolutePath());
     conf.setInt(MRJobConfig.SPILL_FILES_COUNT_LIMIT, -2);
     MapOutputFile mof = new MROutputFiles();
     mof.setConf(conf);
@@ -132,7 +132,7 @@ public class TestMapTask {
   public void testSpillFilesCountBreach() throws Exception {
     JobConf conf = new JobConf();
     conf.set(CommonConfigurationKeys.FS_PERMISSIONS_UMASK_KEY, "077");
-    conf.set(MRConfig.LOCAL_DIR, TEST_ROOT_DIR.getAbsolutePath());
+    conf.set(MRConfig.LOCAL_DIR, testRootDir.getAbsolutePath());
     conf.setInt(MRJobConfig.SPILL_FILES_COUNT_LIMIT, 2);
     MapOutputFile mof = new MROutputFiles();
     mof.setConf(conf);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskProgressReporter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskProgressReporter.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.checkpoint.TaskCheckpointID;
 import org.apache.hadoop.util.ExitUtil;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -178,6 +179,11 @@ public class TestTaskProgressReporter {
       taskLimitIsChecked = true;
       super.checkTaskLimits();
     }
+  }
+
+  @Before
+  public void setup() {
+    statusUpdateTimes = 0;
   }
 
   @After

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/NotificationTestCase.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/NotificationTestCase.java
@@ -158,6 +158,8 @@ public abstract class NotificationTestCase extends HadoopTestCase {
   @After
   public void tearDown() throws Exception {
     stopHttpServer();
+    NotificationServlet.counter = 0;
+    NotificationServlet.failureCounter = 0;
     super.tearDown();
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestOldCombinerGrouping.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestOldCombinerGrouping.java
@@ -41,7 +41,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 public class TestOldCombinerGrouping {
-  private static File TEST_ROOT_DIR = GenericTestUtils.getRandomizedTestDir();
+  private static File testRootDir = GenericTestUtils.getRandomizedTestDir();
 
   public static class Map implements
       Mapper<LongWritable, Text, Text, LongWritable> {
@@ -121,19 +121,19 @@ public class TestOldCombinerGrouping {
 
   @After
   public void cleanup() {
-    FileUtil.fullyDelete(TEST_ROOT_DIR);
+    FileUtil.fullyDelete(testRootDir);
   }
 
   @Test
   public void testCombiner() throws Exception {
-    if (!TEST_ROOT_DIR.mkdirs()) {
-      throw new RuntimeException("Could not create test dir: " + TEST_ROOT_DIR);
+    if (!testRootDir.mkdirs()) {
+      throw new RuntimeException("Could not create test dir: " + testRootDir);
     }
-    File in = new File(TEST_ROOT_DIR, "input");
+    File in = new File(testRootDir, "input");
     if (!in.mkdirs()) {
       throw new RuntimeException("Could not create test dir: " + in);
     }
-    File out = new File(TEST_ROOT_DIR, "output");
+    File out = new File(testRootDir, "output");
     PrintWriter pw = new PrintWriter(new FileWriter(new File(in, "data.txt")));
     pw.println("A|a,1");
     pw.println("A|b,2");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestOldCombinerGrouping.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestOldCombinerGrouping.java
@@ -18,11 +18,16 @@
 
 package org.apache.hadoop.mapred;
 
+import org.junit.After;
 import org.junit.Assert;
+
+import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.RawComparator;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.test.GenericTestUtils;
+
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -34,12 +39,9 @@ import java.io.PrintWriter;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.UUID;
 
 public class TestOldCombinerGrouping {
-  private static String TEST_ROOT_DIR = new File(System.getProperty(
-      "test.build.data", "build/test/data"), UUID.randomUUID().toString())
-          .getAbsolutePath();
+  private static File TEST_ROOT_DIR = GenericTestUtils.getRandomizedTestDir();
 
   public static class Map implements
       Mapper<LongWritable, Text, Text, LongWritable> {
@@ -117,9 +119,14 @@ public class TestOldCombinerGrouping {
 
   }
 
+  @After
+  public void cleanup() {
+    FileUtil.fullyDelete(TEST_ROOT_DIR);
+  } 
+
   @Test
   public void testCombiner() throws Exception {
-    if (!new File(TEST_ROOT_DIR).mkdirs()) {
+    if (!TEST_ROOT_DIR.mkdirs()) {
       throw new RuntimeException("Could not create test dir: " + TEST_ROOT_DIR);
     }
     File in = new File(TEST_ROOT_DIR, "input");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestOldCombinerGrouping.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestOldCombinerGrouping.java
@@ -122,7 +122,7 @@ public class TestOldCombinerGrouping {
   @After
   public void cleanup() {
     FileUtil.fullyDelete(TEST_ROOT_DIR);
-  } 
+  }
 
   @Test
   public void testCombiner() throws Exception {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestNewCombinerGrouping.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestNewCombinerGrouping.java
@@ -18,7 +18,10 @@
 
 package org.apache.hadoop.mapreduce;
 
+import org.junit.After;
 import org.junit.Assert;
+
+import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.RawComparator;
@@ -26,6 +29,8 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -36,12 +41,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
 
 public class TestNewCombinerGrouping {
-  private static String TEST_ROOT_DIR = new File(System.getProperty(
-      "test.build.data", "build/test/data"), UUID.randomUUID().toString())
-          .getAbsolutePath();
+  private static File TEST_ROOT_DIR = GenericTestUtils.getRandomizedTestDir();
 
   public static class Map extends
       Mapper<LongWritable, Text, Text, LongWritable> {
@@ -103,9 +105,14 @@ public class TestNewCombinerGrouping {
 
   }
 
+  @After
+  public void cleanup() {
+    FileUtil.fullyDelete(TEST_ROOT_DIR);
+  }
+  
   @Test
   public void testCombiner() throws Exception {
-    if (!new File(TEST_ROOT_DIR).mkdirs()) {
+    if (!TEST_ROOT_DIR.mkdirs()) {
       throw new RuntimeException("Could not create test dir: " + TEST_ROOT_DIR);
     }
     File in = new File(TEST_ROOT_DIR, "input");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestNewCombinerGrouping.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestNewCombinerGrouping.java
@@ -43,7 +43,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class TestNewCombinerGrouping {
-  private static File TEST_ROOT_DIR = GenericTestUtils.getRandomizedTestDir();
+  private static File testRootDir = GenericTestUtils.getRandomizedTestDir();
 
   public static class Map extends
       Mapper<LongWritable, Text, Text, LongWritable> {
@@ -107,19 +107,19 @@ public class TestNewCombinerGrouping {
 
   @After
   public void cleanup() {
-    FileUtil.fullyDelete(TEST_ROOT_DIR);
+    FileUtil.fullyDelete(testRootDir);
   }
 
   @Test
   public void testCombiner() throws Exception {
-    if (!TEST_ROOT_DIR.mkdirs()) {
-      throw new RuntimeException("Could not create test dir: " + TEST_ROOT_DIR);
+    if (!testRootDir.mkdirs()) {
+      throw new RuntimeException("Could not create test dir: " + testRootDir);
     }
-    File in = new File(TEST_ROOT_DIR, "input");
+    File in = new File(testRootDir, "input");
     if (!in.mkdirs()) {
       throw new RuntimeException("Could not create test dir: " + in);
     }
-    File out = new File(TEST_ROOT_DIR, "output");
+    File out = new File(testRootDir, "output");
     PrintWriter pw = new PrintWriter(new FileWriter(new File(in, "data.txt")));
     pw.println("A|a,1");
     pw.println("A|b,2");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestNewCombinerGrouping.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestNewCombinerGrouping.java
@@ -109,7 +109,7 @@ public class TestNewCombinerGrouping {
   public void cleanup() {
     FileUtil.fullyDelete(TEST_ROOT_DIR);
   }
-  
+
   @Test
   public void testCombiner() throws Exception {
     if (!TEST_ROOT_DIR.mkdirs()) {


### PR DESCRIPTION
## Description of PR
This PR fixes unit tests that are not idempotent and fail upon repeated execution within the same JVM instance due to self-induced state pollution. The tests shall be fixed as unit tests shall be idempotent, and it shall be good to clean the state pollution so that potential newly introduced tests do not fail in the future due to the shared state polluted by these tests.

## Overview & Proposed Fix of all non-idempotent unit tests in the MapReduce Module
The following tests try to make the directory `TEST_ROOT_DIR` and write to it. The tests do not clean up (remove) the directory after execution. Therefore, in the second execution, `TEST_ROOT_DIR` would already exist and the exception `Could not create test dir` would be thrown. 

* org.apache.hadoop.mapred.TestOldCombinerGrouping.testCombiner
* org.apache.hadoop.mapreduce.TestNewCombinerGrouping.testCombiner

## Sample Failure Message (in the 2nd run of the test):
```
java.lang.RuntimeException: Could not create test dir: /home/kaiyaok2/NIOExperiments/github.com/apache/hadoop/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/build/test/data/e4ee268d-2946-43a2-93b5-f2b4ac647279
        at org.apache.hadoop.mapreduce.TestNewCombinerGrouping.testCombiner(TestNewCombinerGrouping.java:109)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
```
The fix is done by fully deleting the test directory after test execution.

-----------------------------------------------------------------------------------------------

The following two tests below do not reset `NotificationServlet.counter`, so repeated runs throw assertion failures due to accumulation. 

- org.apache.hadoop.mapred.TestClusterMRNotification#testMR
- org.apache.hadoop.mapred.TestLocalMRNotification#testMR

Fixed by resetting `NotificationServlet.counter` and `NotificationServlet.failureCounter` to 0 after test execution.

-----------------------------------------------------------------------------------------------

The following test does not remove the key `AMParams.ATTEMPT_STATE`, so repeated runs of the test will not be missing the attempt-state at all:

- org.apache.hadoop.mapreduce.v2.app.webapp.TestAppController.testAttempts

Fixed by removing `AMParams.ATTEMPT_STATE` at the end of the test.

-----------------------------------------------------------------------------------------------

The following test fully deletes `TEST_ROOT_DIR` after execution, so repeated runs will throw a`DiskErrorException`:

- org.apache.hadoop.mapred.TestMapTask#testShufflePermissions

Fixed by checking if `TEST_ROOT_DIR` exists before test execution. Make the directory if not.

-----------------------------------------------------------------------------------------------

The following test does not restore the static variable `statusUpdateTimes` after execution, so consecutive runs throws `AssertionError`:

- org.apache.hadoop.mapred.TestTaskProgressReporter#testTaskProgress

Fixed by resetting `statusUpdateTimes` to 0 before test execution

## How was this patch tested?
After the patch, rerunning the tests in the same JVM does not produce any exceptions.

