### PR TITLE
 HDFS-17526. getMetadataInputStream should use getShareDeleteFileInputStream for windows

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/LocalReplica.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/LocalReplica.java
@@ -291,6 +291,12 @@ abstract public class LocalReplica extends ReplicaInfo {
   public LengthInputStream getMetadataInputStream(long offset)
       throws IOException {
     final File meta = getMetaFile();
+    if (NativeIO.isAvailable()) {
+      return new LengthInputStream(
+          getFileIoProvider().getShareDeleteFileInputStream(
+              getVolume(), meta, offset),
+          meta.length());
+    }
     return new LengthInputStream(
         getFileIoProvider().openAndSeek(getVolume(), meta, offset),
         meta.length());


### PR DESCRIPTION
### Description of PR
In HDFS-10636, the getDataInputStream method uses the getShareDeleteFileInputStream for windows, but the getMetaDataInputStream does not use this. The following error can happen when a DataNode is trying to update the genstamp on a block in Windows.

DataNode Logs:
```
Caused by: java.io.IOException: Failed to rename G:\data\hdfs\data\current\BP-1\current\finalized\subdir5\subdir16\blk_1_1.meta to G:\data\hdfs\data\current\BP-1\current\finalized\subdir5\subdir16\blk_1_2.meta due to failure in native rename. 32: The process cannot access the file because it is being used by another process.
```

### How was this patch tested?


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

