### PR TITLE
MAPREDUCE-7476. Fixed more non-idempotent unit tests

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAppController.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAppController.java
@@ -319,6 +319,8 @@ public class TestAppController {
     appController.attempts();
 
     assertEquals(AttemptsPage.class, appController.getClazz());
+
+    appController.getProperty().remove(AMParams.ATTEMPT_STATE);
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMapTask.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMapTask.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.mapreduce.TaskCounter;
 import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.util.Progress;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,6 +53,13 @@ public class TestMapTask {
           System.getProperty("java.io.tmpdir", "/tmp")),
       TestMapTask.class.getName());
 
+  @Before
+  public void setup() throws Exception {
+    if(!TEST_ROOT_DIR.exists()) {
+      TEST_ROOT_DIR.mkdirs();
+    }
+  } 
+ 
   @After
   public void cleanup() throws Exception {
     FileUtil.fullyDelete(TEST_ROOT_DIR);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskProgressReporter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskProgressReporter.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.checkpoint.TaskCheckpointID;
 import org.apache.hadoop.util.ExitUtil;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -179,6 +180,11 @@ public class TestTaskProgressReporter {
       super.checkTaskLimits();
     }
   }
+
+  @Before
+  public void setup() {
+    statusUpdateTimes = 0;
+  }  
 
   @After
   public void cleanup() {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/NotificationTestCase.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/NotificationTestCase.java
@@ -158,6 +158,8 @@ public abstract class NotificationTestCase extends HadoopTestCase {
   @After
   public void tearDown() throws Exception {
     stopHttpServer();
+    NotificationServlet.counter = 0;
+    NotificationServlet.failureCounter = 0;
     super.tearDown();
   }
 


### PR DESCRIPTION
### Description of PR

Similar with https://issues.apache.org/jira/browse/MAPREDUCE-7475 , this PR fixes more non-idempotent unit tests detected.

## Overview & Proposed Fix of all remaining non-idempotent unit tests in the MapReduce Project

The following two tests below do not reset `NotificationServlet.counter`, so repeated runs throw assertion failures due to accumulation. 

- org.apache.hadoop.mapred.TestClusterMRNotification#testMR
- org.apache.hadoop.mapred.TestLocalMRNotification#testMR

Fixed by resetting `NotificationServlet.counter` and `NotificationServlet.failureCounter` to 0 after test execution.

-----------------------------------------------------------------------------------------------

The following test does not remove the key `AMParams.ATTEMPT_STATE`, so repeated runs of the test will not be missing the attempt-state at all:

- org.apache.hadoop.mapreduce.v2.app.webapp.TestAppController.testAttempts

Fixed by removing `AMParams.ATTEMPT_STATE` at the end of the test.

-----------------------------------------------------------------------------------------------

The following test fully deletes `TEST_ROOT_DIR` after execution, so repeated runs will throw a`DiskErrorException`:

- org.apache.hadoop.mapred.TestMapTask#testShufflePermissions

Fixed by checking if `TEST_ROOT_DIR` exists before test execution. Make the directory if not.

-----------------------------------------------------------------------------------------------

The following test does not restore the static variable `statusUpdateTimes` after execution, so consecutive runs throws `AssertionError`:

- org.apache.hadoop.mapred.TestTaskProgressReporter#testTaskProgress

Fixed by resetting `statusUpdateTimes` to 0 before test execution



### How was this patch tested?

After the patch, rerunning the tests in the same JVM does not produce any exceptions.




