### PR TITLE
HADOOP-19180. EC: Fix calculation errors caused by special index order

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/io/erasurecode/erasure_coder.c
+++ b/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/io/erasurecode/erasure_coder.c
@@ -132,9 +132,6 @@ static int processErasures(IsalDecoder* pCoder, unsigned char** inputs,
     index = erasedIndexes[i];
     pCoder->erasedIndexes[i] = index;
     pCoder->erasureFlags[index] = 1;
-    if (index < numDataUnits) {
-      pCoder->numErasedDataUnits++;
-    }
   }
 
   pCoder->numErased = numErased;
@@ -175,7 +172,6 @@ int decode(IsalDecoder* pCoder, unsigned char** inputs,
 
 // Clear variables used per decode call
 void clearDecoder(IsalDecoder* decoder) {
-  decoder->numErasedDataUnits = 0;
   decoder->numErased = 0;
   memset(decoder->gftbls, 0, sizeof(decoder->gftbls));
   memset(decoder->decodeMatrix, 0, sizeof(decoder->decodeMatrix));
@@ -205,24 +201,24 @@ int generateDecodeMatrix(IsalDecoder* pCoder) {
   h_gf_invert_matrix(pCoder->tmpMatrix,
                                 pCoder->invertMatrix, numDataUnits);
 
-  for (i = 0; i < pCoder->numErasedDataUnits; i++) {
+  for (p = 0; p < pCoder->numErased; p++) {
     for (j = 0; j < numDataUnits; j++) {
-      pCoder->decodeMatrix[numDataUnits * i + j] =
-                      pCoder->invertMatrix[numDataUnits *
-                      pCoder->erasedIndexes[i] + j];
-    }
-  }
-
-  for (p = pCoder->numErasedDataUnits; p < pCoder->numErased; p++) {
-    for (i = 0; i < numDataUnits; i++) {
-      s = 0;
-      for (j = 0; j < numDataUnits; j++) {
-        s ^= h_gf_mul(pCoder->invertMatrix[j * numDataUnits + i],
-          pCoder->encodeMatrix[numDataUnits *
-                                        pCoder->erasedIndexes[p] + j]);
+      int erasedIndex = pCoder->erasedIndexes[p];
+      if (erasedIndex < numDataUnits) {
+        pCoder->decodeMatrix[numDataUnits * p + j] =
+            pCoder->invertMatrix[numDataUnits *
+                                     pCoder->erasedIndexes[p] + j];
+      } else {
+        for (i = 0; i < numDataUnits; i++) {
+          s = 0;
+          for (j = 0; j < numDataUnits; j++) {
+            s ^= h_gf_mul(pCoder->invertMatrix[j * numDataUnits + i],
+                          pCoder->encodeMatrix[numDataUnits *
+                            pCoder->erasedIndexes[p] + j]);
+          }
+          pCoder->decodeMatrix[numDataUnits * p + i] = s;
+        }
       }
-
-      pCoder->decodeMatrix[numDataUnits * p + i] = s;
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/io/erasurecode/erasure_coder.h
+++ b/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/io/erasurecode/erasure_coder.h
@@ -62,7 +62,6 @@ typedef struct _IsalDecoder {
   unsigned char erasureFlags[MMAX];
   int erasedIndexes[MMAX];
   int numErased;
-  int numErasedDataUnits;
   unsigned char* realInputs[MMAX];
 } IsalDecoder;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestErasureCodingEncodeAndDecode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestErasureCodingEncodeAndDecode.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
+import org.apache.hadoop.io.erasurecode.CodecUtil;
+import org.apache.hadoop.io.erasurecode.ErasureCoderOptions;
+import org.apache.hadoop.io.erasurecode.rawcoder.RawErasureDecoder;
+import org.apache.hadoop.io.erasurecode.rawcoder.RawErasureEncoder;
+import org.junit.Test;
+
+import java.util.Random;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class TestErasureCodingEncodeAndDecode {
+
+  private static int CHUNCK = 1024;
+  private final ErasureCodingPolicy ecPolicy = StripedFileTestUtil.getDefaultECPolicy();
+  private final int dataBlocks = ecPolicy.getNumDataUnits();
+  private final int parityBlocks = ecPolicy.getNumParityUnits();
+  private final int totalBlocks = ecPolicy.getNumDataUnits() + ecPolicy.getNumParityUnits();
+  private final Configuration conf = new HdfsConfiguration();
+
+  @Test
+  public void testEncodeAndDecode() throws Exception {
+    int totalBytes = CHUNCK * dataBlocks;
+    Random random = new Random();
+    byte[] tmpBytes = new byte[totalBytes];
+    random.nextBytes(tmpBytes);
+    byte[][] data = new byte[dataBlocks][CHUNCK];
+    for (int i = 0; i < dataBlocks; i++) {
+      System.arraycopy(tmpBytes, i * CHUNCK, data[i], 0, CHUNCK);
+    }
+    ErasureCoderOptions coderOptions = new ErasureCoderOptions(dataBlocks, parityBlocks);
+
+    // 1 Encode
+    RawErasureEncoder encoder =
+        CodecUtil.createRawEncoder(conf, ecPolicy.getCodecName(), coderOptions);
+    byte[][] parity = new byte[parityBlocks][CHUNCK];
+    encoder.encode(data, parity);
+
+    // 2 Compose the complete data
+    byte[][] all = new byte[dataBlocks + parityBlocks][CHUNCK];
+    for (int i = 0; i < dataBlocks; i++) {
+      System.arraycopy(data[i], 0, all[i], 0, CHUNCK);
+    }
+    for (int i = 0; i < parityBlocks; i++) {
+      System.arraycopy(parity[i], 0, all[i + dataBlocks], 0, CHUNCK);
+    }
+
+    // 3 Decode
+    RawErasureDecoder rawDecoder = CodecUtil.createRawDecoder(conf,
+        ecPolicy.getCodecName(), coderOptions);
+    byte[][] backup = new byte[parityBlocks][CHUNCK];
+    for (int i = 0; i < totalBlocks; i++) {
+      for (int j = 0; j < totalBlocks; j++) {
+        for (int k = 0; k < totalBlocks; k++) {
+          int[] erasedIndexes;
+          if (i == j && j == k) {
+            erasedIndexes = new int[]{i};
+            backup[0] = all[i];
+            all[i] = null;
+          } else if (i == j) {
+            erasedIndexes = new int[]{i, k};
+            backup[0] = all[i];
+            backup[1] = all[k];
+            all[i] = null;
+            all[k] = null;
+          } else if ((i == k) || ((j == k))) {
+            erasedIndexes = new int[]{i, j};
+            backup[0] = all[i];
+            backup[1] = all[j];
+            all[i] = null;
+            all[j] = null;
+          } else {
+            erasedIndexes = new int[]{i, j, k};
+            backup[0] = all[i];
+            backup[1] = all[j];
+            backup[2] = all[k];
+            all[i] = null;
+            all[j] = null;
+            all[k] = null;
+          }
+          byte[][] decoded = new byte[erasedIndexes.length][CHUNCK];
+          rawDecoder.decode(all, erasedIndexes, decoded);
+          for (int l = 0; l < erasedIndexes.length; l++) {
+            assertArrayEquals(backup[l], decoded[l]);
+            all[erasedIndexes[l]] = backup[l];
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description of PR

I found that if the erasedIndexes distribution is such that the parity index is in front of the data index, ec will produce wrong results when decoding.

In fact, [HDFS-15186](https://issues.apache.org/jira/browse/HDFS-15186) has described this problem, but does not fundamentally solve it.

The reason is that the code assumes that erasedIndexes is preceded by the data index and followed by parity index. If there is a parity index placed in front of the data index in the incoming code, a calculation error will occur.

When we decode the data unit, we multiply the existing data by the decoding matrix. (Look at the formula [doc](https://zhengchenyu.github.io/2024/05/17/ErasuceCode%E7%AE%97%E6%B3%95%E5%AE%9E%E7%8E%B0/) in 1.2)
When we decode the parity unit, we multiply the existing data by the decoding matrix, get data unit, then multiply by encoding matrix. (Look at the formula [doc](https://zhengchenyu.github.io/2024/05/17/ErasuceCode%E7%AE%97%E6%B3%95%E5%AE%9E%E7%8E%B0/)  in 1.1 and 1.2 )
The calculations for parity and block are different. But They calculate in two separate loops, then the code requires that the data index must precede the parity index.

### How was this patch tested?

The TestErasureCodingEncodeAndDecode unit test and the erasure_code_test binary were executed on different machines. The test machines include those with isa-l installed and those without isa-l installed.

### For code changes:

- Make erasedIndexes support arbitrary index distribution.

