### PR TITLE
HADOOP-19160. hadoop-auth should not depend on kerb-simplekdc

### DIFF
--- a/hadoop-common-project/hadoop-auth/pom.xml
+++ b/hadoop-common-project/hadoop-auth/pom.xml
@@ -136,7 +136,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.kerby</groupId>
-      <artifactId>kerb-simplekdc</artifactId>
+      <artifactId>kerb-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kerby</groupId>
+      <artifactId>kerb-util</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.directory.server</groupId>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1960,6 +1960,11 @@
           <version>${kerby.version}</version>
         </dependency>
         <dependency>
+          <groupId>org.apache.kerby</groupId>
+          <artifactId>kerb-util</artifactId>
+          <version>${kerby.version}</version>
+        </dependency>
+        <dependency>
           <groupId>org.ehcache</groupId>
           <artifactId>ehcache</artifactId>
           <version>${ehcache.version}</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

HADOOP-16179 attempted to remove dependency on `kerb-simplekdc` from `hadoop-common`.  However, `hadoop-auth` still has a `compile`-scope dependency on the same, and `hadoop-common` proper depends on `hadoop-auth`.  So `kerb-simplekdc` is still a transitive dependency of `hadoop-common`.

```
[INFO] --- maven-dependency-plugin:3.0.2:tree (default-cli) @ hadoop-common ---
[INFO] org.apache.hadoop:hadoop-common:jar:3.5.0-SNAPSHOT
...
[INFO] +- org.apache.hadoop:hadoop-auth:jar:3.5.0-SNAPSHOT:compile
...
[INFO] |  \- org.apache.kerby:kerb-simplekdc:jar:2.0.3:compile
[INFO] |     +- org.apache.kerby:kerb-client:jar:2.0.3:compile
[INFO] |     |  +- org.apache.kerby:kerby-config:jar:2.0.3:compile
[INFO] |     |  +- org.apache.kerby:kerb-common:jar:2.0.3:compile
[INFO] |     |  |  \- org.apache.kerby:kerb-crypto:jar:2.0.3:compile
[INFO] |     |  +- org.apache.kerby:kerb-util:jar:2.0.3:compile
[INFO] |     |  \- org.apache.kerby:token-provider:jar:2.0.3:compile
[INFO] |     \- org.apache.kerby:kerb-admin:jar:2.0.3:compile
[INFO] |        +- org.apache.kerby:kerb-server:jar:2.0.3:compile
[INFO] |        |  \- org.apache.kerby:kerb-identity:jar:2.0.3:compile
[INFO] |        +- org.apache.kerby:kerby-xdr:jar:2.0.3:compile
[INFO] |        \- org.jline:jline:jar:3.9.0:compile
```

This PR replaces the dependency in `hadoop-auth` with more specific modules.

https://issues.apache.org/jira/browse/HADOOP-19160

## How was this patch tested?

Updated dependency tree:

```
[INFO] --- maven-dependency-plugin:3.0.2:tree (default-cli) @ hadoop-auth ---
[INFO] org.apache.hadoop:hadoop-auth:jar:3.5.0-SNAPSHOT
...
[INFO] +- org.apache.kerby:kerb-core:jar:2.0.3:compile
[INFO] |  \- org.apache.kerby:kerby-pkix:jar:2.0.3:compile
[INFO] |     +- org.apache.kerby:kerby-asn1:jar:2.0.3:compile
[INFO] |     \- org.apache.kerby:kerby-util:jar:2.0.3:compile
[INFO] +- org.apache.kerby:kerb-util:jar:2.0.3:compile
[INFO] |  +- org.apache.kerby:kerby-config:jar:2.0.3:compile
[INFO] |  \- org.apache.kerby:kerb-crypto:jar:2.0.3:compile
```

`kerb-simplekdc` is still a `test`-scope dependency via `hadoop-minikdc` (for both `hadoop-auth` and `hadoop-common`):

```
[INFO] --- maven-dependency-plugin:3.0.2:tree (default-cli) @ hadoop-auth ---
[INFO] org.apache.hadoop:hadoop-auth:jar:3.5.0-SNAPSHOT
...
[INFO] +- org.apache.hadoop:hadoop-minikdc:jar:3.5.0-SNAPSHOT:test
[INFO] |  +- commons-io:commons-io:jar:2.14.0:test
[INFO] |  \- org.apache.kerby:kerb-simplekdc:jar:2.0.3:test
```

Hadoop `trunk` compiles fine locally.