### PR TITLE
HDFS-17513. Fix reconfigure slow peer enable for Namenode.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -5808,6 +5808,16 @@ public class BlockManager implements BlockStatsMXBean {
     return spsManager;
   }
 
+  public void setDataNodePeerStatsEnabled(boolean enable) {
+    placementPolicies.getPolicy(CONTIGUOUS).setDataNodePeerStatsEnabled(enable);
+    placementPolicies.getPolicy(STRIPED).setDataNodePeerStatsEnabled(enable);
+  }
+
+  @VisibleForTesting
+  public boolean getDataNodePeerStatsEnabled(BlockType blockType) {
+    return placementPolicies.getPolicy(blockType).getDataNodePeerStatsEnabled();
+  }
+
   public void setExcludeSlowNodesEnabled(boolean enable) {
     placementPolicies.getPolicy(CONTIGUOUS).setExcludeSlowNodesEnabled(enable);
     placementPolicies.getPolicy(STRIPED).setExcludeSlowNodesEnabled(enable);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicy.java
@@ -264,6 +264,17 @@ public abstract class BlockPlacementPolicy {
   }
 
   /**
+   * Updates the value used for dataNodePeerStatsEnabled, which is set by
+   * {@link org.apache.hadoop.hdfs.DFSConfigKeys#DFS_DATANODE_PEER_STATS_ENABLED_KEY}
+   * initially.
+   *
+   * @param enable true, It indicates the write latency of record datanode.
+   */
+  public abstract void setDataNodePeerStatsEnabled(boolean enable);
+
+  public abstract boolean getDataNodePeerStatsEnabled();
+
+  /**
    * Updates the value used for excludeSlowNodesEnabled, which is set by
    * {@code DFSConfigKeys.DFS_NAMENODE_BLOCKPLACEMENTPOLICY_EXCLUDE_SLOW_NODES_ENABLED_KEY}
    * initially.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
@@ -106,7 +106,7 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy {
   protected double considerLoadFactor;
   private boolean considerLoadByVolume = false;
   private boolean preferLocalNode;
-  private boolean dataNodePeerStatsEnabled;
+  private volatile boolean dataNodePeerStatsEnabled;
   private volatile boolean excludeSlowNodesEnabled;
   protected NetworkTopology clusterMap;
   protected Host2NodesMap host2datanodeMap;
@@ -1111,7 +1111,7 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy {
         return false;
       }
     }
-      
+
     // check if the target rack has chosen too many nodes
     String rackname = node.getNetworkLocation();
     int counter=1;
@@ -1381,6 +1381,15 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy {
   @VisibleForTesting
   void setPreferLocalNode(boolean prefer) {
     this.preferLocalNode = prefer;
+  }
+  @Override
+  public void setDataNodePeerStatsEnabled(boolean enable) {
+    this.dataNodePeerStatsEnabled = enable;
+  }
+
+  @Override
+  public boolean getDataNodePeerStatsEnabled() {
+    return dataNodePeerStatsEnabled;
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -2658,6 +2658,7 @@ public class NameNode extends ReconfigurableBase implements
             DFS_DATANODE_PEER_STATS_ENABLED_DEFAULT :
             Boolean.parseBoolean(newVal);
         result = Boolean.toString(peerStatsEnabled);
+        bm.setDataNodePeerStatsEnabled(peerStatsEnabled);
         datanodeManager.initSlowPeerTracker(getConf(), timer, peerStatsEnabled);
         break;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeReconfigure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeReconfigure.java
@@ -505,12 +505,15 @@ public class TestNameNodeReconfigure {
   @Test
   public void testSlowPeerTrackerEnabled() throws Exception {
     final NameNode nameNode = cluster.getNameNode();
-    final DatanodeManager datanodeManager = nameNode.namesystem.getBlockManager()
-        .getDatanodeManager();
+    final BlockManager blockManager = nameNode.namesystem.getBlockManager();
+    final DatanodeManager datanodeManager = blockManager.getDatanodeManager();
 
     assertFalse("SlowNode tracker is already enabled. It should be disabled by default",
         datanodeManager.getSlowPeerTracker().isSlowPeerTrackerEnabled());
     assertTrue(datanodeManager.isSlowPeerCollectorInitialized());
+    // By default, dataNodePeerStatsEnabled is false.
+    assertFalse(blockManager.getDataNodePeerStatsEnabled(BlockType.CONTIGUOUS));
+    assertFalse(blockManager.getDataNodePeerStatsEnabled(BlockType.STRIPED));
 
     try {
       nameNode.reconfigurePropertyImpl(DFS_DATANODE_PEER_STATS_ENABLED_KEY, "non-boolean");
@@ -525,11 +528,14 @@ public class TestNameNodeReconfigure {
     assertTrue("SlowNode tracker is still disabled. Reconfiguration could not be successful",
         datanodeManager.getSlowPeerTracker().isSlowPeerTrackerEnabled());
     assertFalse(datanodeManager.isSlowPeerCollectorInitialized());
+    assertTrue(blockManager.getDataNodePeerStatsEnabled(BlockType.CONTIGUOUS));
+    assertTrue(blockManager.getDataNodePeerStatsEnabled(BlockType.STRIPED));
 
     nameNode.reconfigurePropertyImpl(DFS_DATANODE_PEER_STATS_ENABLED_KEY, null);
     assertFalse("SlowNode tracker is still enabled. Reconfiguration could not be successful",
         datanodeManager.getSlowPeerTracker().isSlowPeerTrackerEnabled());
-
+    assertFalse(blockManager.getDataNodePeerStatsEnabled(BlockType.CONTIGUOUS));
+    assertFalse(blockManager.getDataNodePeerStatsEnabled(BlockType.STRIPED));
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Reconfigure slow peer parameters did not take effect in the BlockPlacementPolicyDefault class. 

### How was this patch tested?
Add UT
