### PR TITLE
HDFS-17528. FsImageValidation: set txid when saving a new image

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FsImageValidation.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FsImageValidation.java
@@ -214,6 +214,7 @@ public class FsImageValidation {
     initConf(conf);
 
     // check INodeReference
+    NameNode.initMetrics(conf, HdfsServerConstants.NamenodeRole.NAMENODE); // to avoid NPE
     final FSNamesystem namesystem = checkINodeReference(conf, errorCount);
 
     // check INodeMap
@@ -276,14 +277,16 @@ public class FsImageValidation {
       namesystem.getFSDirectory().writeLock();
       try {
         loader.load(fsImageFile, false);
+        fsImage.setLastAppliedTxId(loader);
       } finally {
         namesystem.getFSDirectory().writeUnlock();
         namesystem.writeUnlock("loadImage");
       }
     }
     t.cancel();
-    Cli.println("Loaded %s %s successfully in %s",
-        FS_IMAGE, fsImageFile, StringUtils.formatTime(now() - loadStart));
+    Cli.println("Loaded %s %s with txid %d successfully in %s",
+        FS_IMAGE, fsImageFile, namesystem.getFSImage().getLastAppliedTxId(),
+        StringUtils.formatTime(now() - loadStart));
     return namesystem;
   }
 


### PR DESCRIPTION
### Description of PR

HDFS-17528
- When the fsimage is specified as a file and the FsImageValidation tool saves a new image (for removing inaccessible inodes), the txid is not set. Then, the resulted image will have 0 as its txid.
- When the fsimage is specified as a directory, the txid is set. However, it will get NPE since NameNode metrics is uninitialized (although the metrics is not used by FsImageValidation).

### How was this patch tested?

Tested manually
- before: the output file is `fsimage.ckpt_0000000000000000000` (i.e. txid is 0)
> 2024-05-14 13:37:27,531 [main] INFO  namenode.FSImageFormatProtobuf (FSImageFormatProtobuf.java:save(732)) - Saving image file .../fsimage/current/newFsImage5968764763996132609/current/fsimage.ckpt_0000000000000000000 using no compression
> 2024-05-14 13:37:30,522 [main] INFO  namenode.FSImageFormatProtobuf (FSImageFormatProtobuf.java:save(736)) - Image file .../fsimage/current/newFsImage5968764763996132609/current/fsimage.ckpt_0000000000000000000 of size 200392059 bytes saved in 2 seconds .

- after: the output file is `fsimage.ckpt_0000000023945925442` with correct txid
> 2024-05-14 13:38:32,414 [main] INFO  namenode.FSImage (FSImage.java:save(1223)) - save fsimage with txid=23945925442 to .../fsimage/current/newFsImage4409944859316006440
> 2024-05-14 13:38:32,436 [main] INFO  namenode.FSImageFormatProtobuf (FSImageFormatProtobuf.java:save(732)) - Saving image file .../fsimage/current/newFsImage4409944859316006440/current/fsimage.ckpt_0000000023945925442 using no compression
> 2024-05-14 13:38:35,437 [main] INFO  namenode.FSImageFormatProtobuf (FSImageFormatProtobuf.java:save(736)) - Image file .../fsimage/current/newFsImage4409944859316006440/current/fsimage.ckpt_0000000023945925442 of size 200392062 bytes saved in 3 seconds .

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

