### PR TITLE
YARN-11695. Fixed non-idempotent unit tests in `TestTaskRunner`

### DIFF
--- a/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/scheduler/TestTaskRunner.java
+++ b/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/scheduler/TestTaskRunner.java
@@ -40,7 +40,7 @@ public class TestTaskRunner {
   }
 
   public static class SingleTask extends TaskRunner.Task {
-    public static CountDownLatch latch = new CountDownLatch(1);
+    public static CountDownLatch latch;
     public static boolean first;
 
     public SingleTask(long startTime) {
@@ -69,6 +69,8 @@ public class TestTaskRunner {
 
   @Test
   public void testSingleTask() throws Exception {
+    SingleTask.first = false;
+    SingleTask.latch = new CountDownLatch(1);
     runner.start();
     runner.schedule(new SingleTask(0));
     SingleTask.latch.await(5000, TimeUnit.MILLISECONDS);
@@ -76,7 +78,7 @@ public class TestTaskRunner {
   }
 
   public static class DualTask extends TaskRunner.Task {
-    public static CountDownLatch latch = new CountDownLatch(1);
+    public static CountDownLatch latch;
     public static boolean first;
     public static boolean last;
 
@@ -109,6 +111,9 @@ public class TestTaskRunner {
 
   @Test
   public void testDualTask() throws Exception {
+    DualTask.first = false;
+    DualTask.last = false;
+    DualTask.latch = new CountDownLatch(1);
     runner.start();
     runner.schedule(new DualTask(0, 10, 10));
     DualTask.latch.await(5000, TimeUnit.MILLISECONDS);
@@ -117,7 +122,7 @@ public class TestTaskRunner {
   }
 
   public static class TriTask extends TaskRunner.Task {
-    public static CountDownLatch latch = new CountDownLatch(1);
+    public static CountDownLatch latch;
     public static boolean first;
     public static boolean middle;
     public static boolean last;
@@ -154,6 +159,10 @@ public class TestTaskRunner {
 
   @Test
   public void testTriTask() throws Exception {
+    TriTask.first = false;
+    TriTask.middle = false;
+    TriTask.last = false;
+    TriTask.latch = new CountDownLatch(1);
     runner.start();
     runner.schedule(new TriTask(0, 10, 5));
     TriTask.latch.await(5000, TimeUnit.MILLISECONDS);
@@ -163,7 +172,7 @@ public class TestTaskRunner {
   }
 
   public static class MultiTask extends TaskRunner.Task {
-    public static CountDownLatch latch = new CountDownLatch(1);
+    public static CountDownLatch latch;
     public static boolean first;
     public static int middle;
     public static boolean last;
@@ -197,6 +206,10 @@ public class TestTaskRunner {
 
   @Test
   public void testMultiTask() throws Exception {
+    MultiTask.first = false;
+    MultiTask.middle = 0;
+    MultiTask.last = false;
+    MultiTask.latch = new CountDownLatch(1);
     runner.start();
     runner.schedule(new MultiTask(0, 20, 5));
     MultiTask.latch.await(5000, TimeUnit.MILLISECONDS);
@@ -207,7 +220,7 @@ public class TestTaskRunner {
 
 
   public static class PreStartTask extends TaskRunner.Task {
-    public static CountDownLatch latch = new CountDownLatch(1);
+    public static CountDownLatch latch;
     public static boolean first;
 
     public PreStartTask(long startTime) {
@@ -234,6 +247,8 @@ public class TestTaskRunner {
 
   @Test
   public void testPreStartQueueing() throws Exception {
+    PreStartTask.first = false;
+    PreStartTask.latch = new CountDownLatch(1);
     runner.schedule(new PreStartTask(210));
     Thread.sleep(210);
     runner.start();


### PR DESCRIPTION
### Description of PR

Following up #6793 

All tests in `org.apache.hadoop.yarn.sls.scheduler.TestTaskRunner` are not idempotent and fails upon repeated execution within the same JVM instance due to self-induced state pollution. Specifically, the test runs made changes to the static fields (e.g. `PreStartTask.first` in the task classes without restoring them. Therefore, repeated runs throw assertion errors.

Sample error message of `TestTaskRunner#testPreStartQueueing` in repeated test run:
```
java.lang.AssertionError:
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at org.apache.hadoop.yarn.sls.scheduler.TestTaskRunner.testPreStartQueueing(TestTaskRunner.java:244)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
``` 
The fix is done by explicitly setting (resetting) the static variables (countdown latches and booleans) at the start of each test, so that each test runs on a fresh state.


### How was this patch tested?
After the patch, rerunning the tests in the same JVM does not produce any exceptions.
