### PR TITLE
HDFS-17520. [BugFix] TestDFSAdmin.testAllDatanodesReconfig and TestDFSAdmin.testDecommissionDataNodesReconfig failed

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
@@ -2095,22 +2095,20 @@ public class DFSAdmin extends FsShell {
     if (errMsg != null) {
       err.println(errMsg);
       return 1;
-    } else {
-      out.print(outMsg);
     }
 
     if (status != null) {
       if (!status.hasTask()) {
-        out.println("no task was found.");
+        out.println(outMsg + "no task was found.");
         return 0;
       }
-      out.print("started at " + new Date(status.getStartTime()));
+      String startMsg = outMsg + "started at " + new Date(status.getStartTime());
       if (!status.stopped()) {
-        out.println(" and is still running.");
+        out.println(startMsg + " and is still running.");
         return 0;
       }
 
-      out.println(" and finished at "
+      out.println(startMsg + " and finished at "
           + new Date(status.getEndTime()).toString() + ".");
       if (status.getStatus() == null) {
         // Nothing to report.
@@ -2133,6 +2131,7 @@ public class DFSAdmin extends FsShell {
         }
       }
     } else {
+      out.println(outMsg);
       return 1;
     }
 


### PR DESCRIPTION
HDFS-17520. [BugFix] TestDFSAdmin.testAllDatanodesReconfig and TestDFSAdmin.testDecommissionDataNodesReconfig failed.

[HDFS-17506](https://github.com/apache/hadoop/pull/6806) encountered this failed UT and the error message like:

```
[ERROR] Tests run: 21, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 44.521 s <<< FAILURE! - in org.apache.hadoop.hdfs.tools.TestDFSAdmin
[ERROR] testAllDatanodesReconfig(org.apache.hadoop.hdfs.tools.TestDFSAdmin)  Time elapsed: 2.086 s  <<< FAILURE!
java.lang.AssertionError: 

Expecting:
 <["Reconfiguring status for node [127.0.0.1:43731]: SUCCESS: Changed property dfs.datanode.peer.stats.enabled",
    "	From: "false"",
    "	To: "true"",
    "started at Fri May 10 13:02:51 UTC 2024 and finished at Fri May 10 13:02:51 UTC 2024."]>
to contain subsequence:
 <["SUCCESS: Changed property dfs.datanode.peer.stats.enabled",
    "	From: "false"",
    "	To: "true""]>

	at org.apache.hadoop.hdfs.tools.TestDFSAdmin.testAllDatanodesReconfig(TestDFSAdmin.java:1286)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
```

`getReconfigurationStatusUtil` concurrently get reconfiguration status from multiple DNs. It may cause messages in out is wrong, such as:
```
Line1: Reconfiguring status for node [127.0.0.1:65229]: Reconfiguring status for node [127.0.0.1:65224]: started at Sat May 11 15:05:49 CST 2024started at Sat May 11 15:05:49 CST 2024 and finished at Sat May 11 15:05:49 CST 2024.

Line2: and finished at Sat May 11 15:05:49 CST 2024.
```