### PR TITLE
HADOOP-19173. Upgrade org.apache.derby:derby to 10.17.1.0.

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -309,6 +309,7 @@ org.apache.commons:commons-validator:1.6
 org.apache.curator:curator-client:5.2.0
 org.apache.curator:curator-framework:5.2.0
 org.apache.curator:curator-recipes:5.2.0
+org.apache.derby:derby:10.17.1.0
 org.apache.hbase:hbase-annotations:2.5.8
 org.apache.hbase:hbase-client:2.5.8
 org.apache.hbase:hbase-common:2.5.8


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19173. Upgrade org.apache.derby:derby to 10.17.1.0.

In #6816, we upgraded the version of Derby but forgot to update the LICENSE-binary file. This PR will address the update for the LICENSE-binary file.

### How was this patch tested?

no-test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

