### PR TITLE
HDFS-17515. Erasure Coding: ErasureCodingWork is not effectively limi…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -2072,4 +2072,7 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final long DFS_LEASE_HARDLIMIT_DEFAULT =
       HdfsClientConfigKeys.DFS_LEASE_HARDLIMIT_DEFAULT;
 
+  public static final String DFS_NAMENODE_PENDING_EC_BLOCKS_REPLICATION_FACTOR =
+      "dfs.namenode.pending.ec.blocks.replication.factor";
+  public static final int DFS_NAMENODE_PENDING_EC_BLOCKS_REPLICATION_FACTOR_DEFAULT = 6;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
@@ -229,6 +229,9 @@ public class DatanodeDescriptor extends DatanodeInfo {
   // The number of replication work pending before targets are determined
   private int pendingReplicationWithoutTargets = 0;
 
+  // The number of replication work for ec block pending before targets are determined
+  private int pendingECBlockReplicationWithoutTargets = 0;
+
   // HB processing can use it to tell if it is the first HB since DN restarted
   private boolean heartbeatedSinceRegistration = false;
 
@@ -678,6 +681,14 @@ public class DatanodeDescriptor extends DatanodeInfo {
     pendingReplicationWithoutTargets--;
   }
 
+  public void incrementECBlockPendingReplicationWithoutTargets() {
+    pendingECBlockReplicationWithoutTargets++;
+  }
+
+  public void decrementECBlockPendingReplicationWithoutTargets() {
+    pendingECBlockReplicationWithoutTargets--;
+  }
+
   /**
    * Store block replication work.
    */
@@ -738,9 +749,9 @@ public class DatanodeDescriptor extends DatanodeInfo {
   /**
    * The number of work items that are pending to be replicated.
    */
-  int getNumberOfBlocksToBeReplicated() {
-    return pendingReplicationWithoutTargets + replicateBlocks.size()
-        + ecBlocksToBeReplicated.size();
+  int getNumberOfBlocksToBeReplicated(int factor) {
+    return pendingReplicationWithoutTargets + (pendingECBlockReplicationWithoutTargets / factor)
+        + replicateBlocks.size() + ecBlocksToBeReplicated.size();
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReconstructStripedBlocksWithRackAwareness.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReconstructStripedBlocksWithRackAwareness.java
@@ -213,7 +213,7 @@ public class TestReconstructStripedBlocksWithRackAwareness {
           DatanodeDescriptor dn = storage.getDatanodeDescriptor();
           Assert.assertEquals("Block to be erasure coded is wrong for datanode:"
               + dn, 0, dn.getNumberOfBlocksToBeErasureCoded());
-          if (dn.getNumberOfBlocksToBeReplicated() == 1) {
+          if (dn.getNumberOfBlocksToBeReplicated(1) == 1) {
             scheduled = true;
           }
         }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestUnderReplicatedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestUnderReplicatedBlocks.java
@@ -160,7 +160,7 @@ public class TestUnderReplicatedBlocks {
       BlockManagerTestUtil.updateState(bm);
       assertTrue("The number of blocks to be replicated should be less than "
           + "or equal to " + bm.getReplicationStreamsHardLimit(),
-          secondDn.getNumberOfBlocksToBeReplicated()
+          secondDn.getNumberOfBlocksToBeReplicated(1)
           <= bm.getReplicationStreamsHardLimit());
       DFSTestUtil.verifyClientStats(conf, cluster);
     } finally {


### PR DESCRIPTION
### Description of PR

https://issues.apache.org/jira/browse/HDFS-17515

### How was this patch tested?

unit test

### For code changes:

- Add pendingECBlockReplicationWithoutTargets for DatanodeDescriptor
- When construct ErasureCodingWork, increase pendingECBlockReplicationWithoutTargets. When set targets, decrease pendingECBlockReplicationWithoutTargets.
- Because we can not decide the real source datanode when scheduleReconstruction, so update pendingECBlockReplicationWithoutTargets for all source datanode. So when we calculate getNumberOfBlocksToBeReplicated, use a factor to appropriately lower the value.

