### PR TITLE
HADOOP-19170. Fixes compilation issues on Mac

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/native/src/exception.c
+++ b/hadoop-common-project/hadoop-common/src/main/native/src/exception.c
@@ -110,9 +110,16 @@ jthrowable newIOException(JNIEnv* env, const char *fmt, ...)
 
 const char* terror(int errnum)
 {
-
-#if defined(__sun) || defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 32)
 // MT-Safe under Solaris or glibc >= 2.32 not supporting sys_errlist/sys_nerr
+#if defined(__sun)
+  #define USE_STR_ERROR
+#elif defined(__GLIBC_PREREQ)
+  #if __GLIBC_PREREQ(2, 32)
+    #define USE_STR_ERROR
+  #endif
+#endif
+
+#if defined(USE_STR_ERROR)
   return strerror(errnum); 
 #else
   if ((errnum < 0) || (errnum >= sys_nerr)) {
@@ -121,4 +128,3 @@ const char* terror(int errnum)
   return sys_errlist[errnum];
 #endif
 }
-


### PR DESCRIPTION
### Description of PR

When I build hadoop-common native in Mac OS, I found this error:

/xxxxx/hadoop/hadoop-common-project/hadoop-common/src/main/native/src/exception.c:114:50: error: function-like macro '__GLIBC_PREREQ' is not defined
#if defined(__sun) || defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 32) 
The reason is that Mac OS does not support glibc. And C conditional compilation requires validation of all expressions.

### How was this patch tested?

Compile on Linux and Mac OS

### For code changes:

- Fixes compilation issues on non-Linux systems

