### PR TITLE
HDFS-17514: RBF: Routers should unset cached stateID when namenode does not set stateID in RPC response header.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/PoolAlignmentContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/PoolAlignmentContext.java
@@ -64,7 +64,7 @@ public class PoolAlignmentContext implements AlignmentContext {
    */
   @Override
   public void receiveResponseState(RpcHeaderProtos.RpcResponseHeaderProto header) {
-    if (header.getStateId() <= 0) {
+    if (header.getStateId() == 0 && sharedGlobalStateId.get() > 0) {
       sharedGlobalStateId.reset();
     } else {
       sharedGlobalStateId.accumulate(header.getStateId());

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/PoolAlignmentContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/PoolAlignmentContext.java
@@ -64,7 +64,12 @@ public class PoolAlignmentContext implements AlignmentContext {
    */
   @Override
   public void receiveResponseState(RpcHeaderProtos.RpcResponseHeaderProto header) {
-    sharedGlobalStateId.accumulate(header.getStateId());
+    if (header.getStateId() <= 0) {
+      sharedGlobalStateId.reset();
+      poolLocalStateId.reset();
+    } else {
+      sharedGlobalStateId.accumulate(header.getStateId());
+    }
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/PoolAlignmentContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/PoolAlignmentContext.java
@@ -66,6 +66,7 @@ public class PoolAlignmentContext implements AlignmentContext {
   public void receiveResponseState(RpcHeaderProtos.RpcResponseHeaderProto header) {
     if (header.getStateId() == 0 && sharedGlobalStateId.get() > 0) {
       sharedGlobalStateId.reset();
+      poolLocalStateId.reset();
     } else {
       sharedGlobalStateId.accumulate(header.getStateId());
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/PoolAlignmentContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/PoolAlignmentContext.java
@@ -66,7 +66,6 @@ public class PoolAlignmentContext implements AlignmentContext {
   public void receiveResponseState(RpcHeaderProtos.RpcResponseHeaderProto header) {
     if (header.getStateId() <= 0) {
       sharedGlobalStateId.reset();
-      poolLocalStateId.reset();
     } else {
       sharedGlobalStateId.accumulate(header.getStateId());
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -979,7 +979,8 @@ public class TestObserverWithRouter {
 
   @EnumSource(ConfigSetting.class)
   @ParameterizedTest
-  public void testRestartingNamenodeWithStateIDContextDisabled(ConfigSetting configSetting) throws Exception {
+  public void testRestartingNamenodeWithStateIDContextDisabled(ConfigSetting configSetting)
+      throws Exception {
     fileSystem = routerContext.getFileSystem(getConfToEnableObserverReads(configSetting));
     Path path = new Path("/testFile1");
     // Send Create call to active
@@ -988,7 +989,8 @@ public class TestObserverWithRouter {
     // Send read request
     fileSystem.open(path).close();
 
-    long observerCount1 = routerContext.getRouter().getRpcServer().getRPCMetrics().getObserverProxyOps();
+    long observerCount1 = routerContext.getRouter().getRpcServer()
+        .getRPCMetrics().getObserverProxyOps();
 
     // Restart active namenodes and disable sending state id.
     restartActiveWithStateIDContextDisabled();
@@ -999,11 +1001,13 @@ public class TestObserverWithRouter {
     fileSystem2.msync();
     fileSystem2.open(path).close();
 
-    long observerCount2 = routerContext.getRouter().getRpcServer().getRPCMetrics().getObserverProxyOps();
+    long observerCount2 = routerContext.getRouter().getRpcServer()
+        .getRPCMetrics().getObserverProxyOps();
     assertEquals("There should no extra calls to the observer", observerCount1, observerCount2);
 
     fileSystem.open(path).close();
-    long observerCount3 = routerContext.getRouter().getRpcServer().getRPCMetrics().getObserverProxyOps();
+    long observerCount3 = routerContext.getRouter().getRpcServer()
+        .getRPCMetrics().getObserverProxyOps();
     assertTrue("Old filesystem will send calls to observer", observerCount3 > observerCount2);
   }
 
@@ -1013,8 +1017,8 @@ public class TestObserverWithRouter {
       if (nameNode != null && nameNode.isActiveState()) {
         Configuration conf = new Configuration();
         setConfDefaults(conf);
-        // Disable stateId context
-        cluster.getCluster().getConfiguration(nnIndex).setBoolean(DFS_NAMENODE_STATE_CONTEXT_ENABLED_KEY, false);
+        cluster.getCluster().getConfiguration(nnIndex)
+            .setBoolean(DFS_NAMENODE_STATE_CONTEXT_ENABLED_KEY, false);
         cluster.getCluster().restartNameNode(nnIndex, true);
         cluster.getCluster().getNameNode(nnIndex).isActiveState();
       }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -1000,8 +1000,12 @@ public class TestObserverWithRouter {
     fileSystem2.open(path).close();
     
     long observerCount2 = routerContext.getRouter().getRpcServer().getRPCMetrics().getObserverProxyOps();
-    
     assertEquals("There should no extra calls to the observer", observerCount1, observerCount2);
+
+    fileSystem.open(path).close();
+    long observerCount3 = routerContext.getRouter().getRpcServer().getRPCMetrics().getObserverProxyOps();
+    assertTrue("Old filesystem will send calls to observer", observerCount3 > observerCount2);
+
   }
   
   

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -107,10 +107,7 @@ public class TestObserverWithRouter {
   public void startUpCluster(int numberOfObserver, Configuration confOverrides) throws Exception {
     int numberOfNamenode = 2 + numberOfObserver;
     Configuration conf = new Configuration(false);
-    conf.setBoolean(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_DEFAULT_KEY, true);
-    conf.setBoolean(DFSConfigKeys.DFS_HA_TAILEDITS_INPROGRESS_KEY, true);
-    conf.set(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, "0ms");
-    conf.setBoolean(DFS_NAMENODE_STATE_CONTEXT_ENABLED_KEY, true);
+    setConfDefaults(conf);
     if (confOverrides != null) {
       confOverrides
           .iterator()
@@ -151,6 +148,13 @@ public class TestObserverWithRouter {
 
     cluster.waitActiveNamespaces();
     routerContext  = cluster.getRandomRouter();
+  }
+
+  private void setConfDefaults(Configuration conf) {
+    conf.setBoolean(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_DEFAULT_KEY, true);
+    conf.setBoolean(DFSConfigKeys.DFS_HA_TAILEDITS_INPROGRESS_KEY, true);
+    conf.set(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, "0ms");
+    conf.setBoolean(DFS_NAMENODE_STATE_CONTEXT_ENABLED_KEY, true);
   }
 
   public enum ConfigSetting {
@@ -971,5 +975,50 @@ public class TestObserverWithRouter {
         .getRPCMetrics().getActiveProxyOps();
     // There should no calls to any namespace.
     assertEquals("No calls to any namespace", 0, rpcCountForActive);
+  }
+
+  @EnumSource(ConfigSetting.class)
+  @ParameterizedTest
+  public void testStateIDInvalidationWhenNNDisablesCRS(ConfigSetting configSetting) throws Exception {
+    fileSystem = routerContext.getFileSystem(getConfToEnableObserverReads(configSetting));
+    Path path = new Path("/testFile1");
+    // Send Create call to active
+    fileSystem.create(path).close();
+    
+    // Send read request
+    fileSystem.open(path).close();
+    
+    long observerCount1 = routerContext.getRouter().getRpcServer().getRPCMetrics().getObserverProxyOps();
+    
+    // Restart active namenodes and disable sending state id.
+    restartActiveWithStateIDContextDisabled();
+    
+    Configuration conf = getConfToEnableObserverReads(configSetting);
+    conf.setBoolean("fs.hdfs.impl.disable.cache", true);
+    FileSystem fileSystem2 = routerContext.getFileSystem(conf);
+    fileSystem2.msync();
+    fileSystem2.open(path).close();
+    
+    long observerCount2 = routerContext.getRouter().getRpcServer().getRPCMetrics().getObserverProxyOps();
+    
+    assertEquals("There should no extra calls to the observer", observerCount1, observerCount2);
+  }
+  
+  
+  void restartActiveWithStateIDContextDisabled() throws Exception {
+    for (int nnIndex = 0; nnIndex < cluster.getNamenodes().size(); nnIndex++) {
+      NameNode nameNode = cluster.getCluster().getNameNode(nnIndex);
+      if (nameNode != null && nameNode.isActiveState()) {
+        Configuration conf = new Configuration();
+        setConfDefaults(conf);
+        // Disable stateId context
+        cluster.getCluster().getConfiguration(nnIndex).setBoolean(DFS_NAMENODE_STATE_CONTEXT_ENABLED_KEY, false);
+        cluster.getCluster().restartNameNode(nnIndex, true);
+        cluster.getCluster().getNameNode(nnIndex).isActiveState();
+      }
+    }
+    for (String ns : cluster.getNameservices()) {
+      cluster.switchToActive(ns, NAMENODES[0]);
+    }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -984,31 +984,29 @@ public class TestObserverWithRouter {
     Path path = new Path("/testFile1");
     // Send Create call to active
     fileSystem.create(path).close();
-    
+
     // Send read request
     fileSystem.open(path).close();
-    
+
     long observerCount1 = routerContext.getRouter().getRpcServer().getRPCMetrics().getObserverProxyOps();
-    
+
     // Restart active namenodes and disable sending state id.
     restartActiveWithStateIDContextDisabled();
-    
+
     Configuration conf = getConfToEnableObserverReads(configSetting);
     conf.setBoolean("fs.hdfs.impl.disable.cache", true);
     FileSystem fileSystem2 = routerContext.getFileSystem(conf);
     fileSystem2.msync();
     fileSystem2.open(path).close();
-    
+
     long observerCount2 = routerContext.getRouter().getRpcServer().getRPCMetrics().getObserverProxyOps();
     assertEquals("There should no extra calls to the observer", observerCount1, observerCount2);
 
     fileSystem.open(path).close();
     long observerCount3 = routerContext.getRouter().getRpcServer().getRPCMetrics().getObserverProxyOps();
     assertTrue("Old filesystem will send calls to observer", observerCount3 > observerCount2);
-
   }
-  
-  
+
   void restartActiveWithStateIDContextDisabled() throws Exception {
     for (int nnIndex = 0; nnIndex < cluster.getNamenodes().size(); nnIndex++) {
       NameNode nameNode = cluster.getCluster().getNameNode(nnIndex);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -979,7 +979,7 @@ public class TestObserverWithRouter {
 
   @EnumSource(ConfigSetting.class)
   @ParameterizedTest
-  public void testStateIDInvalidationWhenNNDisablesCRS(ConfigSetting configSetting) throws Exception {
+  public void testRestartingNamenodeWithStateIDContextDisabled(ConfigSetting configSetting) throws Exception {
     fileSystem = routerContext.getFileSystem(getConfToEnableObserverReads(configSetting));
     Path path = new Path("/testFile1");
     // Send Create call to active

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestPoolAlignmentContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestPoolAlignmentContext.java
@@ -70,7 +70,7 @@ public class TestPoolAlignmentContext {
     poolContext.receiveResponseState(getRpcResponseHeader(0));
     // Routers should reset the cached state Id to not send a stale value to the observer.
     Assertions.assertEquals(Long.MIN_VALUE, poolContext.getLastSeenStateId());
-    assertRequestHeaderStateId(poolContext, 10L);
+    assertRequestHeaderStateId(poolContext, Long.MIN_VALUE);
   }
 
   private RpcHeaderProtos.RpcResponseHeaderProto getRpcResponseHeader(long stateID) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestPoolAlignmentContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestPoolAlignmentContext.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs.server.federation.router;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos;
 import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcRequestHeaderProto;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -49,5 +50,35 @@ public class TestPoolAlignmentContext {
     RpcRequestHeaderProto.Builder builder = RpcRequestHeaderProto.newBuilder();
     poolAlignmentContext.updateRequestState(builder);
     Assertions.assertEquals(expectedValue, builder.getStateId());
+  }
+
+  @Test
+  public void testWhenNamenodeStopsSendingStateId() {
+    RouterStateIdContext routerStateIdContext = new RouterStateIdContext(new Configuration());
+    String namespaceId = "namespace1";
+    PoolAlignmentContext poolContext = new PoolAlignmentContext(routerStateIdContext, namespaceId);
+
+    poolContext.receiveResponseState(getRpcResponseHeader(10L));
+    // Last seen value is the one from namenode, but request header is the max seen by clients so far.
+    Assertions.assertEquals(10L, poolContext.getLastSeenStateId());
+    assertRequestHeaderStateId(poolContext, Long.MIN_VALUE);
+
+    poolContext.advanceClientStateId(10L);
+    assertRequestHeaderStateId(poolContext, 10L);
+
+    // When namenode state context is disabled, it returns a stateId of zero
+    poolContext.receiveResponseState(getRpcResponseHeader(0));
+    // Routers should reset the cached state Id to not send a stale value to the observer.
+    Assertions.assertEquals(Long.MIN_VALUE, poolContext.getLastSeenStateId());
+    assertRequestHeaderStateId(poolContext, 10L);
+  }
+
+  private RpcHeaderProtos.RpcResponseHeaderProto getRpcResponseHeader(long stateID) {
+    return RpcHeaderProtos.RpcResponseHeaderProto
+        .newBuilder()
+        .setCallId(1)
+        .setStatus(RpcHeaderProtos.RpcResponseHeaderProto.RpcStatusProto.SUCCESS)
+        .setStateId(stateID)
+        .build();
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestPoolAlignmentContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestPoolAlignmentContext.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hdfs.server.federation.router;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos;
+import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcResponseHeaderProto;
 import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcRequestHeaderProto;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -59,7 +59,8 @@ public class TestPoolAlignmentContext {
     PoolAlignmentContext poolContext = new PoolAlignmentContext(routerStateIdContext, namespaceId);
 
     poolContext.receiveResponseState(getRpcResponseHeader(10L));
-    // Last seen value is the one from namenode, but request header is the max seen by clients so far.
+    // Last seen value is the one from namenode,
+    // but request header is the max seen by clients so far.
     Assertions.assertEquals(10L, poolContext.getLastSeenStateId());
     assertRequestHeaderStateId(poolContext, Long.MIN_VALUE);
 
@@ -73,11 +74,11 @@ public class TestPoolAlignmentContext {
     assertRequestHeaderStateId(poolContext, Long.MIN_VALUE);
   }
 
-  private RpcHeaderProtos.RpcResponseHeaderProto getRpcResponseHeader(long stateID) {
-    return RpcHeaderProtos.RpcResponseHeaderProto
+  private RpcResponseHeaderProto getRpcResponseHeader(long stateID) {
+    return RpcResponseHeaderProto
         .newBuilder()
         .setCallId(1)
-        .setStatus(RpcHeaderProtos.RpcResponseHeaderProto.RpcStatusProto.SUCCESS)
+        .setStatus(RpcResponseHeaderProto.RpcStatusProto.SUCCESS)
         .setStateId(stateID)
         .build();
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

[HDFS-17514](https://issues.apache.org/jira/browse/HDFS-17514)

### Description of PR
When a namenode that had "dfs.namenode.state.context.enabled" set to true is restarted with the configuration set to false, routers will keep using a previously cached state ID.

Without RBF

- clients that fetched the old stateID could have stale reads even after msyncing
- new clients will go to the active.

With RBF

- client that fetched the old stateID could have stale reads like above.
- New clients will also fetch the stale stateID and potentially have stale reads

New clients that are created after the restart should not fetch the stale state ID.

### How was this patch tested?

New unit test
Unit test fails with the patch is PoolAlignmentContext in the second commit.
Unit test pass with the patch.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

