### PR TITLE
HDFS-17511. method storagespaceConsumedContiguous should use BlockInfo#getReplication to compute dsDelta.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
@@ -1054,13 +1054,12 @@ public class INodeFile extends INodeWithAdditionalFields
       blocks = allBlocks;
     }
 
-    final short replication = getPreferredBlockReplication();
     for (BlockInfo b : blocks) {
       long blockSize = b.isComplete() ? b.getNumBytes() :
           getPreferredBlockSize();
-      counts.addStorageSpace(blockSize * replication);
+      counts.addStorageSpace(blockSize * b.getReplication());
       if (bsp != null) {
-        List<StorageType> types = bsp.chooseStorageTypes(replication);
+        List<StorageType> types = bsp.chooseStorageTypes(b.getReplication());
         for (StorageType t : types) {
           if (t.supportTypeQuota()) {
             counts.addTypeSpace(t, blockSize);


### PR DESCRIPTION
### Description of PR
Refer to HDFS-17511.
We should use BlockInfo#getReplication to compute storage space in method INodeFile#storagespaceConsumedContiguous.