### PR TITLE
YARN-11692. Support mixed cgroup v1/v2 controller structure

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2733,6 +2733,10 @@ public class YarnConfiguration extends Configuration {
   public static final String NM_LINUX_CONTAINER_CGROUPS_MOUNT_PATH =
     NM_PREFIX + "linux-container-executor.cgroups.mount-path";
 
+  /** Where the linux container executor should mount cgroups v2 if not found */
+  public static final String NM_LINUX_CONTAINER_CGROUPS_V2_MOUNT_PATH =
+      NM_PREFIX + "linux-container-executor.cgroups.v2.mount-path";
+
   /**
    * Whether the apps should run in strict resource usage mode(not allowed to
    * use spare CPU)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2733,7 +2733,7 @@ public class YarnConfiguration extends Configuration {
   public static final String NM_LINUX_CONTAINER_CGROUPS_MOUNT_PATH =
     NM_PREFIX + "linux-container-executor.cgroups.mount-path";
 
-  /** Where the linux container executor should mount cgroups v2 if not found */
+  /** Where the linux container executor should mount cgroups v2 if not found. */
   public static final String NM_LINUX_CONTAINER_CGROUPS_V2_MOUNT_PATH =
       NM_PREFIX + "linux-container-executor.cgroups.v2.mount-path";
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -2088,6 +2088,20 @@
   </property>
 
   <property>
+    <description>This property sets the mount path for CGroups v2.
+      This parameter is optional, and needed to be set only in mixed mode,
+      when CGroups v2 is mounted in a different path than Cgroups v1.
+      For example, in hybrid mode, CGroups v1 controllers can be mounted in
+      /sys/fs/cgroup, while v2 can be mounted in /sys/fs/cgroup/unified folder.
+      
+      If this value is not set, the value of
+      yarn.nodemanager.linux-container-executor.cgroups.mount-path
+      will be used for CGroups v2 as well.
+    </description>
+    <name>yarn.nodemanager.linux-container-executor.cgroups.v2.mount-path</name>
+  </property>
+
+  <property>
     <description>Delay in ms between attempts to remove linux cgroup</description>
     <name>yarn.nodemanager.linux-container-executor.cgroups.delete-delay-ms</name>
     <value>20</value>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -2090,10 +2090,10 @@
   <property>
     <description>This property sets the mount path for CGroups v2.
       This parameter is optional, and needed to be set only in mixed mode,
-      when CGroups v2 is mounted in a different path than Cgroups v1.
-      For example, in hybrid mode, CGroups v1 controllers can be mounted in
-      /sys/fs/cgroup, while v2 can be mounted in /sys/fs/cgroup/unified folder.
-      
+      when CGroups v2 is mounted alongside with Cgroups v1.
+      For example, in hybrid mode, CGroups v1 controllers can be mounted under /sys/fs/cgroup/
+      (for example /sys/fs/cgroup/cpu,cpuacct), while v2 can be mounted in /sys/fs/cgroup/unified folder.
+
       If this value is not set, the value of
       yarn.nodemanager.linux-container-executor.cgroups.mount-path
       will be used for CGroups v2 as well.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsMountConfig.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsMountConfig.java
@@ -25,9 +25,9 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 public class CGroupsMountConfig {
   private final boolean enableMount;
   private final String mountPath;
-  
+
   // CGroups v2 mount path is only relevant in mixed CGroups v1/v2 mode,
-  // where v2 can be mounted in a different folder than v1.
+  // where v2 is mounted alongside with v1.
   private final String v2MountPath;
 
   public CGroupsMountConfig(Configuration conf) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsMountConfig.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsMountConfig.java
@@ -25,12 +25,18 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 public class CGroupsMountConfig {
   private final boolean enableMount;
   private final String mountPath;
+  
+  // CGroups v2 mount path is only relevant in mixed CGroups v1/v2 mode,
+  // where v2 can be mounted in a different folder than v1.
+  private final String v2MountPath;
 
   public CGroupsMountConfig(Configuration conf) {
     this.enableMount = conf.getBoolean(YarnConfiguration.
         NM_LINUX_CONTAINER_CGROUPS_MOUNT, false);
     this.mountPath = conf.get(YarnConfiguration.
         NM_LINUX_CONTAINER_CGROUPS_MOUNT_PATH, null);
+    this.v2MountPath = conf.get(YarnConfiguration.
+        NM_LINUX_CONTAINER_CGROUPS_V2_MOUNT_PATH, mountPath);
   }
 
   public boolean ensureMountPathIsDefined() throws ResourceHandlerException {
@@ -62,11 +68,16 @@ public class CGroupsMountConfig {
     return mountPath;
   }
 
+  public String getV2MountPath() {
+    return v2MountPath;
+  }
+
   @Override
   public String toString() {
     return "CGroupsMountConfig{" +
         "enableMount=" + enableMount +
-        ", mountPath='" + mountPath + '\'' +
+        ", mountPath='" + mountPath +
+        ", v2MountPath='" + v2MountPath + '\'' +
         '}';
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsV2HandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsV2HandlerImpl.java
@@ -97,8 +97,8 @@ class CGroupsV2HandlerImpl extends AbstractCGroupsHandler {
   @Override
   protected Map<String, Set<String>> parsePreConfiguredMountPath() throws IOException {
     Map<String, Set<String>> controllerMappings = new HashMap<>();
-    controllerMappings.put(this.cGroupsMountConfig.getMountPath(),
-        readControllersFile(this.cGroupsMountConfig.getMountPath()));
+    controllerMappings.put(this.cGroupsMountConfig.getV2MountPath(),
+        readControllersFile(this.cGroupsMountConfig.getV2MountPath()));
     return controllerMappings;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2HandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2HandlerImpl.java
@@ -212,11 +212,11 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
 
   /*
    * Create a mock mtab file with the following content for hybrid v1/v2:
-   * cgroup2 /path/to/parentV2Dir cgroup2 rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot 0 0
+   * cgroup2 /path/to/parentV2Dir cgroup2 rw,nosuid,nodev,noexec,relatime,memory_recursiveprot 0 0
    * cgroup /path/to/parentDir/memory cgroup rw,nosuid,nodev,noexec,relatime,memory 0 0
    *
    * Create the following cgroup hierarchy:
-   * 
+   *
    *                                           parentDir
    *                              __________________________________
    *                             /                                  \
@@ -236,13 +236,13 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
         "cgroup " + v1ParentDir.getAbsolutePath() + "/memory"
             + " cgroup rw,nosuid,nodev,noexec,relatime,memory 0 0\n"
         + "cgroup2 " + v2ParentDir.getAbsolutePath()
-            + " cgroup2 rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot 0 0\n";
-    
+            + " cgroup2 rw,nosuid,nodev,noexec,relatime,memory_recursiveprot 0 0\n";
+
     File mockMtab = createFileWithContent(v1ParentDir, UUID.randomUUID().toString(), mtabContent);
 
     String enabledV2Controllers = "cpuset cpu io hugetlb pids rdma misc\n";
-    File controllersFile = createFileWithContent(v2ParentDir, CGroupsHandler.CGROUP_CONTROLLERS_FILE,
-        enabledV2Controllers);
+    File controllersFile = createFileWithContent(v2ParentDir,
+        CGroupsHandler.CGROUP_CONTROLLERS_FILE, enabledV2Controllers);
 
     File subtreeControlFile = new File(v2ParentDir, CGroupsHandler.CGROUP_SUBTREE_CONTROL_FILE);
     Assert.assertTrue("empty subtree_control file should be created",
@@ -267,14 +267,14 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
   public void testHybridMtabParsing() throws Exception {
     // Initialize mtab and cgroup dir
     File v1ParentDir = new File(tmpPath);
-    
+
     File v2ParentDir = new File(v1ParentDir, "unified");
     Assert.assertTrue("temp dir should be created", v2ParentDir.mkdirs());
     v2ParentDir.deleteOnExit();
-    
+
     // create mock cgroup
     File mockMtabFile = createPremountedHybridCgroups(v1ParentDir);
-    
+
     // create memory cgroup for v1
     File memoryCgroup = new File(v1ParentDir, "memory");
     assertTrue("Directory should be created", memoryCgroup.mkdirs());
@@ -328,7 +328,7 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
   @Test
   public void testManualHybridCgroupSetting() throws Exception {
     String unifiedPath = tmpPath + "/unified";
-    
+
     YarnConfiguration conf = new YarnConfiguration();
     conf.set(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_MOUNT_PATH, tmpPath);
     conf.set(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_MOUNT_PATH, unifiedPath);
@@ -339,7 +339,8 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
     validateCgroupV2Controllers(conf, unifiedPath);
   }
 
-  private void validateCgroupV2Controllers(YarnConfiguration conf, String mountPath) throws Exception {
+  private void validateCgroupV2Controllers(YarnConfiguration conf, String mountPath)
+      throws Exception {
     File baseCgroup = new File(mountPath);
     File subCgroup = new File(mountPath, "/hadoop-yarn");
     Assert.assertTrue("temp dir should be created", subCgroup.mkdirs());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2HandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2HandlerImpl.java
@@ -213,14 +213,14 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
   /*
    * Create a mock mtab file with the following content for hybrid v1/v2:
    * cgroup2 /path/to/parentV2Dir cgroup2 rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot 0 0
-   * cgroup /path/to/parentDir cgroup rw,nosuid,nodev,noexec,relatime,memory 0 0
+   * cgroup /path/to/parentDir/memory cgroup rw,nosuid,nodev,noexec,relatime,memory 0 0
    *
    * Create the following cgroup hierarchy:
    * 
-   *                                       parentDir
-   *                              ___________________________
-   *                             /                           \
-   *                          unified                      memory
+   *                                           parentDir
+   *                              __________________________________
+   *                             /                                  \
+   *                          unified                             memory
    *       _________________________________________________
    *      /                     \                           \
    *  cgroup.controllers     cgroup.subtree_control   test-hadoop-yarn (hierarchyDir)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestResourceHandlerModule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestResourceHandlerModule.java
@@ -49,7 +49,7 @@ public class TestResourceHandlerModule {
     networkEnabledConf.setBoolean(YarnConfiguration.NM_NETWORK_RESOURCE_ENABLED,
         true);
     ResourceHandlerModule.nullifyResourceHandlerChain();
-    ResourceHandlerModule.resetCgroupsHandler();
+    ResourceHandlerModule.resetCGroupsHandlers();
     ResourceHandlerModule.resetCpuResourceHandler();
     ResourceHandlerModule.resetMemoryResourceHandler();
   }
@@ -116,57 +116,25 @@ public class TestResourceHandlerModule {
   }
 
   @Test
-  public void testCpuResourceHandlerClassForCgroupV1() throws ResourceHandlerException {
-    Configuration conf = new YarnConfiguration();
-    conf.setBoolean(YarnConfiguration.NM_CPU_RESOURCE_ENABLED, true);
-    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, false);
-
-    initResourceHandlerChain(conf);
-
-    Assert.assertTrue(ResourceHandlerModule.getCpuResourceHandler()
-        instanceof CGroupsCpuResourceHandlerImpl);
-    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
-        instanceof CGroupsHandlerImpl);
-  }
-
-  @Test
-  public void testCpuResourceHandlerClassForCgroupV2() throws ResourceHandlerException {
-    Configuration conf = new YarnConfiguration();
-    conf.setBoolean(YarnConfiguration.NM_CPU_RESOURCE_ENABLED, true);
-    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, true);
-
-    initResourceHandlerChain(conf);
-
-    Assert.assertTrue(ResourceHandlerModule.getCpuResourceHandler()
-        instanceof CGroupsV2CpuResourceHandlerImpl);
-    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
-        instanceof CGroupsV2HandlerImpl);
-  }
-
-  @Test
-  public void testMemoryResourceHandlerClassForCgroupV1() throws ResourceHandlerException {
+  public void testCgroupsHandlerClassForCgroupV1() throws ResourceHandlerException {
     Configuration conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.NM_MEMORY_RESOURCE_ENABLED, true);
     conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, false);
 
     initResourceHandlerChain(conf);
 
-    Assert.assertTrue(ResourceHandlerModule.getMemoryResourceHandler()
-        instanceof CGroupsMemoryResourceHandlerImpl);
     Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
         instanceof CGroupsHandlerImpl);
   }
 
   @Test
-  public void testMemoryResourceHandlerClassForCgroupV2() throws ResourceHandlerException {
+  public void testCgroupsHandlerClassForCgroupV2() throws ResourceHandlerException {
     Configuration conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.NM_MEMORY_RESOURCE_ENABLED, true);
     conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, true);
 
     initResourceHandlerChain(conf);
 
-    Assert.assertTrue(ResourceHandlerModule.getMemoryResourceHandler()
-        instanceof CGroupsV2MemoryResourceHandlerImpl);
     Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
         instanceof CGroupsV2HandlerImpl);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestResourceHandlerModule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestResourceHandlerModule.java
@@ -49,9 +49,6 @@ public class TestResourceHandlerModule {
     networkEnabledConf.setBoolean(YarnConfiguration.NM_NETWORK_RESOURCE_ENABLED,
         true);
     ResourceHandlerModule.nullifyResourceHandlerChain();
-    ResourceHandlerModule.resetCGroupsHandlers();
-    ResourceHandlerModule.resetCpuResourceHandler();
-    ResourceHandlerModule.resetMemoryResourceHandler();
   }
 
   @Test
@@ -112,39 +109,6 @@ public class TestResourceHandlerModule {
       Assert.assertTrue(resourceHandlers.get(0) == handler);
     } else {
       Assert.fail("Null returned");
-    }
-  }
-
-  @Test
-  public void testCgroupsHandlerClassForCgroupV1() throws ResourceHandlerException {
-    Configuration conf = new YarnConfiguration();
-    conf.setBoolean(YarnConfiguration.NM_MEMORY_RESOURCE_ENABLED, true);
-    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, false);
-
-    initResourceHandlerChain(conf);
-
-    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
-        instanceof CGroupsHandlerImpl);
-  }
-
-  @Test
-  public void testCgroupsHandlerClassForCgroupV2() throws ResourceHandlerException {
-    Configuration conf = new YarnConfiguration();
-    conf.setBoolean(YarnConfiguration.NM_MEMORY_RESOURCE_ENABLED, true);
-    conf.setBoolean(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_V2_ENABLED, true);
-
-    initResourceHandlerChain(conf);
-
-    Assert.assertTrue(ResourceHandlerModule.getCGroupsHandler()
-        instanceof CGroupsV2HandlerImpl);
-  }
-
-  private void initResourceHandlerChain(Configuration conf) throws ResourceHandlerException {
-    ResourceHandlerChain resourceHandlerChain =
-        ResourceHandlerModule.getConfiguredResourceHandlerChain(conf,
-            mock(Context.class));
-    if (resourceHandlerChain == null) {
-      Assert.fail("Could not initialize resource handler chain");
     }
   }
 }


### PR DESCRIPTION
Change-Id: I10a024b3fa88aaeb5dfcd9173f53200b00ccc7df

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
There were heavy changes on the device side in cgroup v2. To keep supporting FGPAs and GPUs short term, mixed structures where some of the cgroup controllers are from v1 while others from v2 should be supported. More info: https://dropbear.xyz/2023/05/23/devices-with-cgroup-v2/

### How was this patch tested?
Unit tests
Tested on a cluster in mixed mode, where CPU was mounted in v1 and memory was in v2. When running a job, both v1 and v2 control files contained the correct limits.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

