### PR TITLE
HADOOP-19160. hadoop-auth should not depend on kerb-simplekdc

### DIFF
--- a/hadoop-common-project/hadoop-auth/pom.xml
+++ b/hadoop-common-project/hadoop-auth/pom.xml
@@ -136,7 +136,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.kerby</groupId>
-      <artifactId>kerb-simplekdc</artifactId>
+      <artifactId>kerb-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kerby</groupId>
+      <artifactId>kerb-util</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.directory.server</groupId>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1944,6 +1944,11 @@
           <version>${kerby.version}</version>
         </dependency>
         <dependency>
+          <groupId>org.apache.kerby</groupId>
+          <artifactId>kerb-util</artifactId>
+          <version>${kerby.version}</version>
+        </dependency>
+        <dependency>
           <groupId>org.ehcache</groupId>
           <artifactId>ehcache</artifactId>
           <version>${ehcache.version}</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Backport #6788 to `branch-3.4`.

https://issues.apache.org/jira/browse/HADOOP-19160