### PR TITLE
HDFS-17531. [Discuss] RBF: Aynchronous router RPC.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -96,6 +96,8 @@ public class Client implements AutoCloseable {
   private static final ThreadLocal<Integer> retryCount = new ThreadLocal<Integer>();
   private static final ThreadLocal<Object> EXTERNAL_CALL_HANDLER
       = new ThreadLocal<>();
+  public static final ThreadLocal<CompletableFuture<Object>> COMPLETABLE_FUTURE_THREAD_LOCAL
+      = new ThreadLocal<>();
   private static final ThreadLocal<AsyncGet<? extends Writable, IOException>>
       ASYNC_RPC_RESPONSE = new ThreadLocal<>();
   private static final ThreadLocal<Boolean> asynchronousMode =
@@ -283,6 +285,7 @@ public class Client implements AutoCloseable {
     boolean done;               // true when call is done
     private final Object externalHandler;
     private AlignmentContext alignmentContext;
+    private CompletableFuture<Object> completableFuture;
 
     private Call(RPC.RpcKind rpcKind, Writable param) {
       this.rpcKind = rpcKind;
@@ -304,6 +307,7 @@ public class Client implements AutoCloseable {
       }
 
       this.externalHandler = EXTERNAL_CALL_HANDLER.get();
+      this.completableFuture = COMPLETABLE_FUTURE_THREAD_LOCAL.get();
     }
 
     @Override
@@ -321,6 +325,9 @@ public class Client implements AutoCloseable {
         synchronized (externalHandler) {
           externalHandler.notify();
         }
+      }
+      if (completableFuture != null) {
+        completableFuture.complete(this);
       }
     }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/protocolPB/RefreshUserMappingsProtocolClientSideTranslatorPB.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/protocolPB/RefreshUserMappingsProtocolClientSideTranslatorPB.java
@@ -35,14 +35,14 @@ public class RefreshUserMappingsProtocolClientSideTranslatorPB implements
     ProtocolMetaInterface, RefreshUserMappingsProtocol, Closeable {
 
   /** RpcController is not used and hence is set to null */
-  private final static RpcController NULL_CONTROLLER = null;
+  protected final static RpcController NULL_CONTROLLER = null;
   private final RefreshUserMappingsProtocolPB rpcProxy;
   
-  private final static RefreshUserToGroupsMappingsRequestProto 
+  protected final static RefreshUserToGroupsMappingsRequestProto
   VOID_REFRESH_USER_TO_GROUPS_MAPPING_REQUEST = 
       RefreshUserToGroupsMappingsRequestProto.newBuilder().build();
 
-  private final static RefreshSuperUserGroupsConfigurationRequestProto
+  protected final static RefreshSuperUserGroupsConfigurationRequestProto
   VOID_REFRESH_SUPERUSER_GROUPS_CONFIGURATION_REQUEST = 
       RefreshSuperUserGroupsConfigurationRequestProto.newBuilder().build();
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/protocolPB/RefreshUserMappingsProtocolServerSideTranslatorPB.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/protocolPB/RefreshUserMappingsProtocolServerSideTranslatorPB.java
@@ -33,12 +33,12 @@ public class RefreshUserMappingsProtocolServerSideTranslatorPB implements Refres
 
   private final RefreshUserMappingsProtocol impl;
   
-  private final static RefreshUserToGroupsMappingsResponseProto 
-  VOID_REFRESH_USER_GROUPS_MAPPING_RESPONSE =
+  protected final static RefreshUserToGroupsMappingsResponseProto
+      VOID_REFRESH_USER_GROUPS_MAPPING_RESPONSE =
       RefreshUserToGroupsMappingsResponseProto.newBuilder().build();
 
-  private final static RefreshSuperUserGroupsConfigurationResponseProto
-  VOID_REFRESH_SUPERUSER_GROUPS_CONFIGURATION_RESPONSE = 
+  protected final static RefreshSuperUserGroupsConfigurationResponseProto
+      VOID_REFRESH_SUPERUSER_GROUPS_CONFIGURATION_RESPONSE =
       RefreshSuperUserGroupsConfigurationResponseProto.newBuilder()
       .build();
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/tools/protocolPB/GetUserMappingsProtocolClientSideTranslatorPB.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/tools/protocolPB/GetUserMappingsProtocolClientSideTranslatorPB.java
@@ -36,7 +36,7 @@ public class GetUserMappingsProtocolClientSideTranslatorPB implements
     ProtocolMetaInterface, GetUserMappingsProtocol, Closeable {
 
   /** RpcController is not used and hence is set to null */
-  private final static RpcController NULL_CONTROLLER = null;
+  protected final static RpcController NULL_CONTROLLER = null;
   private final GetUserMappingsProtocolPB rpcProxy;
   
   public GetUserMappingsProtocolClientSideTranslatorPB(

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Time.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Time.java
@@ -34,7 +34,7 @@ public final class Time {
   /**
    * number of nano seconds in 1 millisecond
    */
-  private static final long NANOSECONDS_PER_MILLISECOND = 1000000;
+  public static final long NANOSECONDS_PER_MILLISECOND = 1000000;
 
   private static final TimeZone UTC_ZONE = TimeZone.getTimeZone("UTC");
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRpcServerHandoff.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRpcServerHandoff.java
@@ -89,11 +89,11 @@ public class TestRpcServerHandoff {
     }
 
     void sendResponse() {
-      deferredCall.setDeferredResponse(request);
+      deferredCall.setDeferredResponse(request, 0);
     }
 
     void sendError() {
-      deferredCall.setDeferredError(new IOException("DeferredError"));
+      deferredCall.setDeferredError(new IOException("DeferredError"), 0);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/AsyncRpcProtocolPBUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/AsyncRpcProtocolPBUtil.java
@@ -80,7 +80,7 @@ public final class AsyncRpcProtocolPBUtil {
     // transfer originCall & callerContext to worker threads of executor.
     final Server.Call originCall = Server.getCurCall().get();
     final CallerContext originContext = CallerContext.getCurrent();
-    completableFuture.thenComposeAsync(o -> {
+    completableFuture.thenCompose(o -> {
       Server.getCurCall().set(originCall);
       CallerContext.setCurrent(originContext);
       try {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/AsyncRpcProtocolPBUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/AsyncRpcProtocolPBUtil.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.protocolPB;
+
+import org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil;
+import org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer;
+import org.apache.hadoop.ipc.CallerContext;
+import org.apache.hadoop.ipc.Client;
+import org.apache.hadoop.ipc.ProtobufRpcEngine2;
+import org.apache.hadoop.ipc.ProtobufRpcEngineCallback2;
+import org.apache.hadoop.ipc.Server;
+import org.apache.hadoop.ipc.internal.ShadedProtobufHelper;
+import org.apache.hadoop.thirdparty.protobuf.Message;
+import org.apache.hadoop.util.concurrent.AsyncGet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+
+import static org.apache.hadoop.ipc.internal.ShadedProtobufHelper.ipc;
+
+public final class AsyncRpcProtocolPBUtil {
+  public static final Logger LOG = LoggerFactory.getLogger(AsyncRpcProtocolPBUtil.class);
+  public static final ThreadLocal<CompletableFuture<Object>> completableFutureThreadLocal
+      = new ThreadLocal<>();
+
+  private AsyncRpcProtocolPBUtil() {}
+
+  public static  <T> AsyncGet<T, Exception> asyncIpc(
+      ShadedProtobufHelper.IpcCall<T> call) throws IOException {
+    CompletableFuture<Object> completableFuture = new CompletableFuture<>();
+    Client.COMPLETABLE_FUTURE_THREAD_LOCAL.set(completableFuture);
+    ipc(call);
+    return (AsyncGet<T, Exception>) ProtobufRpcEngine2.getAsyncReturnMessage();
+  }
+
+  public static <T> void asyncResponse(Response<T> response) {
+    CompletableFuture<T> completableFuture =
+        (CompletableFuture<T>) Client.COMPLETABLE_FUTURE_THREAD_LOCAL.get();
+    // transfer originCall & callerContext to worker threads of executor.
+    final Server.Call originCall = Server.getCurCall().get();
+    final CallerContext originContext = CallerContext.getCurrent();
+
+    CompletableFuture<Object> resCompletableFuture = completableFuture.thenApplyAsync(t -> {
+      try {
+        Server.getCurCall().set(originCall);
+        CallerContext.setCurrent(originContext);
+        return response.response();
+      }catch (Exception e) {
+        throw new CompletionException(e);
+      }
+    }, RouterRpcServer.getExecutor());
+    setThreadLocal(resCompletableFuture);
+  }
+
+  public static <T> void asyncRouterServer(ServerReq<T> req, ServerRes<T> res) {
+    final ProtobufRpcEngineCallback2 callback =
+        ProtobufRpcEngine2.Server.registerForDeferredResponse2();
+    CompletableFuture<Object> completableFuture =
+        CompletableFuture.completedFuture(null);
+    // transfer originCall & callerContext to worker threads of executor.
+    final Server.Call originCall = Server.getCurCall().get();
+    final CallerContext originContext = CallerContext.getCurrent();
+    completableFuture.thenComposeAsync(o -> {
+      Server.getCurCall().set(originCall);
+      CallerContext.setCurrent(originContext);
+      try {
+        req.req();
+        return (CompletableFuture<T>)RouterAsyncRpcUtil.getCompletableFuture();
+      } catch (Exception e) {
+        throw new CompletionException(e);
+      }
+    }).handle((result, e) -> {
+      LOG.info("async response by [{}], callback: {}, CallerContext: {}, result: [{}]",
+          Thread.currentThread().getName(), callback, originContext, result);
+      if (e == null) {
+        Message value = null;
+        try {
+          value = res.res(result);
+        } catch (RuntimeException re) {
+          callback.error(re);
+          return null;
+        }
+        callback.setResponse(value);
+      } else {
+        callback.error(e.getCause());
+      }
+      return null;
+    });
+  }
+
+  public static void setThreadLocal(CompletableFuture<Object> completableFuture) {
+    completableFutureThreadLocal.set(completableFuture);
+  }
+
+  public static CompletableFuture<Object> getCompletableFuture() {
+    return completableFutureThreadLocal.get();
+  }
+
+  @FunctionalInterface
+   interface Response<T> {
+    T response() throws Exception;
+  }
+
+  @FunctionalInterface
+  interface ServerReq<T> {
+    T req() throws Exception;
+  }
+
+  @FunctionalInterface
+  interface ServerRes<T> {
+    Message res(T result) throws RuntimeException;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/AsyncRpcProtocolPBUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/AsyncRpcProtocolPBUtil.java
@@ -86,8 +86,10 @@ public final class AsyncRpcProtocolPBUtil {
         throw new CompletionException(e);
       }
     }).handle((result, e) -> {
-      LOG.info("Async response, callback: {}, CallerContext: {}, result: [{}]",
-          callback, CallerContext.getCurrent(), result, e);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Async response, callback: {}, CallerContext: {}, result: [{}]",
+            callback, CallerContext.getCurrent(), result, e);
+      }
       if (e == null) {
         Message value = null;
         try {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterClientNamenodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterClientNamenodeProtocolServerSideTranslatorPB.java
@@ -1,0 +1,1579 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.protocolPB;
+
+import org.apache.hadoop.fs.CreateFlag;
+import org.apache.hadoop.fs.Options;
+import org.apache.hadoop.fs.permission.FsCreateModes;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.ha.proto.HAServiceProtocolProtos;
+import org.apache.hadoop.hdfs.AddBlockFlag;
+import org.apache.hadoop.hdfs.protocol.BatchedDirectoryListing;
+import org.apache.hadoop.hdfs.protocol.BlockStoragePolicy;
+import org.apache.hadoop.hdfs.protocol.CacheDirectiveInfo;
+import org.apache.hadoop.hdfs.protocol.ClientProtocol;
+import org.apache.hadoop.hdfs.protocol.DirectoryListing;
+import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
+import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicyInfo;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
+import org.apache.hadoop.hdfs.protocol.HdfsPartialListing;
+import org.apache.hadoop.hdfs.protocol.LocatedBlock;
+import org.apache.hadoop.hdfs.protocol.OpenFilesIterator;
+import org.apache.hadoop.hdfs.protocol.proto.AclProtos;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos;
+import org.apache.hadoop.hdfs.protocol.proto.EncryptionZonesProtos;
+import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos;
+import org.apache.hadoop.hdfs.protocol.proto.HdfsProtos;
+import org.apache.hadoop.hdfs.protocol.proto.XAttrProtos;
+import org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer;
+import org.apache.hadoop.io.EnumSetWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.ipc.RemoteException;
+import org.apache.hadoop.security.proto.SecurityProtos;
+import org.apache.hadoop.thirdparty.protobuf.ByteString;
+import org.apache.hadoop.thirdparty.protobuf.ProtocolStringList;
+import org.apache.hadoop.thirdparty.protobuf.RpcController;
+import org.apache.hadoop.thirdparty.protobuf.ServiceException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.hadoop.hdfs.protocolPB.AsyncRpcProtocolPBUtil.asyncRouterServer;
+
+public class RouterClientNamenodeProtocolServerSideTranslatorPB
+    extends ClientNamenodeProtocolServerSideTranslatorPB{
+  private final RouterRpcServer server;
+  public RouterClientNamenodeProtocolServerSideTranslatorPB(
+      ClientProtocol server) throws IOException {
+    super(server);
+    this.server = (RouterRpcServer) server;
+  }
+
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetBlockLocationsResponseProto getBlockLocations(
+      RpcController controller, ClientNamenodeProtocolProtos.GetBlockLocationsRequestProto req) {
+    asyncRouterServer(() -> server.getBlockLocations(req.getSrc(), req.getOffset(),
+        req.getLength()),
+        b -> {
+          ClientNamenodeProtocolProtos.GetBlockLocationsResponseProto.Builder builder
+              = ClientNamenodeProtocolProtos.GetBlockLocationsResponseProto
+              .newBuilder();
+          if (b != null) {
+            builder.setLocations(PBHelperClient.convert(b)).build();
+          }
+          return builder.build();
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetServerDefaultsResponseProto getServerDefaults(
+      RpcController controller, ClientNamenodeProtocolProtos.GetServerDefaultsRequestProto req) {
+    asyncRouterServer(server::getServerDefaults,
+        result -> ClientNamenodeProtocolProtos.GetServerDefaultsResponseProto.newBuilder()
+            .setServerDefaults(PBHelperClient.convert(result))
+            .build());
+    return null;
+  }
+
+
+  @Override
+  public ClientNamenodeProtocolProtos.CreateResponseProto create(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.CreateRequestProto req) {
+    asyncRouterServer(() -> {
+      FsPermission masked = req.hasUnmasked() ?
+          FsCreateModes.create(PBHelperClient.convert(req.getMasked()),
+              PBHelperClient.convert(req.getUnmasked())) :
+          PBHelperClient.convert(req.getMasked());
+      return server.create(req.getSrc(),
+          masked, req.getClientName(),
+          PBHelperClient.convertCreateFlag(req.getCreateFlag()), req.getCreateParent(),
+          (short) req.getReplication(), req.getBlockSize(),
+          PBHelperClient.convertCryptoProtocolVersions(
+              req.getCryptoProtocolVersionList()),
+          req.getEcPolicyName(), req.getStoragePolicy());
+    }, result -> {
+      if (result != null) {
+        return ClientNamenodeProtocolProtos
+            .CreateResponseProto.newBuilder().setFs(PBHelperClient.convert(result))
+            .build();
+      }
+      return VOID_CREATE_RESPONSE;
+    });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.AppendResponseProto append(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.AppendRequestProto req) {
+    asyncRouterServer(() -> {
+      EnumSetWritable<CreateFlag> flags = req.hasFlag() ?
+          PBHelperClient.convertCreateFlag(req.getFlag()) :
+          new EnumSetWritable<>(EnumSet.of(CreateFlag.APPEND));
+      return server.append(req.getSrc(),
+          req.getClientName(), flags);
+    }, result -> {
+      ClientNamenodeProtocolProtos.AppendResponseProto.Builder builder =
+          ClientNamenodeProtocolProtos.AppendResponseProto.newBuilder();
+      if (result.getLastBlock() != null) {
+        builder.setBlock(PBHelperClient.convertLocatedBlock(
+            result.getLastBlock()));
+      }
+      if (result.getFileStatus() != null) {
+        builder.setStat(PBHelperClient.convert(result.getFileStatus()));
+      }
+      return builder.build();
+    });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.SetReplicationResponseProto setReplication(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.SetReplicationRequestProto req) {
+    asyncRouterServer(() ->
+        server.setReplication(req.getSrc(), (short) req.getReplication()),
+        result -> ClientNamenodeProtocolProtos
+        .SetReplicationResponseProto.newBuilder().setResult(result).build());
+    return null;
+  }
+
+
+  @Override
+  public ClientNamenodeProtocolProtos.SetPermissionResponseProto setPermission(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.SetPermissionRequestProto req) {
+    asyncRouterServer(() -> {
+      server.setPermission(req.getSrc(), PBHelperClient.convert(req.getPermission()));
+      return null;
+    }, result -> VOID_SET_PERM_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.SetOwnerResponseProto setOwner(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.SetOwnerRequestProto req) {
+    asyncRouterServer(() -> {
+      server.setOwner(req.getSrc(),
+          req.hasUsername() ? req.getUsername() : null,
+          req.hasGroupname() ? req.getGroupname() : null);
+      return null;
+    }, result -> VOID_SET_OWNER_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.AbandonBlockResponseProto abandonBlock(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.AbandonBlockRequestProto req) {
+    asyncRouterServer(() -> {
+      server.abandonBlock(PBHelperClient.convert(req.getB()), req.getFileId(),
+          req.getSrc(), req.getHolder());
+      return null;
+    }, result -> VOID_ADD_BLOCK_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.AddBlockResponseProto addBlock(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.AddBlockRequestProto req) {
+    asyncRouterServer(() -> {
+      List<HdfsProtos.DatanodeInfoProto> excl = req.getExcludeNodesList();
+      List<String> favor = req.getFavoredNodesList();
+      EnumSet<AddBlockFlag> flags =
+          PBHelperClient.convertAddBlockFlags(req.getFlagsList());
+      return server.addBlock(
+          req.getSrc(),
+          req.getClientName(),
+          req.hasPrevious() ? PBHelperClient.convert(req.getPrevious()) : null,
+          (excl == null || excl.size() == 0) ? null : PBHelperClient.convert(excl
+              .toArray(new HdfsProtos.DatanodeInfoProto[excl.size()])), req.getFileId(),
+          (favor == null || favor.size() == 0) ? null : favor
+              .toArray(new String[favor.size()]),
+          flags);
+    }, result -> ClientNamenodeProtocolProtos.AddBlockResponseProto.newBuilder()
+        .setBlock(PBHelperClient.convertLocatedBlock(result)).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetAdditionalDatanodeResponseProto getAdditionalDatanode(
+      RpcController controller, ClientNamenodeProtocolProtos.GetAdditionalDatanodeRequestProto req) {
+    asyncRouterServer(() -> {
+      List<HdfsProtos.DatanodeInfoProto> existingList = req.getExistingsList();
+      List<String> existingStorageIDsList = req.getExistingStorageUuidsList();
+      List<HdfsProtos.DatanodeInfoProto> excludesList = req.getExcludesList();
+      LocatedBlock result = server.getAdditionalDatanode(req.getSrc(),
+          req.getFileId(), PBHelperClient.convert(req.getBlk()),
+          PBHelperClient.convert(existingList.toArray(
+              new HdfsProtos.DatanodeInfoProto[existingList.size()])),
+          existingStorageIDsList.toArray(
+              new String[existingStorageIDsList.size()]),
+          PBHelperClient.convert(excludesList.toArray(
+              new HdfsProtos.DatanodeInfoProto[excludesList.size()])),
+          req.getNumAdditionalNodes(), req.getClientName());
+      return result;
+    }, result -> ClientNamenodeProtocolProtos
+        .GetAdditionalDatanodeResponseProto.newBuilder()
+        .setBlock(
+            PBHelperClient.convertLocatedBlock(result))
+        .build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.CompleteResponseProto complete(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.CompleteRequestProto req) {
+    asyncRouterServer(() -> {
+      boolean result =
+          server.complete(req.getSrc(), req.getClientName(),
+              req.hasLast() ? PBHelperClient.convert(req.getLast()) : null,
+              req.hasFileId() ? req.getFileId() : HdfsConstants.GRANDFATHER_INODE_ID);
+      return result;
+    }, result -> ClientNamenodeProtocolProtos
+        .CompleteResponseProto.newBuilder().setResult(result).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.ReportBadBlocksResponseProto reportBadBlocks(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.ReportBadBlocksRequestProto req) {
+    asyncRouterServer(() -> {
+      List<HdfsProtos.LocatedBlockProto> bl = req.getBlocksList();
+      server.reportBadBlocks(PBHelperClient.convertLocatedBlocks(
+          bl.toArray(new HdfsProtos.LocatedBlockProto[bl.size()])));
+      return null;
+    }, result -> VOID_REP_BAD_BLOCK_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.ConcatResponseProto concat(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.ConcatRequestProto req) {
+    asyncRouterServer(() -> {
+      List<String> srcs = req.getSrcsList();
+      server.concat(req.getTrg(), srcs.toArray(new String[srcs.size()]));
+      return null;
+    }, result -> VOID_CONCAT_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.RenameResponseProto rename(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.RenameRequestProto req) {
+    asyncRouterServer(() -> {
+      return server.rename(req.getSrc(), req.getDst());
+    }, result -> ClientNamenodeProtocolProtos
+        .RenameResponseProto.newBuilder().setResult(result).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.Rename2ResponseProto rename2(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.Rename2RequestProto req) {
+    asyncRouterServer(() -> {
+      // resolve rename options
+      ArrayList<Options.Rename> optionList = new ArrayList<Options.Rename>();
+      if (req.getOverwriteDest()) {
+        optionList.add(Options.Rename.OVERWRITE);
+      }
+      if (req.hasMoveToTrash() && req.getMoveToTrash()) {
+        optionList.add(Options.Rename.TO_TRASH);
+      }
+
+      if (optionList.isEmpty()) {
+        optionList.add(Options.Rename.NONE);
+      }
+      server.rename2(req.getSrc(), req.getDst(),
+          optionList.toArray(new Options.Rename[optionList.size()]));
+      return null;
+    }, result -> VOID_RENAME2_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.TruncateResponseProto truncate(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.TruncateRequestProto req) {
+    asyncRouterServer(() -> server.truncate(req.getSrc(), req.getNewLength(),
+        req.getClientName()), result -> ClientNamenodeProtocolProtos
+            .TruncateResponseProto.newBuilder().setResult(result).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.DeleteResponseProto delete(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.DeleteRequestProto req) {
+    asyncRouterServer(() -> server.delete(req.getSrc(), req.getRecursive()),
+        result -> ClientNamenodeProtocolProtos
+        .DeleteResponseProto.newBuilder().setResult(result).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.MkdirsResponseProto mkdirs(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.MkdirsRequestProto req) {
+    asyncRouterServer(() -> {
+      FsPermission masked = req.hasUnmasked() ?
+          FsCreateModes.create(PBHelperClient.convert(req.getMasked()),
+              PBHelperClient.convert(req.getUnmasked())) :
+          PBHelperClient.convert(req.getMasked());
+      boolean result = server.mkdirs(req.getSrc(), masked,
+          req.getCreateParent());
+      return result;
+    }, result -> ClientNamenodeProtocolProtos
+        .MkdirsResponseProto.newBuilder().setResult(result).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetListingResponseProto getListing(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.GetListingRequestProto req) {
+    asyncRouterServer(() -> {
+      DirectoryListing result = server.getListing(
+          req.getSrc(), req.getStartAfter().toByteArray(),
+          req.getNeedLocation());
+      return result;
+    }, result -> {
+      if (result !=null) {
+        return ClientNamenodeProtocolProtos
+            .GetListingResponseProto.newBuilder().setDirList(
+            PBHelperClient.convert(result)).build();
+      } else {
+        return VOID_GETLISTING_RESPONSE;
+      }
+    });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetBatchedListingResponseProto getBatchedListing(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.GetBatchedListingRequestProto request) {
+    asyncRouterServer(() -> {
+      BatchedDirectoryListing result = server.getBatchedListing(
+          request.getPathsList().toArray(new String[]{}),
+          request.getStartAfter().toByteArray(),
+          request.getNeedLocation());
+      return result;
+    }, result -> {
+      if (result != null) {
+        ClientNamenodeProtocolProtos.GetBatchedListingResponseProto.Builder builder =
+            ClientNamenodeProtocolProtos.GetBatchedListingResponseProto.newBuilder();
+        for (HdfsPartialListing partialListing : result.getListings()) {
+          HdfsProtos.BatchedDirectoryListingProto.Builder listingBuilder =
+              HdfsProtos.BatchedDirectoryListingProto.newBuilder();
+          if (partialListing.getException() != null) {
+            RemoteException ex = partialListing.getException();
+            HdfsProtos.RemoteExceptionProto.Builder rexBuilder =
+                HdfsProtos.RemoteExceptionProto.newBuilder();
+            rexBuilder.setClassName(ex.getClassName());
+            if (ex.getMessage() != null) {
+              rexBuilder.setMessage(ex.getMessage());
+            }
+            listingBuilder.setException(rexBuilder.build());
+          } else {
+            for (HdfsFileStatus f : partialListing.getPartialListing()) {
+              listingBuilder.addPartialListing(PBHelperClient.convert(f));
+            }
+          }
+          listingBuilder.setParentIdx(partialListing.getParentIdx());
+          builder.addListings(listingBuilder);
+        }
+        builder.setHasMore(result.hasMore());
+        builder.setStartAfter(ByteString.copyFrom(result.getStartAfter()));
+        return builder.build();
+      } else {
+        return VOID_GETBATCHEDLISTING_RESPONSE;
+      }
+    });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.RenewLeaseResponseProto renewLease(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.RenewLeaseRequestProto req) {
+    asyncRouterServer(() -> {
+      server.renewLease(req.getClientName(), req.getNamespacesList());
+      return null;
+    }, result -> VOID_RENEWLEASE_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.RecoverLeaseResponseProto recoverLease(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.RecoverLeaseRequestProto req) {
+    asyncRouterServer(() -> server.recoverLease(req.getSrc(), req.getClientName()),
+        result -> ClientNamenodeProtocolProtos
+            .RecoverLeaseResponseProto.newBuilder()
+            .setResult(result).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.RestoreFailedStorageResponseProto restoreFailedStorage(
+      RpcController controller, ClientNamenodeProtocolProtos.RestoreFailedStorageRequestProto req) {
+    asyncRouterServer(() -> server.restoreFailedStorage(req.getArg()),
+        result -> ClientNamenodeProtocolProtos
+            .RestoreFailedStorageResponseProto.newBuilder().setResult(result)
+            .build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetFsStatsResponseProto getFsStats(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.GetFsStatusRequestProto req) {
+    asyncRouterServer(server::getStats, PBHelperClient::convert);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetFsReplicatedBlockStatsResponseProto getFsReplicatedBlockStats(
+      RpcController controller, ClientNamenodeProtocolProtos.GetFsReplicatedBlockStatsRequestProto request) {
+    asyncRouterServer(server::getReplicatedBlockStats, PBHelperClient::convert);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetFsECBlockGroupStatsResponseProto getFsECBlockGroupStats(
+      RpcController controller, ClientNamenodeProtocolProtos.GetFsECBlockGroupStatsRequestProto request) {
+    asyncRouterServer(server::getECBlockGroupStats, PBHelperClient::convert);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetDatanodeReportResponseProto getDatanodeReport(
+      RpcController controller, ClientNamenodeProtocolProtos.GetDatanodeReportRequestProto req) {
+    asyncRouterServer(() -> server.getDatanodeReport(PBHelperClient.convert(req.getType())),
+        result -> {
+          List<? extends HdfsProtos.DatanodeInfoProto> re = PBHelperClient.convert(result);
+          return ClientNamenodeProtocolProtos.GetDatanodeReportResponseProto.newBuilder()
+          .addAllDi(re).build();
+      });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetDatanodeStorageReportResponseProto getDatanodeStorageReport(
+      RpcController controller, ClientNamenodeProtocolProtos.GetDatanodeStorageReportRequestProto req) {
+    asyncRouterServer(() -> server.getDatanodeStorageReport(PBHelperClient.convert(req.getType())),
+        result -> {
+          List<ClientNamenodeProtocolProtos.DatanodeStorageReportProto> reports =
+              PBHelperClient.convertDatanodeStorageReports(result);
+          return ClientNamenodeProtocolProtos.GetDatanodeStorageReportResponseProto.newBuilder()
+              .addAllDatanodeStorageReports(reports)
+              .build();
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetPreferredBlockSizeResponseProto getPreferredBlockSize(
+      RpcController controller, ClientNamenodeProtocolProtos.GetPreferredBlockSizeRequestProto req) {
+    asyncRouterServer(() -> server.getPreferredBlockSize(req.getFilename()),
+        result -> ClientNamenodeProtocolProtos
+            .GetPreferredBlockSizeResponseProto.newBuilder().setBsize(result)
+            .build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.SetSafeModeResponseProto setSafeMode(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.SetSafeModeRequestProto req) {
+    asyncRouterServer(() -> server.setSafeMode(PBHelperClient.convert(req.getAction()),
+        req.getChecked()),
+        result -> ClientNamenodeProtocolProtos
+            .SetSafeModeResponseProto.newBuilder().setResult(result).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.SaveNamespaceResponseProto saveNamespace(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.SaveNamespaceRequestProto req) {
+    asyncRouterServer(() -> {
+      final long timeWindow = req.hasTimeWindow() ? req.getTimeWindow() : 0;
+      final long txGap = req.hasTxGap() ? req.getTxGap() : 0;
+      return server.saveNamespace(timeWindow, txGap);
+    }, result -> ClientNamenodeProtocolProtos
+        .SaveNamespaceResponseProto.newBuilder().setSaved(result).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.RollEditsResponseProto rollEdits(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.RollEditsRequestProto request) {
+    asyncRouterServer(server::rollEdits,
+        txid -> ClientNamenodeProtocolProtos.RollEditsResponseProto.newBuilder()
+            .setNewSegmentTxId(txid)
+            .build());
+    return null;
+  }
+
+
+  @Override
+  public ClientNamenodeProtocolProtos.RefreshNodesResponseProto refreshNodes(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.RefreshNodesRequestProto req) {
+    asyncRouterServer(() -> {
+      server.refreshNodes();
+      return null;
+    }, result -> VOID_REFRESHNODES_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.FinalizeUpgradeResponseProto finalizeUpgrade(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.FinalizeUpgradeRequestProto req) {
+    asyncRouterServer(() -> {
+      server.finalizeUpgrade();
+      return null;
+    }, result -> VOID_REFRESHNODES_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.UpgradeStatusResponseProto upgradeStatus(
+      RpcController controller, ClientNamenodeProtocolProtos.UpgradeStatusRequestProto req) {
+    asyncRouterServer(server::upgradeStatus,
+        result -> {
+          ClientNamenodeProtocolProtos.UpgradeStatusResponseProto.Builder b =
+              ClientNamenodeProtocolProtos.UpgradeStatusResponseProto.newBuilder();
+          b.setUpgradeFinalized(result);
+          return b.build();
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.RollingUpgradeResponseProto rollingUpgrade(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.RollingUpgradeRequestProto req) {
+    asyncRouterServer(() ->
+        server.rollingUpgrade(PBHelperClient.convert(req.getAction())),
+        info -> {
+          final ClientNamenodeProtocolProtos.RollingUpgradeResponseProto.Builder b =
+              ClientNamenodeProtocolProtos.RollingUpgradeResponseProto.newBuilder();
+          if (info != null) {
+            b.setRollingUpgradeInfo(PBHelperClient.convert(info));
+          }
+          return b.build();
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.ListCorruptFileBlocksResponseProto listCorruptFileBlocks(
+      RpcController controller, ClientNamenodeProtocolProtos.ListCorruptFileBlocksRequestProto req) {
+    asyncRouterServer(() -> server.listCorruptFileBlocks(
+        req.getPath(), req.hasCookie() ? req.getCookie(): null),
+        result -> ClientNamenodeProtocolProtos.ListCorruptFileBlocksResponseProto.newBuilder()
+            .setCorrupt(PBHelperClient.convert(result))
+            .build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.MetaSaveResponseProto metaSave(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.MetaSaveRequestProto req) {
+    asyncRouterServer(() -> {
+      server.metaSave(req.getFilename());
+      return null;
+    }, result -> VOID_METASAVE_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetFileInfoResponseProto getFileInfo(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.GetFileInfoRequestProto req) {
+    asyncRouterServer(() -> server.getFileInfo(req.getSrc()),
+        result -> {
+          if (result != null) {
+            return ClientNamenodeProtocolProtos.GetFileInfoResponseProto.newBuilder().setFs(
+                PBHelperClient.convert(result)).build();
+          }
+          return VOID_GETFILEINFO_RESPONSE;
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetLocatedFileInfoResponseProto getLocatedFileInfo(
+      RpcController controller, ClientNamenodeProtocolProtos.GetLocatedFileInfoRequestProto req) {
+    asyncRouterServer(() -> server.getLocatedFileInfo(req.getSrc(),
+        req.getNeedBlockToken()),
+        result -> {
+          if (result != null) {
+            return ClientNamenodeProtocolProtos.GetLocatedFileInfoResponseProto.newBuilder().setFs(
+                PBHelperClient.convert(result)).build();
+          }
+          return VOID_GETLOCATEDFILEINFO_RESPONSE;
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetFileLinkInfoResponseProto getFileLinkInfo(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.GetFileLinkInfoRequestProto req) {
+    asyncRouterServer(() -> server.getFileLinkInfo(req.getSrc()),
+        result -> {
+          if (result != null) {
+            return ClientNamenodeProtocolProtos.GetFileLinkInfoResponseProto.newBuilder().setFs(
+                PBHelperClient.convert(result)).build();
+          } else {
+            return VOID_GETFILELINKINFO_RESPONSE;
+          }
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetContentSummaryResponseProto getContentSummary(
+      RpcController controller, ClientNamenodeProtocolProtos.GetContentSummaryRequestProto req) {
+    asyncRouterServer(() -> server.getContentSummary(req.getPath()),
+        result -> ClientNamenodeProtocolProtos.GetContentSummaryResponseProto.newBuilder()
+            .setSummary(PBHelperClient.convert(result)).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.SetQuotaResponseProto setQuota(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.SetQuotaRequestProto req) throws ServiceException {
+    asyncRouterServer(() -> {
+      server.setQuota(req.getPath(), req.getNamespaceQuota(),
+          req.getStoragespaceQuota(),
+          req.hasStorageType() ?
+              PBHelperClient.convertStorageType(req.getStorageType()): null);
+      return null;
+    }, result -> VOID_SETQUOTA_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.FsyncResponseProto fsync(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.FsyncRequestProto req) {
+    asyncRouterServer(() -> {
+      server.fsync(req.getSrc(), req.getFileId(),
+          req.getClient(), req.getLastBlockLength());
+      return null;
+    }, result -> VOID_FSYNC_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.SetTimesResponseProto setTimes(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.SetTimesRequestProto req) {
+    asyncRouterServer(() -> {
+      server.setTimes(req.getSrc(), req.getMtime(), req.getAtime());
+      return null;
+    }, result -> VOID_SETTIMES_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.CreateSymlinkResponseProto createSymlink(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.CreateSymlinkRequestProto req) {
+    asyncRouterServer(() -> {
+      server.createSymlink(req.getTarget(), req.getLink(),
+          PBHelperClient.convert(req.getDirPerm()), req.getCreateParent());
+      return null;
+    }, result -> VOID_CREATESYMLINK_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetLinkTargetResponseProto getLinkTarget(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.GetLinkTargetRequestProto req) {
+    asyncRouterServer(() -> server.getLinkTarget(req.getPath()),
+        result -> {
+          ClientNamenodeProtocolProtos.GetLinkTargetResponseProto.Builder builder =
+              ClientNamenodeProtocolProtos.GetLinkTargetResponseProto
+              .newBuilder();
+          if (result != null) {
+            builder.setTargetPath(result);
+          }
+          return builder.build();
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.UpdateBlockForPipelineResponseProto updateBlockForPipeline(
+      RpcController controller, ClientNamenodeProtocolProtos.UpdateBlockForPipelineRequestProto req) {
+    asyncRouterServer(() -> server.updateBlockForPipeline(PBHelperClient.convert(req.getBlock()),
+        req.getClientName()),
+        result -> {
+          HdfsProtos.LocatedBlockProto res = PBHelperClient.convertLocatedBlock(result);
+          return ClientNamenodeProtocolProtos
+              .UpdateBlockForPipelineResponseProto.newBuilder().setBlock(res)
+              .build();
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.UpdatePipelineResponseProto updatePipeline(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.UpdatePipelineRequestProto req) {
+    asyncRouterServer(() -> {
+      List<HdfsProtos.DatanodeIDProto> newNodes = req.getNewNodesList();
+      List<String> newStorageIDs = req.getStorageIDsList();
+      server.updatePipeline(req.getClientName(),
+          PBHelperClient.convert(req.getOldBlock()),
+          PBHelperClient.convert(req.getNewBlock()),
+          PBHelperClient.convert(newNodes.toArray(new HdfsProtos.DatanodeIDProto[newNodes.size()])),
+          newStorageIDs.toArray(new String[newStorageIDs.size()]));
+      return null;
+    }, result -> VOID_UPDATEPIPELINE_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public SecurityProtos.GetDelegationTokenResponseProto getDelegationToken(
+      RpcController controller, SecurityProtos.GetDelegationTokenRequestProto req) {
+    asyncRouterServer(() -> server
+        .getDelegationToken(new Text(req.getRenewer())),
+        token -> {
+          SecurityProtos.GetDelegationTokenResponseProto.Builder rspBuilder =
+              SecurityProtos.GetDelegationTokenResponseProto.newBuilder();
+          if (token != null) {
+            rspBuilder.setToken(PBHelperClient.convert(token));
+          }
+          return rspBuilder.build();
+        });
+    return null;
+  }
+
+  @Override
+  public SecurityProtos.RenewDelegationTokenResponseProto renewDelegationToken(
+      RpcController controller, SecurityProtos.RenewDelegationTokenRequestProto req) {
+    asyncRouterServer(() -> server.renewDelegationToken(PBHelperClient
+        .convertDelegationToken(req.getToken())),
+        result -> SecurityProtos.RenewDelegationTokenResponseProto.newBuilder()
+            .setNewExpiryTime(result).build());
+    return null;
+  }
+
+  @Override
+  public SecurityProtos.CancelDelegationTokenResponseProto cancelDelegationToken(
+      RpcController controller, SecurityProtos.CancelDelegationTokenRequestProto req) {
+    asyncRouterServer(() -> {
+      server.cancelDelegationToken(PBHelperClient.convertDelegationToken(req
+          .getToken()));
+      return null;
+    }, result -> VOID_CANCELDELEGATIONTOKEN_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.SetBalancerBandwidthResponseProto setBalancerBandwidth(
+      RpcController controller, ClientNamenodeProtocolProtos.SetBalancerBandwidthRequestProto req) {
+    asyncRouterServer(() -> {
+      server.setBalancerBandwidth(req.getBandwidth());
+      return null;
+    }, result -> VOID_SETBALANCERBANDWIDTH_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetDataEncryptionKeyResponseProto getDataEncryptionKey(
+      RpcController controller, ClientNamenodeProtocolProtos.GetDataEncryptionKeyRequestProto request) {
+    asyncRouterServer(server::getDataEncryptionKey, encryptionKey -> {
+      ClientNamenodeProtocolProtos.GetDataEncryptionKeyResponseProto.Builder builder =
+          ClientNamenodeProtocolProtos.GetDataEncryptionKeyResponseProto.newBuilder();
+      if (encryptionKey != null) {
+        builder.setDataEncryptionKey(PBHelperClient.convert(encryptionKey));
+      }
+      return builder.build();
+    });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.CreateSnapshotResponseProto createSnapshot(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.CreateSnapshotRequestProto req) throws ServiceException {
+    asyncRouterServer(() -> server.createSnapshot(req.getSnapshotRoot(),
+        req.hasSnapshotName()? req.getSnapshotName(): null),
+        snapshotPath -> {
+          final ClientNamenodeProtocolProtos.CreateSnapshotResponseProto.Builder builder
+              = ClientNamenodeProtocolProtos.CreateSnapshotResponseProto.newBuilder();
+          if (snapshotPath != null) {
+            builder.setSnapshotPath(snapshotPath);
+          }
+          return builder.build();
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.DeleteSnapshotResponseProto deleteSnapshot(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.DeleteSnapshotRequestProto req) {
+    asyncRouterServer(() -> {
+      server.deleteSnapshot(req.getSnapshotRoot(), req.getSnapshotName());
+      return null;
+    }, result -> VOID_DELETE_SNAPSHOT_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.AllowSnapshotResponseProto allowSnapshot(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.AllowSnapshotRequestProto req) {
+    asyncRouterServer(() -> {
+      server.allowSnapshot(req.getSnapshotRoot());
+      return null;
+    }, result -> VOID_ALLOW_SNAPSHOT_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.DisallowSnapshotResponseProto disallowSnapshot(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.DisallowSnapshotRequestProto req) {
+    asyncRouterServer(() -> {
+      server.disallowSnapshot(req.getSnapshotRoot());
+      return null;
+    }, result -> VOID_DISALLOW_SNAPSHOT_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.RenameSnapshotResponseProto renameSnapshot(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.RenameSnapshotRequestProto request) {
+    asyncRouterServer(() -> {
+      server.renameSnapshot(request.getSnapshotRoot(),
+          request.getSnapshotOldName(), request.getSnapshotNewName());
+      return null;
+    }, result -> VOID_RENAME_SNAPSHOT_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetSnapshottableDirListingResponseProto getSnapshottableDirListing(
+      RpcController controller, ClientNamenodeProtocolProtos.GetSnapshottableDirListingRequestProto request) {
+    asyncRouterServer(server::getSnapshottableDirListing,
+        result -> {
+          if (result != null) {
+            return ClientNamenodeProtocolProtos.GetSnapshottableDirListingResponseProto.newBuilder().
+                setSnapshottableDirList(PBHelperClient.convert(result)).build();
+          } else {
+            return NULL_GET_SNAPSHOTTABLE_DIR_LISTING_RESPONSE;
+          }
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetSnapshotListingResponseProto getSnapshotListing(
+      RpcController controller, ClientNamenodeProtocolProtos.GetSnapshotListingRequestProto request) {
+    asyncRouterServer(() -> server
+        .getSnapshotListing(request.getSnapshotRoot()),
+        result -> {
+          if (result != null) {
+            return ClientNamenodeProtocolProtos.GetSnapshotListingResponseProto.newBuilder().
+                setSnapshotList(PBHelperClient.convert(result)).build();
+          } else {
+            return NULL_GET_SNAPSHOT_LISTING_RESPONSE;
+          }
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetSnapshotDiffReportResponseProto getSnapshotDiffReport(
+      RpcController controller, ClientNamenodeProtocolProtos.GetSnapshotDiffReportRequestProto request) {
+    asyncRouterServer(() -> server.getSnapshotDiffReport(
+        request.getSnapshotRoot(), request.getFromSnapshot(),
+        request.getToSnapshot()),
+        report -> ClientNamenodeProtocolProtos.GetSnapshotDiffReportResponseProto.newBuilder()
+            .setDiffReport(PBHelperClient.convert(report)).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetSnapshotDiffReportListingResponseProto getSnapshotDiffReportListing(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.GetSnapshotDiffReportListingRequestProto request) {
+    asyncRouterServer(() -> server
+        .getSnapshotDiffReportListing(request.getSnapshotRoot(),
+            request.getFromSnapshot(), request.getToSnapshot(),
+            request.getCursor().getStartPath().toByteArray(),
+            request.getCursor().getIndex()),
+        report -> ClientNamenodeProtocolProtos
+            .GetSnapshotDiffReportListingResponseProto.newBuilder()
+            .setDiffReport(PBHelperClient.convert(report)).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.IsFileClosedResponseProto isFileClosed(
+      RpcController controller, ClientNamenodeProtocolProtos.IsFileClosedRequestProto request) {
+    asyncRouterServer(() -> server.isFileClosed(request.getSrc()),
+        result -> ClientNamenodeProtocolProtos
+            .IsFileClosedResponseProto.newBuilder()
+            .setResult(result).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.AddCacheDirectiveResponseProto addCacheDirective(
+      RpcController controller, ClientNamenodeProtocolProtos.AddCacheDirectiveRequestProto request) {
+    asyncRouterServer(() -> server.addCacheDirective(
+        PBHelperClient.convert(request.getInfo()),
+        PBHelperClient.convertCacheFlags(request.getCacheFlags())),
+        id -> ClientNamenodeProtocolProtos.AddCacheDirectiveResponseProto.newBuilder().
+            setId(id).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.ModifyCacheDirectiveResponseProto modifyCacheDirective(
+      RpcController controller, ClientNamenodeProtocolProtos.ModifyCacheDirectiveRequestProto request) {
+    asyncRouterServer(() -> {
+      server.modifyCacheDirective(
+          PBHelperClient.convert(request.getInfo()),
+          PBHelperClient.convertCacheFlags(request.getCacheFlags()));
+      return null;
+    }, result -> ClientNamenodeProtocolProtos.ModifyCacheDirectiveResponseProto.newBuilder().build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.RemoveCacheDirectiveResponseProto
+      removeCacheDirective(
+          RpcController controller,
+          ClientNamenodeProtocolProtos.RemoveCacheDirectiveRequestProto request) {
+    asyncRouterServer(() -> {
+      server.removeCacheDirective(request.getId());
+      return null;
+    }, result -> ClientNamenodeProtocolProtos.RemoveCacheDirectiveResponseProto.
+        newBuilder().build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.ListCacheDirectivesResponseProto listCacheDirectives(
+      RpcController controller, ClientNamenodeProtocolProtos.ListCacheDirectivesRequestProto request) {
+    asyncRouterServer(() -> {
+      CacheDirectiveInfo filter =
+          PBHelperClient.convert(request.getFilter());
+      return  server.listCacheDirectives(request.getPrevId(), filter);
+    }, entries -> {
+      ClientNamenodeProtocolProtos.ListCacheDirectivesResponseProto.Builder builder =
+          ClientNamenodeProtocolProtos.ListCacheDirectivesResponseProto.newBuilder();
+      builder.setHasMore(entries.hasMore());
+      for (int i=0, n=entries.size(); i<n; i++) {
+        builder.addElements(PBHelperClient.convert(entries.get(i)));
+      }
+      return builder.build();
+    });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.AddCachePoolResponseProto addCachePool(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.AddCachePoolRequestProto request) {
+    asyncRouterServer(() -> {
+      server.addCachePool(PBHelperClient.convert(request.getInfo()));
+      return null;
+    }, result -> ClientNamenodeProtocolProtos.AddCachePoolResponseProto.newBuilder().build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.ModifyCachePoolResponseProto modifyCachePool(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.ModifyCachePoolRequestProto request) {
+    asyncRouterServer(() -> {
+      server.modifyCachePool(PBHelperClient.convert(request.getInfo()));
+      return null;
+    }, result -> ClientNamenodeProtocolProtos.ModifyCachePoolResponseProto.newBuilder().build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.RemoveCachePoolResponseProto removeCachePool(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.RemoveCachePoolRequestProto request) {
+    asyncRouterServer(() -> {
+      server.removeCachePool(request.getPoolName());
+      return null;
+    }, result -> ClientNamenodeProtocolProtos.RemoveCachePoolResponseProto.newBuilder().build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.ListCachePoolsResponseProto listCachePools(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.ListCachePoolsRequestProto request) {
+    asyncRouterServer(() -> server.listCachePools(request.getPrevPoolName()),
+        entries -> {
+          ClientNamenodeProtocolProtos.ListCachePoolsResponseProto.Builder responseBuilder =
+              ClientNamenodeProtocolProtos.ListCachePoolsResponseProto.newBuilder();
+          responseBuilder.setHasMore(entries.hasMore());
+          for (int i=0, n=entries.size(); i<n; i++) {
+            responseBuilder.addEntries(PBHelperClient.convert(entries.get(i)));
+          }
+          return responseBuilder.build();
+        });
+    return null;
+  }
+
+  @Override
+  public AclProtos.ModifyAclEntriesResponseProto modifyAclEntries(
+      RpcController controller, AclProtos.ModifyAclEntriesRequestProto req)
+      throws ServiceException {
+    asyncRouterServer(() -> {
+      server.modifyAclEntries(req.getSrc(), PBHelperClient.convertAclEntry(req.getAclSpecList()));
+      return null;
+    }, vo -> VOID_MODIFYACLENTRIES_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public AclProtos.RemoveAclEntriesResponseProto removeAclEntries(
+      RpcController controller, AclProtos.RemoveAclEntriesRequestProto req) {
+    asyncRouterServer(() -> {
+      server.removeAclEntries(req.getSrc(),
+          PBHelperClient.convertAclEntry(req.getAclSpecList()));
+      return null;
+    }, vo -> VOID_REMOVEACLENTRIES_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public AclProtos.RemoveDefaultAclResponseProto removeDefaultAcl(
+      RpcController controller, AclProtos.RemoveDefaultAclRequestProto req) {
+    asyncRouterServer(() -> {
+      server.removeDefaultAcl(req.getSrc());
+      return null;
+    }, vo -> VOID_REMOVEDEFAULTACL_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public AclProtos.RemoveAclResponseProto removeAcl(
+      RpcController controller,
+      AclProtos.RemoveAclRequestProto req) {
+    asyncRouterServer(() -> {
+      server.removeAcl(req.getSrc());
+      return null;
+    }, vo -> VOID_REMOVEACL_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public AclProtos.SetAclResponseProto setAcl(
+      RpcController controller,
+      AclProtos.SetAclRequestProto req) {
+    asyncRouterServer(() -> {
+      server.setAcl(req.getSrc(), PBHelperClient.convertAclEntry(req.getAclSpecList()));
+      return null;
+    }, vo -> VOID_SETACL_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public AclProtos.GetAclStatusResponseProto getAclStatus(
+      RpcController controller,
+      AclProtos.GetAclStatusRequestProto req) {
+    asyncRouterServer(() -> server.getAclStatus(req.getSrc()),
+        PBHelperClient::convert);
+    return null;
+  }
+
+  @Override
+  public EncryptionZonesProtos.CreateEncryptionZoneResponseProto createEncryptionZone(
+      RpcController controller, EncryptionZonesProtos.CreateEncryptionZoneRequestProto req) {
+    asyncRouterServer(() -> {
+      server.createEncryptionZone(req.getSrc(), req.getKeyName());
+      return null;
+    }, vo -> EncryptionZonesProtos.CreateEncryptionZoneResponseProto.newBuilder().build());
+    return null;
+  }
+
+  @Override
+  public EncryptionZonesProtos.GetEZForPathResponseProto getEZForPath(
+      RpcController controller, EncryptionZonesProtos.GetEZForPathRequestProto req) {
+    asyncRouterServer(() -> server.getEZForPath(req.getSrc()),
+        ret -> {
+          EncryptionZonesProtos.GetEZForPathResponseProto.Builder builder =
+              EncryptionZonesProtos.GetEZForPathResponseProto.newBuilder();
+          if (ret != null) {
+            builder.setZone(PBHelperClient.convert(ret));
+          }
+          return builder.build();
+        });
+    return null;
+  }
+
+  @Override
+  public EncryptionZonesProtos.ListEncryptionZonesResponseProto listEncryptionZones(
+      RpcController controller, EncryptionZonesProtos.ListEncryptionZonesRequestProto req) {
+    asyncRouterServer(() -> server.listEncryptionZones(req.getId()),
+        entries -> {
+          EncryptionZonesProtos.ListEncryptionZonesResponseProto.Builder builder =
+              EncryptionZonesProtos.ListEncryptionZonesResponseProto.newBuilder();
+          builder.setHasMore(entries.hasMore());
+          for (int i=0; i<entries.size(); i++) {
+            builder.addZones(PBHelperClient.convert(entries.get(i)));
+          }
+          return builder.build();
+        });
+    return null;
+  }
+
+  @Override
+  public EncryptionZonesProtos.ReencryptEncryptionZoneResponseProto reencryptEncryptionZone(
+      RpcController controller, EncryptionZonesProtos.ReencryptEncryptionZoneRequestProto req) {
+    asyncRouterServer(() -> {
+      server.reencryptEncryptionZone(req.getZone(),
+          PBHelperClient.convert(req.getAction()));
+      return null;
+    }, vo -> EncryptionZonesProtos.ReencryptEncryptionZoneResponseProto.newBuilder().build());
+    return null;
+  }
+
+  public EncryptionZonesProtos.ListReencryptionStatusResponseProto listReencryptionStatus(
+      RpcController controller, EncryptionZonesProtos.ListReencryptionStatusRequestProto req) {
+    asyncRouterServer(() -> server.listReencryptionStatus(req.getId()),
+        entries -> {
+          EncryptionZonesProtos.ListReencryptionStatusResponseProto.Builder builder =
+              EncryptionZonesProtos.ListReencryptionStatusResponseProto.newBuilder();
+          builder.setHasMore(entries.hasMore());
+          for (int i=0; i<entries.size(); i++) {
+            builder.addStatuses(PBHelperClient.convert(entries.get(i)));
+          }
+          return builder.build();
+        });
+    return null;
+  }
+
+  @Override
+  public ErasureCodingProtos.SetErasureCodingPolicyResponseProto setErasureCodingPolicy(
+      RpcController controller, ErasureCodingProtos.SetErasureCodingPolicyRequestProto req) {
+    asyncRouterServer(() -> {
+      String ecPolicyName = req.hasEcPolicyName() ?
+          req.getEcPolicyName() : null;
+      server.setErasureCodingPolicy(req.getSrc(), ecPolicyName);
+      return null;
+    }, vo -> ErasureCodingProtos
+        .SetErasureCodingPolicyResponseProto.newBuilder().build());
+    return null;
+  }
+
+  @Override
+  public ErasureCodingProtos.UnsetErasureCodingPolicyResponseProto unsetErasureCodingPolicy(
+      RpcController controller, ErasureCodingProtos.UnsetErasureCodingPolicyRequestProto req) {
+    asyncRouterServer(() -> {
+      server.unsetErasureCodingPolicy(req.getSrc());
+      return null;
+    }, vo -> ErasureCodingProtos
+        .UnsetErasureCodingPolicyResponseProto.newBuilder().build());
+    return null;
+  }
+
+  @Override
+  public ErasureCodingProtos.GetECTopologyResultForPoliciesResponseProto getECTopologyResultForPolicies(
+      RpcController controller, ErasureCodingProtos.GetECTopologyResultForPoliciesRequestProto req) {
+    asyncRouterServer(() -> {
+      ProtocolStringList policies = req.getPoliciesList();
+      return server.getECTopologyResultForPolicies(
+          policies.toArray(policies.toArray(new String[policies.size()])));
+    }, result -> {
+      ErasureCodingProtos.GetECTopologyResultForPoliciesResponseProto.Builder builder =
+          ErasureCodingProtos.GetECTopologyResultForPoliciesResponseProto.newBuilder();
+      builder
+          .setResponse(PBHelperClient.convertECTopologyVerifierResult(result));
+      return builder.build();
+    });
+    return null;
+  }
+
+  @Override
+  public XAttrProtos.SetXAttrResponseProto setXAttr(
+      RpcController controller,
+      XAttrProtos.SetXAttrRequestProto req) {
+    asyncRouterServer(() -> {
+      server.setXAttr(req.getSrc(), PBHelperClient.convertXAttr(req.getXAttr()),
+          PBHelperClient.convert(req.getFlag()));
+      return null;
+    }, vo -> VOID_SETXATTR_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public XAttrProtos.GetXAttrsResponseProto getXAttrs(
+      RpcController controller,
+      XAttrProtos.GetXAttrsRequestProto req) {
+    asyncRouterServer(() -> server.getXAttrs(req.getSrc(),
+        PBHelperClient.convertXAttrs(req.getXAttrsList())),
+        PBHelperClient::convertXAttrsResponse);
+    return null;
+  }
+
+  @Override
+  public XAttrProtos.ListXAttrsResponseProto listXAttrs(
+      RpcController controller,
+      XAttrProtos.ListXAttrsRequestProto req) {
+    asyncRouterServer(() -> server.listXAttrs(req.getSrc()),
+        PBHelperClient::convertListXAttrsResponse);
+    return null;
+  }
+
+  @Override
+  public XAttrProtos.RemoveXAttrResponseProto removeXAttr(
+      RpcController controller,
+      XAttrProtos.RemoveXAttrRequestProto req) {
+    asyncRouterServer(() -> {
+      server.removeXAttr(req.getSrc(), PBHelperClient.convertXAttr(req.getXAttr()));
+      return null;
+    }, vo -> VOID_REMOVEXATTR_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.CheckAccessResponseProto checkAccess(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.CheckAccessRequestProto req) {
+    asyncRouterServer(() -> {
+      server.checkAccess(req.getPath(), PBHelperClient.convert(req.getMode()));
+      return null;
+    }, vo -> VOID_CHECKACCESS_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.SetStoragePolicyResponseProto setStoragePolicy(
+      RpcController controller, ClientNamenodeProtocolProtos.SetStoragePolicyRequestProto request) {
+    asyncRouterServer(() -> {
+      server.setStoragePolicy(request.getSrc(), request.getPolicyName());
+      return null;
+    }, vo -> VOID_SET_STORAGE_POLICY_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.UnsetStoragePolicyResponseProto unsetStoragePolicy(
+      RpcController controller, ClientNamenodeProtocolProtos.UnsetStoragePolicyRequestProto request) {
+    asyncRouterServer(() -> {
+      server.unsetStoragePolicy(request.getSrc());
+      return null;
+    }, vo -> VOID_UNSET_STORAGE_POLICY_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetStoragePolicyResponseProto getStoragePolicy(
+      RpcController controller, ClientNamenodeProtocolProtos.GetStoragePolicyRequestProto request) {
+    asyncRouterServer(() -> server.getStoragePolicy(request.getPath()),
+        result -> {
+          HdfsProtos.BlockStoragePolicyProto policy = PBHelperClient.convert(result);
+          return ClientNamenodeProtocolProtos.GetStoragePolicyResponseProto.newBuilder()
+              .setStoragePolicy(policy).build();
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetStoragePoliciesResponseProto getStoragePolicies(
+      RpcController controller, ClientNamenodeProtocolProtos.GetStoragePoliciesRequestProto request) {
+    asyncRouterServer(server::getStoragePolicies,
+        policies -> {
+          ClientNamenodeProtocolProtos.GetStoragePoliciesResponseProto.Builder builder =
+              ClientNamenodeProtocolProtos.GetStoragePoliciesResponseProto.newBuilder();
+          if (policies == null) {
+            return builder.build();
+          }
+          for (BlockStoragePolicy policy : policies) {
+            builder.addPolicies(PBHelperClient.convert(policy));
+          }
+          return builder.build();
+        });
+    return null;
+  }
+
+  public ClientNamenodeProtocolProtos.GetCurrentEditLogTxidResponseProto getCurrentEditLogTxid(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.GetCurrentEditLogTxidRequestProto req) throws ServiceException {
+    asyncRouterServer(server::getCurrentEditLogTxid,
+        result -> ClientNamenodeProtocolProtos
+            .GetCurrentEditLogTxidResponseProto.newBuilder()
+            .setTxid(result).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetEditsFromTxidResponseProto getEditsFromTxid(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.GetEditsFromTxidRequestProto req) {
+    asyncRouterServer(() -> server.getEditsFromTxid(req.getTxid()),
+        PBHelperClient::convertEditsResponse);
+    return null;
+  }
+
+  @Override
+  public ErasureCodingProtos.GetErasureCodingPoliciesResponseProto getErasureCodingPolicies(
+      RpcController controller,
+      ErasureCodingProtos.GetErasureCodingPoliciesRequestProto request) {
+    asyncRouterServer(server::getErasureCodingPolicies,
+        ecpInfos -> {
+          ErasureCodingProtos.GetErasureCodingPoliciesResponseProto.Builder resBuilder =
+              ErasureCodingProtos.GetErasureCodingPoliciesResponseProto
+              .newBuilder();
+          for (ErasureCodingPolicyInfo info : ecpInfos) {
+            resBuilder.addEcPolicies(
+                PBHelperClient.convertErasureCodingPolicy(info));
+          }
+          return resBuilder.build();
+        });
+    return null;
+  }
+
+  @Override
+  public ErasureCodingProtos.GetErasureCodingCodecsResponseProto getErasureCodingCodecs(
+      RpcController controller, ErasureCodingProtos.GetErasureCodingCodecsRequestProto request) {
+    asyncRouterServer(server::getErasureCodingCodecs,
+        codecs -> {
+          ErasureCodingProtos.GetErasureCodingCodecsResponseProto.Builder resBuilder =
+              ErasureCodingProtos.GetErasureCodingCodecsResponseProto.newBuilder();
+          for (Map.Entry<String, String> codec : codecs.entrySet()) {
+            resBuilder.addCodec(
+                PBHelperClient.convertErasureCodingCodec(
+                    codec.getKey(), codec.getValue()));
+          }
+          return resBuilder.build();
+        });
+    return null;
+  }
+
+  @Override
+  public ErasureCodingProtos.AddErasureCodingPoliciesResponseProto addErasureCodingPolicies(
+      RpcController controller, ErasureCodingProtos.AddErasureCodingPoliciesRequestProto request) {
+    asyncRouterServer(() -> {
+      ErasureCodingPolicy[] policies = request.getEcPoliciesList().stream()
+          .map(PBHelperClient::convertErasureCodingPolicy)
+          .toArray(ErasureCodingPolicy[]::new);
+      return server
+          .addErasureCodingPolicies(policies);
+    }, result -> {
+      List<HdfsProtos.AddErasureCodingPolicyResponseProto> responseProtos =
+          Arrays.stream(result)
+              .map(PBHelperClient::convertAddErasureCodingPolicyResponse)
+              .collect(Collectors.toList());
+      ErasureCodingProtos.AddErasureCodingPoliciesResponseProto response =
+          ErasureCodingProtos.AddErasureCodingPoliciesResponseProto.newBuilder()
+              .addAllResponses(responseProtos).build();
+      return response;
+    });
+    return null;
+  }
+
+  @Override
+  public ErasureCodingProtos.RemoveErasureCodingPolicyResponseProto removeErasureCodingPolicy(
+      RpcController controller, ErasureCodingProtos.RemoveErasureCodingPolicyRequestProto request) {
+    asyncRouterServer(() -> {
+      server.removeErasureCodingPolicy(request.getEcPolicyName());
+      return null;
+    }, vo -> ErasureCodingProtos.RemoveErasureCodingPolicyResponseProto.newBuilder().build());
+    return null;
+  }
+
+  @Override
+  public ErasureCodingProtos.EnableErasureCodingPolicyResponseProto enableErasureCodingPolicy(
+      RpcController controller, ErasureCodingProtos.EnableErasureCodingPolicyRequestProto request) {
+    asyncRouterServer(() -> {
+      server.enableErasureCodingPolicy(request.getEcPolicyName());
+      return null;
+    }, vo -> ErasureCodingProtos.EnableErasureCodingPolicyResponseProto.newBuilder().build());
+    return null;
+  }
+
+  @Override
+  public ErasureCodingProtos.DisableErasureCodingPolicyResponseProto disableErasureCodingPolicy(
+      RpcController controller, ErasureCodingProtos.DisableErasureCodingPolicyRequestProto request) {
+    asyncRouterServer(() -> {
+      server.disableErasureCodingPolicy(request.getEcPolicyName());
+      return null;
+    }, vo -> ErasureCodingProtos.DisableErasureCodingPolicyResponseProto.newBuilder().build());
+    return null;
+  }
+
+  @Override
+  public ErasureCodingProtos.GetErasureCodingPolicyResponseProto getErasureCodingPolicy(
+      RpcController controller,
+      ErasureCodingProtos.GetErasureCodingPolicyRequestProto request) {
+    asyncRouterServer(() -> server.getErasureCodingPolicy(request.getSrc()),
+        ecPolicy -> {
+          ErasureCodingProtos.GetErasureCodingPolicyResponseProto.Builder builder =
+              ErasureCodingProtos.GetErasureCodingPolicyResponseProto.newBuilder();
+          if (ecPolicy != null) {
+            builder.setEcPolicy(PBHelperClient.convertErasureCodingPolicy(ecPolicy));
+          }
+          return builder.build();
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetQuotaUsageResponseProto getQuotaUsage(
+      RpcController controller, ClientNamenodeProtocolProtos.GetQuotaUsageRequestProto req) {
+    asyncRouterServer(() -> server.getQuotaUsage(req.getPath()),
+        result -> ClientNamenodeProtocolProtos.GetQuotaUsageResponseProto.newBuilder()
+            .setUsage(PBHelperClient.convert(result)).build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.ListOpenFilesResponseProto listOpenFiles(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.ListOpenFilesRequestProto req) {
+    asyncRouterServer(() -> {
+      EnumSet<OpenFilesIterator.OpenFilesType> openFilesTypes =
+          PBHelperClient.convertOpenFileTypes(req.getTypesList());
+      return server.listOpenFiles(req.getId(),
+          openFilesTypes, req.getPath());
+    }, entries -> {
+      ClientNamenodeProtocolProtos.ListOpenFilesResponseProto.Builder builder =
+          ClientNamenodeProtocolProtos.ListOpenFilesResponseProto.newBuilder();
+      builder.setHasMore(entries.hasMore());
+      for (int i = 0; i < entries.size(); i++) {
+        builder.addEntries(PBHelperClient.convert(entries.get(i)));
+      }
+      builder.addAllTypes(req.getTypesList());
+      return builder.build();
+    });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.MsyncResponseProto msync(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.MsyncRequestProto req) {
+    asyncRouterServer(() -> {
+      server.msync();
+      return null;
+    }, vo -> ClientNamenodeProtocolProtos.MsyncResponseProto.newBuilder().build());
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.SatisfyStoragePolicyResponseProto satisfyStoragePolicy(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.SatisfyStoragePolicyRequestProto request) throws ServiceException {
+    try {
+      server.satisfyStoragePolicy(request.getSrc());
+    } catch (IOException e) {
+      throw new ServiceException(e);
+    }
+    return VOID_SATISFYSTORAGEPOLICY_RESPONSE;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.HAServiceStateResponseProto getHAServiceState(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.HAServiceStateRequestProto request) {
+    asyncRouterServer(server::getHAServiceState,
+        state -> {
+          HAServiceProtocolProtos.HAServiceStateProto retState;
+          switch (state) {
+            case ACTIVE:
+              retState = HAServiceProtocolProtos.HAServiceStateProto.ACTIVE;
+              break;
+            case STANDBY:
+              retState = HAServiceProtocolProtos.HAServiceStateProto.STANDBY;
+              break;
+            case OBSERVER:
+              retState = HAServiceProtocolProtos.HAServiceStateProto.OBSERVER;
+              break;
+            case INITIALIZING:
+            default:
+              retState = HAServiceProtocolProtos.HAServiceStateProto.INITIALIZING;
+              break;
+          }
+          ClientNamenodeProtocolProtos.HAServiceStateResponseProto.Builder builder =
+              ClientNamenodeProtocolProtos.HAServiceStateResponseProto.newBuilder();
+          builder.setState(retState);
+          return builder.build();
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetSlowDatanodeReportResponseProto getSlowDatanodeReport(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.GetSlowDatanodeReportRequestProto request) {
+    asyncRouterServer(server::getSlowDatanodeReport,
+        res -> {
+          List<? extends HdfsProtos.DatanodeInfoProto> result = PBHelperClient.convert(res);
+          return ClientNamenodeProtocolProtos.GetSlowDatanodeReportResponseProto.newBuilder()
+              .addAllDatanodeInfoProto(result)
+              .build();
+        });
+    return null;
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.GetEnclosingRootResponseProto getEnclosingRoot(
+      RpcController controller, ClientNamenodeProtocolProtos.GetEnclosingRootRequestProto req) {
+    asyncRouterServer(() -> server.getEnclosingRoot(req.getFilename()),
+        enclosingRootPath -> ClientNamenodeProtocolProtos
+            .GetEnclosingRootResponseProto.newBuilder()
+            .setEnclosingRootPath(enclosingRootPath.toUri().toString())
+            .build());
+    return null;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterClientProtocolTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterClientProtocolTranslatorPB.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdfs.protocolPB;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -25,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -58,7 +56,6 @@ import org.apache.hadoop.hdfs.protocol.CacheDirectiveEntry;
 import org.apache.hadoop.hdfs.protocol.CacheDirectiveInfo;
 import org.apache.hadoop.hdfs.protocol.CachePoolEntry;
 import org.apache.hadoop.hdfs.protocol.CachePoolInfo;
-import org.apache.hadoop.hdfs.protocol.ClientProtocol;
 import org.apache.hadoop.hdfs.protocol.CorruptFileBlocks;
 import org.apache.hadoop.hdfs.protocol.DatanodeID;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
@@ -89,6 +86,7 @@ import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
 import org.apache.hadoop.hdfs.protocol.SnapshotDiffReportListing;
 import org.apache.hadoop.hdfs.protocol.SnapshottableDirectoryStatus;
 import org.apache.hadoop.hdfs.protocol.SnapshotStatus;
+import org.apache.hadoop.hdfs.protocol.proto.AclProtos;
 import org.apache.hadoop.hdfs.protocol.proto.AclProtos.GetAclStatusRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.AclProtos.GetAclStatusResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.AclProtos.ModifyAclEntriesRequestProto;
@@ -96,47 +94,66 @@ import org.apache.hadoop.hdfs.protocol.proto.AclProtos.RemoveAclEntriesRequestPr
 import org.apache.hadoop.hdfs.protocol.proto.AclProtos.RemoveAclRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.AclProtos.RemoveDefaultAclRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.AclProtos.SetAclRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetFsStatsResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.AbandonBlockRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.AbandonBlockResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.AddBlockRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.AddBlockResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.AddCacheDirectiveRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.AddCacheDirectiveResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.AddCachePoolRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.AddCachePoolResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.AllowSnapshotRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.AllowSnapshotResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.AppendRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.AppendResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.CachePoolEntryProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.CheckAccessRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.CheckAccessResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.CompleteRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.CompleteResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ConcatRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ConcatResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.CreateRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.CreateResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.CreateSnapshotRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.CreateSnapshotResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.CreateSymlinkRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.CreateSymlinkResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.DeleteRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.DeleteResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.DeleteSnapshotRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.DeleteSnapshotResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.DisallowSnapshotRequestProto;
-import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.FinalizeUpgradeRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.DisallowSnapshotResponseProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.FinalizeUpgradeResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.FsyncRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.FsyncResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetAdditionalDatanodeRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetAdditionalDatanodeResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetBatchedListingRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetBatchedListingResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetBlockLocationsRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetBlockLocationsResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetContentSummaryRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetContentSummaryResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetCurrentEditLogTxidRequestProto;
-import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetDataEncryptionKeyRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetCurrentEditLogTxidResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetDataEncryptionKeyResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetDatanodeReportRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetDatanodeReportResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetDatanodeStorageReportRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetDatanodeStorageReportResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetEditsFromTxidRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetEditsFromTxidResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetEnclosingRootRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetEnclosingRootResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetFileInfoRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetFileInfoResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetFileLinkInfoRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetFileLinkInfoResponseProto;
-import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetFsECBlockGroupStatsRequestProto;
-import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetFsReplicatedBlockStatsRequestProto;
-import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetFsStatusRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetFsECBlockGroupStatsResponseProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetFsReplicatedBlockStatsResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetLinkTargetRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetLinkTargetResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetListingRequestProto;
@@ -144,9 +161,13 @@ import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetLis
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetLocatedFileInfoRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetLocatedFileInfoResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetPreferredBlockSizeRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetPreferredBlockSizeResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetQuotaUsageRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetQuotaUsageResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetServerDefaultsRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetServerDefaultsResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetSlowDatanodeReportRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetSlowDatanodeReportResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetSnapshotDiffReportRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetSnapshotDiffReportResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetSnapshotDiffReportListingRequestProto;
@@ -155,55 +176,84 @@ import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetSna
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetSnapshottableDirListingResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetSnapshotListingRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetSnapshotListingResponseProto;
-import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetStoragePoliciesRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetStoragePoliciesResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetStoragePolicyRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.GetStoragePolicyResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.HAServiceStateRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.HAServiceStateResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.IsFileClosedRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.IsFileClosedResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ListCacheDirectivesRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ListCacheDirectivesResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ListCachePoolsRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ListCachePoolsResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ListCorruptFileBlocksRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ListCorruptFileBlocksResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ListOpenFilesRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ListOpenFilesResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.MetaSaveRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.MetaSaveResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.MkdirsRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.MkdirsResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ModifyCacheDirectiveRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ModifyCacheDirectiveResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ModifyCachePoolRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ModifyCachePoolResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.MsyncRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.MsyncResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.OpenFilesBatchResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RecoverLeaseRequestProto;
-import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RefreshNodesRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RecoverLeaseResponseProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RefreshNodesResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RemoveCacheDirectiveRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RemoveCacheDirectiveResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RemoveCachePoolRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RemoveCachePoolResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.Rename2RequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.Rename2ResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RenameRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RenameResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RenameSnapshotRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RenameSnapshotResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RenewLeaseRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RenewLeaseResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ReportBadBlocksRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ReportBadBlocksResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RestoreFailedStorageRequestProto;
-import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RollEditsRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RestoreFailedStorageResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RollEditsResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RollingUpgradeRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RollingUpgradeResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SaveNamespaceRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SaveNamespaceResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetBalancerBandwidthRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetBalancerBandwidthResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetOwnerRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetOwnerResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetPermissionRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetPermissionResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetQuotaRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetQuotaResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetReplicationRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetReplicationResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetSafeModeRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetSafeModeResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetStoragePolicyRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetStoragePolicyResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetTimesRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetTimesResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.TruncateRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.TruncateResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.UnsetStoragePolicyRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.UnsetStoragePolicyResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.UpdateBlockForPipelineRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.UpdateBlockForPipelineResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.UpdatePipelineRequestProto;
-import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.UpgradeStatusRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.UpdatePipelineResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.UpgradeStatusResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SatisfyStoragePolicyRequestProto;
-import org.apache.hadoop.hdfs.protocol.proto.*;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SatisfyStoragePolicyResponseProto;
+import org.apache.hadoop.hdfs.protocol.proto.EncryptionZonesProtos;
 import org.apache.hadoop.hdfs.protocol.proto.EncryptionZonesProtos.CreateEncryptionZoneRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.EncryptionZonesProtos.EncryptionZoneProto;
 import org.apache.hadoop.hdfs.protocol.proto.EncryptionZonesProtos.GetEZForPathRequestProto;
@@ -212,24 +262,25 @@ import org.apache.hadoop.hdfs.protocol.proto.EncryptionZonesProtos.ListReencrypt
 import org.apache.hadoop.hdfs.protocol.proto.EncryptionZonesProtos.ListReencryptionStatusResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.EncryptionZonesProtos.ZoneReencryptionStatusProto;
 import org.apache.hadoop.hdfs.protocol.proto.EncryptionZonesProtos.ReencryptEncryptionZoneRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos;
 import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.AddErasureCodingPoliciesRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.AddErasureCodingPoliciesResponseProto;
-import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.GetErasureCodingPoliciesRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.GetErasureCodingPoliciesResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.GetErasureCodingPolicyRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.GetErasureCodingPolicyResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.RemoveErasureCodingPolicyRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.EnableErasureCodingPolicyRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.DisableErasureCodingPolicyRequestProto;
-import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.GetErasureCodingCodecsRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.GetErasureCodingCodecsResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.SetErasureCodingPolicyRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.UnsetErasureCodingPolicyRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.CodecProto;
+import org.apache.hadoop.hdfs.protocol.proto.HdfsProtos;
 import org.apache.hadoop.hdfs.protocol.proto.HdfsProtos.BatchedDirectoryListingProto;
 import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.GetECTopologyResultForPoliciesRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ErasureCodingProtos.GetECTopologyResultForPoliciesResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.HdfsProtos.ErasureCodingPolicyProto;
+import org.apache.hadoop.hdfs.protocol.proto.XAttrProtos;
 import org.apache.hadoop.hdfs.protocol.proto.XAttrProtos.GetXAttrsRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.XAttrProtos.ListXAttrsRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.XAttrProtos.RemoveXAttrRequestProto;
@@ -239,14 +290,11 @@ import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifie
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorageReport;
 import org.apache.hadoop.io.EnumSetWritable;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.retry.AsyncCallHandler;
 import org.apache.hadoop.ipc.Client;
-import org.apache.hadoop.ipc.ProtobufRpcEngine2;
-import org.apache.hadoop.ipc.ProtocolMetaInterface;
-import org.apache.hadoop.ipc.ProtocolTranslator;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ipc.RpcClientUtil;
+import org.apache.hadoop.security.proto.SecurityProtos;
 import org.apache.hadoop.security.proto.SecurityProtos.CancelDelegationTokenRequestProto;
 import org.apache.hadoop.security.proto.SecurityProtos.GetDelegationTokenRequestProto;
 import org.apache.hadoop.security.proto.SecurityProtos.GetDelegationTokenResponseProto;
@@ -254,14 +302,17 @@ import org.apache.hadoop.security.proto.SecurityProtos.RenewDelegationTokenReque
 import org.apache.hadoop.security.token.Token;
 
 import org.apache.hadoop.thirdparty.protobuf.ByteString;
-import org.apache.hadoop.thirdparty.protobuf.Message;
 import org.apache.hadoop.thirdparty.protobuf.ServiceException;
 
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.concurrent.AsyncGet;
+import org.apache.hadoop.hdfs.protocolPB.AsyncRpcProtocolPBUtil.Response;
 
+import static org.apache.hadoop.hdfs.protocolPB.AsyncRpcProtocolPBUtil.asyncIpc;
+import static org.apache.hadoop.hdfs.protocolPB.AsyncRpcProtocolPBUtil.asyncResponse;
 import static org.apache.hadoop.ipc.internal.ShadedProtobufHelper.getRemoteException;
 import static org.apache.hadoop.ipc.internal.ShadedProtobufHelper.ipc;
+
 
 /**
  * This class forwards NN's ClientProtocol calls as RPC calls to the NN server
@@ -270,93 +321,67 @@ import static org.apache.hadoop.ipc.internal.ShadedProtobufHelper.ipc;
  */
 @InterfaceAudience.Private
 @InterfaceStability.Stable
-public class ClientNamenodeProtocolTranslatorPB implements
-    ProtocolMetaInterface, ClientProtocol, Closeable, ProtocolTranslator {
-  final protected ClientNamenodeProtocolPB rpcProxy;
+public class RouterClientProtocolTranslatorPB extends ClientNamenodeProtocolTranslatorPB {
 
-  protected static final GetServerDefaultsRequestProto VOID_GET_SERVER_DEFAULT_REQUEST =
-      GetServerDefaultsRequestProto.newBuilder().build();
-
-  protected final static GetFsStatusRequestProto VOID_GET_FSSTATUS_REQUEST =
-      GetFsStatusRequestProto.newBuilder().build();
-
-  protected final static GetFsReplicatedBlockStatsRequestProto
-      VOID_GET_FS_REPLICATED_BLOCK_STATS_REQUEST =
-      GetFsReplicatedBlockStatsRequestProto.newBuilder().build();
-
-  protected final static GetFsECBlockGroupStatsRequestProto
-      VOID_GET_FS_ECBLOCKGROUP_STATS_REQUEST =
-      GetFsECBlockGroupStatsRequestProto.newBuilder().build();
-
-  protected final static RollEditsRequestProto VOID_ROLLEDITS_REQUEST =
-      RollEditsRequestProto.getDefaultInstance();
-
-  protected final static RefreshNodesRequestProto VOID_REFRESH_NODES_REQUEST =
-      RefreshNodesRequestProto.newBuilder().build();
-
-  protected final static FinalizeUpgradeRequestProto
-      VOID_FINALIZE_UPGRADE_REQUEST =
-      FinalizeUpgradeRequestProto.newBuilder().build();
-
-  protected final static UpgradeStatusRequestProto
-      VOID_UPGRADE_STATUS_REQUEST =
-      UpgradeStatusRequestProto.newBuilder().build();
-
-  protected final static GetDataEncryptionKeyRequestProto
-      VOID_GET_DATA_ENCRYPTIONKEY_REQUEST =
-      GetDataEncryptionKeyRequestProto.newBuilder().build();
-
-  protected final static GetStoragePoliciesRequestProto
-      VOID_GET_STORAGE_POLICIES_REQUEST =
-      GetStoragePoliciesRequestProto.newBuilder().build();
-
-  protected final static GetErasureCodingPoliciesRequestProto
-      VOID_GET_EC_POLICIES_REQUEST = GetErasureCodingPoliciesRequestProto
-      .newBuilder().build();
-
-  protected final static GetErasureCodingCodecsRequestProto
-      VOID_GET_EC_CODEC_REQUEST = GetErasureCodingCodecsRequestProto
-      .newBuilder().build();
-
-
-  public ClientNamenodeProtocolTranslatorPB(ClientNamenodeProtocolPB proxy) {
-    rpcProxy = proxy;
+  public RouterClientProtocolTranslatorPB(ClientNamenodeProtocolPB proxy) {
+    super(proxy);
   }
 
   @Override
   public void close() {
-    RPC.stopProxy(rpcProxy);
+    super.close();
   }
 
   @Override
   public LocatedBlocks getBlockLocations(String src, long offset, long length)
       throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.getBlockLocations(src, offset, length);
+    }
     GetBlockLocationsRequestProto req = GetBlockLocationsRequestProto
         .newBuilder()
         .setSrc(src)
         .setOffset(offset)
         .setLength(length)
         .build();
-    GetBlockLocationsResponseProto resp = ipc(() -> rpcProxy.getBlockLocations(null,
-        req));
-    return resp.hasLocations() ?
-        PBHelperClient.convert(resp.getLocations()) : null;
+
+    AsyncGet<GetBlockLocationsResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getBlockLocations(null, req));
+    asyncResponse(() -> {
+      GetBlockLocationsResponseProto resp = asyncGet.get(-1, null);
+      return resp.hasLocations() ?
+            PBHelperClient.convert(resp.getLocations()) : null;
+    });
+    return null;
   }
 
   @Override
   public FsServerDefaults getServerDefaults() throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.getServerDefaults();
+    }
     GetServerDefaultsRequestProto req = VOID_GET_SERVER_DEFAULT_REQUEST;
-    return PBHelperClient
-        .convert(ipc(() -> rpcProxy.getServerDefaults(null, req).getServerDefaults()));
+
+    AsyncGet<GetServerDefaultsResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getServerDefaults(null, req));
+    asyncResponse(() ->
+          PBHelperClient.convert(asyncGet.get(-1, null).getServerDefaults()));
+    return null;
   }
 
   @Override
-  public HdfsFileStatus create(String src, FsPermission masked,
+  public HdfsFileStatus create(
+      String src, FsPermission masked,
       String clientName, EnumSetWritable<CreateFlag> flag,
       boolean createParent, short replication, long blockSize,
       CryptoProtocolVersion[] supportedVersions, String ecPolicyName,
-      String storagePolicy)
-      throws IOException {
+      String storagePolicy) throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.create(
+          src, masked, clientName, flag, createParent, replication,
+          blockSize, supportedVersions, ecPolicyName, storagePolicy);
+    }
+
     CreateRequestProto.Builder builder = CreateRequestProto.newBuilder()
         .setSrc(src)
         .setMasked(PBHelperClient.convert(masked))
@@ -378,117 +403,152 @@ public class ClientNamenodeProtocolTranslatorPB implements
     builder.addAllCryptoProtocolVersion(
         PBHelperClient.convert(supportedVersions));
     CreateRequestProto req = builder.build();
-    CreateResponseProto res = ipc(() -> rpcProxy.create(null, req));
-    return res.hasFs() ? PBHelperClient.convert(res.getFs()) : null;
+
+    AsyncGet<CreateResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.create(null, req));
+    asyncResponse(() -> {
+      CreateResponseProto res = asyncGet.get(-1, null);
+      return res.hasFs() ? PBHelperClient.convert(res.getFs()) : null;
+    });
+    return null;
   }
 
   @Override
   public boolean truncate(String src, long newLength, String clientName)
       throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.truncate(src, newLength, clientName);
+    }
+
     TruncateRequestProto req = TruncateRequestProto.newBuilder()
         .setSrc(src)
         .setNewLength(newLength)
         .setClientName(clientName)
         .build();
-    return ipc(() -> rpcProxy.truncate(null, req).getResult());
+
+    AsyncGet<TruncateResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.truncate(null, req));
+    asyncResponse(() -> asyncGet.get(-1, null).getResult());
+    return true;
   }
 
   @Override
   public LastBlockWithStatus append(String src, String clientName,
-      EnumSetWritable<CreateFlag> flag) throws IOException {
+                                    EnumSetWritable<CreateFlag> flag) throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.append(src, clientName, flag);
+    }
+
     AppendRequestProto req = AppendRequestProto.newBuilder().setSrc(src)
         .setClientName(clientName).setFlag(
             PBHelperClient.convertCreateFlag(flag))
         .build();
-    AppendResponseProto res = ipc(() -> rpcProxy.append(null, req));
-    LocatedBlock lastBlock = res.hasBlock() ? PBHelperClient
-        .convertLocatedBlockProto(res.getBlock()) : null;
-    HdfsFileStatus stat = (res.hasStat()) ?
-        PBHelperClient.convert(res.getStat()) : null;
-    return new LastBlockWithStatus(lastBlock, stat);
+
+    AsyncGet<AppendResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.append(null, req));
+    asyncResponse(() -> {
+      AppendResponseProto res = asyncGet.get(-1, null);
+      LocatedBlock lastBlock = res.hasBlock() ? PBHelperClient
+          .convertLocatedBlockProto(res.getBlock()) : null;
+      HdfsFileStatus stat = (res.hasStat()) ?
+          PBHelperClient.convert(res.getStat()) : null;
+      return new LastBlockWithStatus(lastBlock, stat);
+    });
+    return null;
   }
 
   @Override
   public boolean setReplication(String src, short replication)
       throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.setReplication(src, replication);
+    }
+
     SetReplicationRequestProto req = SetReplicationRequestProto.newBuilder()
         .setSrc(src)
         .setReplication(replication)
         .build();
-    return ipc(() -> rpcProxy.setReplication(null, req)).getResult();
+
+    AsyncGet<SetReplicationResponseProto, Exception> asyncGet
+        = asyncIpc(() -> rpcProxy.setReplication(null, req));
+    asyncResponse(() -> asyncGet.get(-1, null).getResult());
+    return true;
   }
 
   @Override
   public void setPermission(String src, FsPermission permission)
       throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      super.setPermission(src, permission);
+      return;
+    }
+
     SetPermissionRequestProto req = SetPermissionRequestProto.newBuilder()
         .setSrc(src)
         .setPermission(PBHelperClient.convert(permission))
         .build();
-    if (Client.isAsynchronousMode()) {
-      ipc(() -> rpcProxy.setPermission(null, req));
-      setAsyncReturnValue();
-    } else {
-      ipc(() -> rpcProxy.setPermission(null, req));
-    }
-  }
 
-  private void setAsyncReturnValue() {
-    final AsyncGet<Message, Exception> asyncReturnMessage
-        = ProtobufRpcEngine2.getAsyncReturnMessage();
-    final AsyncGet<Void, Exception> asyncGet
-        = new AsyncGet<Void, Exception>() {
-      @Override
-      public Void get(long timeout, TimeUnit unit) throws Exception {
-        asyncReturnMessage.get(timeout, unit);
-        return null;
-      }
-
-      @Override
-      public boolean isDone() {
-        return asyncReturnMessage.isDone();
-      }
-    };
-    AsyncCallHandler.setLowerLayerAsyncReturn(asyncGet);
+    AsyncGet<SetPermissionResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.setPermission(null, req));
+    asyncResponse(() -> {
+      asyncGet.get(-1, null);
+      return null;
+    });
   }
 
   @Override
   public void setOwner(String src, String username, String groupname)
       throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      super.setOwner(src, username, groupname);
+    }
+
     SetOwnerRequestProto.Builder req = SetOwnerRequestProto.newBuilder()
         .setSrc(src);
-    if (username != null)
+    if (username != null) {
       req.setUsername(username);
-    if (groupname != null)
-      req.setGroupname(groupname);
-    if (Client.isAsynchronousMode()) {
-      ipc(() -> rpcProxy.setOwner(null, req.build()));
-      setAsyncReturnValue();
-    } else {
-      ipc(() -> rpcProxy.setOwner(null, req.build()));
     }
+    if (groupname != null) {
+      req.setGroupname(groupname);
+    }
+
+    AsyncGet<SetOwnerResponseProto, Exception> asyncGet
+        = asyncIpc(() -> rpcProxy.setOwner(null, req.build()));
+    asyncResponse(() -> asyncGet.get(-1, null));
   }
 
   @Override
   public void abandonBlock(ExtendedBlock b, long fileId, String src,
-      String holder) throws IOException {
+                           String holder) throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      super.abandonBlock(b, fileId, src, holder);
+    }
     AbandonBlockRequestProto req = AbandonBlockRequestProto.newBuilder()
         .setB(PBHelperClient.convert(b)).setSrc(src).setHolder(holder)
         .setFileId(fileId).build();
-    ipc(() -> rpcProxy.abandonBlock(null, req));
+    AsyncGet<AbandonBlockResponseProto, Exception> asyncGet
+        = asyncIpc(() -> rpcProxy.abandonBlock(null, req));
+    asyncResponse(() -> asyncGet.get(-1, null));
   }
 
   @Override
-  public LocatedBlock addBlock(String src, String clientName,
+  public LocatedBlock addBlock(
+      String src, String clientName,
       ExtendedBlock previous, DatanodeInfo[] excludeNodes, long fileId,
       String[] favoredNodes, EnumSet<AddBlockFlag> addBlockFlags)
       throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.addBlock(src, clientName, previous, excludeNodes,
+          fileId, favoredNodes, addBlockFlags);
+    }
     AddBlockRequestProto.Builder req = AddBlockRequestProto.newBuilder()
         .setSrc(src).setClientName(clientName).setFileId(fileId);
-    if (previous != null)
+    if (previous != null) {
       req.setPrevious(PBHelperClient.convert(previous));
-    if (excludeNodes != null)
+    }
+    if (excludeNodes != null) {
       req.addAllExcludeNodes(PBHelperClient.convert(excludeNodes));
+    }
     if (favoredNodes != null) {
       req.addAllFavoredNodes(Arrays.asList(favoredNodes));
     }
@@ -496,15 +556,23 @@ public class ClientNamenodeProtocolTranslatorPB implements
       req.addAllFlags(PBHelperClient.convertAddBlockFlags(
           addBlockFlags));
     }
-    return PBHelperClient.convertLocatedBlockProto(
-        ipc(() -> rpcProxy.addBlock(null, req.build())).getBlock());
+    AsyncGet<AddBlockResponseProto, Exception> asyncGet
+        = asyncIpc(() -> rpcProxy.addBlock(null, req.build()));
+    asyncResponse(() -> PBHelperClient.convertLocatedBlockProto(
+              asyncGet.get(-1, null).getBlock()));
+    return null;
   }
 
   @Override
-  public LocatedBlock getAdditionalDatanode(String src, long fileId,
+  public LocatedBlock getAdditionalDatanode(
+      String src, long fileId,
       ExtendedBlock blk, DatanodeInfo[] existings, String[] existingStorageIDs,
       DatanodeInfo[] excludes, int numAdditionalNodes, String clientName)
       throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.getAdditionalDatanode(src, fileId, blk, existings,
+          existingStorageIDs, excludes, numAdditionalNodes, clientName);
+    }
     GetAdditionalDatanodeRequestProto req = GetAdditionalDatanodeRequestProto
         .newBuilder()
         .setSrc(src)
@@ -516,44 +584,74 @@ public class ClientNamenodeProtocolTranslatorPB implements
         .setNumAdditionalNodes(numAdditionalNodes)
         .setClientName(clientName)
         .build();
-    return PBHelperClient.convertLocatedBlockProto(
-        ipc(() -> rpcProxy.getAdditionalDatanode(null, req)).getBlock());
+
+    AsyncGet<GetAdditionalDatanodeResponseProto, Exception> asyncGet
+        = asyncIpc(() -> rpcProxy.getAdditionalDatanode(null, req));
+    asyncResponse(() -> PBHelperClient.convertLocatedBlockProto(
+              asyncGet.get(-1, null).getBlock()));
+    return null;
   }
 
   @Override
   public boolean complete(String src, String clientName,
-      ExtendedBlock last, long fileId) throws IOException {
+                          ExtendedBlock last, long fileId) throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.complete(src, clientName, last, fileId);
+    }
     CompleteRequestProto.Builder req = CompleteRequestProto.newBuilder()
         .setSrc(src)
         .setClientName(clientName)
         .setFileId(fileId);
-    if (last != null)
+    if (last != null) {
       req.setLast(PBHelperClient.convert(last));
-    return ipc(() -> rpcProxy.complete(null, req.build())).getResult();
+    }
+
+    AsyncGet<CompleteResponseProto, Exception> asyncGet
+        = asyncIpc(() -> rpcProxy.complete(null, req.build()));
+    asyncResponse(() -> asyncGet.get(-1, null).getResult());
+    return true;
   }
 
   @Override
   public void reportBadBlocks(LocatedBlock[] blocks) throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      super.reportBadBlocks(blocks);
+      return;
+    }
     ReportBadBlocksRequestProto req = ReportBadBlocksRequestProto.newBuilder()
         .addAllBlocks(Arrays.asList(
             PBHelperClient.convertLocatedBlocks(blocks)))
         .build();
-    ipc(() -> rpcProxy.reportBadBlocks(null, req));
+
+    AsyncGet<ReportBadBlocksResponseProto, Exception> asyncGet
+        = asyncIpc(() -> rpcProxy.reportBadBlocks(null, req));
+    asyncResponse(() -> asyncGet.get(-1, null));
   }
 
   @Override
   public boolean rename(String src, String dst) throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.rename(src, dst);
+    }
     RenameRequestProto req = RenameRequestProto.newBuilder()
         .setSrc(src)
         .setDst(dst).build();
 
-    return ipc(() -> rpcProxy.rename(null, req)).getResult();
+    AsyncGet<RenameResponseProto, Exception> asyncGet
+        = asyncIpc(() -> rpcProxy.rename(null, req));
+    asyncResponse(() ->
+        asyncGet.get(-1, null).getResult());
+    return true;
   }
 
 
   @Override
   public void rename2(String src, String dst, Rename... options)
       throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      super.rename2(src, dst, options);
+      return;
+    }
     boolean overwrite = false;
     boolean toTrash = false;
     if (options != null) {
@@ -572,12 +670,10 @@ public class ClientNamenodeProtocolTranslatorPB implements
         setOverwriteDest(overwrite).
         setMoveToTrash(toTrash).
         build();
-    if (Client.isAsynchronousMode()) {
-      ipc(() -> rpcProxy.rename2(null, req));
-      setAsyncReturnValue();
-    } else {
-      ipc(() -> rpcProxy.rename2(null, req));
-    }
+
+    AsyncGet<Rename2ResponseProto, Exception> asyncGet
+        = asyncIpc(() -> rpcProxy.rename2(null, req));
+    asyncResponse(() -> asyncGet.get(-1, null));
   }
 
   @Override
@@ -585,7 +681,14 @@ public class ClientNamenodeProtocolTranslatorPB implements
     ConcatRequestProto req = ConcatRequestProto.newBuilder().
         setTrg(trg).
         addAllSrcs(Arrays.asList(srcs)).build();
-    ipc(() -> rpcProxy.concat(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<ConcatResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.concat(null, req));
+      asyncResponse(() -> asyncGet.get(-1, null));
+    } else {
+      ipc(() -> rpcProxy.concat(null, req));
+    }
   }
 
 
@@ -593,6 +696,14 @@ public class ClientNamenodeProtocolTranslatorPB implements
   public boolean delete(String src, boolean recursive) throws IOException {
     DeleteRequestProto req = DeleteRequestProto.newBuilder().setSrc(src)
         .setRecursive(recursive).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<DeleteResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.delete(null, req));
+      asyncResponse(() ->
+          asyncGet.get(-1, null).getResult());
+      return true;
+    }
     return ipc(() -> rpcProxy.delete(null, req).getResult());
   }
 
@@ -608,16 +719,37 @@ public class ClientNamenodeProtocolTranslatorPB implements
       builder.setUnmasked(PBHelperClient.convert(unmasked));
     }
     MkdirsRequestProto req = builder.build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<MkdirsResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.mkdirs(null, req));
+      asyncResponse(() ->
+          asyncGet.get(-1, null).getResult());
+      return true;
+    }
     return ipc(() -> rpcProxy.mkdirs(null, req)).getResult();
   }
 
   @Override
   public DirectoryListing getListing(String src, byte[] startAfter,
-      boolean needLocation) throws IOException {
+                                     boolean needLocation) throws IOException {
     GetListingRequestProto req = GetListingRequestProto.newBuilder()
         .setSrc(src)
         .setStartAfter(ByteString.copyFrom(startAfter))
         .setNeedLocation(needLocation).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetListingResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getListing(null, req));
+      asyncResponse(() -> {
+        GetListingResponseProto result = asyncGet.get(-1, null);
+        if (result.hasDirList()) {
+          return PBHelperClient.convert(result.getDirList());
+        }
+        return null;
+      });
+      return null;
+    }
     GetListingResponseProto result = ipc(() -> rpcProxy.getListing(null, req));
     if (result.hasDirList()) {
       return PBHelperClient.convert(result.getDirList());
@@ -634,6 +766,41 @@ public class ClientNamenodeProtocolTranslatorPB implements
         .addAllPaths(Arrays.asList(srcs))
         .setStartAfter(ByteString.copyFrom(startAfter))
         .setNeedLocation(needLocation).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetBatchedListingResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getBatchedListing(null, req));
+      asyncResponse(() -> {
+        GetBatchedListingResponseProto result = asyncGet.get(-1, null);
+
+        if (result.getListingsCount() > 0) {
+          HdfsPartialListing[] listingArray =
+              new HdfsPartialListing[result.getListingsCount()];
+          int listingIdx = 0;
+          for (BatchedDirectoryListingProto proto : result.getListingsList()) {
+            HdfsPartialListing listing;
+            if (proto.hasException()) {
+              HdfsProtos.RemoteExceptionProto reProto = proto.getException();
+              RemoteException ex = new RemoteException(
+                  reProto.getClassName(), reProto.getMessage());
+              listing = new HdfsPartialListing(proto.getParentIdx(), ex);
+            } else {
+              List<HdfsFileStatus> statuses =
+                  PBHelperClient.convertHdfsFileStatus(
+                      proto.getPartialListingList());
+              listing = new HdfsPartialListing(proto.getParentIdx(), statuses);
+            }
+            listingArray[listingIdx++] = listing;
+          }
+          BatchedDirectoryListing batchedListing =
+              new BatchedDirectoryListing(listingArray, result.getHasMore(),
+                  result.getStartAfter().toByteArray());
+          return batchedListing;
+        }
+        return null;
+      });
+      return null;
+    }
     GetBatchedListingResponseProto result =
         ipc(() -> rpcProxy.getBatchedListing(null, req));
 
@@ -673,7 +840,14 @@ public class ClientNamenodeProtocolTranslatorPB implements
     if (namespaces != null && !namespaces.isEmpty()) {
       builder.addAllNamespaces(namespaces);
     }
-    ipc(() -> rpcProxy.renewLease(null, builder.build()));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<RenewLeaseResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.renewLease(null, builder.build()));
+      asyncResponse(() -> asyncGet.get(-1, null));
+    } else {
+      ipc(() -> rpcProxy.renewLease(null, builder.build()));
+    }
   }
 
   @Override
@@ -682,23 +856,52 @@ public class ClientNamenodeProtocolTranslatorPB implements
     RecoverLeaseRequestProto req = RecoverLeaseRequestProto.newBuilder()
         .setSrc(src)
         .setClientName(clientName).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<RecoverLeaseResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.recoverLease(null, req));
+      asyncResponse(() -> asyncGet.get(-1, null).getResult());
+      return true;
+    }
     return ipc(() -> rpcProxy.recoverLease(null, req)).getResult();
   }
 
   @Override
   public long[] getStats() throws IOException {
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetFsStatsResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getFsStats(null, VOID_GET_FSSTATUS_REQUEST));
+      asyncResponse(() -> PBHelperClient.convert(asyncGet.get(-1, null)));
+      return null;
+    }
     return PBHelperClient.convert(ipc(() -> rpcProxy.getFsStats(null,
         VOID_GET_FSSTATUS_REQUEST)));
   }
 
   @Override
   public ReplicatedBlockStats getReplicatedBlockStats() throws IOException {
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetFsReplicatedBlockStatsResponseProto, Exception> asyncGet =
+          asyncIpc(() -> rpcProxy.getFsReplicatedBlockStats(null,
+              VOID_GET_FS_REPLICATED_BLOCK_STATS_REQUEST));
+      asyncResponse(() -> PBHelperClient.convert(
+          asyncGet.get(-1, null)));
+      return null;
+    }
     return PBHelperClient.convert(ipc(() -> rpcProxy.getFsReplicatedBlockStats(null,
         VOID_GET_FS_REPLICATED_BLOCK_STATS_REQUEST)));
   }
 
   @Override
   public ECBlockGroupStats getECBlockGroupStats() throws IOException {
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetFsECBlockGroupStatsResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getFsECBlockGroupStats(null,
+          VOID_GET_FS_ECBLOCKGROUP_STATS_REQUEST));
+      asyncResponse(() -> PBHelperClient.convert(
+          asyncGet.get(-1, null)));
+      return null;
+    }
     return PBHelperClient.convert(ipc(() -> rpcProxy.getFsECBlockGroupStats(null,
         VOID_GET_FS_ECBLOCKGROUP_STATS_REQUEST)));
   }
@@ -709,6 +912,14 @@ public class ClientNamenodeProtocolTranslatorPB implements
     GetDatanodeReportRequestProto req = GetDatanodeReportRequestProto
         .newBuilder()
         .setType(PBHelperClient.convert(type)).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetDatanodeReportResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getDatanodeReport(null, req));
+      asyncResponse(() ->
+          PBHelperClient.convert(asyncGet.get(-1, null).getDiList()));
+      return null;
+    }
     return PBHelperClient.convert(
         ipc(() -> rpcProxy.getDatanodeReport(null, req)).getDiList());
   }
@@ -719,6 +930,15 @@ public class ClientNamenodeProtocolTranslatorPB implements
     final GetDatanodeStorageReportRequestProto req
         = GetDatanodeStorageReportRequestProto.newBuilder()
         .setType(PBHelperClient.convert(type)).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetDatanodeStorageReportResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getDatanodeStorageReport(null, req));
+      asyncResponse(() ->
+          PBHelperClient.convertDatanodeStorageReports(
+              asyncGet.get(-1, null).getDatanodeStorageReportsList()));
+      return null;
+    }
     return PBHelperClient.convertDatanodeStorageReports(
         ipc(() -> rpcProxy.getDatanodeStorageReport(null, req)
             .getDatanodeStorageReportsList()));
@@ -730,6 +950,13 @@ public class ClientNamenodeProtocolTranslatorPB implements
         .newBuilder()
         .setFilename(filename)
         .build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetPreferredBlockSizeResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getPreferredBlockSize(null, req));
+      asyncResponse(() -> asyncGet.get(-1, null).getBsize());
+      return -1;
+    }
     return ipc(() -> rpcProxy.getPreferredBlockSize(null, req)).getBsize();
   }
 
@@ -739,6 +966,13 @@ public class ClientNamenodeProtocolTranslatorPB implements
     SetSafeModeRequestProto req = SetSafeModeRequestProto.newBuilder()
         .setAction(PBHelperClient.convert(action))
         .setChecked(isChecked).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<SetSafeModeResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.setSafeMode(null, req));
+      asyncResponse(() -> asyncGet.get(-1, null).getResult());
+      return true;
+    }
     return ipc(() -> rpcProxy.setSafeMode(null, req)).getResult();
   }
 
@@ -746,11 +980,24 @@ public class ClientNamenodeProtocolTranslatorPB implements
   public boolean saveNamespace(long timeWindow, long txGap) throws IOException {
     SaveNamespaceRequestProto req = SaveNamespaceRequestProto.newBuilder()
         .setTimeWindow(timeWindow).setTxGap(txGap).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<SaveNamespaceResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.saveNamespace(null, req));
+      asyncResponse(() -> asyncGet.get(-1, null).getSaved());
+      return true;
+    }
     return ipc(() -> rpcProxy.saveNamespace(null, req)).getSaved();
   }
 
   @Override
   public long rollEdits() throws IOException {
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<RollEditsResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.rollEdits(null, VOID_ROLLEDITS_REQUEST));
+      asyncResponse(() -> asyncGet.get(-1, null).getNewSegmentTxId());
+      return -1;
+    }
     RollEditsResponseProto resp = ipc(() -> rpcProxy.rollEdits(null,
         VOID_ROLLEDITS_REQUEST));
     return resp.getNewSegmentTxId();
@@ -761,21 +1008,46 @@ public class ClientNamenodeProtocolTranslatorPB implements
     RestoreFailedStorageRequestProto req = RestoreFailedStorageRequestProto
         .newBuilder()
         .setArg(arg).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<RestoreFailedStorageResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.restoreFailedStorage(null, req));
+      asyncResponse(() -> asyncGet.get(-1, null).getResult());
+      return true;
+    }
     return ipc(() -> rpcProxy.restoreFailedStorage(null, req)).getResult();
   }
 
   @Override
   public void refreshNodes() throws IOException {
-    ipc(() -> rpcProxy.refreshNodes(null, VOID_REFRESH_NODES_REQUEST));
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<RefreshNodesResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.refreshNodes(null, VOID_REFRESH_NODES_REQUEST));
+      asyncResponse(() -> asyncGet.get(-1, null));
+    } else {
+      ipc(() -> rpcProxy.refreshNodes(null, VOID_REFRESH_NODES_REQUEST));
+    }
   }
 
   @Override
   public void finalizeUpgrade() throws IOException {
-    ipc(() -> rpcProxy.finalizeUpgrade(null, VOID_FINALIZE_UPGRADE_REQUEST));
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<FinalizeUpgradeResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.finalizeUpgrade(null, VOID_FINALIZE_UPGRADE_REQUEST));
+      asyncResponse(() -> asyncGet.get(-1, null));
+    } else {
+      ipc(() -> rpcProxy.finalizeUpgrade(null, VOID_FINALIZE_UPGRADE_REQUEST));
+    }
   }
 
   @Override
   public boolean upgradeStatus() throws IOException {
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<UpgradeStatusResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.upgradeStatus(null, VOID_UPGRADE_STATUS_REQUEST));
+      asyncResponse(() -> asyncGet.get(-1, null).getUpgradeFinalized());
+      return true;
+    }
     final UpgradeStatusResponseProto proto = ipc(() -> rpcProxy.upgradeStatus(
         null, VOID_UPGRADE_STATUS_REQUEST));
     return proto.getUpgradeFinalized();
@@ -786,6 +1058,14 @@ public class ClientNamenodeProtocolTranslatorPB implements
       throws IOException {
     final RollingUpgradeRequestProto r = RollingUpgradeRequestProto.newBuilder()
         .setAction(PBHelperClient.convert(action)).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<RollingUpgradeResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.rollingUpgrade(null, r));
+      asyncResponse(() -> PBHelperClient.convert(
+          asyncGet.get(-1, null).getRollingUpgradeInfo()));
+      return null;
+    }
     final RollingUpgradeResponseProto proto =
         ipc(() -> rpcProxy.rollingUpgrade(null, r));
     if (proto.hasRollingUpgradeInfo()) {
@@ -799,8 +1079,16 @@ public class ClientNamenodeProtocolTranslatorPB implements
       throws IOException {
     ListCorruptFileBlocksRequestProto.Builder req =
         ListCorruptFileBlocksRequestProto.newBuilder().setPath(path);
-    if (cookie != null)
+    if (cookie != null) {
       req.setCookie(cookie);
+    }
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<ListCorruptFileBlocksResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.listCorruptFileBlocks(null, req.build()));
+      asyncResponse(() -> asyncGet.get(-1, null).getCorrupt());
+      return null;
+    }
     return PBHelperClient.convert(
         ipc(() -> rpcProxy.listCorruptFileBlocks(null, req.build())).getCorrupt());
   }
@@ -809,7 +1097,14 @@ public class ClientNamenodeProtocolTranslatorPB implements
   public void metaSave(String filename) throws IOException {
     MetaSaveRequestProto req = MetaSaveRequestProto.newBuilder()
         .setFilename(filename).build();
-    ipc(() -> rpcProxy.metaSave(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<MetaSaveResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.metaSave(null, req));
+      asyncResponse(() -> asyncGet.get(-1, null));
+    } else {
+      ipc(() -> rpcProxy.metaSave(null, req));
+    }
   }
 
   @Override
@@ -817,18 +1112,38 @@ public class ClientNamenodeProtocolTranslatorPB implements
     GetFileInfoRequestProto req = GetFileInfoRequestProto.newBuilder()
         .setSrc(src)
         .build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetFileInfoResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getFileInfo(null, req));
+      asyncResponse(() -> {
+        GetFileInfoResponseProto res = asyncGet.get(-1, null);
+        return res.hasFs() ? PBHelperClient.convert(res.getFs()) : null;
+      });
+      return null;
+    }
     GetFileInfoResponseProto res = ipc(() -> rpcProxy.getFileInfo(null, req));
     return res.hasFs() ? PBHelperClient.convert(res.getFs()) : null;
   }
 
   @Override
   public HdfsLocatedFileStatus getLocatedFileInfo(String src,
-      boolean needBlockToken) throws IOException {
+                                                  boolean needBlockToken) throws IOException {
     GetLocatedFileInfoRequestProto req =
         GetLocatedFileInfoRequestProto.newBuilder()
             .setSrc(src)
             .setNeedBlockToken(needBlockToken)
             .build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetLocatedFileInfoResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getLocatedFileInfo(null, req));
+      asyncResponse((AsyncRpcProtocolPBUtil.Response<Object>) () -> {
+        GetLocatedFileInfoResponseProto res = asyncGet.get(-1, null);
+        return res.hasFs() ? PBHelperClient.convert(res.getFs()) : null;
+      });
+      return null;
+    }
     GetLocatedFileInfoResponseProto res =
         ipc(() -> rpcProxy.getLocatedFileInfo(null, req));
     return (HdfsLocatedFileStatus) (res.hasFs()
@@ -840,6 +1155,16 @@ public class ClientNamenodeProtocolTranslatorPB implements
   public HdfsFileStatus getFileLinkInfo(String src) throws IOException {
     GetFileLinkInfoRequestProto req = GetFileLinkInfoRequestProto.newBuilder()
         .setSrc(src).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetFileLinkInfoResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getFileLinkInfo(null, req));
+      asyncResponse(() -> {
+        GetFileLinkInfoResponseProto result =  asyncGet.get(-1, null);
+        return result.hasFs() ? PBHelperClient.convert(result.getFs()) : null;
+      });
+      return null;
+    }
     GetFileLinkInfoResponseProto result = ipc(() -> rpcProxy.getFileLinkInfo(null, req));
     return result.hasFs() ? PBHelperClient.convert(result.getFs()) : null;
   }
@@ -850,13 +1175,21 @@ public class ClientNamenodeProtocolTranslatorPB implements
         .newBuilder()
         .setPath(path)
         .build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetContentSummaryResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getContentSummary(null, req));
+      asyncResponse(() -> PBHelperClient.convert(
+          asyncGet.get(-1, null).getSummary()));
+      return null;
+    }
     return PBHelperClient.convert(ipc(() -> rpcProxy.getContentSummary(null, req))
         .getSummary());
   }
 
   @Override
   public void setQuota(String path, long namespaceQuota, long storagespaceQuota,
-      StorageType type) throws IOException {
+                       StorageType type) throws IOException {
     final SetQuotaRequestProto.Builder builder
         = SetQuotaRequestProto.newBuilder()
         .setPath(path)
@@ -866,16 +1199,30 @@ public class ClientNamenodeProtocolTranslatorPB implements
       builder.setStorageType(PBHelperClient.convertStorageType(type));
     }
     final SetQuotaRequestProto req = builder.build();
-    ipc(() -> rpcProxy.setQuota(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<SetQuotaResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.setQuota(null, req));
+      asyncResponse(() -> asyncGet.get(-1, null));
+    } else {
+      ipc(() -> rpcProxy.setQuota(null, req));
+    }
   }
 
   @Override
   public void fsync(String src, long fileId, String client,
-      long lastBlockLength) throws IOException {
+                    long lastBlockLength) throws IOException {
     FsyncRequestProto req = FsyncRequestProto.newBuilder().setSrc(src)
         .setClient(client).setLastBlockLength(lastBlockLength)
         .setFileId(fileId).build();
-    ipc(() -> rpcProxy.fsync(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<FsyncResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.fsync(null, req));
+      asyncResponse(() -> asyncGet.get(-1, null));
+    } else {
+      ipc(() -> rpcProxy.fsync(null, req));
+    }
   }
 
   @Override
@@ -885,44 +1232,80 @@ public class ClientNamenodeProtocolTranslatorPB implements
         .setMtime(mtime)
         .setAtime(atime)
         .build();
-    ipc(() -> rpcProxy.setTimes(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<SetTimesResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.setTimes(null, req));
+      asyncResponse(() -> asyncGet.get(-1, null));
+    } else {
+      ipc(() -> rpcProxy.setTimes(null, req));
+    }
   }
 
   @Override
   public void createSymlink(String target, String link, FsPermission dirPerm,
-      boolean createParent) throws IOException {
+                            boolean createParent) throws IOException {
     CreateSymlinkRequestProto req = CreateSymlinkRequestProto.newBuilder()
         .setTarget(target)
         .setLink(link)
         .setDirPerm(PBHelperClient.convert(dirPerm))
         .setCreateParent(createParent)
         .build();
-    ipc(() -> rpcProxy.createSymlink(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<CreateSymlinkResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.createSymlink(null, req));
+      asyncResponse(() -> asyncGet.get(-1, null));
+    } else {
+      ipc(() -> rpcProxy.createSymlink(null, req));
+    }
   }
 
   @Override
   public String getLinkTarget(String path) throws IOException {
     GetLinkTargetRequestProto req = GetLinkTargetRequestProto.newBuilder()
         .setPath(path).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetLinkTargetResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getLinkTarget(null, req));
+      asyncResponse(new AsyncRpcProtocolPBUtil.Response<Object>() {
+        @Override
+        public Object response() throws Exception {
+          GetLinkTargetResponseProto rsp = asyncGet.get(-1, null);
+          return rsp.hasTargetPath() ? rsp.getTargetPath() : null;
+        }
+      });
+      return null;
+    }
     GetLinkTargetResponseProto rsp = ipc(() -> rpcProxy.getLinkTarget(null, req));
     return rsp.hasTargetPath() ? rsp.getTargetPath() : null;
   }
 
   @Override
   public LocatedBlock updateBlockForPipeline(ExtendedBlock block,
-      String clientName) throws IOException {
+                                             String clientName) throws IOException {
     UpdateBlockForPipelineRequestProto req = UpdateBlockForPipelineRequestProto
         .newBuilder()
         .setBlock(PBHelperClient.convert(block))
         .setClientName(clientName)
         .build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<UpdateBlockForPipelineResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.updateBlockForPipeline(null, req));
+      asyncResponse(
+          () -> PBHelperClient.convertLocatedBlockProto(
+              asyncGet.get(-1, null).getBlock()));
+      return null;
+    }
     return PBHelperClient.convertLocatedBlockProto(
         ipc(() -> rpcProxy.updateBlockForPipeline(null, req)).getBlock());
   }
 
   @Override
   public void updatePipeline(String clientName, ExtendedBlock oldBlock,
-      ExtendedBlock newBlock, DatanodeID[] newNodes, String[] storageIDs)
+                             ExtendedBlock newBlock, DatanodeID[] newNodes, String[] storageIDs)
       throws IOException {
     UpdatePipelineRequestProto req = UpdatePipelineRequestProto.newBuilder()
         .setClientName(clientName)
@@ -931,7 +1314,17 @@ public class ClientNamenodeProtocolTranslatorPB implements
         .addAllNewNodes(Arrays.asList(PBHelperClient.convert(newNodes)))
         .addAllStorageIDs(storageIDs == null ? null : Arrays.asList(storageIDs))
         .build();
-    ipc(() -> rpcProxy.updatePipeline(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<UpdatePipelineResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.updatePipeline(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.updatePipeline(null, req));
+    }
   }
 
   @Override
@@ -941,6 +1334,17 @@ public class ClientNamenodeProtocolTranslatorPB implements
         .newBuilder()
         .setRenewer(renewer == null ? "" : renewer.toString())
         .build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetDelegationTokenResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getDelegationToken(null, req));
+      asyncResponse(() -> {
+        GetDelegationTokenResponseProto resp = asyncGet.get(-1, null);
+        return resp.hasToken() ?
+            PBHelperClient.convertDelegationToken(resp.getToken()) : null;
+      });
+      return null;
+    }
     GetDelegationTokenResponseProto resp =
         ipc(() -> rpcProxy.getDelegationToken(null, req));
     return resp.hasToken() ?
@@ -954,6 +1358,14 @@ public class ClientNamenodeProtocolTranslatorPB implements
         RenewDelegationTokenRequestProto.newBuilder().
             setToken(PBHelperClient.convert(token)).
             build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<SecurityProtos.RenewDelegationTokenResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.renewDelegationToken(null, req));
+      asyncResponse(() ->
+          asyncGet.get(-1, null).getNewExpiryTime());
+      return -1;
+    }
     return ipc(() -> rpcProxy.renewDelegationToken(null, req)).getNewExpiryTime();
   }
 
@@ -964,7 +1376,17 @@ public class ClientNamenodeProtocolTranslatorPB implements
         .newBuilder()
         .setToken(PBHelperClient.convert(token))
         .build();
-    ipc(() -> rpcProxy.cancelDelegationToken(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<SecurityProtos.CancelDelegationTokenResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.cancelDelegationToken(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.cancelDelegationToken(null, req));
+    }
   }
 
   @Override
@@ -973,7 +1395,20 @@ public class ClientNamenodeProtocolTranslatorPB implements
         SetBalancerBandwidthRequestProto.newBuilder()
             .setBandwidth(bandwidth)
             .build();
-    ipc(() -> rpcProxy.setBalancerBandwidth(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<SetBalancerBandwidthResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.setBalancerBandwidth(null, req));
+      asyncResponse(new Response<Object>() {
+        @Override
+        public Object response() throws Exception {
+          asyncGet.get(-1, null);
+          return null;
+        }
+      });
+    } else {
+      ipc(() -> rpcProxy.setBalancerBandwidth(null, req));
+    }
   }
 
   @Override
@@ -985,6 +1420,17 @@ public class ClientNamenodeProtocolTranslatorPB implements
 
   @Override
   public DataEncryptionKey getDataEncryptionKey() throws IOException {
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetDataEncryptionKeyResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getDataEncryptionKey(null,
+          VOID_GET_DATA_ENCRYPTIONKEY_REQUEST));
+      asyncResponse(() -> {
+        GetDataEncryptionKeyResponseProto rsp = asyncGet.get(-1, null);
+        return rsp.hasDataEncryptionKey() ?
+            PBHelperClient.convert(rsp.getDataEncryptionKey()) : null;
+      });
+      return null;
+    }
     GetDataEncryptionKeyResponseProto rsp = ipc(() -> rpcProxy.getDataEncryptionKey(
         null, VOID_GET_DATA_ENCRYPTIONKEY_REQUEST));
     return rsp.hasDataEncryptionKey() ?
@@ -996,6 +1442,13 @@ public class ClientNamenodeProtocolTranslatorPB implements
   public boolean isFileClosed(String src) throws IOException {
     IsFileClosedRequestProto req = IsFileClosedRequestProto.newBuilder()
         .setSrc(src).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<IsFileClosedResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.isFileClosed(null, req));
+      asyncResponse(() -> asyncGet.get(-1, null).getResult());
+      return true;
+    }
     return ipc(() -> rpcProxy.isFileClosed(null, req)).getResult();
   }
 
@@ -1013,6 +1466,14 @@ public class ClientNamenodeProtocolTranslatorPB implements
       builder.setSnapshotName(snapshotName);
     }
     final CreateSnapshotRequestProto req = builder.build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<CreateSnapshotResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.createSnapshot(null, req));
+      asyncResponse(() ->
+          asyncGet.get(-1, null).getSnapshotPath());
+      return null;
+    }
     return ipc(() -> rpcProxy.createSnapshot(null, req)).getSnapshotPath();
   }
 
@@ -1021,30 +1482,70 @@ public class ClientNamenodeProtocolTranslatorPB implements
       throws IOException {
     DeleteSnapshotRequestProto req = DeleteSnapshotRequestProto.newBuilder()
         .setSnapshotRoot(snapshotRoot).setSnapshotName(snapshotName).build();
-    ipc(() -> rpcProxy.deleteSnapshot(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<DeleteSnapshotResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.deleteSnapshot(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.deleteSnapshot(null, req));
+    }
   }
 
   @Override
   public void allowSnapshot(String snapshotRoot) throws IOException {
     AllowSnapshotRequestProto req = AllowSnapshotRequestProto.newBuilder()
         .setSnapshotRoot(snapshotRoot).build();
-    ipc(() -> rpcProxy.allowSnapshot(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<AllowSnapshotResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.allowSnapshot(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.allowSnapshot(null, req));
+    }
   }
 
   @Override
   public void disallowSnapshot(String snapshotRoot) throws IOException {
     DisallowSnapshotRequestProto req = DisallowSnapshotRequestProto
         .newBuilder().setSnapshotRoot(snapshotRoot).build();
-    ipc(() -> rpcProxy.disallowSnapshot(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<DisallowSnapshotResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.disallowSnapshot(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.disallowSnapshot(null, req));
+    }
   }
 
   @Override
   public void renameSnapshot(String snapshotRoot, String snapshotOldName,
-      String snapshotNewName) throws IOException {
+                             String snapshotNewName) throws IOException {
     RenameSnapshotRequestProto req = RenameSnapshotRequestProto.newBuilder()
         .setSnapshotRoot(snapshotRoot).setSnapshotOldName(snapshotOldName)
         .setSnapshotNewName(snapshotNewName).build();
-    ipc(() -> rpcProxy.renameSnapshot(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<RenameSnapshotResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.renameSnapshot(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.renameSnapshot(null, req));
+    }
   }
 
   @Override
@@ -1052,6 +1553,19 @@ public class ClientNamenodeProtocolTranslatorPB implements
       throws IOException {
     GetSnapshottableDirListingRequestProto req =
         GetSnapshottableDirListingRequestProto.newBuilder().build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetSnapshottableDirListingResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getSnapshottableDirListing(null, req));
+      asyncResponse(() -> {
+        GetSnapshottableDirListingResponseProto result = asyncGet.get(-1, null);
+        if (result.hasSnapshottableDirList()) {
+          return PBHelperClient.convert(result.getSnapshottableDirList());
+        }
+        return null;
+      });
+      return null;
+    }
     GetSnapshottableDirListingResponseProto result = ipc(() -> rpcProxy
         .getSnapshottableDirListing(null, req));
 
@@ -1067,6 +1581,19 @@ public class ClientNamenodeProtocolTranslatorPB implements
     GetSnapshotListingRequestProto req =
         GetSnapshotListingRequestProto.newBuilder()
             .setSnapshotRoot(path).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetSnapshotListingResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getSnapshotListing(null, req));
+      asyncResponse(() -> {
+        GetSnapshotListingResponseProto result = asyncGet.get(-1, null);
+        if (result.hasSnapshotList()) {
+          return PBHelperClient.convert(result.getSnapshotList());
+        }
+        return null;
+      });
+      return null;
+    }
     GetSnapshotListingResponseProto result = ipc(() -> rpcProxy
         .getSnapshotListing(null, req));
 
@@ -1078,10 +1605,18 @@ public class ClientNamenodeProtocolTranslatorPB implements
 
   @Override
   public SnapshotDiffReport getSnapshotDiffReport(String snapshotRoot,
-      String fromSnapshot, String toSnapshot) throws IOException {
+                                                  String fromSnapshot, String toSnapshot) throws IOException {
     GetSnapshotDiffReportRequestProto req = GetSnapshotDiffReportRequestProto
         .newBuilder().setSnapshotRoot(snapshotRoot)
         .setFromSnapshot(fromSnapshot).setToSnapshot(toSnapshot).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetSnapshotDiffReportResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getSnapshotDiffReport(null, req));
+      asyncResponse(() -> PBHelperClient.convert(asyncGet.get(-1, null)
+          .getDiffReport()));
+      return null;
+    }
     GetSnapshotDiffReportResponseProto result =
         ipc(() -> rpcProxy.getSnapshotDiffReport(null, req));
 
@@ -1096,9 +1631,21 @@ public class ClientNamenodeProtocolTranslatorPB implements
         GetSnapshotDiffReportListingRequestProto.newBuilder()
             .setSnapshotRoot(snapshotRoot).setFromSnapshot(fromSnapshot)
             .setToSnapshot(toSnapshot).setCursor(
-            HdfsProtos.SnapshotDiffReportCursorProto.newBuilder()
-                .setStartPath(PBHelperClient.getByteString(startPath))
-                .setIndex(index).build()).build();
+                HdfsProtos.SnapshotDiffReportCursorProto.newBuilder()
+                    .setStartPath(PBHelperClient.getByteString(startPath))
+                    .setIndex(index).build()).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetSnapshotDiffReportListingResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getSnapshotDiffReportListing(null, req));
+      asyncResponse(new Response<Object>() {
+        @Override
+        public Object response() throws Exception {
+          return PBHelperClient.convert(asyncGet.get(-1, null).getDiffReport());
+        }
+      });
+      return null;
+    }
     GetSnapshotDiffReportListingResponseProto result =
         ipc(() -> rpcProxy.getSnapshotDiffReportListing(null, req));
 
@@ -1107,34 +1654,61 @@ public class ClientNamenodeProtocolTranslatorPB implements
 
   @Override
   public long addCacheDirective(CacheDirectiveInfo directive,
-      EnumSet<CacheFlag> flags) throws IOException {
+                                EnumSet<CacheFlag> flags) throws IOException {
     AddCacheDirectiveRequestProto.Builder builder =
         AddCacheDirectiveRequestProto.newBuilder().
             setInfo(PBHelperClient.convert(directive));
     if (!flags.isEmpty()) {
       builder.setCacheFlags(PBHelperClient.convertCacheFlags(flags));
     }
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<AddCacheDirectiveResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.addCacheDirective(null, builder.build()));
+      asyncResponse(() -> asyncGet.get(-1, null).getId());
+      return -1;
+    }
     return ipc(() -> rpcProxy.addCacheDirective(null, builder.build())).getId();
   }
 
   @Override
   public void modifyCacheDirective(CacheDirectiveInfo directive,
-      EnumSet<CacheFlag> flags) throws IOException {
+                                   EnumSet<CacheFlag> flags) throws IOException {
     ModifyCacheDirectiveRequestProto.Builder builder =
         ModifyCacheDirectiveRequestProto.newBuilder().
             setInfo(PBHelperClient.convert(directive));
     if (!flags.isEmpty()) {
       builder.setCacheFlags(PBHelperClient.convertCacheFlags(flags));
     }
-    ipc(() -> rpcProxy.modifyCacheDirective(null, builder.build()));
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<ModifyCacheDirectiveResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.modifyCacheDirective(null, builder.build()));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.modifyCacheDirective(null, builder.build()));
+    }
   }
 
   @Override
   public void removeCacheDirective(long id)
       throws IOException {
-    ipc(() -> rpcProxy.removeCacheDirective(null,
-        RemoveCacheDirectiveRequestProto.newBuilder().
-            setId(id).build()));
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<RemoveCacheDirectiveResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.removeCacheDirective(null,
+          RemoveCacheDirectiveRequestProto.newBuilder().
+              setId(id).build()));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.removeCacheDirective(null,
+          RemoveCacheDirectiveRequestProto.newBuilder().
+              setId(id).build()));
+    }
   }
 
   private static class BatchedCacheEntries
@@ -1164,11 +1738,22 @@ public class ClientNamenodeProtocolTranslatorPB implements
 
   @Override
   public BatchedEntries<CacheDirectiveEntry> listCacheDirectives(long prevId,
-      CacheDirectiveInfo filter) throws IOException {
+                                                                 CacheDirectiveInfo filter) throws IOException {
     if (filter == null) {
       filter = new CacheDirectiveInfo.Builder().build();
     }
     CacheDirectiveInfo f = filter;
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<ListCacheDirectivesResponseProto, Exception> asyncGet =
+          asyncIpc(() -> rpcProxy.listCacheDirectives(null,
+              ListCacheDirectivesRequestProto.newBuilder().
+                  setPrevId(prevId).
+                  setFilter(PBHelperClient.convert(f)).
+                  build()));
+      asyncResponse(() -> new BatchedCacheEntries(asyncGet.get(-1, null)));
+      return null;
+    }
     return new BatchedCacheEntries(
         ipc(() -> rpcProxy.listCacheDirectives(null,
             ListCacheDirectivesRequestProto.newBuilder().
@@ -1182,7 +1767,17 @@ public class ClientNamenodeProtocolTranslatorPB implements
     AddCachePoolRequestProto.Builder builder =
         AddCachePoolRequestProto.newBuilder();
     builder.setInfo(PBHelperClient.convert(info));
-    ipc(() -> rpcProxy.addCachePool(null, builder.build()));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<AddCachePoolResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.addCachePool(null, builder.build()));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.addCachePool(null, builder.build()));
+    }
   }
 
   @Override
@@ -1190,14 +1785,36 @@ public class ClientNamenodeProtocolTranslatorPB implements
     ModifyCachePoolRequestProto.Builder builder =
         ModifyCachePoolRequestProto.newBuilder();
     builder.setInfo(PBHelperClient.convert(req));
-    ipc(() -> rpcProxy.modifyCachePool(null, builder.build()));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<ModifyCachePoolResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.modifyCachePool(null, builder.build()));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.modifyCachePool(null, builder.build()));
+    }
   }
 
   @Override
   public void removeCachePool(String cachePoolName) throws IOException {
-    ipc(() -> rpcProxy.removeCachePool(null,
-        RemoveCachePoolRequestProto.newBuilder().
-            setPoolName(cachePoolName).build()));
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<RemoveCachePoolResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.removeCachePool(null,
+          RemoveCachePoolRequestProto.newBuilder().
+              setPoolName(cachePoolName).build()));
+
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.removeCachePool(null,
+          RemoveCachePoolRequestProto.newBuilder().
+              setPoolName(cachePoolName).build()));
+    }
   }
 
   private static class BatchedCachePoolEntries
@@ -1228,6 +1845,14 @@ public class ClientNamenodeProtocolTranslatorPB implements
   @Override
   public BatchedEntries<CachePoolEntry> listCachePools(String prevKey)
       throws IOException {
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<ListCachePoolsResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.listCachePools(null,
+          ListCachePoolsRequestProto.newBuilder().
+              setPrevPoolName(prevKey).build()));
+      asyncResponse((Response<Object>) () ->
+          new BatchedCachePoolEntries(asyncGet.get(-1, null)));
+    }
     return new BatchedCachePoolEntries(
         ipc(() -> rpcProxy.listCachePools(null,
             ListCachePoolsRequestProto.newBuilder().
@@ -1240,7 +1865,17 @@ public class ClientNamenodeProtocolTranslatorPB implements
     ModifyAclEntriesRequestProto req = ModifyAclEntriesRequestProto
         .newBuilder().setSrc(src)
         .addAllAclSpec(PBHelperClient.convertAclEntryProto(aclSpec)).build();
-    ipc(() -> rpcProxy.modifyAclEntries(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<AclProtos.ModifyAclEntriesResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.modifyAclEntries(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.modifyAclEntries(null, req));
+    }
   }
 
   @Override
@@ -1249,21 +1884,51 @@ public class ClientNamenodeProtocolTranslatorPB implements
     RemoveAclEntriesRequestProto req = RemoveAclEntriesRequestProto
         .newBuilder().setSrc(src)
         .addAllAclSpec(PBHelperClient.convertAclEntryProto(aclSpec)).build();
-    ipc(() -> rpcProxy.removeAclEntries(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<AclProtos.RemoveAclEntriesResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.removeAclEntries(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.removeAclEntries(null, req));
+    }
   }
 
   @Override
   public void removeDefaultAcl(String src) throws IOException {
     RemoveDefaultAclRequestProto req = RemoveDefaultAclRequestProto
         .newBuilder().setSrc(src).build();
-    ipc(() -> rpcProxy.removeDefaultAcl(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<AclProtos.RemoveDefaultAclResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.removeDefaultAcl(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.removeDefaultAcl(null, req));
+    }
   }
 
   @Override
   public void removeAcl(String src) throws IOException {
     RemoveAclRequestProto req = RemoveAclRequestProto.newBuilder()
         .setSrc(src).build();
-    ipc(() -> rpcProxy.removeAcl(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<AclProtos.RemoveAclResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.removeAcl(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.removeAcl(null, req));
+    }
   }
 
   @Override
@@ -1272,9 +1937,14 @@ public class ClientNamenodeProtocolTranslatorPB implements
         .setSrc(src)
         .addAllAclSpec(PBHelperClient.convertAclEntryProto(aclSpec))
         .build();
+
     if (Client.isAsynchronousMode()) {
-      ipc(() -> rpcProxy.setAcl(null, req));
-      setAsyncReturnValue();
+      AsyncGet<AclProtos.SetAclResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.setAcl(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
     } else {
       ipc(() -> rpcProxy.setAcl(null, req));
     }
@@ -1286,23 +1956,10 @@ public class ClientNamenodeProtocolTranslatorPB implements
         .setSrc(src).build();
     try {
       if (Client.isAsynchronousMode()) {
-        rpcProxy.getAclStatus(null, req);
-        final AsyncGet<Message, Exception> asyncReturnMessage
-            = ProtobufRpcEngine2.getAsyncReturnMessage();
-        final AsyncGet<AclStatus, Exception> asyncGet
-            = new AsyncGet<AclStatus, Exception>() {
-          @Override
-          public AclStatus get(long timeout, TimeUnit unit) throws Exception {
-            return PBHelperClient.convert((GetAclStatusResponseProto)
-                asyncReturnMessage.get(timeout, unit));
-          }
-
-          @Override
-          public boolean isDone() {
-            return asyncReturnMessage.isDone();
-          }
-        };
-        AsyncCallHandler.setLowerLayerAsyncReturn(asyncGet);
+        AsyncGet<GetAclStatusResponseProto, Exception> asyncGet =
+            asyncIpc(() -> rpcProxy.getAclStatus(null, req));
+        asyncResponse((Response<Object>) () ->
+            PBHelperClient.convert(asyncGet.get(-1, null)));
         return null;
       } else {
         return PBHelperClient.convert(rpcProxy.getAclStatus(null, req));
@@ -1322,7 +1979,17 @@ public class ClientNamenodeProtocolTranslatorPB implements
       builder.setKeyName(keyName);
     }
     CreateEncryptionZoneRequestProto req = builder.build();
-    ipc(() -> rpcProxy.createEncryptionZone(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<EncryptionZonesProtos.CreateEncryptionZoneResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.createEncryptionZone(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.createEncryptionZone(null, req));
+    }
   }
 
   @Override
@@ -1331,6 +1998,21 @@ public class ClientNamenodeProtocolTranslatorPB implements
         GetEZForPathRequestProto.newBuilder();
     builder.setSrc(src);
     final GetEZForPathRequestProto req = builder.build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<EncryptionZonesProtos.GetEZForPathResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getEZForPath(null, req));
+      asyncResponse((Response<Object>) () -> {
+        final EncryptionZonesProtos.GetEZForPathResponseProto response
+            = asyncGet.get(-1, null);
+        if (response.hasZone()) {
+          return PBHelperClient.convert(response.getZone());
+        } else {
+          return null;
+        }
+      });
+      return null;
+    }
     final EncryptionZonesProtos.GetEZForPathResponseProto response =
         ipc(() -> rpcProxy.getEZForPath(null, req));
     if (response.hasZone()) {
@@ -1347,6 +2029,22 @@ public class ClientNamenodeProtocolTranslatorPB implements
         ListEncryptionZonesRequestProto.newBuilder()
             .setId(id)
             .build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<EncryptionZonesProtos.ListEncryptionZonesResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.listEncryptionZones(null, req));
+      asyncResponse((Response<Object>) () -> {
+        EncryptionZonesProtos.ListEncryptionZonesResponseProto response
+            = asyncGet.get(-1, null);
+        List<EncryptionZone> elements =
+            Lists.newArrayListWithCapacity(response.getZonesCount());
+        for (EncryptionZoneProto p : response.getZonesList()) {
+          elements.add(PBHelperClient.convert(p));
+        }
+        return new BatchedListEntries<>(elements, response.getHasMore());
+      });
+      return null;
+    }
     EncryptionZonesProtos.ListEncryptionZonesResponseProto response =
         ipc(() -> rpcProxy.listEncryptionZones(null, req));
     List<EncryptionZone> elements =
@@ -1367,7 +2065,17 @@ public class ClientNamenodeProtocolTranslatorPB implements
       builder.setEcPolicyName(ecPolicyName);
     }
     SetErasureCodingPolicyRequestProto req = builder.build();
-    ipc(() -> rpcProxy.setErasureCodingPolicy(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<ErasureCodingProtos.SetErasureCodingPolicyResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.setErasureCodingPolicy(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.setErasureCodingPolicy(null, req));
+    }
   }
 
   @Override
@@ -1376,7 +2084,17 @@ public class ClientNamenodeProtocolTranslatorPB implements
         UnsetErasureCodingPolicyRequestProto.newBuilder();
     builder.setSrc(src);
     UnsetErasureCodingPolicyRequestProto req = builder.build();
-    ipc(() -> rpcProxy.unsetErasureCodingPolicy(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<ErasureCodingProtos.UnsetErasureCodingPolicyResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.unsetErasureCodingPolicy(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.unsetErasureCodingPolicy(null, req));
+    }
   }
 
   @Override
@@ -1386,6 +2104,14 @@ public class ClientNamenodeProtocolTranslatorPB implements
         GetECTopologyResultForPoliciesRequestProto.newBuilder();
     builder.addAllPolicies(Arrays.asList(policyNames));
     GetECTopologyResultForPoliciesRequestProto req = builder.build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetECTopologyResultForPoliciesResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getECTopologyResultForPolicies(null, req));
+      asyncResponse((Response<Object>) () -> PBHelperClient
+          .convertECTopologyVerifierResultProto(
+              asyncGet.get(-1, null).getResponse()));
+    }
     GetECTopologyResultForPoliciesResponseProto response =
         ipc(() -> rpcProxy.getECTopologyResultForPolicies(null, req));
     return PBHelperClient
@@ -1399,7 +2125,17 @@ public class ClientNamenodeProtocolTranslatorPB implements
         ReencryptEncryptionZoneRequestProto.newBuilder();
     builder.setZone(zone).setAction(PBHelperClient.convert(action));
     ReencryptEncryptionZoneRequestProto req = builder.build();
-    ipc(() -> rpcProxy.reencryptEncryptionZone(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<EncryptionZonesProtos.ReencryptEncryptionZoneResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.reencryptEncryptionZone(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.reencryptEncryptionZone(null, req));
+    }
   }
 
   @Override
@@ -1407,6 +2143,21 @@ public class ClientNamenodeProtocolTranslatorPB implements
       throws IOException {
     final ListReencryptionStatusRequestProto req =
         ListReencryptionStatusRequestProto.newBuilder().setId(id).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<ListReencryptionStatusResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.listReencryptionStatus(null, req));
+      asyncResponse((Response<Object>) () -> {
+        ListReencryptionStatusResponseProto response = asyncGet.get(-1, null);
+        List<ZoneReencryptionStatus> elements =
+            Lists.newArrayListWithCapacity(response.getStatusesCount());
+        for (ZoneReencryptionStatusProto p : response.getStatusesList()) {
+          elements.add(PBHelperClient.convert(p));
+        }
+        return new BatchedListEntries<>(elements, response.getHasMore());
+      });
+      return null;
+    }
     ListReencryptionStatusResponseProto response =
         ipc(() -> rpcProxy.listReencryptionStatus(null, req));
     List<ZoneReencryptionStatus> elements =
@@ -1425,7 +2176,17 @@ public class ClientNamenodeProtocolTranslatorPB implements
         .setXAttr(PBHelperClient.convertXAttrProto(xAttr))
         .setFlag(PBHelperClient.convert(flag))
         .build();
-    ipc(() -> rpcProxy.setXAttr(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<XAttrProtos.SetXAttrResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.setXAttr(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.setXAttr(null, req));
+    }
   }
 
   @Override
@@ -1437,6 +2198,14 @@ public class ClientNamenodeProtocolTranslatorPB implements
       builder.addAllXAttrs(PBHelperClient.convertXAttrProto(xAttrs));
     }
     GetXAttrsRequestProto req = builder.build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<XAttrProtos.GetXAttrsResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getXAttrs(null, req));
+      asyncResponse((Response<Object>) () ->
+          PBHelperClient.convert(asyncGet.get(-1, null)));
+      return null;
+    }
     return PBHelperClient.convert(ipc(() -> rpcProxy.getXAttrs(null, req)));
   }
 
@@ -1446,6 +2215,14 @@ public class ClientNamenodeProtocolTranslatorPB implements
         ListXAttrsRequestProto.newBuilder();
     builder.setSrc(src);
     ListXAttrsRequestProto req = builder.build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<XAttrProtos.ListXAttrsResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.listXAttrs(null, req));
+      asyncResponse((Response<Object>) () ->
+          PBHelperClient.convert(asyncGet.get(-1, null)));
+      return null;
+    }
     return PBHelperClient.convert(ipc(() -> rpcProxy.listXAttrs(null, req)));
   }
 
@@ -1454,14 +2231,34 @@ public class ClientNamenodeProtocolTranslatorPB implements
     RemoveXAttrRequestProto req = RemoveXAttrRequestProto
         .newBuilder().setSrc(src)
         .setXAttr(PBHelperClient.convertXAttrProto(xAttr)).build();
-    ipc(() -> rpcProxy.removeXAttr(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<XAttrProtos.RemoveXAttrResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.removeXAttr(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.removeXAttr(null, req));
+    }
   }
 
   @Override
   public void checkAccess(String path, FsAction mode) throws IOException {
     CheckAccessRequestProto req = CheckAccessRequestProto.newBuilder()
         .setPath(path).setMode(PBHelperClient.convert(mode)).build();
-    ipc(() -> rpcProxy.checkAccess(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<CheckAccessResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.checkAccess(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.checkAccess(null, req));
+    }
   }
 
   @Override
@@ -1469,26 +2266,62 @@ public class ClientNamenodeProtocolTranslatorPB implements
       throws IOException {
     SetStoragePolicyRequestProto req = SetStoragePolicyRequestProto
         .newBuilder().setSrc(src).setPolicyName(policyName).build();
-    ipc(() -> rpcProxy.setStoragePolicy(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<SetStoragePolicyResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.setStoragePolicy(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.setStoragePolicy(null, req));
+    }
   }
 
   @Override
   public void unsetStoragePolicy(String src) throws IOException {
     UnsetStoragePolicyRequestProto req = UnsetStoragePolicyRequestProto
         .newBuilder().setSrc(src).build();
-    ipc(() -> rpcProxy.unsetStoragePolicy(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<UnsetStoragePolicyResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.unsetStoragePolicy(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.unsetStoragePolicy(null, req));
+    }
   }
 
   @Override
   public BlockStoragePolicy getStoragePolicy(String path) throws IOException {
     GetStoragePolicyRequestProto request = GetStoragePolicyRequestProto
         .newBuilder().setPath(path).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetStoragePolicyResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getStoragePolicy(null, request));
+      asyncResponse((Response<Object>) () ->
+          PBHelperClient.convert(asyncGet.get(-1, null).getStoragePolicy()));
+      return null;
+    }
     return PBHelperClient.convert(ipc(() -> rpcProxy.getStoragePolicy(null, request))
         .getStoragePolicy());
   }
 
   @Override
   public BlockStoragePolicy[] getStoragePolicies() throws IOException {
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetStoragePoliciesResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy
+          .getStoragePolicies(null, VOID_GET_STORAGE_POLICIES_REQUEST));
+      asyncResponse((Response<Object>) () -> PBHelperClient.convertStoragePolicies(
+          asyncGet.get(-1, null).getPoliciesList()));
+      return null;
+    }
     GetStoragePoliciesResponseProto response = ipc(() -> rpcProxy
         .getStoragePolicies(null, VOID_GET_STORAGE_POLICIES_REQUEST));
     return PBHelperClient.convertStoragePolicies(response.getPoliciesList());
@@ -1497,6 +2330,13 @@ public class ClientNamenodeProtocolTranslatorPB implements
   public long getCurrentEditLogTxid() throws IOException {
     GetCurrentEditLogTxidRequestProto req = GetCurrentEditLogTxidRequestProto
         .getDefaultInstance();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetCurrentEditLogTxidResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getCurrentEditLogTxid(null, req));
+      asyncResponse((Response<Object>) () -> asyncGet.get(-1, null).getTxid());
+      return -1;
+    }
     return ipc(() -> rpcProxy.getCurrentEditLogTxid(null, req)).getTxid();
   }
 
@@ -1504,6 +2344,13 @@ public class ClientNamenodeProtocolTranslatorPB implements
   public EventBatchList getEditsFromTxid(long txid) throws IOException {
     GetEditsFromTxidRequestProto req = GetEditsFromTxidRequestProto.newBuilder()
         .setTxid(txid).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetEditsFromTxidResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getEditsFromTxid(null, req));
+      asyncResponse((Response<Object>) () -> PBHelperClient.convert(asyncGet.get(-1, null)));
+      return null;
+    }
     return PBHelperClient.convert(ipc(() -> rpcProxy.getEditsFromTxid(null, req)));
   }
 
@@ -1515,7 +2362,22 @@ public class ClientNamenodeProtocolTranslatorPB implements
         .collect(Collectors.toList());
     AddErasureCodingPoliciesRequestProto req =
         AddErasureCodingPoliciesRequestProto.newBuilder()
-        .addAllEcPolicies(protos).build();
+            .addAllEcPolicies(protos).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<AddErasureCodingPoliciesResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy
+          .addErasureCodingPolicies(null, req));
+      asyncResponse((Response<Object>) () -> {
+        AddErasureCodingPoliciesResponseProto rep = asyncGet.get(-1, null);
+        AddErasureCodingPolicyResponse[] responses =
+            rep.getResponsesList().stream()
+                .map(PBHelperClient::convertAddErasureCodingPolicyResponse)
+                .toArray(AddErasureCodingPolicyResponse[]::new);
+        return responses;
+      });
+      return null;
+    }
     AddErasureCodingPoliciesResponseProto rep = ipc(() -> rpcProxy
         .addErasureCodingPolicies(null, req));
     AddErasureCodingPolicyResponse[] responses =
@@ -1532,7 +2394,17 @@ public class ClientNamenodeProtocolTranslatorPB implements
         RemoveErasureCodingPolicyRequestProto.newBuilder();
     builder.setEcPolicyName(ecPolicyName);
     RemoveErasureCodingPolicyRequestProto req = builder.build();
-    ipc(() -> rpcProxy.removeErasureCodingPolicy(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<ErasureCodingProtos.RemoveErasureCodingPolicyResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.removeErasureCodingPolicy(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.removeErasureCodingPolicy(null, req));
+    }
   }
 
   @Override
@@ -1542,7 +2414,17 @@ public class ClientNamenodeProtocolTranslatorPB implements
         EnableErasureCodingPolicyRequestProto.newBuilder();
     builder.setEcPolicyName(ecPolicyName);
     EnableErasureCodingPolicyRequestProto req = builder.build();
-    ipc(() -> rpcProxy.enableErasureCodingPolicy(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<ErasureCodingProtos.EnableErasureCodingPolicyResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.enableErasureCodingPolicy(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.enableErasureCodingPolicy(null, req));
+    }
   }
 
   @Override
@@ -1552,12 +2434,39 @@ public class ClientNamenodeProtocolTranslatorPB implements
         DisableErasureCodingPolicyRequestProto.newBuilder();
     builder.setEcPolicyName(ecPolicyName);
     DisableErasureCodingPolicyRequestProto req = builder.build();
-    ipc(() -> rpcProxy.disableErasureCodingPolicy(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<ErasureCodingProtos.DisableErasureCodingPolicyResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.disableErasureCodingPolicy(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.disableErasureCodingPolicy(null, req));
+    }
   }
 
   @Override
   public ErasureCodingPolicyInfo[] getErasureCodingPolicies()
       throws IOException {
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetErasureCodingPoliciesResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy
+          .getErasureCodingPolicies(null, VOID_GET_EC_POLICIES_REQUEST));
+      asyncResponse((Response<Object>) () -> {
+        GetErasureCodingPoliciesResponseProto response = asyncGet.get(-1, null);
+        ErasureCodingPolicyInfo[] ecPolicies =
+            new ErasureCodingPolicyInfo[response.getEcPoliciesCount()];
+        int i = 0;
+        for (ErasureCodingPolicyProto proto : response.getEcPoliciesList()) {
+          ecPolicies[i++] =
+              PBHelperClient.convertErasureCodingPolicyInfo(proto);
+        }
+        return ecPolicies;
+      });
+      return null;
+    }
     GetErasureCodingPoliciesResponseProto response = ipc(() -> rpcProxy
         .getErasureCodingPolicies(null, VOID_GET_EC_POLICIES_REQUEST));
     ErasureCodingPolicyInfo[] ecPolicies =
@@ -1572,6 +2481,20 @@ public class ClientNamenodeProtocolTranslatorPB implements
 
   @Override
   public Map<String, String> getErasureCodingCodecs() throws IOException {
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetErasureCodingCodecsResponseProto, Exception> asyncGet =
+          asyncIpc(() -> rpcProxy
+              .getErasureCodingCodecs(null, VOID_GET_EC_CODEC_REQUEST));
+      asyncResponse(() -> {
+        GetErasureCodingCodecsResponseProto response = asyncGet.get(-1, null);
+        Map<String, String> ecCodecs = new HashMap<>();
+        for (CodecProto codec : response.getCodecList()) {
+          ecCodecs.put(codec.getCodec(), codec.getCoders());
+        }
+        return ecCodecs;
+      });
+      return null;
+    }
     GetErasureCodingCodecsResponseProto response = ipc(() -> rpcProxy
         .getErasureCodingCodecs(null, VOID_GET_EC_CODEC_REQUEST));
     Map<String, String> ecCodecs = new HashMap<>();
@@ -1586,6 +2509,20 @@ public class ClientNamenodeProtocolTranslatorPB implements
       throws IOException {
     GetErasureCodingPolicyRequestProto req =
         GetErasureCodingPolicyRequestProto.newBuilder().setSrc(src).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetErasureCodingPolicyResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getErasureCodingPolicy(null, req));
+      asyncResponse((Response<Object>) () -> {
+        GetErasureCodingPolicyResponseProto response = asyncGet.get(-1, null);
+        if (response.hasEcPolicy()) {
+          return PBHelperClient.convertErasureCodingPolicy(
+              response.getEcPolicy());
+        }
+        return null;
+      });
+      return null;
+    }
     GetErasureCodingPolicyResponseProto response =
         ipc(() -> rpcProxy.getErasureCodingPolicy(null, req));
     if (response.hasEcPolicy()) {
@@ -1599,6 +2536,14 @@ public class ClientNamenodeProtocolTranslatorPB implements
   public QuotaUsage getQuotaUsage(String path) throws IOException {
     GetQuotaUsageRequestProto req =
         GetQuotaUsageRequestProto.newBuilder().setPath(path).build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetQuotaUsageResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getQuotaUsage(null, req));
+      asyncResponse((Response<Object>) () ->
+          PBHelperClient.convert(asyncGet.get(-1, null).getUsage()));
+      return null;
+    }
     return PBHelperClient.convert(ipc(() -> rpcProxy.getQuotaUsage(null, req))
         .getUsage());
   }
@@ -1613,7 +2558,7 @@ public class ClientNamenodeProtocolTranslatorPB implements
 
   @Override
   public BatchedEntries<OpenFileEntry> listOpenFiles(long prevId,
-      EnumSet<OpenFilesType> openFilesTypes, String path) throws IOException {
+                                                     EnumSet<OpenFilesType> openFilesTypes, String path) throws IOException {
     ListOpenFilesRequestProto.Builder req =
         ListOpenFilesRequestProto.newBuilder().setId(prevId);
     if (openFilesTypes != null) {
@@ -1621,6 +2566,20 @@ public class ClientNamenodeProtocolTranslatorPB implements
     }
     req.setPath(path);
 
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<ListOpenFilesResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.listOpenFiles(null, req.build()));
+      asyncResponse(() -> {
+        ListOpenFilesResponseProto response = asyncGet.get(-1, null);
+        List<OpenFileEntry> openFileEntries =
+            Lists.newArrayListWithCapacity(response.getEntriesCount());
+        for (OpenFilesBatchResponseProto p : response.getEntriesList()) {
+          openFileEntries.add(PBHelperClient.convert(p));
+        }
+        return new BatchedListEntries<>(openFileEntries, response.getHasMore());
+      });
+      return null;
+    }
     ListOpenFilesResponseProto response =
         ipc(() -> rpcProxy.listOpenFiles(null, req.build()));
     List<OpenFileEntry> openFileEntries =
@@ -1634,20 +2593,48 @@ public class ClientNamenodeProtocolTranslatorPB implements
   @Override
   public void msync() throws IOException {
     MsyncRequestProto.Builder req = MsyncRequestProto.newBuilder();
-    ipc(() -> rpcProxy.msync(null, req.build()));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<MsyncResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.msync(null, req.build()));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.msync(null, req.build()));
+    }
   }
 
   @Override
   public void satisfyStoragePolicy(String src) throws IOException {
     SatisfyStoragePolicyRequestProto req =
         SatisfyStoragePolicyRequestProto.newBuilder().setSrc(src).build();
-    ipc(() -> rpcProxy.satisfyStoragePolicy(null, req));
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<SatisfyStoragePolicyResponseProto, Exception> asyncGet =
+          asyncIpc(() -> rpcProxy.satisfyStoragePolicy(null, req));
+      asyncResponse(() -> {
+        asyncGet.get(-1, null);
+        return null;
+      });
+    } else {
+      ipc(() -> rpcProxy.satisfyStoragePolicy(null, req));
+    }
   }
 
   @Override
   public DatanodeInfo[] getSlowDatanodeReport() throws IOException {
     GetSlowDatanodeReportRequestProto req =
         GetSlowDatanodeReportRequestProto.newBuilder().build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetSlowDatanodeReportResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getSlowDatanodeReport(null, req));
+      asyncResponse(() ->
+          PBHelperClient.convert(asyncGet.get(-1, null).getDatanodeInfoProtoList()));
+      return null;
+    }
     return PBHelperClient.convert(
         ipc(() -> rpcProxy.getSlowDatanodeReport(null, req)).getDatanodeInfoProtoList());
   }
@@ -1657,18 +2644,38 @@ public class ClientNamenodeProtocolTranslatorPB implements
       throws IOException {
     HAServiceStateRequestProto req =
         HAServiceStateRequestProto.newBuilder().build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<HAServiceStateResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getHAServiceState(null, req));
+      asyncResponse(() -> {
+        HAServiceStateProto res = asyncGet.get(-1, null).getState();
+        switch(res) {
+          case ACTIVE:
+            return HAServiceProtocol.HAServiceState.ACTIVE;
+          case STANDBY:
+            return HAServiceProtocol.HAServiceState.STANDBY;
+          case OBSERVER:
+            return HAServiceProtocol.HAServiceState.OBSERVER;
+          case INITIALIZING:
+          default:
+            return HAServiceProtocol.HAServiceState.INITIALIZING;
+        }
+      });
+      return null;
+    }
     HAServiceStateProto res =
         ipc(() -> rpcProxy.getHAServiceState(null, req)).getState();
     switch(res) {
-    case ACTIVE:
-      return HAServiceProtocol.HAServiceState.ACTIVE;
-    case STANDBY:
-      return HAServiceProtocol.HAServiceState.STANDBY;
-    case OBSERVER:
-      return HAServiceProtocol.HAServiceState.OBSERVER;
-    case INITIALIZING:
-    default:
-      return HAServiceProtocol.HAServiceState.INITIALIZING;
+      case ACTIVE:
+        return HAServiceProtocol.HAServiceState.ACTIVE;
+      case STANDBY:
+        return HAServiceProtocol.HAServiceState.STANDBY;
+      case OBSERVER:
+        return HAServiceProtocol.HAServiceState.OBSERVER;
+      case INITIALIZING:
+      default:
+        return HAServiceProtocol.HAServiceState.INITIALIZING;
     }
   }
 
@@ -1678,6 +2685,14 @@ public class ClientNamenodeProtocolTranslatorPB implements
         GetEnclosingRootRequestProto.newBuilder();
     builder.setFilename(filename);
     final GetEnclosingRootRequestProto req = builder.build();
+
+    if (Client.isAsynchronousMode()) {
+      AsyncGet<GetEnclosingRootResponseProto, Exception> asyncGet
+          = asyncIpc(() -> rpcProxy.getEnclosingRoot(null, req));
+      asyncResponse(() ->
+          new Path(asyncGet.get(-1, null).getEnclosingRootPath()));
+      return null;
+    }
     try {
       final GetEnclosingRootResponseProto response =
           rpcProxy.getEnclosingRoot(null, req);
@@ -1686,5 +2701,5 @@ public class ClientNamenodeProtocolTranslatorPB implements
       throw getRemoteException(e);
     }
   }
-
 }
+

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterGetUserMappingsProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterGetUserMappingsProtocolServerSideTranslatorPB.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.protocolPB;
+
+
+import org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer;
+import org.apache.hadoop.tools.GetUserMappingsProtocol;
+import org.apache.hadoop.tools.proto.GetUserMappingsProtocolProtos.GetGroupsForUserRequestProto;
+import org.apache.hadoop.tools.proto.GetUserMappingsProtocolProtos.GetGroupsForUserResponseProto;
+
+import org.apache.hadoop.thirdparty.protobuf.RpcController;
+import org.apache.hadoop.thirdparty.protobuf.ServiceException;
+import org.apache.hadoop.tools.protocolPB.GetUserMappingsProtocolServerSideTranslatorPB;
+
+import static org.apache.hadoop.hdfs.protocolPB.AsyncRpcProtocolPBUtil.asyncRouterServer;
+
+public class RouterGetUserMappingsProtocolServerSideTranslatorPB
+    extends GetUserMappingsProtocolServerSideTranslatorPB {
+  private final RouterRpcServer server;
+  private final boolean isAsyncRpc;
+
+  public RouterGetUserMappingsProtocolServerSideTranslatorPB(GetUserMappingsProtocol impl) {
+    super(impl);
+    this.server = (RouterRpcServer) impl;
+    this.isAsyncRpc = server.isAsync();
+  }
+
+  @Override
+  public GetGroupsForUserResponseProto getGroupsForUser(
+      RpcController controller,
+      GetGroupsForUserRequestProto request) throws ServiceException {
+    if (!isAsyncRpc) {
+      return super.getGroupsForUser(controller, request);
+    }
+    asyncRouterServer(() -> server.getGroupsForUser(request.getUser()), groups -> {
+      GetGroupsForUserResponseProto.Builder builder = GetGroupsForUserResponseProto
+          .newBuilder();
+      for (String g : groups) {
+        builder.addGroups(g);
+      }
+      return builder.build();
+    });
+    return null;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterGetUserMappingsProtocolTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterGetUserMappingsProtocolTranslatorPB.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.protocolPB;
+
+import org.apache.hadoop.ipc.Client;
+import org.apache.hadoop.tools.proto.GetUserMappingsProtocolProtos;
+import org.apache.hadoop.tools.protocolPB.GetUserMappingsProtocolClientSideTranslatorPB;
+import org.apache.hadoop.tools.protocolPB.GetUserMappingsProtocolPB;
+import org.apache.hadoop.util.concurrent.AsyncGet;
+
+import java.io.IOException;
+
+import static org.apache.hadoop.hdfs.protocolPB.AsyncRpcProtocolPBUtil.asyncIpc;
+import static org.apache.hadoop.hdfs.protocolPB.AsyncRpcProtocolPBUtil.asyncResponse;
+
+public class RouterGetUserMappingsProtocolTranslatorPB
+    extends GetUserMappingsProtocolClientSideTranslatorPB {
+  private final GetUserMappingsProtocolPB rpcProxy;
+
+  public RouterGetUserMappingsProtocolTranslatorPB(GetUserMappingsProtocolPB rpcProxy) {
+    super(rpcProxy);
+    this.rpcProxy = rpcProxy;
+  }
+
+  @Override
+  public String[] getGroupsForUser(String user) throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.getGroupsForUser(user);
+    }
+    GetUserMappingsProtocolProtos.GetGroupsForUserRequestProto request = GetUserMappingsProtocolProtos.GetGroupsForUserRequestProto
+        .newBuilder().setUser(user).build();
+    AsyncGet<GetUserMappingsProtocolProtos.GetGroupsForUserResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.getGroupsForUser(NULL_CONTROLLER, request));
+    asyncResponse(() -> {
+      GetUserMappingsProtocolProtos.GetGroupsForUserResponseProto resp = asyncGet.get(-1, null);
+      return resp.getGroupsList().toArray(new String[resp.getGroupsCount()]);
+    });
+    return null;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterNamenodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterNamenodeProtocolServerSideTranslatorPB.java
@@ -1,0 +1,261 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.protocolPB;
+
+import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
+import org.apache.hadoop.hdfs.protocol.proto.HdfsServerProtos;
+import org.apache.hadoop.hdfs.protocol.proto.NamenodeProtocolProtos;
+import org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer;
+import org.apache.hadoop.hdfs.server.namenode.NNStorage;
+import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocol;
+import org.apache.hadoop.thirdparty.protobuf.RpcController;
+import org.apache.hadoop.thirdparty.protobuf.ServiceException;
+
+import static org.apache.hadoop.hdfs.protocolPB.AsyncRpcProtocolPBUtil.asyncRouterServer;
+
+public class RouterNamenodeProtocolServerSideTranslatorPB
+    extends NamenodeProtocolServerSideTranslatorPB{
+  private final RouterRpcServer server;
+  private final boolean isAsyncRpc;
+
+  public RouterNamenodeProtocolServerSideTranslatorPB(NamenodeProtocol impl) {
+    super(impl);
+    this.server = (RouterRpcServer) impl;
+    this.isAsyncRpc = server.isAsync();
+  }
+
+
+  @Override
+  public NamenodeProtocolProtos.GetBlocksResponseProto getBlocks(
+      RpcController unused,
+      NamenodeProtocolProtos.GetBlocksRequestProto request) {
+    if (!isAsyncRpc) {
+      return getBlocks(unused, request);
+    }
+    asyncRouterServer(() -> {
+      DatanodeInfo dnInfo = new DatanodeInfo.DatanodeInfoBuilder()
+          .setNodeID(PBHelperClient.convert(request.getDatanode()))
+          .build();
+      return server.getBlocks(dnInfo, request.getSize(),
+          request.getMinBlockSize(), request.getTimeInterval(),
+          request.hasStorageType() ?
+              PBHelperClient.convertStorageType(request.getStorageType()) : null);
+    }, blocks ->
+        NamenodeProtocolProtos.GetBlocksResponseProto.newBuilder()
+        .setBlocks(PBHelper.convert(blocks)).build());
+    return null;
+  }
+
+  @Override
+  public NamenodeProtocolProtos.GetBlockKeysResponseProto getBlockKeys(
+      RpcController unused,
+      NamenodeProtocolProtos.GetBlockKeysRequestProto request) {
+    if (!isAsyncRpc) {
+      return getBlockKeys(unused, request);
+    }
+    asyncRouterServer(server::getBlockKeys, keys -> {
+      NamenodeProtocolProtos.GetBlockKeysResponseProto.Builder builder =
+          NamenodeProtocolProtos.GetBlockKeysResponseProto.newBuilder();
+      if (keys != null) {
+        builder.setKeys(PBHelper.convert(keys));
+      }
+      return builder.build();
+    });
+    return null;
+  }
+
+  @Override
+  public NamenodeProtocolProtos.GetTransactionIdResponseProto getTransactionId(
+      RpcController unused,
+      NamenodeProtocolProtos.GetTransactionIdRequestProto request) {
+    if (!isAsyncRpc) {
+      return getTransactionId(unused, request);
+    }
+    asyncRouterServer(server::getTransactionID,
+        txid -> NamenodeProtocolProtos
+                .GetTransactionIdResponseProto
+                .newBuilder().setTxId(txid).build());
+    return null;
+  }
+
+  @Override
+  public NamenodeProtocolProtos.GetMostRecentCheckpointTxIdResponseProto getMostRecentCheckpointTxId(
+      RpcController unused, NamenodeProtocolProtos.GetMostRecentCheckpointTxIdRequestProto request) {
+    if (!isAsyncRpc) {
+      return getMostRecentCheckpointTxId(unused, request);
+    }
+    asyncRouterServer(server::getMostRecentCheckpointTxId,
+        txid -> NamenodeProtocolProtos
+            .GetMostRecentCheckpointTxIdResponseProto
+            .newBuilder().setTxId(txid).build());
+    return null;
+  }
+
+  @Override
+  public NamenodeProtocolProtos.GetMostRecentNameNodeFileTxIdResponseProto getMostRecentNameNodeFileTxId(
+      RpcController unused, NamenodeProtocolProtos.GetMostRecentNameNodeFileTxIdRequestProto request) {
+    if (!isAsyncRpc) {
+      return getMostRecentNameNodeFileTxId(unused, request);
+    }
+    asyncRouterServer(() -> server.getMostRecentNameNodeFileTxId(
+        NNStorage.NameNodeFile.valueOf(request.getNameNodeFile())),
+        txid -> NamenodeProtocolProtos
+            .GetMostRecentNameNodeFileTxIdResponseProto
+            .newBuilder().setTxId(txid).build());
+    return null;
+  }
+
+
+  @Override
+  public NamenodeProtocolProtos.RollEditLogResponseProto rollEditLog(
+      RpcController unused,
+      NamenodeProtocolProtos.RollEditLogRequestProto request) {
+    if (!isAsyncRpc) {
+      return rollEditLog(unused, request);
+    }
+    asyncRouterServer(server::rollEditLog,
+        signature -> NamenodeProtocolProtos
+            .RollEditLogResponseProto.newBuilder()
+            .setSignature(PBHelper.convert(signature)).build());
+    return null;
+  }
+
+  @Override
+  public NamenodeProtocolProtos.ErrorReportResponseProto errorReport(
+      RpcController unused,
+      NamenodeProtocolProtos.ErrorReportRequestProto request) {
+    if (!isAsyncRpc) {
+      return errorReport(unused, request);
+    }
+    asyncRouterServer(() -> {
+      server.errorReport(PBHelper.convert(request.getRegistration()),
+          request.getErrorCode(), request.getMsg());
+      return null;
+    }, result -> VOID_ERROR_REPORT_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public NamenodeProtocolProtos.RegisterResponseProto registerSubordinateNamenode(
+      RpcController unused, NamenodeProtocolProtos.RegisterRequestProto request) {
+    if (!isAsyncRpc) {
+      return registerSubordinateNamenode(unused, request);
+    }
+    asyncRouterServer(() -> server.registerSubordinateNamenode(
+        PBHelper.convert(request.getRegistration())),
+        reg -> NamenodeProtocolProtos.RegisterResponseProto.newBuilder()
+            .setRegistration(PBHelper.convert(reg)).build());
+    return null;
+  }
+
+  @Override
+  public NamenodeProtocolProtos.StartCheckpointResponseProto startCheckpoint(
+      RpcController unused,
+      NamenodeProtocolProtos.StartCheckpointRequestProto request) {
+    if (!isAsyncRpc) {
+      return startCheckpoint(unused, request);
+    }
+    asyncRouterServer(() ->
+            server.startCheckpoint(PBHelper.convert(request.getRegistration())),
+        cmd -> NamenodeProtocolProtos.StartCheckpointResponseProto.newBuilder()
+        .setCommand(PBHelper.convert(cmd)).build());
+    return null;
+  }
+
+  @Override
+  public NamenodeProtocolProtos.EndCheckpointResponseProto endCheckpoint(
+      RpcController unused,
+      NamenodeProtocolProtos.EndCheckpointRequestProto request) {
+    if (!isAsyncRpc) {
+      return endCheckpoint(unused, request);
+    }
+    asyncRouterServer(() -> {
+      server.endCheckpoint(PBHelper.convert(request.getRegistration()),
+          PBHelper.convert(request.getSignature()));
+      return null;
+    }, result -> VOID_END_CHECKPOINT_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public NamenodeProtocolProtos.GetEditLogManifestResponseProto getEditLogManifest(
+      RpcController unused, NamenodeProtocolProtos.GetEditLogManifestRequestProto request) {
+    if (!isAsyncRpc) {
+      return getEditLogManifest(unused, request);
+    }
+    asyncRouterServer(() -> server.getEditLogManifest(request.getSinceTxId()),
+        manifest -> NamenodeProtocolProtos
+            .GetEditLogManifestResponseProto.newBuilder()
+            .setManifest(PBHelper.convert(manifest)).build());
+    return null;
+  }
+
+  @Override
+  public HdfsServerProtos.VersionResponseProto versionRequest(
+      RpcController controller,
+      HdfsServerProtos.VersionRequestProto request) {
+    if (!isAsyncRpc) {
+      return versionRequest(controller, request);
+    }
+    asyncRouterServer(server::versionRequest,
+        info -> HdfsServerProtos.VersionResponseProto.newBuilder()
+        .setInfo(PBHelper.convert(info)).build());
+    return null;
+  }
+
+  @Override
+  public NamenodeProtocolProtos.IsUpgradeFinalizedResponseProto isUpgradeFinalized(
+      RpcController controller, NamenodeProtocolProtos.IsUpgradeFinalizedRequestProto request) {
+    if (!isAsyncRpc) {
+      return isUpgradeFinalized(controller, request);
+    }
+    asyncRouterServer(server::isUpgradeFinalized,
+        isUpgradeFinalized -> NamenodeProtocolProtos
+            .IsUpgradeFinalizedResponseProto.newBuilder()
+            .setIsUpgradeFinalized(isUpgradeFinalized).build());
+    return null;
+  }
+
+  @Override
+  public NamenodeProtocolProtos.IsRollingUpgradeResponseProto isRollingUpgrade(
+      RpcController controller, NamenodeProtocolProtos.IsRollingUpgradeRequestProto request)
+      throws ServiceException {
+    if (!isAsyncRpc) {
+      return isRollingUpgrade(controller, request);
+    }
+    asyncRouterServer(server::isRollingUpgrade,
+        isRollingUpgrade -> NamenodeProtocolProtos
+            .IsRollingUpgradeResponseProto.newBuilder()
+            .setIsRollingUpgrade(isRollingUpgrade).build());
+    return null;
+  }
+
+  @Override
+  public NamenodeProtocolProtos.GetNextSPSPathResponseProto getNextSPSPath(
+      RpcController controller, NamenodeProtocolProtos.GetNextSPSPathRequestProto request) {
+    if (!isAsyncRpc) {
+      return getNextSPSPath(controller, request);
+    }
+    asyncRouterServer(server::getNextSPSPath,
+        nextSPSPath -> NamenodeProtocolProtos
+            .GetNextSPSPathResponseProto.newBuilder()
+            .setSpsPath(nextSPSPath).build());
+    return null;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterNamenodeProtocolTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterNamenodeProtocolTranslatorPB.java
@@ -1,0 +1,274 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.protocolPB;
+
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdfs.protocol.DatanodeID;
+import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
+import org.apache.hadoop.hdfs.protocol.proto.HdfsServerProtos;
+import org.apache.hadoop.hdfs.protocol.proto.NamenodeProtocolProtos;
+import org.apache.hadoop.hdfs.security.token.block.ExportedBlockKeys;
+import org.apache.hadoop.hdfs.server.namenode.CheckpointSignature;
+import org.apache.hadoop.hdfs.server.namenode.NNStorage;
+import org.apache.hadoop.hdfs.server.protocol.BlocksWithLocations;
+import org.apache.hadoop.hdfs.server.protocol.NamenodeCommand;
+import org.apache.hadoop.hdfs.server.protocol.NamenodeRegistration;
+import org.apache.hadoop.hdfs.server.protocol.NamespaceInfo;
+import org.apache.hadoop.hdfs.server.protocol.RemoteEditLogManifest;
+import org.apache.hadoop.ipc.Client;
+import org.apache.hadoop.util.concurrent.AsyncGet;
+
+import java.io.IOException;
+import org.apache.hadoop.hdfs.protocolPB.AsyncRpcProtocolPBUtil.Response;
+import static org.apache.hadoop.hdfs.protocolPB.AsyncRpcProtocolPBUtil.asyncIpc;
+import static org.apache.hadoop.hdfs.protocolPB.AsyncRpcProtocolPBUtil.asyncResponse;
+
+public class RouterNamenodeProtocolTranslatorPB extends NamenodeProtocolTranslatorPB{
+  private final NamenodeProtocolPB rpcProxy;
+
+  public RouterNamenodeProtocolTranslatorPB(NamenodeProtocolPB rpcProxy) {
+    super(rpcProxy);
+    this.rpcProxy = rpcProxy;
+  }
+
+  @Override
+  public BlocksWithLocations getBlocks(DatanodeInfo datanode, long size, long
+      minBlockSize, long timeInterval, StorageType storageType)
+      throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.getBlocks(datanode, size, minBlockSize, timeInterval, storageType);
+    }
+    NamenodeProtocolProtos.GetBlocksRequestProto.Builder builder =
+        NamenodeProtocolProtos.GetBlocksRequestProto.newBuilder()
+        .setDatanode(PBHelperClient.convert((DatanodeID)datanode)).setSize(size)
+        .setMinBlockSize(minBlockSize).setTimeInterval(timeInterval);
+    if (storageType != null) {
+      builder.setStorageType(PBHelperClient.convertStorageType(storageType));
+    }
+    NamenodeProtocolProtos.GetBlocksRequestProto req = builder.build();
+
+    AsyncGet<NamenodeProtocolProtos.GetBlocksResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.getBlocks(NULL_CONTROLLER, req));
+    asyncResponse(() -> PBHelper.convert(
+        asyncGet.get(-1, null).getBlocks()));
+    return null;
+  }
+
+  @Override
+  public ExportedBlockKeys getBlockKeys() throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.getBlockKeys();
+    }
+    AsyncGet<NamenodeProtocolProtos.GetBlockKeysResponseProto, Exception> asyncGet =
+        asyncIpc(() ->
+            rpcProxy.getBlockKeys(NULL_CONTROLLER, VOID_GET_BLOCKKEYS_REQUEST));
+    asyncResponse(() -> {
+      NamenodeProtocolProtos.GetBlockKeysResponseProto rsp =
+          asyncGet.get(-1, null);
+      return rsp.hasKeys() ? PBHelper.convert(rsp.getKeys()) : null;
+    });
+    return null;
+  }
+
+  @Override
+  public long getTransactionID() throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.getTransactionID();
+    }
+    AsyncGet<NamenodeProtocolProtos.GetTransactionIdResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.getTransactionId(NULL_CONTROLLER,
+            VOID_GET_TRANSACTIONID_REQUEST));
+    asyncResponse(() -> asyncGet.get(-1, null).getTxId());
+    return -1;
+  }
+
+  @Override
+  public long getMostRecentCheckpointTxId() throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.getMostRecentCheckpointTxId();
+    }
+    AsyncGet<NamenodeProtocolProtos.GetMostRecentCheckpointTxIdResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.getMostRecentCheckpointTxId(NULL_CONTROLLER,
+        NamenodeProtocolProtos.GetMostRecentCheckpointTxIdRequestProto.getDefaultInstance()));
+    asyncResponse((Response<Object>) () -> asyncGet.get(-1, null).getTxId());
+    return -1;
+  }
+
+  @Override
+  public long getMostRecentNameNodeFileTxId(NNStorage.NameNodeFile nnf) throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.getMostRecentNameNodeFileTxId(nnf);
+    }
+    AsyncGet<NamenodeProtocolProtos.GetMostRecentNameNodeFileTxIdResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.getMostRecentNameNodeFileTxId(NULL_CONTROLLER,
+        NamenodeProtocolProtos.GetMostRecentNameNodeFileTxIdRequestProto.newBuilder()
+            .setNameNodeFile(nnf.toString()).build()));
+    asyncResponse(() -> asyncGet.get(-1, null).getTxId());
+    return -1;
+  }
+
+  @Override
+  public CheckpointSignature rollEditLog() throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.rollEditLog();
+    }
+    AsyncGet<NamenodeProtocolProtos.RollEditLogResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.rollEditLog(NULL_CONTROLLER,
+        VOID_ROLL_EDITLOG_REQUEST));
+    asyncResponse(() -> PBHelper.convert(asyncGet.get(-1, null).getSignature()));
+    return null;
+  }
+
+  @Override
+  public NamespaceInfo versionRequest() throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.versionRequest();
+    }
+    AsyncGet<HdfsServerProtos.VersionResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.versionRequest(NULL_CONTROLLER,
+        VOID_VERSION_REQUEST));
+    asyncResponse(() -> PBHelper.convert(asyncGet.get(-1, null).getInfo()));
+    return null;
+  }
+
+  @Override
+  public void errorReport(NamenodeRegistration registration, int errorCode,
+                          String msg) throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      super.errorReport(registration, errorCode, msg);
+      return;
+    }
+    NamenodeProtocolProtos.ErrorReportRequestProto req = NamenodeProtocolProtos.ErrorReportRequestProto.newBuilder()
+        .setErrorCode(errorCode).setMsg(msg)
+        .setRegistration(PBHelper.convert(registration)).build();
+    AsyncGet<NamenodeProtocolProtos.ErrorReportResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.errorReport(NULL_CONTROLLER, req));
+    asyncResponse(() -> {
+      asyncGet.get(-1, null);
+      return null;
+    });
+  }
+
+  @Override
+  public NamenodeRegistration registerSubordinateNamenode(
+      NamenodeRegistration registration) throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.registerSubordinateNamenode(registration);
+    }
+    NamenodeProtocolProtos.RegisterRequestProto req = NamenodeProtocolProtos.RegisterRequestProto.newBuilder()
+        .setRegistration(PBHelper.convert(registration)).build();
+    AsyncGet<NamenodeProtocolProtos.RegisterResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.registerSubordinateNamenode(NULL_CONTROLLER, req));
+    asyncResponse(() -> PBHelper.convert(asyncGet.get(-1, null).getRegistration()));
+    return null;
+  }
+
+  @Override
+  public NamenodeCommand startCheckpoint(NamenodeRegistration registration)
+      throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.startCheckpoint(registration);
+    }
+    NamenodeProtocolProtos.StartCheckpointRequestProto req = NamenodeProtocolProtos.StartCheckpointRequestProto.newBuilder()
+        .setRegistration(PBHelper.convert(registration)).build();
+    AsyncGet<NamenodeProtocolProtos.StartCheckpointResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.startCheckpoint(NULL_CONTROLLER, req));
+    asyncResponse(() -> {
+      HdfsServerProtos.NamenodeCommandProto cmd =
+          asyncGet.get(-1, null).getCommand();
+      return PBHelper.convert(cmd);
+    });
+    return null;
+  }
+
+  @Override
+  public void endCheckpoint(NamenodeRegistration registration,
+                            CheckpointSignature sig) throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      super.endCheckpoint(registration, sig);
+      return;
+    }
+    NamenodeProtocolProtos.EndCheckpointRequestProto req = NamenodeProtocolProtos.EndCheckpointRequestProto.newBuilder()
+        .setRegistration(PBHelper.convert(registration))
+        .setSignature(PBHelper.convert(sig)).build();
+    AsyncGet<NamenodeProtocolProtos.EndCheckpointResponseProto, Exception> asyncGet
+        = asyncIpc(() -> rpcProxy.endCheckpoint(NULL_CONTROLLER, req));
+    asyncResponse(() -> {
+      asyncGet.get(-1, null);
+      return null;
+    });
+  }
+
+  @Override
+  public RemoteEditLogManifest getEditLogManifest(long sinceTxId)
+      throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.getEditLogManifest(sinceTxId);
+    }
+    NamenodeProtocolProtos.GetEditLogManifestRequestProto req = NamenodeProtocolProtos.GetEditLogManifestRequestProto
+        .newBuilder().setSinceTxId(sinceTxId).build();
+    AsyncGet<NamenodeProtocolProtos.GetEditLogManifestResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.getEditLogManifest(NULL_CONTROLLER, req));
+    asyncResponse(() -> PBHelper.convert(asyncGet.get(-1, null).getManifest()));
+    return null;
+  }
+
+  @Override
+  public boolean isUpgradeFinalized() throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.isUpgradeFinalized();
+    }
+    NamenodeProtocolProtos.IsUpgradeFinalizedRequestProto req = NamenodeProtocolProtos.IsUpgradeFinalizedRequestProto
+        .newBuilder().build();
+    AsyncGet<NamenodeProtocolProtos.IsUpgradeFinalizedResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.isUpgradeFinalized(NULL_CONTROLLER, req));
+    asyncResponse(() -> asyncGet.get(-1, null).getIsUpgradeFinalized());
+    return false;
+  }
+
+  @Override
+  public boolean isRollingUpgrade() throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.isRollingUpgrade();
+    }
+    NamenodeProtocolProtos.IsRollingUpgradeRequestProto req = NamenodeProtocolProtos.IsRollingUpgradeRequestProto
+        .newBuilder().build();
+    AsyncGet<NamenodeProtocolProtos.IsRollingUpgradeResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.isRollingUpgrade(NULL_CONTROLLER, req));
+    asyncResponse(() -> asyncGet.get(-1, null).getIsRollingUpgrade());
+    return false;
+  }
+
+  @Override
+  public Long getNextSPSPath() throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      return super.getNextSPSPath();
+    }
+    NamenodeProtocolProtos.GetNextSPSPathRequestProto req =
+        NamenodeProtocolProtos.GetNextSPSPathRequestProto.newBuilder().build();
+    AsyncGet<NamenodeProtocolProtos.GetNextSPSPathResponseProto, Exception> ayncGet =
+        asyncIpc(() -> rpcProxy.getNextSPSPath(NULL_CONTROLLER, req));
+    asyncResponse(() -> {
+      NamenodeProtocolProtos.GetNextSPSPathResponseProto nextSPSPath =
+          ayncGet.get(-1, null);
+      return nextSPSPath.hasSpsPath() ? nextSPSPath.getSpsPath() : null;
+    });
+    return null;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterRefreshUserMappingsProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterRefreshUserMappingsProtocolServerSideTranslatorPB.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.protocolPB;
+
+import org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer;
+import org.apache.hadoop.security.RefreshUserMappingsProtocol;
+import org.apache.hadoop.security.protocolPB.RefreshUserMappingsProtocolServerSideTranslatorPB;
+import org.apache.hadoop.thirdparty.protobuf.RpcController;
+import org.apache.hadoop.thirdparty.protobuf.ServiceException;
+import org.apache.hadoop.security.proto.RefreshUserMappingsProtocolProtos.RefreshSuperUserGroupsConfigurationRequestProto;
+import org.apache.hadoop.security.proto.RefreshUserMappingsProtocolProtos.RefreshSuperUserGroupsConfigurationResponseProto;
+import org.apache.hadoop.security.proto.RefreshUserMappingsProtocolProtos.RefreshUserToGroupsMappingsRequestProto;
+import org.apache.hadoop.security.proto.RefreshUserMappingsProtocolProtos.RefreshUserToGroupsMappingsResponseProto;
+
+import static org.apache.hadoop.hdfs.protocolPB.AsyncRpcProtocolPBUtil.asyncRouterServer;
+
+public class RouterRefreshUserMappingsProtocolServerSideTranslatorPB
+    extends RefreshUserMappingsProtocolServerSideTranslatorPB {
+
+  private final RouterRpcServer server;
+  private final boolean isAsyncRpc;
+
+  public RouterRefreshUserMappingsProtocolServerSideTranslatorPB(
+      RefreshUserMappingsProtocol impl) {
+    super(impl);
+    this.server = (RouterRpcServer) impl;
+    this.isAsyncRpc = server.isAsync();
+  }
+
+  @Override
+  public RefreshUserToGroupsMappingsResponseProto
+      refreshUserToGroupsMappings(
+          RpcController controller,
+          RefreshUserToGroupsMappingsRequestProto request) throws ServiceException {
+    if (!isAsyncRpc) {
+      return super.refreshUserToGroupsMappings(controller, request);
+    }
+    asyncRouterServer(() -> {
+      server.refreshUserToGroupsMappings();
+      return null;
+    }, result ->
+        VOID_REFRESH_USER_GROUPS_MAPPING_RESPONSE);
+    return null;
+  }
+
+  @Override
+  public RefreshSuperUserGroupsConfigurationResponseProto
+      refreshSuperUserGroupsConfiguration(
+      RpcController controller,
+      RefreshSuperUserGroupsConfigurationRequestProto request) throws ServiceException {
+    if (!isAsyncRpc) {
+      return super.refreshSuperUserGroupsConfiguration(controller, request);
+    }
+    asyncRouterServer(() -> {
+      server.refreshSuperUserGroupsConfiguration();
+      return null;
+    }, result ->
+        VOID_REFRESH_SUPERUSER_GROUPS_CONFIGURATION_RESPONSE);
+    return null;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterRefreshUserMappingsProtocolTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/RouterRefreshUserMappingsProtocolTranslatorPB.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.protocolPB;
+
+import org.apache.hadoop.ipc.Client;
+import org.apache.hadoop.security.proto.RefreshUserMappingsProtocolProtos;
+import org.apache.hadoop.security.protocolPB.RefreshUserMappingsProtocolClientSideTranslatorPB;
+import org.apache.hadoop.security.protocolPB.RefreshUserMappingsProtocolPB;
+
+import org.apache.hadoop.util.concurrent.AsyncGet;
+
+import java.io.IOException;
+
+import static org.apache.hadoop.hdfs.protocolPB.AsyncRpcProtocolPBUtil.asyncIpc;
+import static org.apache.hadoop.hdfs.protocolPB.AsyncRpcProtocolPBUtil.asyncResponse;
+
+
+public class RouterRefreshUserMappingsProtocolTranslatorPB
+    extends RefreshUserMappingsProtocolClientSideTranslatorPB {
+  private final RefreshUserMappingsProtocolPB rpcProxy;
+  public RouterRefreshUserMappingsProtocolTranslatorPB(RefreshUserMappingsProtocolPB rpcProxy) {
+    super(rpcProxy);
+    this.rpcProxy = rpcProxy;
+  }
+
+  @Override
+  public void refreshUserToGroupsMappings() throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      super.refreshUserToGroupsMappings();
+      return;
+    }
+    AsyncGet<RefreshUserMappingsProtocolProtos.RefreshUserToGroupsMappingsResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.refreshUserToGroupsMappings(NULL_CONTROLLER,
+        VOID_REFRESH_USER_TO_GROUPS_MAPPING_REQUEST));
+    asyncResponse(() -> {
+      asyncGet.get(-1, null);
+      return null;
+    });
+  }
+
+  @Override
+  public void refreshSuperUserGroupsConfiguration() throws IOException {
+    if (!Client.isAsynchronousMode()) {
+      super.refreshSuperUserGroupsConfiguration();
+      return;
+    }
+    AsyncGet<RefreshUserMappingsProtocolProtos.RefreshSuperUserGroupsConfigurationResponseProto, Exception> asyncGet =
+        asyncIpc(() -> rpcProxy.refreshSuperUserGroupsConfiguration(NULL_CONTROLLER,
+        VOID_REFRESH_SUPERUSER_GROUPS_CONFIGURATION_REQUEST));
+    asyncResponse(() -> {
+      asyncGet.get(-1, null);
+      return null;
+    });
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/AsyncWorkerMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/AsyncWorkerMBean.java
@@ -1,0 +1,19 @@
+package org.apache.hadoop.hdfs.server.federation.metrics;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
+public interface AsyncWorkerMBean {
+  long getEnTaskTotal();
+
+  long getEnTaskPerSecond();
+
+  long getOutTaskTotal();
+
+  long getOutTaskPerSecond();
+
+  double getTaskQueueAvg();
+  double getTaskProcessAvg();
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/AsyncWorkerMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/AsyncWorkerMetrics.java
@@ -1,0 +1,84 @@
+package org.apache.hadoop.hdfs.server.federation.metrics;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.server.federation.router.AsyncExecutor;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.annotation.Metric;
+import org.apache.hadoop.metrics2.annotation.Metrics;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MetricsRegistry;
+import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.metrics2.lib.MutableRate;
+
+@Metrics(name = "AsyncWorkerActivity", about = "Async Worker Activity",
+    context = "dfs")
+public class AsyncWorkerMetrics implements AsyncWorkerMBean{
+  private final MetricsRegistry registry = new MetricsRegistry("AsyncWorkerActivity");
+  private AsyncExecutor asyncExecutor;
+
+  @Metric("task queue")
+  private MutableRate taskQueue;
+  @Metric("task process")
+  private MutableRate taskProcess;
+  @Metric("task en queue")
+  private MutableCounterLong taskEnQueueOp;
+  @Metric("task out queue")
+  private MutableCounterLong taskOutQueueOp;
+
+  public AsyncWorkerMetrics(String name, AsyncExecutor asyncExecutor) {
+    registry.tag("worker", "worker name", name);
+    this.asyncExecutor = asyncExecutor;
+  }
+
+  public static AsyncWorkerMetrics create(String name, AsyncExecutor asyncExecutor) {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    return ms.register(name + "-Activity",
+        "HDFS Federation AsyncWorker", new AsyncWorkerMetrics(name, asyncExecutor));
+  }
+
+  public void incrEnQueue() {
+    taskEnQueueOp.incr();
+  }
+
+  public void incrOutQueue() {
+    taskOutQueueOp.incr();
+  }
+
+  public void addQueueTime(long time) {
+    taskQueue.add(time);
+  }
+
+  public void addtaskProcess(long time) {
+    taskQueue.add(time);
+  }
+
+  public double getTaskQueueAvg() {
+    return taskQueue.lastStat().mean();
+  }
+
+  public double getTaskProcessAvg() {
+    return taskProcess.lastStat().mean();
+  }
+
+  @Override
+  public long getEnTaskTotal() {
+    return taskEnQueueOp.value();
+  }
+
+  @Override
+  @Metric("en queue")
+  public long getEnTaskPerSecond() {
+    return asyncExecutor.getTaskEnqueuePerSecond();
+  }
+
+  @Override
+  public long getOutTaskTotal() {
+    return taskOutQueueOp.value();
+  }
+
+  @Override
+  @Metric("out queue")
+  public long getOutTaskPerSecond() {
+    return asyncExecutor.getTaskOutqueuePerSecond();
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCMetrics.java
@@ -302,6 +302,10 @@ public class FederationRPCMetrics implements FederationRPCMBean {
     processingOp.incr();
   }
 
+  public void incrProcessingOp() {
+    processingOp.incr();
+  }
+
   @Override
   public double getProcessingAvg() {
     return processing.lastStat().mean();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCPerformanceMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCPerformanceMonitor.java
@@ -152,21 +152,34 @@ public class FederationRPCPerformanceMonitor implements RouterRpcMonitor {
   }
 
   @Override
+  public void incrProcessingOp() {
+    if (metrics != null) {
+      metrics.incrProcessingOp();
+    }
+  }
+
+  @Override
   public void proxyOpComplete(boolean success, String nsId,
       FederationNamenodeServiceState state) {
+    proxyOpComplete(success, nsId, state, getProxyTime());
+  }
+
+  @Override
+  public void proxyOpComplete(
+      boolean success, String nsId, FederationNamenodeServiceState state, long costMs) {
     if (success) {
-      long proxyTime = getProxyTime();
-      if (proxyTime >= 0) {
+      if (costMs >= 0) {
         if (metrics != null && !CONCURRENT.equals(nsId)) {
-          metrics.addProxyTime(proxyTime, state);
+          metrics.addProxyTime(costMs, state);
         }
         if (nameserviceRPCMetricsMap != null &&
             nameserviceRPCMetricsMap.containsKey(nsId)) {
-          nameserviceRPCMetricsMap.get(nsId).addProxyTime(proxyTime);
+          nameserviceRPCMetricsMap.get(nsId).addProxyTime(costMs);
         }
       }
     }
   }
+
 
   @Override
   public void proxyOpFailureStandby(String nsId) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NamenodeBeanMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NamenodeBeanMetrics.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.hdfs.server.common.Util;
 import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamespaceInfo;
 import org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys;
 import org.apache.hadoop.hdfs.server.federation.router.Router;
+import org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil;
 import org.apache.hadoop.hdfs.server.federation.router.RouterClientProtocol;
 import org.apache.hadoop.hdfs.server.federation.router.SubClusterTimeoutException;
 import org.apache.hadoop.hdfs.server.federation.store.MembershipStore;
@@ -468,6 +469,9 @@ public class NamenodeBeanMetrics
           this.router.getRpcServer().getClientProtocolModule();
       DatanodeStorageReport[] datanodeStorageReports =
           clientProtocol.getDatanodeStorageReport(type, false, dnReportTimeOut);
+      if (router.isEnableAsync()) {
+        datanodeStorageReports = (DatanodeStorageReport[]) RouterAsyncRpcUtil.getResult();
+      }
       for (DatanodeStorageReport datanodeStorageReport : datanodeStorageReports) {
         DatanodeInfo node = datanodeStorageReport.getDatanodeInfo();
         StorageReport[] storageReports = datanodeStorageReport.getStorageReports();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamespaceInfo
 import org.apache.hadoop.hdfs.server.federation.resolver.RemoteLocation;
 import org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys;
 import org.apache.hadoop.hdfs.server.federation.router.Router;
+import org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil;
 import org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer;
 import org.apache.hadoop.hdfs.server.federation.router.RouterServiceState;
 import org.apache.hadoop.hdfs.server.federation.router.security.RouterSecurityManager;
@@ -559,7 +560,12 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
       DatanodeInfo[] live = null;
       if (this.enableGetDNUsage) {
         RouterRpcServer rpcServer = this.router.getRpcServer();
-        live = rpcServer.getDatanodeReport(DatanodeReportType.LIVE, false, timeOut);
+        if (rpcServer.isAsync()) {
+          rpcServer.getDatanodeReportAsync(DatanodeReportType.LIVE, false, timeOut);
+          live = (DatanodeInfo[]) RouterAsyncRpcUtil.getResult();
+        } else {
+          live = rpcServer.getDatanodeReport(DatanodeReportType.LIVE, false, timeOut);
+        }
       } else {
         LOG.debug("Getting node usage is disabled.");
       }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.sun.javafx.UnmodifiableArrayList;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.server.federation.store.DisabledNameserviceStore;
@@ -239,7 +240,7 @@ public class MembershipNamenodeResolver
 
     List<? extends FederationNamenodeContext> ret = cacheNS.get(Pair.of(nsId, listObserversFirst));
     if (ret != null) {
-      return shuffleObserverNN(ret, listObserversFirst);
+      return new ArrayList<>(shuffleObserverNN(ret, listObserversFirst));
     }
 
     // Not cached, generate the value

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/AsyncErasureCoding.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/AsyncErasureCoding.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import org.apache.hadoop.hdfs.protocol.AddErasureCodingPolicyResponse;
+import org.apache.hadoop.hdfs.protocol.ECBlockGroupStats;
+import org.apache.hadoop.hdfs.protocol.ECTopologyVerifierResult;
+import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
+import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicyInfo;
+import org.apache.hadoop.hdfs.server.federation.resolver.ActiveNamenodeResolver;
+import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamespaceInfo;
+import org.apache.hadoop.hdfs.server.namenode.NameNode;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil.asyncRequestThenApply;
+
+import static org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer.merge;
+
+public class AsyncErasureCoding extends ErasureCoding{
+  /** RPC server to receive client calls. */
+  private final RouterRpcServer rpcServer;
+  /** RPC clients to connect to the Namenodes. */
+  private final RouterRpcClient rpcClient;
+  /** Interface to identify the active NN for a nameservice or blockpool ID. */
+  private final ActiveNamenodeResolver namenodeResolver;
+
+  public AsyncErasureCoding(RouterRpcServer server) {
+    super(server);
+    this.rpcServer = server;
+    this.rpcClient =  this.rpcServer.getRPCClient();
+    this.namenodeResolver = this.rpcClient.getNamenodeResolver();
+  }
+
+  public ErasureCodingPolicyInfo[] getErasureCodingPolicies()
+      throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    RemoteMethod method = new RemoteMethod("getErasureCodingPolicies");
+    Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    return asyncRequestThenApply(
+        () -> rpcClient.invokeConcurrent(
+            nss, method, true, false,
+            ErasureCodingPolicyInfo[].class),
+        ret -> merge(ret, ErasureCodingPolicyInfo.class),
+        ErasureCodingPolicyInfo[].class);
+  }
+
+  public Map getErasureCodingCodecs() throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    RemoteMethod method = new RemoteMethod("getErasureCodingCodecs");
+    Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    return asyncRequestThenApply(
+        () -> rpcClient.invokeConcurrent(
+            nss, method, true, false, Map.class),
+        retCodecs -> {
+          Map<String, String> ret = new HashMap<>();
+          Object obj = retCodecs;
+          @SuppressWarnings("unchecked")
+          Map<FederationNamespaceInfo, Map<String, String>> results =
+              (Map<FederationNamespaceInfo, Map<String, String>>)obj;
+          Collection<Map<String, String>> allCodecs = results.values();
+          for (Map<String, String> codecs : allCodecs) {
+            ret.putAll(codecs);
+          }
+          return ret;
+        }, Map.class);
+  }
+
+  public AddErasureCodingPolicyResponse[] addErasureCodingPolicies(
+      ErasureCodingPolicy[] policies) throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.WRITE);
+
+    RemoteMethod method = new RemoteMethod("addErasureCodingPolicies",
+        new Class<?>[] {ErasureCodingPolicy[].class}, new Object[] {policies});
+    Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    return asyncRequestThenApply(
+        () -> rpcClient.invokeConcurrent(
+            nss, method, true, false, AddErasureCodingPolicyResponse[].class),
+        ret -> merge(ret, AddErasureCodingPolicyResponse.class),
+        AddErasureCodingPolicyResponse[].class);
+  }
+
+  public ECTopologyVerifierResult getECTopologyResultForPolicies(
+      String[] policyNames) throws IOException {
+    RemoteMethod method = new RemoteMethod("getECTopologyResultForPolicies",
+        new Class<?>[] {String[].class}, new Object[] {policyNames});
+    Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    if (nss.isEmpty()) {
+      throw new IOException("No namespace availaible.");
+    }
+    return asyncRequestThenApply(
+        () -> rpcClient.invokeConcurrent(
+            nss, method, true, false,
+            ECTopologyVerifierResult.class),
+        ret -> {
+          for (Map.Entry<FederationNamespaceInfo, ECTopologyVerifierResult> entry : ret
+              .entrySet()) {
+            if (!entry.getValue().isSupported()) {
+              return entry.getValue();
+            }
+          }
+          // If no negative result, return the result from the first namespace.
+          return ret.get(nss.iterator().next());
+        }, ECTopologyVerifierResult.class);
+  }
+
+  public ECBlockGroupStats getECBlockGroupStats() throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    RemoteMethod method = new RemoteMethod("getECBlockGroupStats");
+    Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    return asyncRequestThenApply(
+        () -> rpcClient.invokeConcurrent(
+            nss, method, true, false,
+            ECBlockGroupStats.class),
+        allStats -> ECBlockGroupStats.merge(allStats.values()),
+        ECBlockGroupStats.class);
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/AsyncExecutor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/AsyncExecutor.java
@@ -1,0 +1,149 @@
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import org.apache.hadoop.hdfs.server.federation.metrics.AsyncWorkerMetrics;
+import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.hadoop.util.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class AsyncExecutor implements Executor {
+  public static final Logger LOG = LoggerFactory.getLogger(AsyncExecutor.class);
+  private final ScheduledExecutorService scheduledExecutorService;
+  private final int metricsUpdaterInterval;
+  private final BlockingQueue<Task> taskQueue;
+  private final Thread[] workers;
+  private long taskEnqueuePerSecond = 0;
+  private long taskOutqueuePerSecond = 0;
+  private final AsyncWorkerMetrics asyncWorkerMetrics;
+
+  public AsyncExecutor(int count, String name) {
+    this.metricsUpdaterInterval = 1000;
+    this.scheduledExecutorService = new ScheduledThreadPoolExecutor(1,
+        new ThreadFactoryBuilder().setDaemon(true).setNameFormat("Hadoop-Metrics-Updater-" + name)
+            .build());
+    this.scheduledExecutorService.scheduleWithFixedDelay(new MetricsUpdateRunner(),
+        metricsUpdaterInterval, metricsUpdaterInterval, TimeUnit.MILLISECONDS);
+    this.taskQueue = new LinkedBlockingQueue<>();
+    this.workers = new Thread[count];
+    for (int i = 0; i< count; i++) {
+      Worker worker = new Worker(name + "-" + i);
+      workers[i] = worker;
+      worker.start();
+    }
+    this.asyncWorkerMetrics = AsyncWorkerMetrics.create(name, this);
+  }
+
+  public void stop() {
+    if (workers != null) {
+      for(Thread worker : workers) {
+        worker.interrupt();
+      }
+    }
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    try {
+      taskQueue.put(new Task(command));
+      asyncWorkerMetrics.incrEnQueue();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+
+  class Worker extends Thread {
+
+    Worker(String name) {
+      setDaemon(true);
+      setName(name);
+    }
+
+    @Override
+    public void run() {
+      LOG.info("{} start!", Thread.currentThread().getName());
+      while (!isInterrupted()) {
+        Task task = null;
+        try {
+          task = taskQueue.take();
+          asyncWorkerMetrics.incrOutQueue();
+        } catch (InterruptedException e) {
+          break;
+        }
+        long outqueueTime = Time.monotonicNow();
+        asyncWorkerMetrics.addQueueTime(outqueueTime - task.getEnqueueTime());
+        task.run();
+        asyncWorkerMetrics.addtaskProcess(Time.monotonicNow() - outqueueTime);
+      }
+      LOG.info("{} stop!", Thread.currentThread().getName());
+    }
+  }
+
+  class MetricsUpdateRunner implements Runnable {
+
+    private long lastExecuted = 0;
+    private long lastSeenEnqueue = 0;
+    private long lastSeenOutqueue = 0;
+
+    @Override
+    public synchronized void run() {
+      long currentTime = Time.monotonicNow();
+      if (lastExecuted == 0) {
+        lastExecuted = currentTime - metricsUpdaterInterval;
+      }
+      long currentEnqueue = asyncWorkerMetrics.getEnTaskTotal();
+      long currentOutqueue = asyncWorkerMetrics.getOutTaskTotal();
+
+      long totalEnqueueDiff = currentEnqueue - lastSeenEnqueue;
+      long totalOutqueueDiff = currentOutqueue - lastSeenOutqueue;
+      lastSeenEnqueue = currentEnqueue;
+      lastSeenOutqueue = currentOutqueue;
+      if ((currentTime - lastExecuted) > 0) {
+        double totalEnqueuePerSecInDouble =
+            (double) totalEnqueueDiff / TimeUnit.MILLISECONDS.toSeconds(
+                currentTime - lastExecuted);
+        double totalOutqueuePerSecInDouble =
+            (double) totalOutqueueDiff / TimeUnit.MILLISECONDS.toSeconds(
+                currentTime - lastExecuted);
+        taskEnqueuePerSecond = (long) totalEnqueuePerSecInDouble;
+        taskOutqueuePerSecond = (long) totalOutqueuePerSecInDouble;
+      }
+      lastExecuted = currentTime;
+    }
+  }
+
+  public long getTaskOutqueuePerSecond() {
+    return taskOutqueuePerSecond;
+  }
+
+  public long getTaskEnqueuePerSecond() {
+    return taskEnqueuePerSecond;
+  }
+
+  static class Task implements Runnable {
+    private final Runnable runnable;
+
+    private final long enqueueTime;
+
+    Task(Runnable runnable) {
+      this.runnable = runnable;
+      this.enqueueTime = Time.monotonicNow();
+    }
+
+    @Override
+    public void run() {
+      runnable.run();
+    }
+
+    public long getEnqueueTime() {
+      return enqueueTime;
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/AsyncQuota.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/AsyncQuota.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import org.apache.hadoop.fs.QuotaUsage;
+import org.apache.hadoop.hdfs.server.federation.resolver.RemoteLocation;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class AsyncQuota extends Quota{
+  public AsyncQuota(Router router, RouterRpcServer server) {
+    super(router, server);
+  }
+
+  /**
+   * Get aggregated quota usage for the federation path.
+   * @param path Federation path.
+   * @return Aggregated quota.
+   * @throws IOException If the quota system is disabled.
+   */
+  public QuotaUsage getQuotaUsage(String path) throws IOException {
+    getEachQuotaUsage(path);
+    CompletableFuture<Object> completableFuture =
+        RouterAsyncRpcUtil.getCompletableFuture();
+    completableFuture = completableFuture.thenApply(o -> {
+      Map<RemoteLocation, QuotaUsage> results = (Map<RemoteLocation, QuotaUsage>) o;
+      try {
+        return AsyncQuota.super.aggregateQuota(path, results);
+      } catch (IOException e) {
+        throw new CompletionException(e);
+      }
+    });
+    RouterAsyncRpcUtil.setCurCompletableFuture(completableFuture);
+    return RouterAsyncRpcUtil.asyncReturn(QuotaUsage.class);
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/AsyncRequestDoWhile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/AsyncRequestDoWhile.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.BiFunction;
+
+public class AsyncRequestDoWhile<I, T, R> {
+
+  private boolean satisfy = false;
+  private Iterator<I> iterator;
+  private final CompletableFuture<R> result = new CompletableFuture<>();
+  private RouterAsyncRpcUtil.AsyncRequestUntil<I, T> asyncRequest;
+  private BiFunction<I, T, R> thenApply;
+
+  public final void breakNow() {
+    satisfy = true;
+  }
+
+  public R asyncDoWhile(Class<R> clazz) throws IOException {
+    processOnce(null);
+    RouterAsyncRpcUtil.setCurCompletableFuture(
+        (CompletableFuture<Object>) result);
+    return RouterAsyncRpcUtil.asyncReturn(clazz);
+  }
+
+  private void processOnce(R ret) throws IOException {
+    if (!iterator.hasNext()) {
+      result.complete(ret);
+      return;
+    }
+    I in = iterator.next();
+    asyncRequest.res(in);
+    CompletableFuture<T> completableFuture =
+        (CompletableFuture<T>) RouterAsyncRpcUtil.getCompletableFuture();
+    completableFuture.thenApply(t -> {
+      R r = thenApply.apply(in, t);
+      if (satisfy) {
+        result.complete(r);
+        return null;
+      }
+      try {
+        processOnce(r);
+      } catch (IOException e) {
+        throw new CompletionException(e);
+      }
+      return null;
+    }).exceptionally(throwable -> {
+      breakNow();
+      result.completeExceptionally(throwable);
+      return null;
+    });
+  }
+
+  public AsyncRequestDoWhile<I, T, R> whileFor(Iterator<I> it) {
+    this.iterator = it;
+    return this;
+  }
+
+  public AsyncRequestDoWhile<I, T, R> doAsync(
+      RouterAsyncRpcUtil.AsyncRequestUntil<I, T> asyncReq) {
+    this.asyncRequest = asyncReq;
+    return this;
+  }
+
+  public AsyncRequestDoWhile<I, T, R> thenApply(BiFunction<I, T, R> then) {
+    this.thenApply = then;
+    return this;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/ConnectionPool.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/ConnectionPool.java
@@ -32,6 +32,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.net.SocketFactory;
 
 import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.hdfs.protocolPB.RouterClientProtocolTranslatorPB;
+import org.apache.hadoop.hdfs.protocolPB.RouterGetUserMappingsProtocolTranslatorPB;
+import org.apache.hadoop.hdfs.protocolPB.RouterNamenodeProtocolTranslatorPB;
+import org.apache.hadoop.hdfs.protocolPB.RouterRefreshUserMappingsProtocolTranslatorPB;
 import org.apache.hadoop.ipc.AlignmentContext;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -41,9 +45,7 @@ import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.protocol.ClientProtocol;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolPB;
-import org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB;
 import org.apache.hadoop.hdfs.protocolPB.NamenodeProtocolPB;
-import org.apache.hadoop.hdfs.protocolPB.NamenodeProtocolTranslatorPB;
 import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocol;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.retry.RetryPolicy;
@@ -55,10 +57,8 @@ import org.apache.hadoop.security.RefreshUserMappingsProtocol;
 import org.apache.hadoop.security.SaslRpcServer;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.security.protocolPB.RefreshUserMappingsProtocolClientSideTranslatorPB;
 import org.apache.hadoop.security.protocolPB.RefreshUserMappingsProtocolPB;
 import org.apache.hadoop.tools.GetUserMappingsProtocol;
-import org.apache.hadoop.tools.protocolPB.GetUserMappingsProtocolClientSideTranslatorPB;
 import org.apache.hadoop.tools.protocolPB.GetUserMappingsProtocolPB;
 import org.apache.hadoop.util.Time;
 import org.eclipse.jetty.util.ajax.JSON;
@@ -117,15 +117,15 @@ public class ConnectionPool {
   static {
     PROTO_MAP.put(ClientProtocol.class,
         new ProtoImpl(ClientNamenodeProtocolPB.class,
-            ClientNamenodeProtocolTranslatorPB.class));
+            RouterClientProtocolTranslatorPB.class));
     PROTO_MAP.put(NamenodeProtocol.class, new ProtoImpl(
-        NamenodeProtocolPB.class, NamenodeProtocolTranslatorPB.class));
+        NamenodeProtocolPB.class, RouterNamenodeProtocolTranslatorPB.class));
     PROTO_MAP.put(RefreshUserMappingsProtocol.class,
         new ProtoImpl(RefreshUserMappingsProtocolPB.class,
-            RefreshUserMappingsProtocolClientSideTranslatorPB.class));
+            RouterRefreshUserMappingsProtocolTranslatorPB.class));
     PROTO_MAP.put(GetUserMappingsProtocol.class,
         new ProtoImpl(GetUserMappingsProtocolPB.class,
-            GetUserMappingsProtocolClientSideTranslatorPB.class));
+            RouterGetUserMappingsProtocolTranslatorPB.class));
   }
 
   /** Class to store the protocol implementation. */

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/ErasureCoding.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/ErasureCoding.java
@@ -144,9 +144,8 @@ public class ErasureCoding {
         rpcServer.getLocationsForPath(src, false, false);
     RemoteMethod remoteMethod = new RemoteMethod("getErasureCodingPolicy",
         new Class<?>[] {String.class}, new RemoteParam());
-    ErasureCodingPolicy ret = rpcClient.invokeSequential(
+    return rpcClient.invokeSequential(
         locations, remoteMethod, null, null);
-    return ret;
   }
 
   public void setErasureCodingPolicy(String src, String ecPolicyName)

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Quota.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Quota.java
@@ -149,10 +149,9 @@ public class Quota {
     final List<RemoteLocation> quotaLocs = getValidQuotaLocations(path);
     RemoteMethod method = new RemoteMethod("getQuotaUsage",
         new Class<?>[] {String.class}, new RemoteParam());
-    Map<RemoteLocation, QuotaUsage> results = rpcClient.invokeConcurrent(
-        quotaLocs, method, true, false, QuotaUsage.class);
 
-    return results;
+    return rpcClient.invokeConcurrent(
+        quotaLocs, method, true, false, QuotaUsage.class);
   }
 
   /**
@@ -361,7 +360,7 @@ public class Quota {
    * @return List of quota remote locations.
    * @throws IOException
    */
-  private List<RemoteLocation> getQuotaRemoteLocations(String path)
+  protected List<RemoteLocation> getQuotaRemoteLocations(String path)
       throws IOException {
     List<RemoteLocation> locations = new ArrayList<>();
     RouterQuotaManager manager = this.router.getQuotaManager();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -72,7 +72,9 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
   public static final String DFS_ROUTER_RPC_ENABLE =
       FEDERATION_ROUTER_PREFIX + "rpc.enable";
   public static final boolean DFS_ROUTER_RPC_ENABLE_DEFAULT = true;
-
+  public static final String DFS_ROUTER_RPC_ENABLE_ASYNC =
+      FEDERATION_ROUTER_PREFIX + "rpc.enable.async";
+  public static final boolean DFS_ROUTER_RPC_ENABLE_ASYNC_DEFAULT = false;
   public static final String DFS_ROUTER_METRICS_ENABLE =
       FEDERATION_ROUTER_PREFIX + "metrics.enable";
   public static final boolean DFS_ROUTER_METRICS_ENABLE_DEFAULT = true;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -75,6 +75,16 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
   public static final String DFS_ROUTER_RPC_ENABLE_ASYNC =
       FEDERATION_ROUTER_PREFIX + "rpc.enable.async";
   public static final boolean DFS_ROUTER_RPC_ENABLE_ASYNC_DEFAULT = false;
+  public static final String DFS_ROUTER_RPC_ASYNC_HANDLER_COUNT =
+      FEDERATION_ROUTER_PREFIX + "rpc.async.handler.count";
+  public static final int DFS_ROUTER_RPC_ASYNC_HANDLER_COUNT_DEFAULT = 100;
+  public static final String DFS_ROUTER_RPC_ASYNC_RESPONSE_COUNT =
+      FEDERATION_ROUTER_PREFIX + "rpc.async.response.count";
+  public static final int DFS_ROUTER_RPC_ASYNC_RESPONSE_COUNT_DEFAULT = 100;
+  public static final String DFS_ROUTER_RPC_ASYNC_REQUEST_PERMITS =
+      FEDERATION_ROUTER_PREFIX + "rpc.async.request.permits";
+  public static final int DFS_ROUTER_RPC_ASYNC_REQUEST_PERMITS_DEFAULT =
+      Integer.MAX_VALUE;
   public static final String DFS_ROUTER_METRICS_ENABLE =
       FEDERATION_ROUTER_PREFIX + "metrics.enable";
   public static final boolean DFS_ROUTER_METRICS_ENABLE_DEFAULT = true;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
@@ -142,6 +142,7 @@ public class Router extends CompositeService implements
 
   /** State of the Router. */
   private RouterServiceState state = RouterServiceState.UNINITIALIZED;
+  private boolean enableAsync;
 
 
   /////////////////////////////////////////////////////////
@@ -876,4 +877,7 @@ public class Router extends CompositeService implements
     this.conf = conf;
   }
 
+  public boolean isEnableAsync() {
+    return true;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
@@ -142,7 +142,6 @@ public class Router extends CompositeService implements
 
   /** State of the Router. */
   private RouterServiceState state = RouterServiceState.UNINITIALIZED;
-  private boolean enableAsync;
 
 
   /////////////////////////////////////////////////////////
@@ -878,6 +877,9 @@ public class Router extends CompositeService implements
   }
 
   public boolean isEnableAsync() {
-    return true;
+    if (rpcServer == null) {
+      return false;
+    }
+    return rpcServer.isAsync();
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncCacheAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncCacheAdmin.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import org.apache.hadoop.fs.BatchedRemoteIterator;
+import org.apache.hadoop.fs.CacheFlag;
+import org.apache.hadoop.hdfs.protocol.CacheDirectiveEntry;
+import org.apache.hadoop.hdfs.protocol.CacheDirectiveInfo;
+import org.apache.hadoop.hdfs.protocol.CachePoolEntry;
+import org.apache.hadoop.hdfs.server.federation.resolver.ActiveNamenodeResolver;
+import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamespaceInfo;
+import org.apache.hadoop.hdfs.server.federation.resolver.RemoteLocation;
+import org.apache.hadoop.hdfs.server.namenode.NameNode;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil.asyncRequestThenApply;
+
+public class RouterAsyncCacheAdmin extends RouterCacheAdmin{
+  /** RPC server to receive client calls. */
+  private final RouterRpcServer rpcServer;
+  /** RPC clients to connect to the Namenodes. */
+  private final RouterRpcClient rpcClient;
+  /** Interface to identify the active NN for a nameservice or blockpool ID. */
+  private final ActiveNamenodeResolver namenodeResolver;
+  public RouterAsyncCacheAdmin(RouterRpcServer server) {
+    super(server);
+    this.rpcServer = server;
+    this.rpcClient = this.rpcServer.getRPCClient();
+    this.namenodeResolver = this.rpcClient.getNamenodeResolver();
+  }
+
+  public long addCacheDirective(
+      CacheDirectiveInfo path, EnumSet<CacheFlag> flags) throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.WRITE, true);
+    final List<RemoteLocation> locations =
+        rpcServer.getLocationsForPath(path.getPath().toString(), true,
+            false);
+    RemoteMethod method = new RemoteMethod("addCacheDirective",
+        new Class<?>[] {CacheDirectiveInfo.class, EnumSet.class},
+        new RemoteParam(getRemoteMap(path, locations)), flags);
+    return asyncRequestThenApply(
+        () -> rpcClient.invokeConcurrent(
+            locations, method, false, false, long.class),
+        response -> response.values().iterator().next(),
+        Long.class);
+  }
+
+  public BatchedRemoteIterator.BatchedEntries<CacheDirectiveEntry> listCacheDirectives(
+      long prevId,
+      CacheDirectiveInfo filter) throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.READ, true);
+    CompletableFuture<Object> completableFuture = null;
+    if (filter.getPath() != null) {
+      final List<RemoteLocation> locations = rpcServer
+          .getLocationsForPath(filter.getPath().toString(), true, false);
+      RemoteMethod method = new RemoteMethod("listCacheDirectives",
+          new Class<?>[] {long.class, CacheDirectiveInfo.class}, prevId,
+          new RemoteParam(getRemoteMap(filter, locations)));
+      return asyncRequestThenApply(
+          () -> rpcClient.invokeConcurrent(locations, method, false,
+              false, BatchedRemoteIterator.BatchedEntries.class),
+          response -> response.values().iterator().next(),
+          BatchedRemoteIterator.BatchedEntries.class);
+    }
+    RemoteMethod method = new RemoteMethod("listCacheDirectives",
+        new Class<?>[] {long.class, CacheDirectiveInfo.class}, prevId,
+        filter);
+    Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    return asyncRequestThenApply(
+        () -> rpcClient.invokeConcurrent(nss, method, true,
+            false, BatchedRemoteIterator.BatchedEntries.class),
+        results -> results.values().iterator().next(),
+        BatchedRemoteIterator.BatchedEntries.class);
+  }
+
+  public BatchedRemoteIterator.BatchedEntries<CachePoolEntry> listCachePools(String prevKey)
+      throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.READ, true);
+    RemoteMethod method = new RemoteMethod("listCachePools",
+        new Class<?>[] {String.class}, prevKey);
+    Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    return asyncRequestThenApply(
+        () -> rpcClient.invokeConcurrent(nss, method, true,
+            false, BatchedRemoteIterator.BatchedEntries.class),
+        results -> results.values().iterator().next(),
+        BatchedRemoteIterator.BatchedEntries.class);
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncClientProtocol.java
@@ -1,0 +1,1559 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.crypto.CryptoProtocolVersion;
+import org.apache.hadoop.fs.BatchedRemoteIterator;
+import org.apache.hadoop.fs.CacheFlag;
+import org.apache.hadoop.fs.ContentSummary;
+import org.apache.hadoop.fs.CreateFlag;
+import org.apache.hadoop.fs.FsServerDefaults;
+import org.apache.hadoop.fs.Options;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.QuotaUsage;
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.fs.XAttr;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdfs.DFSUtil;
+import org.apache.hadoop.hdfs.protocol.AddErasureCodingPolicyResponse;
+import org.apache.hadoop.hdfs.protocol.BlockStoragePolicy;
+import org.apache.hadoop.hdfs.protocol.CacheDirectiveEntry;
+import org.apache.hadoop.hdfs.protocol.CacheDirectiveInfo;
+import org.apache.hadoop.hdfs.protocol.CachePoolEntry;
+import org.apache.hadoop.hdfs.protocol.CachePoolInfo;
+import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
+import org.apache.hadoop.hdfs.protocol.DirectoryListing;
+import org.apache.hadoop.hdfs.protocol.ECBlockGroupStats;
+import org.apache.hadoop.hdfs.protocol.ECTopologyVerifierResult;
+import org.apache.hadoop.hdfs.protocol.EncryptionZone;
+import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
+import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicyInfo;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
+import org.apache.hadoop.hdfs.protocol.LastBlockWithStatus;
+import org.apache.hadoop.hdfs.protocol.LocatedBlock;
+import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
+import org.apache.hadoop.hdfs.protocol.ReplicatedBlockStats;
+import org.apache.hadoop.hdfs.protocol.RollingUpgradeInfo;
+import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
+import org.apache.hadoop.hdfs.protocol.SnapshotDiffReportListing;
+import org.apache.hadoop.hdfs.protocol.SnapshotStatus;
+import org.apache.hadoop.hdfs.protocol.SnapshottableDirectoryStatus;
+import org.apache.hadoop.hdfs.protocol.UnresolvedPathException;
+import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier;
+import org.apache.hadoop.hdfs.server.federation.resolver.ActiveNamenodeResolver;
+import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamespaceInfo;
+import org.apache.hadoop.hdfs.server.federation.resolver.FileSubclusterResolver;
+import org.apache.hadoop.hdfs.server.federation.resolver.MountTableResolver;
+import org.apache.hadoop.hdfs.server.federation.resolver.RemoteLocation;
+import org.apache.hadoop.hdfs.server.federation.resolver.RouterResolveException;
+import org.apache.hadoop.hdfs.server.federation.store.records.MountTable;
+import org.apache.hadoop.hdfs.server.namenode.NameNode;
+import org.apache.hadoop.hdfs.server.protocol.DatanodeStorageReport;
+import org.apache.hadoop.io.EnumSetWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.util.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import static org.apache.hadoop.hdfs.server.federation.router.FederationUtil.updateMountPointStatus;
+import static org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil.asyncReturn;
+import static org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil.getCompletableFuture;
+import static org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil.setCurCompletableFuture;
+
+public class RouterAsyncClientProtocol extends RouterClientProtocol {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(RouterAsyncClientProtocol.class.getName());
+
+  private final RouterSnapshot asyncSnapshotProto;
+  private final AsyncErasureCoding asyncErasureCoding;
+  private final RouterAsyncCacheAdmin routerAsyncCacheAdmin;
+  private volatile FsServerDefaults serverDefaults;
+  private final RouterAsyncStoragePolicy asyncstoragePolicy;
+
+  RouterAsyncClientProtocol(Configuration conf, RouterRpcServer rpcServer) {
+    super(conf, rpcServer);
+    asyncSnapshotProto = new RouterAsyncSnapshot(rpcServer);
+    asyncErasureCoding = new AsyncErasureCoding(rpcServer);
+    routerAsyncCacheAdmin = new RouterAsyncCacheAdmin(rpcServer);
+    asyncstoragePolicy = new RouterAsyncStoragePolicy(rpcServer);
+  }
+
+  @Override
+  public FsServerDefaults getServerDefaults() throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    long serverDefaultsLastUpdate = getServerDefaultsLastUpdate();
+    long serverDefaultsValidityPeriod = getServerDefaultsValidityPeriod();
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+    long now = Time.monotonicNow();
+    CompletableFuture<Object> completableFuture = null;
+    if ((serverDefaults == null) || (now - serverDefaultsLastUpdate
+        > serverDefaultsValidityPeriod)) {
+      RemoteMethod method = new RemoteMethod("getServerDefaults");
+      serverDefaults =
+          rpcServer.invokeAtAvailableNsAsync(method, FsServerDefaults.class);
+      completableFuture = getCompletableFuture();
+      completableFuture = completableFuture.thenApply(o -> {
+        serverDefaults = (FsServerDefaults) o;
+        RouterAsyncClientProtocol.super.setServerDefaultsLastUpdate(now);
+        return o;
+      });
+    } else {
+      completableFuture =
+          CompletableFuture.completedFuture(serverDefaults);
+    }
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(FsServerDefaults.class);
+  }
+
+  @Override
+  public HdfsFileStatus create(
+      String src, FsPermission masked, String clientName,
+      EnumSetWritable<CreateFlag> flag, boolean createParent, short replication,
+      long blockSize, CryptoProtocolVersion[] supportedVersions,
+      String ecPolicyName, String storagePolicy) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    rpcServer.checkOperation(NameNode.OperationCategory.WRITE);
+
+    CompletableFuture<Object> completableFuture = null;
+    final Throwable[] throwable = new Throwable[1];
+    if (createParent && rpcServer.isPathAll(src)) {
+      int index = src.lastIndexOf(Path.SEPARATOR);
+      String parent = src.substring(0, index);
+      LOG.debug("Creating {} requires creating parent {}", src, parent);
+      FsPermission parentPermissions = getParentPermission(masked);
+      mkdirs(parent, parentPermissions, createParent);
+      completableFuture = getCompletableFuture();
+      completableFuture = completableFuture.exceptionally(e -> {
+        throwable[0] = e.getCause();
+        throw new CompletionException(e.getCause());
+      });
+    }
+
+    if (completableFuture == null) {
+      completableFuture = CompletableFuture.completedFuture(false);
+    }
+    RemoteMethod method = new RemoteMethod("create",
+        new Class<?>[] {String.class, FsPermission.class, String.class,
+            EnumSetWritable.class, boolean.class, short.class,
+            long.class, CryptoProtocolVersion[].class,
+            String.class, String.class},
+        new RemoteParam(), masked, clientName, flag, createParent,
+        replication, blockSize, supportedVersions, ecPolicyName, storagePolicy);
+    final RemoteLocation[] createLocation = new RemoteLocation[1];
+    final List<RemoteLocation> locations =
+        rpcServer.getLocationsForPath(src, true);
+    completableFuture = completableFuture.thenCompose(o -> {
+      try {
+        rpcServer.getCreateLocationAsync(src, locations);
+        return getCompletableFuture();
+      } catch (IOException e) {
+        throw new CompletionException(e);
+      }
+    }).thenCompose((Function<Object, CompletionStage<Object>>) o -> {
+      createLocation[0] = (RemoteLocation) o;
+      try {
+        rpcClient.invokeSingle(createLocation[0], method,
+            HdfsFileStatus.class);
+        return getCompletableFuture().thenApply(o1 -> {
+          HdfsFileStatus status = (HdfsFileStatus) o1;
+          status.setNamespace(createLocation[0].getNameserviceId());
+          return status;
+        });
+      } catch (IOException e) {
+        throw new CompletionException(e);
+      }
+    }).exceptionally(Throwable::getCause).thenCompose(o -> {
+      if (throwable[0] != null) {
+        throw new CompletionException(throwable[0]);
+      }
+      if (o instanceof Throwable) {
+        if (o instanceof IOException) {
+          try {
+            final List<RemoteLocation> newLocations = checkFaultTolerantRetry(
+                method, src, (IOException) o, createLocation[0], locations);
+            rpcClient.invokeSequential(
+                newLocations, method, HdfsFileStatus.class, null);
+            return getCompletableFuture();
+          } catch (IOException e) {
+            throw new CompletionException(e);
+          }
+        }
+        throw new CompletionException((Throwable) o);
+      }
+      return CompletableFuture.completedFuture(o);
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(HdfsFileStatus.class);
+  }
+
+  @Override
+  public LastBlockWithStatus append(
+      String src, String clientName,
+      EnumSetWritable<CreateFlag> flag) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    rpcServer.checkOperation(NameNode.OperationCategory.WRITE);
+
+    List<RemoteLocation> locations = rpcServer.getLocationsForPath(src, true);
+    RemoteMethod method = new RemoteMethod("append",
+        new Class<?>[] {String.class, String.class, EnumSetWritable.class},
+        new RemoteParam(), clientName, flag);
+    rpcClient.invokeSequential(method, locations, LastBlockWithStatus.class, null);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenApply(o -> {
+      RemoteResult result = (RemoteResult) o;
+      LastBlockWithStatus lbws = (LastBlockWithStatus) result.getResult();
+      lbws.getFileStatus().setNamespace(result.getLocation().getNameserviceId());
+      return lbws;
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(LastBlockWithStatus.class);
+  }
+
+  @Deprecated
+  @Override
+  public boolean rename(final String src, final String dst)
+      throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    RouterFederationRename rbfRename = getRbfRename();
+    rpcServer.checkOperation(NameNode.OperationCategory.WRITE);
+
+    final List<RemoteLocation> srcLocations =
+        rpcServer.getLocationsForPath(src, true, false);
+    final List<RemoteLocation> dstLocations =
+        rpcServer.getLocationsForPath(dst, false, false);
+    // srcLocations may be trimmed by getRenameDestinations()
+    final List<RemoteLocation> locs = new LinkedList<>(srcLocations);
+    RemoteParam dstParam = getRenameDestinations(locs, dstLocations);
+    if (locs.isEmpty()) {
+      return rbfRename.routerFedRename(src, dst, srcLocations, dstLocations);
+    }
+    RemoteMethod method = new RemoteMethod("rename",
+        new Class<?>[] {String.class, String.class},
+        new RemoteParam(), dstParam);
+    isMultiDestDirectory(src);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenCompose(o -> {
+      Boolean isMultiDest = (Boolean) o;
+      if (isMultiDest) {
+        if (locs.size() != srcLocations.size()) {
+          IOException ioe = new IOException("Rename of " + src + " to " + dst + " is not"
+              + " allowed. The number of remote locations for both source and"
+              + " target should be same.");
+          throw new CompletionException(ioe);
+        }
+        try {
+          rpcClient.invokeAll(locs, method);
+          return getCompletableFuture();
+        } catch (IOException e) {
+          throw new CompletionException(e);
+        }
+      } else {
+        try {
+          rpcClient.invokeSequential(locs, method, Boolean.class,
+              Boolean.TRUE);
+          return getCompletableFuture();
+        } catch (IOException e) {
+          throw new CompletionException(e);
+        }
+      }
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(Boolean.class);
+  }
+
+  @Override
+  public void rename2(final String src, final String dst,
+                      final Options.Rename... options) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    RouterFederationRename rbfRename = getRbfRename();
+    rpcServer.checkOperation(NameNode.OperationCategory.WRITE);
+
+    final List<RemoteLocation> srcLocations =
+        rpcServer.getLocationsForPath(src, true, false);
+    final List<RemoteLocation> dstLocations =
+        rpcServer.getLocationsForPath(dst, false, false);
+    // srcLocations may be trimmed by getRenameDestinations()
+    final List<RemoteLocation> locs = new LinkedList<>(srcLocations);
+    RemoteParam dstParam = getRenameDestinations(locs, dstLocations);
+    if (locs.isEmpty()) {
+      rbfRename.routerFedRename(src, dst, srcLocations, dstLocations);
+      return;
+    }
+    RemoteMethod method = new RemoteMethod("rename2",
+        new Class<?>[] {String.class, String.class, options.getClass()},
+        new RemoteParam(), dstParam, options);
+    isMultiDestDirectory(src);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenCompose(o -> {
+      Boolean isMultiDest = (Boolean) o;
+      if (isMultiDest) {
+        if (locs.size() != srcLocations.size()) {
+          IOException ioe = new IOException("Rename of " + src + " to " + dst + " is not"
+              + " allowed. The number of remote locations for both source and"
+              + " target should be same.");
+          throw new CompletionException(ioe);
+        }
+        try {
+          rpcClient.invokeConcurrent(locs, method);
+          return getCompletableFuture();
+        } catch (IOException e) {
+          throw new CompletionException(e);
+        }
+      } else {
+        try {
+          rpcClient.invokeSequential(locs, method, null, null);
+          return getCompletableFuture();
+        } catch (IOException e) {
+          throw new CompletionException(e);
+        }
+      }
+    });
+    setCurCompletableFuture(completableFuture);
+  }
+
+  @Override
+  public void concat(String trg, String[] src) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    rpcServer.checkOperation(NameNode.OperationCategory.WRITE);
+
+    // See if the src and target files are all in the same namespace
+    getBlockLocations(trg, 0, 1);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenCompose(o -> {
+      LocatedBlocks targetBlocks  = (LocatedBlocks) o;
+      if (targetBlocks == null) {
+        throw new CompletionException(
+            new IOException("Cannot locate blocks for target file - " + trg));
+      }
+      LocatedBlock lastLocatedBlock = targetBlocks.getLastLocatedBlock();
+      String targetBlockPoolId = lastLocatedBlock.getBlock().getBlockPoolId();
+      CompletableFuture<Object> future = CompletableFuture.completedFuture(null);
+      for (String source : src) {
+        future = future.thenCompose(o1 -> {
+          try {
+            getBlockLocations(source, 0, 1);
+            CompletableFuture<Object> completableFuture1 = getCompletableFuture();
+            return completableFuture1.thenApply(res -> {
+              if (res == null) {
+                throw new CompletionException(new IOException(
+                    "Cannot located blocks for source file " + source));
+              }
+              LocatedBlocks sourceBlocks1 = (LocatedBlocks) res;
+              String sourceBlockPoolId =
+                  sourceBlocks1.getLastLocatedBlock().getBlock().getBlockPoolId();
+              if (!sourceBlockPoolId.equals(targetBlockPoolId)) {
+                throw new RuntimeException(
+                    new IOException("Cannot concatenate source file " + source
+                        + " because it is located in a different namespace"
+                        + " with block pool id " + sourceBlockPoolId
+                        + " from the target file with block pool id "
+                        + targetBlockPoolId));
+              }
+              return res;
+            });
+          } catch (IOException e) {
+            throw new CompletionException(e);
+          }
+        });
+      }
+      return future.thenApply(r -> targetBlockPoolId);
+    });
+
+    RouterRpcClient rpcClient = getRpcClient();
+    completableFuture = completableFuture.thenCompose(o -> {
+      String targetBlockPoolId = (String) o;
+      // Find locations in the matching namespace.
+      try {
+        final RemoteLocation targetDestination
+            = rpcServer.getLocationForPath(trg, true, targetBlockPoolId);
+        String[] sourceDestinations = new String[src.length];
+        for (int i = 0; i < src.length; i++) {
+          String sourceFile = src[i];
+          RemoteLocation location =
+              rpcServer.getLocationForPath(sourceFile, true, targetBlockPoolId);
+          sourceDestinations[i] = location.getDest();
+        }
+        // Invoke
+        RemoteMethod method = new RemoteMethod("concat",
+            new Class<?>[] {String.class, String[].class},
+            targetDestination.getDest(), sourceDestinations);
+        rpcClient.invokeSingle(targetDestination, method, Void.class);
+        return getCompletableFuture();
+      } catch (IOException e) {
+        throw new CompletionException(e);
+      }
+    });
+
+    setCurCompletableFuture(completableFuture);
+    asyncReturn(Void.class);
+  }
+
+  @Override
+  public boolean mkdirs(String src, FsPermission masked, boolean createParent) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    rpcServer.checkOperation(NameNode.OperationCategory.WRITE);
+
+    final List<RemoteLocation> locations =
+        rpcServer.getLocationsForPath(src, false);
+    RemoteMethod method = new RemoteMethod("mkdirs",
+        new Class<?>[] {String.class, FsPermission.class, boolean.class},
+        new RemoteParam(), masked, createParent);
+
+    // Create in all locations
+    if (rpcServer.isPathAll(src)) {
+      return rpcClient.invokeAll(locations, method);
+    }
+
+    CompletableFuture<Object> completableFuture
+        = CompletableFuture.completedFuture(false);
+    if (locations.size() > 1) {
+      // Check if this directory already exists
+      try {
+        getFileInfo(src);
+        completableFuture = getCompletableFuture();
+        completableFuture = completableFuture.thenApply(o -> {
+          HdfsFileStatus fileStatus = (HdfsFileStatus) o;
+          if (fileStatus != null) {
+            // When existing, the NN doesn't return an exception; return true
+            return true;
+          }
+          return false;
+        });
+      } catch (IOException ioe) {
+        // Can't query if this file exists or not.
+        LOG.error("Error getting file info for {} while proxying mkdirs: {}",
+            src, ioe.getMessage());
+      }
+    }
+
+    completableFuture = completableFuture.thenCompose(o -> {
+      boolean success = (boolean) o;
+      if (success) {
+        return CompletableFuture.completedFuture(true);
+      }
+      final RemoteLocation firstLocation = locations.get(0);
+      try {
+        rpcClient.invokeSingle(firstLocation, method, Boolean.class);
+        return getCompletableFuture();
+      } catch (IOException ioe) {
+        throw new CompletionException(ioe);
+      }
+    }).exceptionally(e -> {
+      Throwable cause = e.getCause();
+      if (cause instanceof IOException) {
+        return cause;
+      } else {
+        throw new CompletionException(cause);
+      }
+    }).thenCompose(o -> {
+      if (o instanceof Boolean) {
+        return CompletableFuture.completedFuture(o);
+      }
+      IOException ioe = (IOException) o;
+      final RemoteLocation firstLocation = locations.get(0);
+      final List<RemoteLocation> newLocations;
+      try {
+        newLocations = checkFaultTolerantRetry(
+            method, src, ioe, firstLocation, locations);
+        rpcClient.invokeSequential(
+            newLocations, method, Boolean.class, Boolean.TRUE);
+        return getCompletableFuture();
+      } catch (IOException e) {
+        throw new CompletionException(e);
+      }
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(Boolean.class);
+  }
+
+  @Override
+  public DirectoryListing getListing(
+      String src, byte[] startAfter, boolean needLocation) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    getListingInt(src, startAfter, needLocation);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+
+    RouterClientProtocol.GetListingComparator comparator = getComparator();
+    TreeMap<byte[], HdfsFileStatus> nnListing = new TreeMap<>(comparator);
+
+    completableFuture = completableFuture.thenApply(new Function<Object, Object>() {
+      @Override
+      public Object apply(Object o) {
+        List<RemoteResult<RemoteLocation, DirectoryListing>> listings =
+            (List<RemoteResult<RemoteLocation, DirectoryListing>>) o;
+        int totalRemainingEntries = 0;
+        int remainingEntries = 0;
+        // Check the subcluster listing with the smallest name to make sure
+        // no file is skipped across subclusters
+        byte[] lastName = null;
+        boolean namenodeListingExists = false;
+        if (listings != null) {
+          for (RemoteResult<RemoteLocation, DirectoryListing> result : listings) {
+            if (result.hasException()) {
+              IOException ioe = result.getException();
+              if (ioe instanceof FileNotFoundException) {
+                RemoteLocation location = result.getLocation();
+                LOG.debug("Cannot get listing from {}", location);
+              } else if (!isAllowPartialList()) {
+                throw new CompletionException(ioe);
+              }
+            } else if (result.getResult() != null) {
+              DirectoryListing listing = result.getResult();
+              totalRemainingEntries += listing.getRemainingEntries();
+              HdfsFileStatus[] partialListing = listing.getPartialListing();
+              int length = partialListing.length;
+              if (length > 0) {
+                HdfsFileStatus lastLocalEntry = partialListing[length-1];
+                byte[] lastLocalName = lastLocalEntry.getLocalNameInBytes();
+                if (lastName == null ||
+                    comparator.compare(lastName, lastLocalName) > 0) {
+                  lastName = lastLocalName;
+                }
+              }
+            }
+          }
+
+          // Add existing entries
+          for (RemoteResult<RemoteLocation, DirectoryListing> result : listings) {
+            DirectoryListing listing = result.getResult();
+            if (listing != null) {
+              namenodeListingExists = true;
+              for (HdfsFileStatus file : listing.getPartialListing()) {
+                byte[] filename = file.getLocalNameInBytes();
+                if (totalRemainingEntries > 0 &&
+                    comparator.compare(filename, lastName) > 0) {
+                  // Discarding entries further than the lastName
+                  remainingEntries++;
+                } else {
+                  nnListing.put(filename, file);
+                }
+              }
+              remainingEntries += listing.getRemainingEntries();
+            }
+          }
+        }
+        return new Object[] {remainingEntries, namenodeListingExists, lastName};
+      }
+    });
+
+    FileSubclusterResolver subclusterResolver = getSubclusterResolver();
+    // Add mount points at this level in the tree
+    final List<String> children = subclusterResolver.getMountPoints(src);
+    if (children != null) {
+      // Get the dates for each mount point
+      Map<String, Long> dates = getMountPointDates(src);
+
+      // Create virtual folder with the mount name
+      for (String child : children) {
+        completableFuture = completableFuture.thenCompose(o -> {
+          Object[] args = (Object[]) o;
+          int remainingEntries = (int) args[0];
+          byte[] lastName = (byte[]) args[2];
+          long date = 0;
+          if (dates != null && dates.containsKey(child)) {
+            date = dates.get(child);
+          }
+          Path childPath = new Path(src, child);
+          getMountPointStatus(childPath.toString(), 0, date);
+          CompletableFuture<Object> future = getCompletableFuture();
+          future = future.thenApply(o1 -> {
+            HdfsFileStatus dirStatus = (HdfsFileStatus) o1;
+            // if there is no subcluster path, always add mount point
+            byte[] bChild = DFSUtil.string2Bytes(child);
+            if (lastName == null) {
+              nnListing.put(bChild, dirStatus);
+            } else {
+              if (shouldAddMountPoint(bChild,
+                  lastName, startAfter, remainingEntries)) {
+                // This may overwrite existing listing entries with the mount point
+                // TODO don't add if already there?
+                nnListing.put(bChild, dirStatus);
+              }
+            }
+            return new Object[] {remainingEntries, args[1], lastName};
+          });
+          return future;
+        });
+      }
+
+      completableFuture = completableFuture.thenApply(o -> {
+        Object[] args = (Object[]) o;
+        int remainingEntries = (int) args[0];
+        // Update the remaining count to include left mount points
+        if (nnListing.size() > 0) {
+          byte[] lastListing = nnListing.lastKey();
+          for (int i = 0; i < children.size(); i++) {
+            byte[] bChild = DFSUtil.string2Bytes(children.get(i));
+            if (comparator.compare(bChild, lastListing) > 0) {
+              remainingEntries += (children.size() - i);
+              break;
+            }
+          }
+        }
+        return new Object[] {remainingEntries, args[1], args[2]};
+      });
+
+    }
+
+    completableFuture = completableFuture.thenApply(o -> {
+      Object[] args = (Object[]) o;
+      int remainingEntries = (int) args[0];
+      boolean namenodeListingExists = (boolean) args[1];
+      if (!namenodeListingExists && nnListing.size() == 0 && children == null) {
+        // NN returns a null object if the directory cannot be found and has no
+        // listing. If we didn't retrieve any NN listing data, and there are no
+        // mount points here, return null.
+        return null;
+      }
+
+      // Generate combined listing
+      HdfsFileStatus[] combinedData = new HdfsFileStatus[nnListing.size()];
+      combinedData = nnListing.values().toArray(combinedData);
+      return new DirectoryListing(combinedData, remainingEntries);
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(DirectoryListing.class);
+  }
+
+  /**
+   * Get listing on remote locations.
+   */
+  @Override
+  List<RemoteResult<RemoteLocation, DirectoryListing>> getListingInt(
+      String src, byte[] startAfter, boolean needLocation) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    try {
+      List<RemoteLocation> locations =
+          rpcServer.getLocationsForPath(src, false, false);
+      // Locate the dir and fetch the listing.
+      if (locations.isEmpty()) {
+        setCurCompletableFuture(CompletableFuture.completedFuture(new ArrayList<>()));
+        return asyncReturn(List.class);
+      }
+      RemoteMethod method = new RemoteMethod("getListing",
+          new Class<?>[] {String.class, startAfter.getClass(), boolean.class},
+          new RemoteParam(), startAfter, needLocation);
+      rpcClient.invokeConcurrent(locations, method, false, -1,
+              DirectoryListing.class);
+    } catch (NoLocationException | RouterResolveException e) {
+      LOG.debug("Cannot get locations for {}, {}.", src, e.getMessage());
+      setCurCompletableFuture(CompletableFuture.completedFuture(new ArrayList<>()));
+    }
+    return asyncReturn(List.class);
+  }
+
+
+  HdfsFileStatus getMountPointStatus(
+      String name, int childrenNum, long date, boolean setPath) {
+    FileSubclusterResolver subclusterResolver = getSubclusterResolver();
+    long modTime = date;
+    long accessTime = date;
+    FsPermission permission = FsPermission.getDirDefault();
+    String owner = getSuperUser();
+    String group = getSuperGroup();
+    EnumSet<HdfsFileStatus.Flags> flags =
+        EnumSet.noneOf(HdfsFileStatus.Flags.class);
+    CompletableFuture<Object> completableFuture = null;
+    if (subclusterResolver instanceof MountTableResolver) {
+      try {
+        String mName = name.startsWith("/") ? name : "/" + name;
+        MountTableResolver mountTable = (MountTableResolver) subclusterResolver;
+        MountTable entry = mountTable.getMountPoint(mName);
+        if (entry != null) {
+          RemoteMethod method = new RemoteMethod("getFileInfo",
+              new Class<?>[] {String.class}, new RemoteParam());
+          getFileInfoAll(entry.getDestinations(), method, getMountStatusTimeOut());
+          completableFuture = getCompletableFuture();
+          completableFuture = completableFuture.thenApply(o -> {
+            HdfsFileStatus fInfo = (HdfsFileStatus) o;
+            if (fInfo != null) {
+              return new Object[] {
+                  fInfo.getPermission(), fInfo.getOwner(), fInfo.getGroup(),
+                  fInfo.getChildrenNum(), DFSUtil
+                  .getFlags(fInfo.isEncrypted(), fInfo.isErasureCoded(),
+                  fInfo.isSnapshotEnabled(), fInfo.hasAcl())};
+            }
+            return new Object[] {entry.getMode(), entry.getOwnerName(), entry.getGroupName(),
+                childrenNum, flags};
+          });
+        }
+      } catch (IOException e) {
+        LOG.error("Cannot get mount point: {}", e.getMessage());
+        completableFuture = CompletableFuture.completedFuture(
+            new Object[]{permission, owner, group, childrenNum, flags});
+      }
+    } else {
+      try {
+        UserGroupInformation ugi = RouterRpcServer.getRemoteUser();
+        owner = ugi.getUserName();
+        group = ugi.getPrimaryGroupName();
+        completableFuture =
+            CompletableFuture.completedFuture(new Object[]{permission, owner, group,
+                childrenNum, flags});
+      } catch (IOException e) {
+        String msg = "Cannot get remote user: " + e.getMessage();
+        if (UserGroupInformation.isSecurityEnabled()) {
+          LOG.error(msg);
+        } else {
+          LOG.debug(msg);
+        }
+        completableFuture = CompletableFuture.completedFuture(
+            new Object[]{permission, owner, group, childrenNum, flags});
+      }
+    }
+
+    completableFuture = completableFuture.thenApply(o -> {
+      Object[] args = (Object[]) o;
+      long inodeId = 0;
+      HdfsFileStatus.Builder builder = new HdfsFileStatus.Builder();
+      if (setPath) {
+        Path path = new Path(name);
+        String nameStr = path.getName();
+        builder.path(DFSUtil.string2Bytes(nameStr));
+      }
+
+      return builder.isdir(true)
+          .mtime(modTime)
+          .atime(accessTime)
+          .perm((FsPermission) args[0])
+          .owner((String) args[1])
+          .group((String) args[2])
+          .symlink(new byte[0])
+          .fileId(inodeId)
+          .children((Integer) args[3])
+          .flags((EnumSet<HdfsFileStatus.Flags>) args[4])
+          .build();
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(HdfsFileStatus.class);
+  }
+
+
+  private HdfsFileStatus getFileInfoAll(
+      final List<RemoteLocation> locations,
+      final RemoteMethod method, long timeOutMs) throws IOException {
+
+    RouterRpcClient rpcClient = getRpcClient();
+    // Get the file info from everybody
+    rpcClient.invokeConcurrent(locations, method, false, false, timeOutMs,
+            HdfsFileStatus.class);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenApply(o -> {
+      Map<RemoteLocation, HdfsFileStatus> results = (Map<RemoteLocation, HdfsFileStatus>) o;
+      int children = 0;
+      // We return the first file
+      HdfsFileStatus dirStatus = null;
+      for (RemoteLocation loc : locations) {
+        HdfsFileStatus fileStatus = results.get(loc);
+        if (fileStatus != null) {
+          children += fileStatus.getChildrenNum();
+          if (!fileStatus.isDirectory()) {
+            return fileStatus;
+          } else if (dirStatus == null) {
+            dirStatus = fileStatus;
+          }
+        }
+      }
+      if (dirStatus != null) {
+        return updateMountPointStatus(dirStatus, children);
+      }
+      return null;
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(HdfsFileStatus.class);
+  }
+
+  @Override
+  public boolean recoverLease(String src, String clientName) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    rpcServer.checkOperation(NameNode.OperationCategory.WRITE);
+
+    final List<RemoteLocation> locations =
+        rpcServer.getLocationsForPath(src, true, false);
+    RemoteMethod method = new RemoteMethod("recoverLease",
+        new Class<?>[] {String.class, String.class}, new RemoteParam(),
+        clientName);
+    rpcClient.invokeSequential(locations, method, Boolean.class, null);
+    return asyncReturn(Boolean.class);
+  }
+
+  @Override
+  public long[] getStats() throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    ActiveNamenodeResolver namenodeResolver = getNamenodeResolver();
+    rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED);
+
+    RemoteMethod method = new RemoteMethod("getStats");
+    Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    rpcClient.invokeConcurrent(nss, method, true, false, long[].class);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenApply(o -> {
+      Map<FederationNamespaceInfo, long[]> results
+          = (Map<FederationNamespaceInfo, long[]>) o;
+      long[] combinedData = new long[STATS_ARRAY_LENGTH];
+      for (long[] data : results.values()) {
+        for (int i = 0; i < combinedData.length && i < data.length; i++) {
+          if (data[i] >= 0) {
+            combinedData[i] += data[i];
+          }
+        }
+      }
+      return combinedData;
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(long[].class);
+  }
+
+  @Override
+  public ErasureCodingPolicyInfo[] getErasureCodingPolicies()
+      throws IOException {
+    return asyncErasureCoding.getErasureCodingPolicies();
+  }
+
+  @Override
+  public Map<String, String> getErasureCodingCodecs() throws IOException {
+    return asyncErasureCoding.getErasureCodingCodecs();
+  }
+
+  @Override
+  public AddErasureCodingPolicyResponse[] addErasureCodingPolicies(
+      ErasureCodingPolicy[] policies) throws IOException {
+    return asyncErasureCoding.addErasureCodingPolicies(policies);
+  }
+
+  @Override
+  public void removeErasureCodingPolicy(String ecPolicyName)
+      throws IOException {
+    asyncErasureCoding.removeErasureCodingPolicy(ecPolicyName);
+  }
+
+  @Override
+  public void disableErasureCodingPolicy(String ecPolicyName)
+      throws IOException {
+    asyncErasureCoding.disableErasureCodingPolicy(ecPolicyName);
+  }
+
+  @Override
+  public void enableErasureCodingPolicy(String ecPolicyName)
+      throws IOException {
+    asyncErasureCoding.enableErasureCodingPolicy(ecPolicyName);
+  }
+
+  @Override
+  public ErasureCodingPolicy getErasureCodingPolicy(String src)
+      throws IOException {
+    return asyncErasureCoding.getErasureCodingPolicy(src);
+  }
+
+  @Override
+  public void setErasureCodingPolicy(String src, String ecPolicyName)
+      throws IOException {
+    asyncErasureCoding.setErasureCodingPolicy(src, ecPolicyName);
+  }
+
+  @Override
+  public void unsetErasureCodingPolicy(String src) throws IOException {
+    asyncErasureCoding.unsetErasureCodingPolicy(src);
+  }
+
+  @Override
+  public ECTopologyVerifierResult getECTopologyResultForPolicies(
+      String... policyNames) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED, true);
+    return asyncErasureCoding.getECTopologyResultForPolicies(policyNames);
+  }
+
+  @Override
+  public ECBlockGroupStats getECBlockGroupStats() throws IOException {
+    return asyncErasureCoding.getECBlockGroupStats();
+  }
+
+
+  @Override
+  public ReplicatedBlockStats getReplicatedBlockStats() throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    ActiveNamenodeResolver namenodeResolver = getNamenodeResolver();
+
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    RemoteMethod method = new RemoteMethod("getReplicatedBlockStats");
+    Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    rpcClient.invokeConcurrent(nss, method, true,
+        false, ReplicatedBlockStats.class);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenApply(o -> {
+      Map<FederationNamespaceInfo, ReplicatedBlockStats> ret =
+          (Map<FederationNamespaceInfo, ReplicatedBlockStats>) o;
+      return ReplicatedBlockStats.merge(ret.values());
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(ReplicatedBlockStats.class);
+  }
+
+  @Override
+  public DatanodeInfo[] getDatanodeReport(HdfsConstants.DatanodeReportType type)
+      throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED);
+    return rpcServer.getDatanodeReportAsync(type, true, 0);
+  }
+
+  @Override
+  public DatanodeStorageReport[] getDatanodeStorageReport(
+      HdfsConstants.DatanodeReportType type) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED);
+
+    rpcServer.getDatanodeStorageReportMapAsync(type);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenApply(o -> {
+      Map<String, DatanodeStorageReport[]> dnSubcluster =
+          (Map<String, DatanodeStorageReport[]>) o;
+      return mergeDtanodeStorageReport(dnSubcluster);
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(DatanodeStorageReport[].class);
+  }
+
+  public DatanodeStorageReport[] getDatanodeStorageReport(
+      HdfsConstants.DatanodeReportType type, boolean requireResponse, long timeOutMs)
+      throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED);
+
+    rpcServer.getDatanodeStorageReportMapAsync(type, requireResponse, timeOutMs);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenApply(o -> {
+      Map<String, DatanodeStorageReport[]> dnSubcluster =
+          (Map<String, DatanodeStorageReport[]>) o;
+      return mergeDtanodeStorageReport(dnSubcluster);
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(DatanodeStorageReport[].class);
+  }
+
+  @Override
+  public boolean setSafeMode(
+      HdfsConstants.SafeModeAction action, boolean isChecked) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    ActiveNamenodeResolver namenodeResolver = getNamenodeResolver();
+    rpcServer.checkOperation(NameNode.OperationCategory.WRITE);
+
+    // Set safe mode in all the name spaces
+    RemoteMethod method = new RemoteMethod("setSafeMode",
+        new Class<?>[] {HdfsConstants.SafeModeAction.class, boolean.class},
+        action, isChecked);
+    Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    rpcClient.invokeConcurrent(
+            nss, method, true, !isChecked, Boolean.class);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenApply(o -> {
+      Map<FederationNamespaceInfo, Boolean> results
+          = (Map<FederationNamespaceInfo, Boolean>) o;
+      // We only report true if all the name space are in safe mode
+      int numSafemode = 0;
+      for (boolean safemode : results.values()) {
+        if (safemode) {
+          numSafemode++;
+        }
+      }
+      return numSafemode == results.size();
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(Boolean.class);
+  }
+
+  @Override
+  public boolean saveNamespace(long timeWindow, long txGap) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    ActiveNamenodeResolver namenodeResolver = getNamenodeResolver();
+    rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED);
+
+    RemoteMethod method = new RemoteMethod("saveNamespace",
+        new Class<?>[] {long.class, long.class}, timeWindow, txGap);
+    final Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    rpcClient.invokeConcurrent(nss, method, true,
+        false, boolean.class);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenApply(o -> {
+      Map<FederationNamespaceInfo, Boolean> ret =
+          (Map<FederationNamespaceInfo, Boolean>) o;
+      boolean success = true;
+      for (boolean s : ret.values()) {
+        if (!s) {
+          success = false;
+          break;
+        }
+      }
+      return success;
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(Boolean.class);
+  }
+
+  @Override
+  public long rollEdits() throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    ActiveNamenodeResolver namenodeResolver = getNamenodeResolver();
+    rpcServer.checkOperation(NameNode.OperationCategory.WRITE);
+
+    RemoteMethod method = new RemoteMethod("rollEdits", new Class<?>[] {});
+    final Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    rpcClient.invokeConcurrent(nss, method, true, false, long.class);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenApply(o -> {
+      Map<FederationNamespaceInfo, Long> ret =
+          (Map<FederationNamespaceInfo, Long>) o;
+      // Return the maximum txid
+      long txid = 0;
+      for (long t : ret.values()) {
+        if (t > txid) {
+          txid = t;
+        }
+      }
+      return txid;
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(Long.class);
+  }
+
+  @Override
+  public boolean restoreFailedStorage(String arg) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    ActiveNamenodeResolver namenodeResolver = getNamenodeResolver();
+    rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED);
+
+    RemoteMethod method = new RemoteMethod("restoreFailedStorage",
+        new Class<?>[] {String.class}, arg);
+    final Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    rpcClient.invokeConcurrent(nss, method, true, false, Boolean.class);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenApply(o -> {
+      Map<FederationNamespaceInfo, Boolean> ret =
+          (Map<FederationNamespaceInfo, Boolean>) o;
+      boolean success = true;
+      for (boolean s : ret.values()) {
+        if (!s) {
+          success = false;
+          break;
+        }
+      }
+      return success;
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(Boolean.class);
+  }
+
+  @Override
+  public RollingUpgradeInfo rollingUpgrade(
+      HdfsConstants.RollingUpgradeAction action) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    ActiveNamenodeResolver namenodeResolver = getNamenodeResolver();
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    RemoteMethod method = new RemoteMethod("rollingUpgrade",
+        new Class<?>[] {HdfsConstants.RollingUpgradeAction.class}, action);
+    final Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+
+    rpcClient.invokeConcurrent(
+            nss, method, true, false, RollingUpgradeInfo.class);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenApply(o -> {
+      Map<FederationNamespaceInfo, RollingUpgradeInfo> ret =
+          (Map<FederationNamespaceInfo, RollingUpgradeInfo>) o;
+      // Return the first rolling upgrade info
+      RollingUpgradeInfo info = null;
+      for (RollingUpgradeInfo infoNs : ret.values()) {
+        if (info == null && infoNs != null) {
+          info = infoNs;
+        }
+      }
+      return info;
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(RollingUpgradeInfo.class);
+  }
+
+  @Override
+  public HdfsFileStatus getFileInfo(String src) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    FileSubclusterResolver subclusterResolver = getSubclusterResolver();
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    IOException noLocationException = null;
+    try {
+      final List<RemoteLocation> locations =
+          rpcServer.getLocationsForPath(src, false, false);
+      RemoteMethod method = new RemoteMethod("getFileInfo",
+          new Class<?>[] {String.class}, new RemoteParam());
+
+      // If it's a directory, we check in all locations
+      if (rpcServer.isPathAll(src)) {
+        getFileInfoAll(locations, method);
+      } else {
+        // Check for file information sequentially
+        rpcClient.invokeSequential(locations,
+            method, HdfsFileStatus.class, null);
+      }
+    } catch (NoLocationException | RouterResolveException e) {
+      noLocationException = e;
+    }
+
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    IOException finalNoLocationException = noLocationException;
+    completableFuture = completableFuture.thenApply(o -> {
+      HdfsFileStatus ret = (HdfsFileStatus) o;
+      // If there is no real path, check mount points
+      if (ret == null) {
+        List<String> children = null;
+        try {
+          children = subclusterResolver.getMountPoints(src);
+        } catch (IOException e) {
+          throw new CompletionException(e);
+        }
+        if (children != null && !children.isEmpty()) {
+          Map<String, Long> dates = getMountPointDates(src);
+          long date = 0;
+          if (dates != null && dates.containsKey(src)) {
+            date = dates.get(src);
+          }
+          ret = getMountPointStatus(src, children.size(), date, false);
+        } else if (children != null) {
+          // The src is a mount point, but there are no files or directories
+          ret = getMountPointStatus(src, 0, 0, false);
+        }
+      }
+
+      // Can't find mount point for path and the path didn't contain any sub monit points,
+      // throw the NoLocationException to client.
+      if (ret == null && finalNoLocationException != null) {
+        throw new CompletionException(finalNoLocationException);
+      }
+
+      return ret;
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(HdfsFileStatus.class);
+  }
+
+  private HdfsFileStatus getFileInfoAll(
+      final List<RemoteLocation> locations,
+      final RemoteMethod method) throws IOException {
+    return getFileInfoAll(locations, method, -1);
+  }
+
+  @Override
+  public ContentSummary getContentSummary(String path) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    // Get the summaries from regular files
+    final Collection<ContentSummary> summaries = new ArrayList<>();
+    final List<RemoteLocation> locations = getLocationsForContentSummary(path);
+    final RemoteMethod method = new RemoteMethod("getContentSummary",
+        new Class<?>[] {String.class}, new RemoteParam());
+    rpcClient.invokeConcurrent(locations, method,
+            false, -1, ContentSummary.class);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenApply(o -> {
+      final List<RemoteResult<RemoteLocation, ContentSummary>> results =
+          (List<RemoteResult<RemoteLocation, ContentSummary>>) o;
+      FileNotFoundException notFoundException = null;
+      for (RemoteResult<RemoteLocation, ContentSummary> result : results) {
+        if (result.hasException()) {
+          IOException ioe = result.getException();
+          if (ioe instanceof FileNotFoundException) {
+            notFoundException = (FileNotFoundException)ioe;
+          } else if (!isAllowPartialList()) {
+            throw new CompletionException(ioe);
+          }
+        } else if (result.getResult() != null) {
+          summaries.add(result.getResult());
+        }
+      }
+
+      // Throw original exception if no original nor mount points
+      if (summaries.isEmpty() && notFoundException != null) {
+        throw new CompletionException(notFoundException);
+      }
+
+      return aggregateContentSummary(summaries);
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(ContentSummary.class);
+  }
+
+  @Override
+  public void setQuota(
+      String path, long namespaceQuota, long storagespaceQuota,
+      StorageType type) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    rpcServer.getQuotaModule()
+        .setQuota(path, namespaceQuota, storagespaceQuota, type, true);
+  }
+
+  @Override
+  public QuotaUsage getQuotaUsage(String path) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    return rpcServer.getQuotaModule().getQuotaUsage(path);
+  }
+
+  // todo
+  @Override
+  public Token<DelegationTokenIdentifier> getDelegationToken(Text renewer) throws IOException {
+    return super.getDelegationToken(renewer);
+  }
+
+  //todo
+  @Override
+  public long renewDelegationToken(Token<DelegationTokenIdentifier> token) throws IOException {
+    return super.renewDelegationToken(token);
+  }
+
+  @Override
+  public void cancelDelegationToken(Token<DelegationTokenIdentifier> token) throws IOException {
+    super.cancelDelegationToken(token);
+  }
+
+  @Override
+  public String createSnapshot(
+      String snapshotRoot, String snapshotName) throws IOException {
+    return asyncSnapshotProto.createSnapshot(snapshotRoot, snapshotName);
+  }
+
+  @Override
+  public void deleteSnapshot(
+      String snapshotRoot, String snapshotName) throws IOException {
+    asyncSnapshotProto.deleteSnapshot(snapshotRoot, snapshotName);
+  }
+
+
+  @Override
+  public void allowSnapshot(String snapshotRoot) throws IOException {
+    asyncSnapshotProto.allowSnapshot(snapshotRoot);
+  }
+
+  @Override
+  public void disallowSnapshot(String snapshot) throws IOException {
+    asyncSnapshotProto.disallowSnapshot(snapshot);
+  }
+
+  @Override
+  public void renameSnapshot(
+      String snapshotRoot, String snapshotOldName,
+      String snapshotNewName) throws IOException {
+    asyncSnapshotProto.renameSnapshot(
+        snapshotRoot, snapshotOldName, snapshotNewName);
+  }
+
+  @Override
+  public SnapshottableDirectoryStatus[] getSnapshottableDirListing()
+      throws IOException {
+    return asyncSnapshotProto.getSnapshottableDirListing();
+  }
+
+  @Override
+  public SnapshotStatus[] getSnapshotListing(String snapshotRoot)
+      throws IOException {
+    return asyncSnapshotProto.getSnapshotListing(snapshotRoot);
+  }
+
+  @Override
+  public SnapshotDiffReport getSnapshotDiffReport(
+      String snapshotRoot,
+      String earlierSnapshotName, String laterSnapshotName) throws IOException {
+    return asyncSnapshotProto.getSnapshotDiffReport(
+        snapshotRoot, earlierSnapshotName, laterSnapshotName);
+  }
+
+  @Override
+  public SnapshotDiffReportListing getSnapshotDiffReportListing(
+      String snapshotRoot, String earlierSnapshotName, String laterSnapshotName,
+      byte[] startPath, int index) throws IOException {
+    return asyncSnapshotProto.getSnapshotDiffReportListing(
+        snapshotRoot, earlierSnapshotName, laterSnapshotName, startPath, index);
+  }
+
+  @Override
+  public List<XAttr> getXAttrs(String src, List<XAttr> xAttrs) throws IOException {
+    RouterRpcClient rpcClient = getRpcClient();
+    RouterRpcServer rpcServer = getRpcServer();
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    // TODO handle virtual directories
+    final List<RemoteLocation> locations =
+        rpcServer.getLocationsForPath(src, false, false);
+    RemoteMethod method = new RemoteMethod("getXAttrs",
+        new Class<?>[] {String.class, List.class}, new RemoteParam(), xAttrs);
+    rpcClient.invokeSequential(locations, method, List.class, null);
+    return asyncReturn(List.class);
+  }
+
+  @Override
+  public List<XAttr> listXAttrs(String src) throws IOException {
+    RouterRpcClient rpcClient = getRpcClient();
+    RouterRpcServer rpcServer = getRpcServer();
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    // TODO handle virtual directories
+    final List<RemoteLocation> locations =
+        rpcServer.getLocationsForPath(src, false, false);
+    RemoteMethod method = new RemoteMethod("listXAttrs",
+        new Class<?>[] {String.class}, new RemoteParam());
+    rpcClient.invokeSequential(locations, method, List.class, null);
+    return asyncReturn(List.class);
+  }
+
+  @Override
+  public long getCurrentEditLogTxid() throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    ActiveNamenodeResolver namenodeResolver = getNamenodeResolver();
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    RemoteMethod method = new RemoteMethod(
+        "getCurrentEditLogTxid", new Class<?>[] {});
+    final Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    rpcClient.invokeConcurrent(nss, method, true, false, long.class);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenApply(o -> {
+      Map<FederationNamespaceInfo, Long> ret =
+          (Map<FederationNamespaceInfo, Long>) o;
+      // Return the maximum txid
+      long txid = 0;
+      for (long t : ret.values()) {
+        if (t > txid) {
+          txid = t;
+        }
+      }
+      return txid;
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(Long.class);
+  }
+
+  @Override
+  public Path getEnclosingRoot(String src) throws IOException {
+    Path mountPath = null;
+    if (isDefaultNameServiceEnabled()) {
+      mountPath = new Path("/");
+    }
+
+    FileSubclusterResolver subclusterResolver = getSubclusterResolver();
+    if (subclusterResolver instanceof MountTableResolver) {
+      MountTableResolver mountTable = (MountTableResolver) subclusterResolver;
+      if (mountTable.getMountPoint(src) != null) {
+        mountPath = new Path(mountTable.getMountPoint(src).getSourcePath());
+      }
+    }
+
+    if (mountPath == null) {
+      throw new IOException(String.format("No mount point for %s", src));
+    }
+
+    getEZForPath(src);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    Path finalMountPath = mountPath;
+    completableFuture = completableFuture.thenApply(o -> {
+      EncryptionZone zone = (EncryptionZone) o;
+      if (zone == null) {
+        return finalMountPath;
+      } else {
+        Path zonePath = new Path(zone.getPath());
+        return zonePath.depth() > finalMountPath.depth() ? zonePath : finalMountPath;
+      }
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(Path.class);
+  }
+
+
+  @Override
+  public long addCacheDirective(CacheDirectiveInfo path,
+                                EnumSet<CacheFlag> flags) throws IOException {
+    return routerAsyncCacheAdmin.addCacheDirective(path, flags);
+  }
+
+  @Override
+  public void modifyCacheDirective(CacheDirectiveInfo directive,
+                                   EnumSet<CacheFlag> flags) throws IOException {
+    routerAsyncCacheAdmin.modifyCacheDirective(directive, flags);
+  }
+
+  @Override
+  public void removeCacheDirective(long id) throws IOException {
+    routerAsyncCacheAdmin.removeCacheDirective(id);
+  }
+
+  @Override
+  public BatchedRemoteIterator.BatchedEntries<CacheDirectiveEntry> listCacheDirectives(
+      long prevId,
+      CacheDirectiveInfo filter) throws IOException {
+    return routerAsyncCacheAdmin.listCacheDirectives(prevId, filter);
+  }
+
+  @Override
+  public void addCachePool(CachePoolInfo info) throws IOException {
+    routerAsyncCacheAdmin.addCachePool(info);
+  }
+
+  @Override
+  public void modifyCachePool(CachePoolInfo info) throws IOException {
+    routerAsyncCacheAdmin.modifyCachePool(info);
+  }
+
+  @Override
+  public void removeCachePool(String cachePoolName) throws IOException {
+    routerAsyncCacheAdmin.removeCachePool(cachePoolName);
+  }
+
+  @Override
+  public BatchedRemoteIterator.BatchedEntries<CachePoolEntry> listCachePools(String prevKey)
+      throws IOException {
+    return routerAsyncCacheAdmin.listCachePools(prevKey);
+  }
+
+  @Override
+  public void setStoragePolicy(String src, String policyName)
+      throws IOException {
+    asyncstoragePolicy.setStoragePolicy(src, policyName);
+  }
+
+  @Override
+  public BlockStoragePolicy[] getStoragePolicies() throws IOException {
+    return asyncstoragePolicy.getStoragePolicies();
+  }
+
+
+  @Override
+  public void unsetStoragePolicy(String src) throws IOException {
+    asyncstoragePolicy.unsetStoragePolicy(src);
+  }
+
+  @Override
+  public BlockStoragePolicy getStoragePolicy(String path) throws IOException {
+    return asyncstoragePolicy.getStoragePolicy(path);
+  }
+
+  @Override
+  public void satisfyStoragePolicy(String path) throws IOException {
+    asyncstoragePolicy.satisfyStoragePolicy(path);
+  }
+
+  @Override
+  public DatanodeInfo[] getSlowDatanodeReport() throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED);
+    return rpcServer.getSlowDatanodeReportAsync(true, 0);
+  }
+
+  @Override
+  public boolean setReplication(String src, short replication)
+      throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    rpcServer.checkOperation(NameNode.OperationCategory.WRITE);
+
+    List<RemoteLocation> locations = rpcServer.getLocationsForPath(src, true);
+    RemoteMethod method = new RemoteMethod("setReplication",
+        new Class<?>[] {String.class, short.class}, new RemoteParam(),
+        replication);
+    if (rpcServer.isInvokeConcurrent(src)) {
+      rpcClient.invokeConcurrent(locations, method, Boolean.class);
+      CompletableFuture<Object> completableFuture = getCompletableFuture();
+      completableFuture = completableFuture.thenApply(o -> {
+        Map<RemoteLocation, Boolean> results = (Map<RemoteLocation, Boolean>) o;
+        return !results.containsValue(false);
+      });
+      setCurCompletableFuture(completableFuture);
+    } else {
+      rpcClient.invokeSequential(locations, method, Boolean.class,
+          Boolean.TRUE);
+    }
+    return false;
+  }
+
+  public boolean isMultiDestDirectory(String src) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    try {
+      if (rpcServer.isPathAll(src)) {
+        List<RemoteLocation> locations;
+        locations = rpcServer.getLocationsForPath(src, false, false);
+        RemoteMethod method = new RemoteMethod("getFileInfo",
+            new Class<?>[] {String.class}, new RemoteParam());
+        rpcClient.invokeSequential(locations,
+            method, HdfsFileStatus.class, null);
+        CompletableFuture<Object> completableFuture = getCompletableFuture();
+        completableFuture = completableFuture.thenApply(o -> {
+          HdfsFileStatus fileStatus = (HdfsFileStatus) o;
+          if (fileStatus != null) {
+            return fileStatus.isDirectory();
+          } else {
+            LOG.debug("The destination {} doesn't exist.", src);
+          }
+          return false;
+        });
+        setCurCompletableFuture(completableFuture);
+        return asyncReturn(Boolean.class);
+      }
+    } catch (UnresolvedPathException e) {
+      LOG.debug("The destination {} is a symlink.", src);
+    }
+    setCurCompletableFuture(CompletableFuture.completedFuture(false));
+    return asyncReturn(Boolean.class);
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncNamenodeProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncNamenodeProtocol.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+import org.apache.hadoop.hdfs.security.token.block.ExportedBlockKeys;
+import org.apache.hadoop.hdfs.server.namenode.NNStorage;
+import org.apache.hadoop.hdfs.server.namenode.NameNode;
+import org.apache.hadoop.hdfs.server.protocol.BlocksWithLocations;
+import org.apache.hadoop.hdfs.server.protocol.DatanodeStorageReport;
+import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocol;
+import org.apache.hadoop.hdfs.server.protocol.NamespaceInfo;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Function;
+
+import static org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil.asyncReturn;
+import static org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil.getCompletableFuture;
+import static org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil.setCurCompletableFuture;
+
+public class RouterAsyncNamenodeProtocol extends RouterNamenodeProtocol{
+  /** RPC server to receive client calls. */
+  private final RouterRpcServer rpcServer;
+  /** RPC clients to connect to the Namenodes. */
+  private final RouterRpcClient rpcClient;
+
+  public RouterAsyncNamenodeProtocol(RouterRpcServer server) {
+    super(server);
+    this.rpcServer = server;
+    this.rpcClient =  this.rpcServer.getRPCClient();
+  }
+
+  @Override
+  public BlocksWithLocations getBlocks(
+      DatanodeInfo datanode, long size,
+      long minBlockSize, long hotBlockTimeInterval, StorageType storageType) throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    // Get the namespace where the datanode is located
+    rpcServer.getDatanodeStorageReportMapAsync(HdfsConstants.DatanodeReportType.ALL);
+    CompletableFuture<Object> completableFuture = getCompletableFuture();
+    completableFuture = completableFuture.thenApply((Function<Object, Object>) o -> {
+      String nsId = null;
+      Map<String, DatanodeStorageReport[]> map = (Map<String, DatanodeStorageReport[]>) o;
+      for (Map.Entry<String, DatanodeStorageReport[]> entry : map.entrySet()) {
+        DatanodeStorageReport[] dns = entry.getValue();
+        for (DatanodeStorageReport dn : dns) {
+          DatanodeInfo dnInfo = dn.getDatanodeInfo();
+          if (dnInfo.getDatanodeUuid().equals(datanode.getDatanodeUuid())) {
+            nsId = entry.getKey();
+            break;
+          }
+        }
+        // Break the loop if already found
+        if (nsId != null) {
+          break;
+        }
+      }
+      return nsId;
+    }).thenCompose(o -> {
+      // Forward to the proper namenode
+      if (o != null) {
+        String nsId = (String) o;
+        try {
+          RemoteMethod method = new RemoteMethod(
+              NamenodeProtocol.class, "getBlocks", new Class<?>[]
+              {DatanodeInfo.class, long.class, long.class, long.class, StorageType.class},
+              datanode, size, minBlockSize, hotBlockTimeInterval, storageType);
+          rpcClient.invokeSingle(nsId, method, BlocksWithLocations.class);
+          return getCompletableFuture();
+        } catch (IOException e) {
+          throw new CompletionException(e);
+        }
+      }
+      return CompletableFuture.completedFuture(null);
+    });
+    setCurCompletableFuture(completableFuture);
+    return asyncReturn(BlocksWithLocations.class);
+  }
+
+  @Override
+  public ExportedBlockKeys getBlockKeys() throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    RemoteMethod method =
+        new RemoteMethod(NamenodeProtocol.class, "getBlockKeys");
+    rpcServer.invokeAtAvailableNsAsync(method, ExportedBlockKeys.class);
+    return asyncReturn(ExportedBlockKeys.class);
+  }
+
+  @Override
+  public long getTransactionID() throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    RemoteMethod method =
+        new RemoteMethod(NamenodeProtocol.class, "getTransactionID");
+    rpcServer.invokeAtAvailableNsAsync(method, long.class);
+    return asyncReturn(Long.class);
+  }
+
+  @Override
+  public long getMostRecentCheckpointTxId() throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    RemoteMethod method =
+        new RemoteMethod(NamenodeProtocol.class, "getMostRecentCheckpointTxId");
+    rpcServer.invokeAtAvailableNsAsync(method, long.class);
+    return asyncReturn(Long.class);
+  }
+
+  @Override
+  public long getMostRecentNameNodeFileTxId(NNStorage.NameNodeFile nnf)
+      throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    RemoteMethod method =
+        new RemoteMethod(NamenodeProtocol.class, "getMostRecentNameNodeFileTxId",
+            new Class<?>[] {NNStorage.NameNodeFile.class}, nnf);
+    rpcServer.invokeAtAvailableNsAsync(method, long.class);
+    return asyncReturn(Long.class);
+  }
+
+  @Override
+  public NamespaceInfo versionRequest() throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    RemoteMethod method =
+        new RemoteMethod(NamenodeProtocol.class, "versionRequest");
+    rpcServer.invokeAtAvailableNsAsync(method, NamespaceInfo.class);
+    return asyncReturn(NamespaceInfo.class);
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncRpcClient.java
@@ -104,7 +104,7 @@ public class RouterAsyncRpcClient extends RouterRpcClient{
       List<? extends FederationNamenodeContext> namenodes,
       boolean useObserver, Class<?> protocol,
       Method method, Object... params) throws IOException {
-    LOG.info("{} zj test : {}, {}, {}, {}", Thread.currentThread(), method.getName(), useObserver, namenodes.toString());
+    LOG.info("{} : {}, {}, {}, {}", Thread.currentThread(), method.getName(), useObserver, namenodes.toString());
     CompletableFuture<Object> completableFuture =
         invokeMethodAsync(ugi, namenodes, useObserver, protocol, method, params);
     CUR_COMPLETABLE_FUTURE.set(completableFuture);
@@ -329,7 +329,6 @@ public class RouterAsyncRpcClient extends RouterRpcClient{
       transferThreadLocalContext(originCall, callerContext);
       Client.setAsynchronousMode(true);
       method.invoke(obj, params);
-      // TODO: for test. because dfsclient and router may use main thread.
       // so unset the value , ensure dfsclient rpc is sync.
       Client.setAsynchronousMode(false);
       CompletableFuture<Object> completableFuture =

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncRpcClient.java
@@ -1,0 +1,720 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.NameNodeProxiesClient;
+import org.apache.hadoop.hdfs.protocolPB.AsyncRpcProtocolPBUtil;
+import org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessPolicyController;
+import org.apache.hadoop.hdfs.server.federation.resolver.ActiveNamenodeResolver;
+import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeContext;
+import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeServiceState;
+import org.apache.hadoop.hdfs.server.federation.resolver.RemoteLocation;
+import org.apache.hadoop.io.retry.RetryPolicy;
+import org.apache.hadoop.ipc.CallerContext;
+import org.apache.hadoop.ipc.Client;
+import org.apache.hadoop.ipc.ObserverRetryOnActiveException;
+import org.apache.hadoop.ipc.RemoteException;
+import org.apache.hadoop.ipc.RetriableException;
+import org.apache.hadoop.ipc.Server;
+import org.apache.hadoop.ipc.StandbyException;
+import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.util.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.function.BiFunction;
+
+import static org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessConstants.CONCURRENT_NS;
+import static org.apache.hadoop.hdfs.server.federation.metrics.FederationRPCPerformanceMonitor.CONCURRENT;
+import static org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil.CUR_COMPLETABLE_FUTURE;
+
+public class RouterAsyncRpcClient extends RouterRpcClient{
+  private static final Logger LOG =
+      LoggerFactory.getLogger(RouterAsyncRpcClient.class);
+
+  /**
+   * Create a router RPC client to manage remote procedure calls to NNs.
+   *
+   * @param conf                 Hdfs Configuration.
+   * @param router               A router using this RPC client.
+   * @param resolver             A NN resolver to determine the currently active NN in HA.
+   * @param monitor              Optional performance monitor.
+   * @param routerStateIdContext the router state context object to hold the state ids for all
+   *                             namespaces.
+   */
+  public RouterAsyncRpcClient(
+      Configuration conf, Router router, ActiveNamenodeResolver resolver,
+      RouterRpcMonitor monitor, RouterStateIdContext routerStateIdContext) {
+    super(conf, router, resolver, monitor, routerStateIdContext);
+  }
+
+  @Override
+  public <T extends RemoteLocationContext> boolean invokeAll(
+      final Collection<T> locations, final RemoteMethod method)
+      throws IOException {
+    invokeConcurrent(locations, method, false, false, Boolean.class);
+    CompletableFuture<Object> completableFuture = CUR_COMPLETABLE_FUTURE.get();
+    completableFuture = completableFuture.thenApply(o -> {
+      Map<T, Boolean> results = (Map<T, Boolean>) o;
+      return results.containsValue(true);
+    });
+    CUR_COMPLETABLE_FUTURE.set(completableFuture);
+//    return (boolean) getResult();
+    return false;
+  }
+
+  @Override
+  public Object invokeMethod(
+      UserGroupInformation ugi,
+      List<? extends FederationNamenodeContext> namenodes,
+      boolean useObserver, Class<?> protocol,
+      Method method, Object... params) throws IOException {
+    LOG.info("{} zj test : {}, {}, {}, {}", Thread.currentThread(), method.getName(), useObserver, namenodes.toString());
+    CompletableFuture<Object> completableFuture =
+        invokeMethodAsync(ugi, namenodes, useObserver, protocol, method, params);
+    CUR_COMPLETABLE_FUTURE.set(completableFuture);
+    return completableFuture;
+  }
+
+  private CompletableFuture<Object> invokeMethodAsync(
+      final UserGroupInformation ugi,
+      final List<? extends FederationNamenodeContext> namenodes,
+      boolean useObserver,
+      final Class<?> protocol, final Method method, final Object... params)
+      throws IOException {
+
+    if (namenodes == null || namenodes.isEmpty()) {
+      throw new IOException("No namenodes to invoke " + method.getName() +
+          " with params " + Arrays.deepToString(params) + " from "
+          + router.getRouterId());
+    }
+
+    addClientInfoToCallerContext(ugi);
+    if (rpcMonitor != null) {
+      rpcMonitor.incrProcessingOp();
+    }
+    // transfer originCall & callerContext to worker threads of executor.
+    final Server.Call originCall = Server.getCurCall().get();
+    final CallerContext originContext = CallerContext.getCurrent();
+
+    final long startProxyTime = Time.monotonicNow();
+    Map<FederationNamenodeContext, IOException> ioes = new LinkedHashMap<>();
+
+    CompletableFuture<Object[]> completableFuture =
+        CompletableFuture.completedFuture(new Object[]{useObserver, false, false, null});
+
+    for (FederationNamenodeContext namenode : namenodes) {
+      completableFuture = completableFuture.thenCompose(args -> {
+        LOG.info("{} invokeAsyncTask {} {} {}",
+            Thread.currentThread(), namenode, method.getName(), params);
+        Boolean shouldUseObserver = (Boolean) args[0];
+        Boolean failover = (Boolean) args[1];
+        Boolean complete = (Boolean) args[2];
+        if (complete) {
+          return CompletableFuture.completedFuture(
+              new Object[]{shouldUseObserver, failover, complete, args[3]});
+        }
+        return invokeAsyncTask(originCall, originContext, startProxyTime, ioes, ugi,
+            namenode, shouldUseObserver, failover, protocol, method, params);
+      });
+    }
+
+    return completableFuture.thenApply(args -> {
+      Boolean complete = (Boolean) args[2];
+      if (complete) {
+        return args[3];
+      }
+      // All namenodes were unavailable or in standby
+      String msg = "No namenode available to invoke " + method.getName() + " " +
+          Arrays.deepToString(params) + " in " + namenodes + " from " +
+          router.getRouterId();
+      LOG.error(msg);
+      int exConnect = 0;
+      for (Map.Entry<FederationNamenodeContext, IOException> entry :
+          ioes.entrySet()) {
+        FederationNamenodeContext namenode = entry.getKey();
+        String nnKey = namenode.getNamenodeKey();
+        String addr = namenode.getRpcAddress();
+        IOException ioe = entry.getValue();
+        if (ioe instanceof StandbyException) {
+          LOG.error("{} at {} is in Standby: {}",
+              nnKey, addr, ioe.getMessage());
+        } else if (isUnavailableException(ioe)) {
+          exConnect++;
+          LOG.error("{} at {} cannot be reached: {}",
+              nnKey, addr, ioe.getMessage());
+        } else {
+          LOG.error("{} at {} error: \"{}\"", nnKey, addr, ioe.getMessage());
+        }
+      }
+      if (exConnect == ioes.size()) {
+        throw new CompletionException(new ConnectException(msg));
+      } else {
+        throw new CompletionException(new StandbyException(msg));
+      }
+    });
+  }
+
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  private CompletableFuture<Object[]> invokeAsyncTask(
+      final Server.Call originCall,
+      final CallerContext callerContext,
+      final long startProxyTime,
+      final Map<FederationNamenodeContext, IOException> ioes,
+      final UserGroupInformation ugi,
+      FederationNamenodeContext namenode,
+      boolean useObserver,
+      boolean failover,
+      final Class<?> protocol, final Method method, final Object... params) {
+    transferThreadLocalContext(originCall, callerContext);
+    if (!useObserver && (namenode.getState() == FederationNamenodeServiceState.OBSERVER)) {
+      return CompletableFuture.completedFuture(new Object[]{useObserver, failover, false, null});
+    }
+    String nsId = namenode.getNameserviceId();
+    String rpcAddress = namenode.getRpcAddress();
+    try {
+      ConnectionContext connection = getConnection(ugi, nsId, rpcAddress, protocol);
+      NameNodeProxiesClient.ProxyAndInfo<?> client = connection.getClient();
+      return invokeAsync(originCall, callerContext, nsId, namenode, useObserver,
+          0, method, client.getProxy(), params)
+          .handle((result, e) -> {
+            connection.release();
+            boolean complete = false;
+            if (result != null || e == null) {
+              complete = true;
+              if (failover &&
+                  FederationNamenodeServiceState.OBSERVER != namenode.getState()) {
+                // Success on alternate server, update
+                InetSocketAddress address = client.getAddress();
+                try {
+                  namenodeResolver.updateActiveNamenode(nsId, address);
+                } catch (IOException ex) {
+                  throw new CompletionException(ex);
+                }
+              }
+              if (this.rpcMonitor != null) {
+                this.rpcMonitor.proxyOpComplete(
+                    true, nsId, namenode.getState(), Time.monotonicNow() - startProxyTime);
+              }
+              if (this.router.getRouterClientMetrics() != null) {
+                this.router.getRouterClientMetrics().incInvokedMethod(method);
+              }
+              return new Object[] {useObserver, failover, complete, result};
+            }
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException) {
+              IOException ioe = (IOException) cause;
+              ioes.put(namenode, ioe);
+              if (ioe instanceof ObserverRetryOnActiveException) {
+                LOG.info("Encountered ObserverRetryOnActiveException from {}."
+                    + " Retry active namenode directly.", namenode);
+                return new Object[]{false, failover, complete, null};
+              } else if (ioe instanceof StandbyException) {
+                // Fail over indicated by retry policy and/or NN
+                if (this.rpcMonitor != null) {
+                  this.rpcMonitor.proxyOpFailureStandby(nsId);
+                }
+                return new Object[]{useObserver, true, complete, null};
+              } else if (isUnavailableException(ioe)) {
+                if (this.rpcMonitor != null) {
+                  this.rpcMonitor.proxyOpFailureCommunicate(nsId);
+                }
+                boolean tmpFailover = failover;
+                if (FederationNamenodeServiceState.OBSERVER == namenode.getState()) {
+                  try {
+                    namenodeResolver.updateUnavailableNamenode(nsId,
+                        NetUtils.createSocketAddr(namenode.getRpcAddress()));
+                  } catch (IOException ex) {
+                    throw new CompletionException(ex);
+                  }
+                } else {
+                  tmpFailover = true;
+                }
+                return new Object[]{useObserver, tmpFailover, complete, null};
+              } else if (ioe instanceof RemoteException) {
+                if (this.rpcMonitor != null) {
+                  this.rpcMonitor.proxyOpComplete(
+                      true, nsId, namenode.getState(), Time.monotonicNow() - startProxyTime);
+                }
+                RemoteException re = (RemoteException) ioe;
+                ioe = re.unwrapRemoteException();
+                ioe = getCleanException(ioe);
+                // RemoteException returned by NN
+                throw new CompletionException(ioe);
+              } else if (ioe instanceof NoNamenodesAvailableException) {
+                IOException cau = (IOException) ioe.getCause();
+                if (this.rpcMonitor != null) {
+                  this.rpcMonitor.proxyOpNoNamenodes(nsId);
+                }
+                LOG.error("Cannot get available namenode for {} {} error: {}",
+                    nsId, rpcAddress, ioe.getMessage());
+                // Rotate cache so that client can retry the next namenode in the cache
+                if (shouldRotateCache(cau)) {
+                  this.namenodeResolver.rotateCache(nsId, namenode, useObserver);
+                }
+                // Throw RetriableException so that client can retry
+                throw new CompletionException(new RetriableException(ioe));
+              } else {
+                // Other communication error, this is a failure
+                // Communication retries are handled by the retry policy
+                if (this.rpcMonitor != null) {
+                  this.rpcMonitor.proxyOpFailureCommunicate(nsId);
+                  this.rpcMonitor.proxyOpComplete(
+                      false, nsId, namenode.getState(), Time.monotonicNow() - startProxyTime);
+                }
+                throw new CompletionException(ioe);
+              }
+            }
+            throw new CompletionException(cause);
+          });
+    }catch (IOException ioe) {
+      assert ioe instanceof ConnectionNullException;
+      if (this.rpcMonitor != null) {
+        this.rpcMonitor.proxyOpFailureCommunicate(nsId);
+      }
+      LOG.error("Get connection for {} {} error: {}", nsId, rpcAddress,
+          ioe.getMessage());
+      // Throw StandbyException so that client can retry
+      StandbyException se = new StandbyException(ioe.getMessage());
+      se.initCause(ioe);
+      throw new CompletionException(se);
+    }
+  }
+
+
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  private CompletableFuture<Object> invokeAsync(
+      final Server.Call originCall,
+      final CallerContext callerContext,
+      String nsId, FederationNamenodeContext namenode,
+      Boolean listObserverFirst,
+      int retryCount, final Method method,
+      final Object obj, final Object... params) {
+    try {
+      transferThreadLocalContext(originCall, callerContext);
+      Client.setAsynchronousMode(true);
+      method.invoke(obj, params);
+      // TODO: for test. because dfsclient and router may use main thread.
+      // so unset the value , ensure dfsclient rpc is sync.
+      Client.setAsynchronousMode(false);
+      CompletableFuture<Object> completableFuture =
+          AsyncRpcProtocolPBUtil.getCompletableFuture();
+
+      return completableFuture.handle((BiFunction<Object, Throwable, Object>) (result, e) -> {
+        if (e == null) {
+          return new Object[]{result, true};
+        }
+
+        Throwable cause = e.getCause();
+        if (cause instanceof IOException) {
+          IOException ioe = (IOException) cause;
+
+          // Check if we should retry.
+          RetryPolicy.RetryAction.RetryDecision decision = null;
+          try {
+            decision = shouldRetry(ioe, retryCount, nsId, namenode, listObserverFirst);
+          } catch (IOException ex) {
+            throw new CompletionException(ex);
+          }
+          if (decision == RetryPolicy.RetryAction.RetryDecision.RETRY) {
+            if (RouterAsyncRpcClient.this.rpcMonitor != null) {
+              RouterAsyncRpcClient.this.rpcMonitor.proxyOpRetries();
+            }
+            // retry
+            return new Object[]{result, false};
+          } else if (decision == RetryPolicy.RetryAction.RetryDecision.FAILOVER_AND_RETRY) {
+            // failover, invoker looks for standby exceptions for failover.
+            if (ioe instanceof StandbyException) {
+              throw new CompletionException(ioe);
+            } else if (isUnavailableException(ioe)) {
+              throw new CompletionException(ioe);
+            } else {
+              throw new CompletionException(new StandbyException(ioe.getMessage()));
+            }
+          } else {
+            throw new CompletionException(ioe);
+          }
+        } else {
+          throw new CompletionException(new IOException(e));
+        }
+      }).thenCompose(o -> {
+        Object[] args = (Object[]) o;
+        boolean complete = (boolean) args[1];
+        if (complete) {
+          return CompletableFuture.completedFuture(args[0]);
+        }
+        return invokeAsync(originCall, callerContext, nsId, namenode,
+            listObserverFirst, retryCount + 1, method, obj, params);
+      });
+    } catch (InvocationTargetException e) {
+      throw new CompletionException(e.getCause());
+    } catch (Exception e) {
+      throw new CompletionException(e);
+    }
+  }
+
+  @Override
+  public <T> T invokeSequential(
+      final List<? extends RemoteLocationContext> locations,
+      final RemoteMethod remoteMethod, Class<T> expectedResultClass,
+      Object expectedResultValue) throws IOException {
+    invokeSequential(remoteMethod, locations, expectedResultClass, expectedResultValue);
+    CompletableFuture<Object> completableFuture = CUR_COMPLETABLE_FUTURE.get();
+    completableFuture = completableFuture.thenApply(o -> {
+      RemoteResult result = (RemoteResult) o;
+      return result.getResult();
+    });
+    CUR_COMPLETABLE_FUTURE.set(completableFuture);
+//    return (T) getResult();
+    return RouterAsyncRpcUtil.asyncReturn(expectedResultClass);
+  }
+
+  @Override
+  public <R extends RemoteLocationContext, T> RemoteResult invokeSequential(
+      final RemoteMethod remoteMethod, final List<R> locations,
+      Class<T> expectedResultClass, Object expectedResultValue)
+      throws IOException {
+    RouterRpcFairnessPolicyController controller = getRouterRpcFairnessPolicyController();
+    final UserGroupInformation ugi = RouterRpcServer.getRemoteUser();
+    final Method m = remoteMethod.getMethod();
+    List<IOException> thrownExceptions = new ArrayList<>();
+    List<Object> results = new ArrayList<>();
+    CompletableFuture<Object[]> completableFuture =
+        CompletableFuture.completedFuture(new Object[] {null, false});
+    // Invoke in priority order
+    for (final RemoteLocationContext loc : locations) {
+      String ns = loc.getNameserviceId();
+      acquirePermit(ns, ugi, remoteMethod, controller);
+      completableFuture = completableFuture.thenCompose(args -> {
+        boolean complete = (boolean) args[1];
+        if (complete) {
+          return CompletableFuture.completedFuture(new Object[]{args[0], true});
+        }
+        return invokeSequentialToOneNs(ugi, m,
+            thrownExceptions, remoteMethod, loc, expectedResultClass,
+            expectedResultValue, results);
+      });
+
+      releasePermit(ns, ugi, remoteMethod, controller);
+    }
+
+    CompletableFuture<Object> resultFuture = completableFuture.thenApply(args -> {
+      boolean complete = (boolean) args[1];
+      if (complete) {
+        return args[0];
+      }
+      if (!thrownExceptions.isEmpty()) {
+        // An unavailable subcluster may be the actual cause
+        // We cannot surface other exceptions (e.g., FileNotFoundException)
+        for (int i = 0; i < thrownExceptions.size(); i++) {
+          IOException ioe = thrownExceptions.get(i);
+          if (isUnavailableException(ioe)) {
+            throw new CompletionException(ioe);
+          }
+        }
+
+        // re-throw the first exception thrown for compatibility
+        throw new CompletionException(thrownExceptions.get(0));
+      }
+      // Return the first result, whether it is the value or not
+      return new RemoteResult<>(locations.get(0), results.get(0));
+    });
+    System.out.println("zjcom2: " + resultFuture);
+    CUR_COMPLETABLE_FUTURE.set(resultFuture);
+//    return (RemoteResult) getResult();
+    return null;
+  }
+
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  private CompletableFuture<Object[]> invokeSequentialToOneNs(
+      final UserGroupInformation ugi, final Method m,
+      final List<IOException> thrownExceptions,
+      final RemoteMethod remoteMethod, final RemoteLocationContext loc,
+      final Class expectedResultClass, final Object expectedResultValue,
+      final List<Object> results) {
+    String ns = loc.getNameserviceId();
+    boolean isObserverRead = isObserverReadEligible(ns, m);
+    try {
+      List<? extends FederationNamenodeContext> namenodes =
+          getOrderedNamenodes(ns, isObserverRead);
+      Class<?> proto = remoteMethod.getProtocol();
+      Object[] params = remoteMethod.getParams(loc);
+
+      CompletableFuture<Object> completableFuture =
+          (CompletableFuture<Object>) invokeMethod(ugi, namenodes,
+              isObserverRead, proto, m, params);
+      return completableFuture.handle((result, e) -> {
+        if (e == null) {
+          // Check if the result is what we expected
+          if (isExpectedClass(expectedResultClass, result) &&
+              isExpectedValue(expectedResultValue, result)) {
+            // Valid result, stop here
+            return new Object[] {new RemoteResult<>(loc, result), true};
+          } else {
+            results.add(result);
+            return new Object[] {null, false};
+          }
+        }
+
+        Throwable cause = e.getCause();
+        if (cause instanceof IOException) {
+          IOException ioe = (IOException) cause;
+          // Localize the exception
+
+          ioe = processException(ioe, loc);
+
+          // Record it and move on
+          thrownExceptions.add(ioe);
+        } else {
+          // Unusual error, ClientProtocol calls always use IOException (or
+          // RemoteException). Re-wrap in IOException for compatibility with
+          // ClientProtocol.
+          LOG.error("Unexpected exception {} proxying {} to {}",
+              e.getClass(), m.getName(), ns, e);
+          IOException ioe = new IOException(
+              "Unexpected exception proxying API " + e.getMessage(), e);
+          thrownExceptions.add(ioe);
+        }
+        return new Object[] {null, false};
+      });
+    }catch (IOException ioe) {
+      throw new CompletionException(ioe);
+    }
+  }
+
+  @Override
+  public <T extends RemoteLocationContext, R> Map<T, R> invokeConcurrent(
+      final Collection<T> locations, final RemoteMethod method,
+      boolean requireResponse, boolean standby, long timeOutMs, Class<R> clazz)
+      throws IOException {
+    invokeConcurrentAsync(locations, method, standby, timeOutMs, clazz);
+    CompletableFuture<Object> completableFuture = CUR_COMPLETABLE_FUTURE.get();
+    completableFuture =  completableFuture.thenApply(o -> {
+      final List<RemoteResult<T, R>> results = (List<RemoteResult<T, R>>) o;
+      // Go over the results and exceptions
+      final Map<T, R> ret = new TreeMap<>();
+      final List<IOException> thrownExceptions = new ArrayList<>();
+      IOException firstUnavailableException = null;
+      for (final RemoteResult<T, R> result : results) {
+        if (result.hasException()) {
+          IOException ioe = result.getException();
+          thrownExceptions.add(ioe);
+          // Track unavailable exceptions to throw them first
+          if (isUnavailableException(ioe)) {
+            firstUnavailableException = ioe;
+          }
+        }
+        if (result.hasResult()) {
+          ret.put(result.getLocation(), result.getResult());
+        }
+      }
+      // Throw exceptions if needed
+      if (!thrownExceptions.isEmpty()) {
+        // Throw if response from all servers required or no results
+        if (requireResponse || ret.isEmpty()) {
+          // Throw unavailable exceptions first
+          if (firstUnavailableException != null) {
+            throw new CompletionException(firstUnavailableException);
+          } else {
+            throw new CompletionException(thrownExceptions.get(0));
+          }
+        }
+      }
+      return ret;
+    });
+    CUR_COMPLETABLE_FUTURE.set(completableFuture);
+//    return (Map<T, R>) getResult();
+    return null;
+  }
+
+  @Override
+  @SuppressWarnings("checkstyle:MethodLength")
+  public <T extends RemoteLocationContext, R> List<RemoteResult<T, R>>
+      invokeConcurrent(final Collection<T> locations,
+                   final RemoteMethod method, boolean standby, long timeOutMs,
+                   Class<R> clazz) throws IOException {
+    invokeConcurrentAsync(locations, method, standby, timeOutMs, clazz);
+//    return (List<RemoteResult<T, R>>) getResult();
+    return null;
+  }
+
+  private  <T extends RemoteLocationContext, R> List<RemoteResult<T, R>>
+      invokeConcurrentAsync(final Collection<T> locations,
+                   final RemoteMethod method, boolean standby, long timeOutMs,
+                   Class<R> clazz) throws IOException {
+    final UserGroupInformation ugi = RouterRpcServer.getRemoteUser();
+    final Method m = method.getMethod();
+
+    if (locations.isEmpty()) {
+      throw new IOException("No remote locations available");
+    } else if (locations.size() == 1 && timeOutMs <= 0) {
+      // Shortcut, just one call
+      T location = locations.iterator().next();
+      String ns = location.getNameserviceId();
+      boolean isObserverRead = isObserverReadEligible(ns, m);
+      final List<? extends FederationNamenodeContext> namenodes =
+          getOrderedNamenodes(ns, isObserverRead);
+      RouterRpcFairnessPolicyController controller = getRouterRpcFairnessPolicyController();
+      acquirePermit(ns, ugi, method, controller);
+      try {
+        Class<?> proto = method.getProtocol();
+        Object[] paramList = method.getParams(location);
+        invokeMethod(ugi, namenodes, isObserverRead, proto, m, paramList);
+        CompletableFuture<Object> completableFuture = CUR_COMPLETABLE_FUTURE.get();
+        completableFuture = completableFuture.exceptionally(e -> {
+          IOException ioe = (IOException) e.getCause();
+          throw new CompletionException(processException(ioe, location));
+        }).thenApply(result -> {
+          RemoteResult<T, R> remoteResult =
+              (RemoteResult<T, R>) new RemoteResult<>(location, result);
+          return Collections.singletonList(remoteResult);
+        });
+        CUR_COMPLETABLE_FUTURE.set(completableFuture);
+        return null;
+      } catch (IOException ioe) {
+        // Localize the exception
+        throw processException(ioe, location);
+      } finally {
+        releasePermit(ns, ugi, method, controller);
+      }
+    }
+
+    if (rpcMonitor != null) {
+      rpcMonitor.incrProcessingOp();
+    }
+    if (this.router.getRouterClientMetrics() != null) {
+      this.router.getRouterClientMetrics().incInvokedConcurrent(m);
+    }
+
+    RouterRpcFairnessPolicyController controller = getRouterRpcFairnessPolicyController();
+    acquirePermit(CONCURRENT_NS, ugi, method, controller);
+
+    List<T> orderedLocations = new ArrayList<>();
+    List<CompletableFuture<Object>> completableFutures = new ArrayList<>();
+    for (final T location : locations) {
+      String nsId = location.getNameserviceId();
+      boolean isObserverRead = isObserverReadEligible(nsId, m);
+      final List<? extends FederationNamenodeContext> namenodes =
+          getOrderedNamenodes(nsId, isObserverRead);
+      final Class<?> proto = method.getProtocol();
+      final Object[] paramList = method.getParams(location);
+      if (standby) {
+        // Call the objectGetter to all NNs (including standby)
+        for (final FederationNamenodeContext nn : namenodes) {
+          final List<FederationNamenodeContext> nnList =
+              Collections.singletonList(nn);
+          String nnId = nn.getNamenodeId();
+          T nnLocation = location;
+          if (location instanceof RemoteLocation) {
+            nnLocation = (T)new RemoteLocation(nsId, nnId, location.getDest());
+          }
+          orderedLocations.add(nnLocation);
+          invokeMethod(ugi, nnList, isObserverRead, proto, m, paramList);
+          completableFutures.add(CUR_COMPLETABLE_FUTURE.get());
+        }
+      } else {
+        // Call the objectGetter in order of nameservices in the NS list
+        orderedLocations.add(location);
+        invokeMethod(ugi, namenodes, isObserverRead, proto, m, paramList);
+        completableFutures.add(CUR_COMPLETABLE_FUTURE.get());
+      }
+    }
+
+    CompletableFuture<Object>[] completableFuturesArray =
+        new CompletableFuture[completableFutures.size()];
+    completableFuturesArray = completableFutures.toArray(completableFuturesArray);
+    CompletableFuture<Void> allFuture = CompletableFuture.allOf(completableFuturesArray);
+    CompletableFuture<Object> resultCompletable = allFuture.handle((unused, throwable) -> {
+      List<RemoteResult<T, R>> results = new ArrayList<>();
+      for (int i=0; i<completableFutures.size(); i++) {
+        T location = orderedLocations.get(i);
+        CompletableFuture<Object> resultFuture = completableFutures.get(i);
+        Object result = null;
+        try {
+          result = resultFuture.get();
+          results.add((RemoteResult<T, R>) new RemoteResult<>(location, result));
+        } catch (InterruptedException ignored) {
+        } catch (ExecutionException e) {
+          Throwable cause = e.getCause();
+          IOException ioe = null;
+          if (cause instanceof CancellationException) {
+            T loc = orderedLocations.get(i);
+            String msg = "Invocation to \"" + loc + "\" for \""
+                + method.getMethodName() + "\" timed out";
+            LOG.error(msg);
+            ioe = new SubClusterTimeoutException(msg);
+          } else if (cause instanceof IOException) {
+            LOG.debug("Cannot execute {} in {}: {}",
+                m.getName(), location, cause.getMessage());
+            ioe = (IOException) cause;
+          } else {
+            ioe = new IOException("Unhandled exception while proxying API " +
+                m.getName() + ": " + cause.getMessage(), cause);
+          }
+          // Store the exceptions
+          results.add(new RemoteResult<>(location, ioe));
+        }
+      }
+      if (rpcMonitor != null) {
+        rpcMonitor.proxyOpComplete(true, CONCURRENT, null);
+      }
+      return results;
+    });
+
+    CUR_COMPLETABLE_FUTURE.set(resultCompletable);
+    releasePermit(CONCURRENT_NS, ugi, method, controller);
+    return null;
+  }
+
+  @Override
+  public <T> T invokeSingle(final RemoteLocationContext location,
+                            RemoteMethod remoteMethod, Class<T> clazz) throws IOException {
+    List<RemoteLocationContext> locations = Collections.singletonList(location);
+    invokeSequential(locations, remoteMethod);
+//    return (T) getResult();
+    return RouterAsyncRpcUtil.asyncReturn(clazz);
+  }
+
+  @Override
+  public Object invokeSingle(final String nsId, RemoteMethod method)
+      throws IOException {
+    super.invokeSingle(nsId, method);
+//    return getResult();
+    return null;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncRpcClient.java
@@ -111,8 +111,10 @@ public class RouterAsyncRpcClient extends RouterRpcClient{
     final Server.Call originCall = Server.getCurCall().get();
     final CallerContext originContext = CallerContext.getCurrent();
     completableFuture = completableFuture.thenComposeAsync(o -> {
-      LOG.info("Async invoke method : {}, {}, {}, {}", method.getName(), useObserver,
-          namenodes.toString(), params);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Async invoke method : {}, {}, {}, {}", method.getName(), useObserver,
+            namenodes.toString(), params);
+      }
       transferThreadLocalContext(originCall, originContext);
       try {
         return invokeMethodAsync(ugi, namenodes, useObserver, protocol, method, params);
@@ -464,7 +466,6 @@ public class RouterAsyncRpcClient extends RouterRpcClient{
       // Return the first result, whether it is the value or not
       return new RemoteResult<>(locations.get(0), results.get(0));
     });
-    System.out.println("zjcom2: " + resultFuture);
     CUR_COMPLETABLE_FUTURE.set(resultFuture);
 //    return (RemoteResult) getResult();
     return null;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncRpcUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncRpcUtil.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hdfs.server.federation.router;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
@@ -81,4 +82,8 @@ public final class RouterAsyncRpcUtil {
     R res() throws IOException;
   }
 
+  @FunctionalInterface
+  interface AsyncRequestUntil<T, R> {
+    R res(T o) throws IOException;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncRpcUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncRpcUtil.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+
+public final class RouterAsyncRpcUtil {
+  public static final ThreadLocal<CompletableFuture<Object>> CUR_COMPLETABLE_FUTURE
+      = new ThreadLocal<>();
+  private static final Boolean BOOLEAN_RESULT = false;
+  private static final Long LONG_RESULT = -1L;
+  private static final Object NULL_RESULT = null;
+
+  private RouterAsyncRpcUtil(){}
+
+  public static CompletableFuture<Object> getCompletableFuture() {
+    return CUR_COMPLETABLE_FUTURE.get();
+  }
+
+  public static void setCurCompletableFuture(
+      CompletableFuture<Object> completableFuture) {
+    CUR_COMPLETABLE_FUTURE.set(completableFuture);
+  }
+
+  public static Object getResult() throws IOException {
+    try {
+      CompletableFuture<Object> completableFuture = CUR_COMPLETABLE_FUTURE.get();
+      Object o =  completableFuture.get();
+      return o;
+    } catch (InterruptedException e) {
+    } catch (ExecutionException e) {
+      IOException ioe = (IOException) e.getCause();
+      throw ioe;
+    }
+    return null;
+  }
+
+  public static <T> T asyncReturn(Class<T> clazz) {
+    if (clazz == null) {
+      return null;
+    }
+    if (clazz.equals(Boolean.class)) {
+      return (T) BOOLEAN_RESULT;
+    } else if (clazz.equals(Long.class)) {
+      return (T) LONG_RESULT;
+    }
+    return (T) NULL_RESULT;
+  }
+
+  public static <T, R> T asyncRequestThenApply(AsyncRequest<R> asyncRequest,
+      Function<R, T> thenDo, Class<T> clazz) throws IOException {
+    asyncRequest.res();
+    CompletableFuture<R> completableFuture =
+        (CompletableFuture<R>) CUR_COMPLETABLE_FUTURE.get();
+    CompletableFuture<T> resCompletableFuture = completableFuture.thenApply(thenDo);
+    setCurCompletableFuture((CompletableFuture<Object>) resCompletableFuture);
+    return asyncReturn(clazz);
+  }
+
+  @FunctionalInterface
+  interface AsyncRequest<R> {
+    R res() throws IOException;
+  }
+
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncSnapshot.java
@@ -1,0 +1,194 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import org.apache.hadoop.hdfs.DFSUtil;
+import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
+import org.apache.hadoop.hdfs.protocol.SnapshotDiffReportListing;
+import org.apache.hadoop.hdfs.protocol.SnapshotStatus;
+import org.apache.hadoop.hdfs.protocol.SnapshottableDirectoryStatus;
+import org.apache.hadoop.hdfs.server.federation.resolver.ActiveNamenodeResolver;
+import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamespaceInfo;
+import org.apache.hadoop.hdfs.server.federation.resolver.RemoteLocation;
+import org.apache.hadoop.hdfs.server.namenode.NameNode;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil.asyncRequestThenApply;
+import static org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil.asyncReturn;
+
+public class RouterAsyncSnapshot extends RouterSnapshot{
+  public RouterAsyncSnapshot(RouterRpcServer server) {
+    super(server);
+  }
+
+  public String createSnapshot(String snapshotRoot, String snapshotName)
+      throws IOException {
+    RouterRpcClient rpcClient = getRpcClient();
+    RouterRpcServer rpcServer = getRpcServer();
+    rpcServer.checkOperation(NameNode.OperationCategory.WRITE);
+
+    final List<RemoteLocation> locations =
+        rpcServer.getLocationsForPath(snapshotRoot, true, false);
+    RemoteMethod method = new RemoteMethod("createSnapshot",
+        new Class<?>[] {String.class, String.class}, new RemoteParam(),
+        snapshotName);
+
+    if (rpcServer.isInvokeConcurrent(snapshotRoot)) {
+      return asyncRequestThenApply(
+          () -> rpcClient.invokeConcurrent(locations, method, String.class),
+          results -> {
+            Map.Entry<RemoteLocation, String> firstelement =
+                results.entrySet().iterator().next();
+            RemoteLocation loc = firstelement.getKey();
+            String result = firstelement.getValue();
+            result = result.replaceFirst(loc.getDest(), loc.getSrc());
+            return result;
+          }, String.class);
+    } else {
+      return asyncRequestThenApply(
+          () -> rpcClient.invokeSequential(method, locations,
+              String.class, null),
+          response -> {
+            RemoteLocation loc = (RemoteLocation) response.getLocation();
+            String invokedResult = (String) response.getResult();
+            return invokedResult.replaceFirst(loc.getDest(), loc.getSrc());
+          }, String.class);
+    }
+  }
+
+  public SnapshottableDirectoryStatus[] getSnapshottableDirListing()
+      throws IOException {
+    RouterRpcClient rpcClient = getRpcClient();
+    RouterRpcServer rpcServer = getRpcServer();
+    ActiveNamenodeResolver namenodeResolver = getNamenodeResolver();
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    RemoteMethod method = new RemoteMethod("getSnapshottableDirListing");
+    Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    return asyncRequestThenApply(
+        () -> rpcClient.invokeConcurrent(nss, method, true,
+            false, SnapshottableDirectoryStatus[].class),
+        ret -> RouterRpcServer.merge(ret, SnapshottableDirectoryStatus.class),
+        SnapshottableDirectoryStatus[].class);
+  }
+
+  public SnapshotStatus[] getSnapshotListing(String snapshotRoot)
+      throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+    final List<RemoteLocation> locations =
+        rpcServer.getLocationsForPath(snapshotRoot, true, false);
+    RemoteMethod remoteMethod = new RemoteMethod("getSnapshotListing",
+        new Class<?>[]{String.class},
+        new RemoteParam());
+
+    if (rpcServer.isInvokeConcurrent(snapshotRoot)) {
+      return asyncRequestThenApply(
+          () -> rpcClient.invokeConcurrent(locations, remoteMethod, true,
+              false, SnapshotStatus[].class),
+          ret -> {
+            SnapshotStatus[] response = ret.values().iterator().next();
+            String src = ret.keySet().iterator().next().getSrc();
+            String dst = ret.keySet().iterator().next().getDest();
+            for (SnapshotStatus s : response) {
+              String mountPath = DFSUtil.bytes2String(s.getParentFullPath()).
+                  replaceFirst(src, dst);
+              s.setParentFullPath(DFSUtil.string2Bytes(mountPath));
+            }
+            return response;
+          }, SnapshotStatus[].class);
+    } else {
+      return asyncRequestThenApply(
+          () -> rpcClient.invokeSequential(remoteMethod, locations,
+              SnapshotStatus[].class, null),
+          invokedResponse -> {
+            RemoteLocation loc = (RemoteLocation) invokedResponse.getLocation();
+            SnapshotStatus[] response = (SnapshotStatus[]) invokedResponse.getResult();
+            for (SnapshotStatus s : response) {
+              String mountPath = DFSUtil.bytes2String(s.getParentFullPath()).
+                  replaceFirst(loc.getDest(), loc.getSrc());
+              s.setParentFullPath(DFSUtil.string2Bytes(mountPath));
+            }
+            return response;
+          }, SnapshotStatus[].class);
+    }
+  }
+
+  public SnapshotDiffReport getSnapshotDiffReport(
+      String snapshotRoot,
+      String earlierSnapshotName, String laterSnapshotName) throws IOException {
+    RouterRpcClient rpcClient = getRpcClient();
+    RouterRpcServer rpcServer = getRpcServer();
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    final List<RemoteLocation> locations =
+        rpcServer.getLocationsForPath(snapshotRoot, true, false);
+    RemoteMethod remoteMethod = new RemoteMethod("getSnapshotDiffReport",
+        new Class<?>[] {String.class, String.class, String.class},
+        new RemoteParam(), earlierSnapshotName, laterSnapshotName);
+
+    if (rpcServer.isInvokeConcurrent(snapshotRoot)) {
+      return asyncRequestThenApply(
+          () -> rpcClient.invokeConcurrent(locations, remoteMethod,
+              true, false, SnapshotDiffReport.class),
+          ret -> ret.values().iterator().next(), SnapshotDiffReport.class);
+    } else {
+      rpcClient.invokeSequential(
+          locations, remoteMethod, SnapshotDiffReport.class, null);
+      return asyncReturn(SnapshotDiffReport.class);
+    }
+  }
+
+  public SnapshotDiffReportListing getSnapshotDiffReportListing(
+      String snapshotRoot, String earlierSnapshotName, String laterSnapshotName,
+      byte[] startPath, int index) throws IOException {
+    RouterRpcServer rpcServer = getRpcServer();
+    RouterRpcClient rpcClient = getRpcClient();
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    final List<RemoteLocation> locations =
+        rpcServer.getLocationsForPath(snapshotRoot, true, false);
+    Class<?>[] params = new Class<?>[] {
+        String.class, String.class, String.class,
+        byte[].class, int.class};
+    RemoteMethod remoteMethod = new RemoteMethod(
+        "getSnapshotDiffReportListing", params,
+        new RemoteParam(), earlierSnapshotName, laterSnapshotName,
+        startPath, index);
+
+    if (rpcServer.isInvokeConcurrent(snapshotRoot)) {
+      return asyncRequestThenApply(() -> rpcClient.invokeConcurrent(locations, remoteMethod,
+          false, false, SnapshotDiffReportListing.class),
+          ret -> {
+            Collection<SnapshotDiffReportListing> listings = ret.values();
+            return listings.iterator().next();
+          }, SnapshotDiffReportListing.class);
+    } else {
+      rpcClient.invokeSequential(
+          locations, remoteMethod, SnapshotDiffReportListing.class, null);
+      return asyncReturn(SnapshotDiffReportListing.class);
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncStoragePolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncStoragePolicy.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import org.apache.hadoop.hdfs.protocol.BlockStoragePolicy;
+import org.apache.hadoop.hdfs.server.namenode.NameNode;
+
+import java.io.IOException;
+
+public class RouterAsyncStoragePolicy extends RouterStoragePolicy{
+  /** RPC server to receive client calls. */
+  private final RouterRpcServer rpcServer;
+  /** RPC clients to connect to the Namenodes. */
+  private final RouterRpcClient rpcClient;
+
+  public RouterAsyncStoragePolicy(RouterRpcServer server) {
+    super(server);
+    this.rpcServer = server;
+    this.rpcClient = this.rpcServer.getRPCClient();
+  }
+
+  public BlockStoragePolicy[] getStoragePolicies() throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.READ);
+
+    RemoteMethod method = new RemoteMethod("getStoragePolicies");
+    return rpcServer.invokeAtAvailableNsAsync(method, BlockStoragePolicy[].class);
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncUserProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAsyncUserProtocol.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import org.apache.hadoop.hdfs.server.federation.resolver.ActiveNamenodeResolver;
+import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamespaceInfo;
+import org.apache.hadoop.hdfs.server.namenode.NameNode;
+import org.apache.hadoop.security.Groups;
+import org.apache.hadoop.security.RefreshUserMappingsProtocol;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.authorize.ProxyUsers;
+import org.apache.hadoop.tools.GetUserMappingsProtocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer.merge;
+import static org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil.getCompletableFuture;
+import static org.apache.hadoop.hdfs.server.federation.router.RouterAsyncRpcUtil.setCurCompletableFuture;
+
+public class RouterAsyncUserProtocol extends RouterUserProtocol{
+  private static final Logger LOG =
+      LoggerFactory.getLogger(RouterAsyncUserProtocol.class);
+
+  /** RPC server to receive client calls. */
+  private final RouterRpcServer rpcServer;
+  /** RPC clients to connect to the Namenodes. */
+  private final RouterRpcClient rpcClient;
+
+  private final ActiveNamenodeResolver namenodeResolver;
+
+  public RouterAsyncUserProtocol(RouterRpcServer server) {
+    super(server);
+    this.rpcServer = server;
+    this.rpcClient = this.rpcServer.getRPCClient();
+    this.namenodeResolver = this.rpcServer.getNamenodeResolver();
+  }
+
+  @Override
+  public void refreshUserToGroupsMappings() throws IOException {
+    LOG.debug("Refresh user groups mapping in Router.");
+    rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED);
+    Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    if (nss.isEmpty()) {
+      Groups.getUserToGroupsMappingService().refresh();
+      setCurCompletableFuture(CompletableFuture.completedFuture(null));
+    } else {
+      RemoteMethod method = new RemoteMethod(RefreshUserMappingsProtocol.class,
+          "refreshUserToGroupsMappings");
+      rpcClient.invokeConcurrent(nss, method);
+    }
+  }
+
+  @Override
+  public void refreshSuperUserGroupsConfiguration() throws IOException {
+    LOG.debug("Refresh superuser groups configuration in Router.");
+    rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED);
+    Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    if (nss.isEmpty()) {
+      ProxyUsers.refreshSuperUserGroupsConfiguration();
+      setCurCompletableFuture(CompletableFuture.completedFuture(null));
+    } else {
+      RemoteMethod method = new RemoteMethod(RefreshUserMappingsProtocol.class,
+          "refreshSuperUserGroupsConfiguration");
+      rpcClient.invokeConcurrent(nss, method);
+    }
+  }
+
+  @Override
+  public String[] getGroupsForUser(String user) throws IOException {
+    LOG.debug("Getting groups for user {}", user);
+    rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED);
+    Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    if (nss.isEmpty()) {
+      setCurCompletableFuture(
+          CompletableFuture
+              .completedFuture(UserGroupInformation.createRemoteUser(user)
+                  .getGroupNames()));
+    } else {
+      RemoteMethod method = new RemoteMethod(GetUserMappingsProtocol.class,
+          "getGroupsForUser", new Class<?>[] {String.class}, user);
+      rpcClient.invokeConcurrent(nss, method, String[].class);
+      CompletableFuture<Object> completableFuture = getCompletableFuture();
+      completableFuture = completableFuture.thenApply(o -> {
+        Map<FederationNamespaceInfo, String[]> results =
+            (Map<FederationNamespaceInfo, String[]>) o;
+        return merge(results, String.class);
+      });
+      setCurCompletableFuture(completableFuture);
+    }
+    return null;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterCacheAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterCacheAdmin.java
@@ -161,7 +161,7 @@ public class RouterCacheAdmin {
    * @param locations the locations to map.
    * @return map with CacheDirectiveInfo mapped to the locations.
    */
-  private Map<RemoteLocation, CacheDirectiveInfo> getRemoteMap(
+  Map<RemoteLocation, CacheDirectiveInfo> getRemoteMap(
       CacheDirectiveInfo path, final List<RemoteLocation> locations) {
     final Map<RemoteLocation, CacheDirectiveInfo> dstMap = new HashMap<>();
     Iterator<RemoteLocation> iterator = locations.iterator();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterQuotaUpdateService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterQuotaUpdateService.java
@@ -99,6 +99,9 @@ public class RouterQuotaUpdateService extends PeriodicService {
         // This is because mount table does not have mtime.
         // For other mount entry get current quota usage
         HdfsFileStatus ret = this.rpcServer.getFileInfo(src);
+        if (rpcServer.isAsync()) {
+          ret = (HdfsFileStatus) RouterAsyncRpcUtil.getResult();
+        }
         if (ret == null || ret.getModificationTime() == 0) {
           long[] zeroConsume = new long[StorageType.values().length];
           currentQuotaUsage =
@@ -113,6 +116,9 @@ public class RouterQuotaUpdateService extends PeriodicService {
             Quota quotaModule = this.rpcServer.getQuotaModule();
             Map<RemoteLocation, QuotaUsage> usageMap =
                 quotaModule.getEachQuotaUsage(src);
+            if (router.isEnableAsync()) {
+              usageMap = (Map<RemoteLocation, QuotaUsage>) RouterAsyncRpcUtil.getResult();
+            }
             currentQuotaUsage = quotaModule.aggregateQuota(src, usageMap);
             remoteQuotaUsage.putAll(usageMap);
           } catch (IOException ioe) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcMonitor.java
@@ -68,6 +68,9 @@ public interface RouterRpcMonitor {
    */
   void proxyOpComplete(boolean success, String nsId, FederationNamenodeServiceState state);
 
+  void proxyOpComplete(
+      boolean success, String nsId, FederationNamenodeServiceState state, long costMs);
+
   /**
    * Failed to proxy an operation to a namenode because it was in standby.
    * @param nsId nameservice id.
@@ -138,4 +141,6 @@ public interface RouterRpcMonitor {
    * If a path is in a read only mount point.
    */
   void routerFailureReadOnly();
+
+  void incrProcessingOp();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterSnapshot.java
@@ -244,4 +244,16 @@ public class RouterSnapshot {
           locations, remoteMethod, SnapshotDiffReportListing.class, null);
     }
   }
+
+  public RouterRpcServer getRpcServer() {
+    return rpcServer;
+  }
+
+  public RouterRpcClient getRpcClient() {
+    return rpcClient;
+  }
+
+  public ActiveNamenodeResolver getNamenodeResolver() {
+    return namenodeResolver;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterStoragePolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterStoragePolicy.java
@@ -89,7 +89,7 @@ public class RouterStoragePolicy {
     RemoteMethod method = new RemoteMethod("getStoragePolicy",
         new Class<?>[] {String.class},
         new RemoteParam());
-    return (BlockStoragePolicy) rpcClient.invokeSequential(locations, method);
+    return rpcClient.invokeSequential(locations, method);
   }
 
   public void satisfyStoragePolicy(String path) throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestNoNamenodesAvailableLongTime.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestNoNamenodesAvailableLongTime.java
@@ -46,6 +46,7 @@ import java.util.List;
 
 import static org.apache.hadoop.ha.HAServiceProtocol.HAServiceState.ACTIVE;
 import static org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.DEFAULT_HEARTBEAT_INTERVAL_MS;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_RPC_ENABLE_ASYNC;
 import static org.apache.hadoop.hdfs.server.namenode.AclTestHelpers.aclEntry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -114,6 +115,7 @@ public class TestNoNamenodesAvailableLongTime {
 
     // Reduce the number of RPC clients threads to overload the Router easy
     routerConf.setInt(RBFConfigKeys.DFS_ROUTER_CLIENT_THREADS_SIZE, 4);
+    routerConf.setBoolean(DFS_ROUTER_RPC_ENABLE_ASYNC, true);
 
     // No need for datanodes
     cluster.setNumDatanodesPerNameservice(0);
@@ -158,6 +160,7 @@ public class TestNoNamenodesAvailableLongTime {
     }
 
     routerContext = cluster.getRandomRouter();
+    assertTrue(routerContext.getRouter().isEnableAsync());
 
     // Get the second namenode in the router cache and make it active
     setSecondNonObserverNamenodeInTheRouterCacheActive(numberOfObserver, false);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HA_NAMENODES_KEY_PREFIX;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMESERVICES;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.NAMENODES;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_RPC_ENABLE_ASYNC;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -133,7 +134,8 @@ public class TestObserverWithRouter {
         .metrics()
         .rpc()
         .build();
-
+    routerConf.setBoolean(DFS_ROUTER_RPC_ENABLE_ASYNC, true);
+    conf.setBoolean(DFS_ROUTER_RPC_ENABLE_ASYNC, true);
     cluster.addRouterOverrides(conf);
     cluster.addRouterOverrides(routerConf);
 
@@ -148,6 +150,7 @@ public class TestObserverWithRouter {
 
     cluster.waitActiveNamespaces();
     routerContext  = cluster.getRandomRouter();
+    assertTrue(routerContext.getRouter().isEnableAsync());
   }
 
   private void setConfDefaults(Configuration conf) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRenewLeaseWithSameINodeId.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRenewLeaseWithSameINodeId.java
@@ -31,7 +31,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_RPC_ENABLE_ASYNC;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Testing DFSClient renewLease with same INodeId.
@@ -55,6 +57,7 @@ public class TestRenewLeaseWithSameINodeId {
         .rpc()
         .quota()
         .build();
+    routerConf.setBoolean(DFS_ROUTER_RPC_ENABLE_ASYNC, true);
     cluster.addRouterOverrides(routerConf);
     cluster.startRouters();
 
@@ -63,6 +66,7 @@ public class TestRenewLeaseWithSameINodeId {
     cluster.waitNamenodeRegistration();
 
     routerContext = cluster.getRouters().get(0);
+    assertTrue(routerContext.getRouter().isEnableAsync());
   }
 
   @AfterClass

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterFederationRename.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterFederationRename.java
@@ -98,6 +98,7 @@ public class TestRouterFederationRename extends TestRouterFederationRenameBase {
     router = getRouterContext();
     routerFS = getRouterFileSystem();
     cluster = getCluster();
+    assertTrue(router.getRouter().isEnableAsync());
   }
 
   private void testRenameDir(RouterContext testRouter, String path,

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterFederationRenameBase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterFederationRenameBase.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.verif
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FEDERATION_RENAME_BANDWIDTH;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FEDERATION_RENAME_MAP;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ADMIN_ENABLE;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_RPC_ENABLE_ASYNC;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.SCHEDULER_JOURNAL_URI;
 
 import java.io.IOException;
@@ -98,6 +99,7 @@ public class TestRouterFederationRenameBase {
     routerConf.setBoolean(DFS_PERMISSIONS_ENABLED_KEY, true);
     routerConf.set(CommonConfigurationKeys.HADOOP_SECURITY_GROUP_MAPPING,
         TestRouterFederationRename.MockGroupsMapping.class.getName());
+    routerConf.setBoolean(DFS_ROUTER_RPC_ENABLE_ASYNC, true);
     cluster.addRouterOverrides(routerConf);
     cluster.startRouters();
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterFederationRenamePermission.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterFederationRenamePermission.java
@@ -92,6 +92,7 @@ public class TestRouterFederationRenamePermission
     foo = UserGroupInformation.createRemoteUser("foo");
     router = getRouterContext();
     routerFS = getRouterFileSystem();
+    assertTrue(router.getRouter().isEnableAsync());
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterQuota.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterQuota.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.federation.router;
 
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_RPC_ENABLE_ASYNC;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -100,6 +101,7 @@ public class TestRouterQuota {
         .rpc()
         .build();
     routerConf.set(RBFConfigKeys.DFS_ROUTER_QUOTA_CACHE_UPDATE_INTERVAL, "2s");
+    routerConf.setBoolean(DFS_ROUTER_RPC_ENABLE_ASYNC, true);
 
     // override some hdfs settings that used in testing space quota
     Configuration hdfsConf = new Configuration(false);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterQuota.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterQuota.java
@@ -947,6 +947,7 @@ public class TestRouterQuota {
 
     routerContext.getRouter().getRpcServer().setQuota("/setquotanmt/testdir17",
         nsQuota, ssQuota, null);
+    RouterAsyncRpcUtil.getResult();
 
     RouterQuotaUpdateService updateService = routerContext.getRouter()
         .getQuotaCacheUpdateService();
@@ -1287,6 +1288,9 @@ public class TestRouterQuota {
     RouterQuotaUpdateService updateService = routerContext.getRouter()
         .getQuotaCacheUpdateService();
     updateService.periodicInvoke();
+    if (routerContext.getRouter().isEnableAsync()) {
+      RouterAsyncRpcUtil.getResult();
+    }
   }
 
   private void verifyTypeQuotaAndConsume(long[] quota, long[] consume,

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRPCMultipleDestinationMountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRPCMultipleDestinationMountTableResolver.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
@@ -2011,6 +2011,9 @@ public class TestRouterRpc {
         new String[] {"bar", "group2"});
     String[] result =
         router.getRouter().getRpcServer().getGroupsForUser("user");
+    if (router.getRouter().isEnableAsync()) {
+      result = (String[]) RouterAsyncRpcUtil.getResult();
+    }
     assertArrayEquals(group, result);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
@@ -27,6 +27,7 @@ import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.delet
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.getFileStatus;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.verifyFileExists;
 import static org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.TEST_STRING;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_RPC_ENABLE_ASYNC;
 import static org.apache.hadoop.ipc.CallerContext.PROXY_USER_PORT;
 import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -248,6 +249,7 @@ public class TestRouterRpc {
     // We decrease the DN cache times to make the test faster
     routerConf.setTimeDuration(
         RBFConfigKeys.DN_REPORT_CACHE_EXPIRE, 1, TimeUnit.SECONDS);
+    routerConf.setBoolean(DFS_ROUTER_RPC_ENABLE_ASYNC, true);
     cluster.addRouterOverrides(routerConf);
     cluster.startRouters();
 
@@ -346,6 +348,7 @@ public class TestRouterRpc {
     this.routerFS = r.getFileSystem();
     this.routerNamenodeProtocol = NameNodeProxies.createProxy(router.getConf(),
         router.getFileSystem().getUri(), NamenodeProtocol.class).getProxy();
+    assertTrue(router.getRouter().isEnableAsync());
   }
 
   protected FileSystem getRouterFileSystem() {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpcSingleNS.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpcSingleNS.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_RPC_ENABLE_ASYNC;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -118,6 +119,7 @@ public class TestRouterRpcSingleNS {
     // We decrease the DN cache times to make the test faster
     routerConf.setTimeDuration(RBFConfigKeys.DN_REPORT_CACHE_EXPIRE, 1,
         TimeUnit.SECONDS);
+    routerConf.setBoolean(DFS_ROUTER_RPC_ENABLE_ASYNC, true);
     cluster.addRouterOverrides(routerConf);
     cluster.startRouters();
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpcStoragePolicySatisfier.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpcStoragePolicySatisfier.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_RPC_ENABLE_ASYNC;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -87,6 +88,7 @@ public class TestRouterRpcStoragePolicySatisfier {
     // We decrease the DN cache times to make the test faster
     routerConf.setTimeDuration(
         RBFConfigKeys.DN_REPORT_CACHE_EXPIRE, 1, TimeUnit.SECONDS);
+    routerConf.setBoolean(DFS_ROUTER_RPC_ENABLE_ASYNC, true);
     cluster.addRouterOverrides(routerConf);
     cluster.startRouters();
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterUserMappings.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterUserMappings.java
@@ -63,6 +63,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_RPC_ENABLE_ASYNC;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -157,6 +158,7 @@ public class TestRouterUserMappings {
   private String setUpMultiRoutersAndReturnDefaultFs() throws Exception {
     //setup a miniroutercluster with 2 nameservices, 4 routers.
     cluster = new MiniRouterDFSCluster(true, 2);
+    conf.setBoolean(DFS_ROUTER_RPC_ENABLE_ASYNC, true);
     cluster.addRouterOverrides(conf);
     cluster.startRouters();
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
@@ -321,131 +321,131 @@ import org.apache.hadoop.thirdparty.protobuf.ServiceException;
 public class ClientNamenodeProtocolServerSideTranslatorPB implements
     ClientNamenodeProtocolPB {
   final private ClientProtocol server;
-  static final DeleteSnapshotResponseProto VOID_DELETE_SNAPSHOT_RESPONSE =
+  protected static final DeleteSnapshotResponseProto VOID_DELETE_SNAPSHOT_RESPONSE =
       DeleteSnapshotResponseProto.newBuilder().build();
-  static final RenameSnapshotResponseProto VOID_RENAME_SNAPSHOT_RESPONSE =
+  protected static final RenameSnapshotResponseProto VOID_RENAME_SNAPSHOT_RESPONSE =
       RenameSnapshotResponseProto.newBuilder().build();
-  static final AllowSnapshotResponseProto VOID_ALLOW_SNAPSHOT_RESPONSE = 
+  protected static final AllowSnapshotResponseProto VOID_ALLOW_SNAPSHOT_RESPONSE =
       AllowSnapshotResponseProto.newBuilder().build();
-  static final DisallowSnapshotResponseProto VOID_DISALLOW_SNAPSHOT_RESPONSE =
+  protected static final DisallowSnapshotResponseProto VOID_DISALLOW_SNAPSHOT_RESPONSE =
       DisallowSnapshotResponseProto.newBuilder().build();
-  static final GetSnapshottableDirListingResponseProto 
+  protected static final GetSnapshottableDirListingResponseProto
       NULL_GET_SNAPSHOTTABLE_DIR_LISTING_RESPONSE = 
       GetSnapshottableDirListingResponseProto.newBuilder().build();
-  static final GetSnapshotListingResponseProto
+  protected static final GetSnapshotListingResponseProto
       NULL_GET_SNAPSHOT_LISTING_RESPONSE =
       GetSnapshotListingResponseProto.newBuilder().build();
-  static final SetStoragePolicyResponseProto VOID_SET_STORAGE_POLICY_RESPONSE =
+  protected static final SetStoragePolicyResponseProto VOID_SET_STORAGE_POLICY_RESPONSE =
       SetStoragePolicyResponseProto.newBuilder().build();
-  static final UnsetStoragePolicyResponseProto
+  protected static final UnsetStoragePolicyResponseProto
       VOID_UNSET_STORAGE_POLICY_RESPONSE =
       UnsetStoragePolicyResponseProto.newBuilder().build();
 
-  private static final CreateResponseProto VOID_CREATE_RESPONSE = 
+  protected static final CreateResponseProto VOID_CREATE_RESPONSE =
   CreateResponseProto.newBuilder().build();
 
-  private static final SetPermissionResponseProto VOID_SET_PERM_RESPONSE = 
+  protected static final SetPermissionResponseProto VOID_SET_PERM_RESPONSE =
   SetPermissionResponseProto.newBuilder().build();
 
-  private static final SetOwnerResponseProto VOID_SET_OWNER_RESPONSE = 
+  protected static final SetOwnerResponseProto VOID_SET_OWNER_RESPONSE =
   SetOwnerResponseProto.newBuilder().build();
 
-  private static final AbandonBlockResponseProto VOID_ADD_BLOCK_RESPONSE = 
+  protected static final AbandonBlockResponseProto VOID_ADD_BLOCK_RESPONSE =
   AbandonBlockResponseProto.newBuilder().build();
 
-  private static final ReportBadBlocksResponseProto VOID_REP_BAD_BLOCK_RESPONSE = 
+  protected static final ReportBadBlocksResponseProto VOID_REP_BAD_BLOCK_RESPONSE =
   ReportBadBlocksResponseProto.newBuilder().build();
 
-  private static final ConcatResponseProto VOID_CONCAT_RESPONSE = 
+  protected static final ConcatResponseProto VOID_CONCAT_RESPONSE =
   ConcatResponseProto.newBuilder().build();
 
-  private static final Rename2ResponseProto VOID_RENAME2_RESPONSE = 
+  protected static final Rename2ResponseProto VOID_RENAME2_RESPONSE =
   Rename2ResponseProto.newBuilder().build();
 
-  private static final GetListingResponseProto VOID_GETLISTING_RESPONSE = 
+  protected static final GetListingResponseProto VOID_GETLISTING_RESPONSE =
   GetListingResponseProto.newBuilder().build();
 
-  private static final GetBatchedListingResponseProto
+  protected static final GetBatchedListingResponseProto
       VOID_GETBATCHEDLISTING_RESPONSE =
       GetBatchedListingResponseProto.newBuilder()
           .setStartAfter(ByteString.copyFromUtf8(""))
           .setHasMore(false)
           .build();
 
-  private static final RenewLeaseResponseProto VOID_RENEWLEASE_RESPONSE = 
+  protected static final RenewLeaseResponseProto VOID_RENEWLEASE_RESPONSE =
   RenewLeaseResponseProto.newBuilder().build();
 
-  private static final RefreshNodesResponseProto VOID_REFRESHNODES_RESPONSE =
+  protected static final RefreshNodesResponseProto VOID_REFRESHNODES_RESPONSE =
   RefreshNodesResponseProto.newBuilder().build();
 
-  private static final FinalizeUpgradeResponseProto VOID_FINALIZEUPGRADE_RESPONSE = 
+  protected static final FinalizeUpgradeResponseProto VOID_FINALIZEUPGRADE_RESPONSE =
   FinalizeUpgradeResponseProto.newBuilder().build();
 
-  private static final MetaSaveResponseProto VOID_METASAVE_RESPONSE = 
+  protected static final MetaSaveResponseProto VOID_METASAVE_RESPONSE =
   MetaSaveResponseProto.newBuilder().build();
 
-  private static final GetFileInfoResponseProto VOID_GETFILEINFO_RESPONSE = 
+  protected static final GetFileInfoResponseProto VOID_GETFILEINFO_RESPONSE =
   GetFileInfoResponseProto.newBuilder().build();
 
-  private static final GetLocatedFileInfoResponseProto
+  protected static final GetLocatedFileInfoResponseProto
       VOID_GETLOCATEDFILEINFO_RESPONSE =
           GetLocatedFileInfoResponseProto.newBuilder().build();
 
-  private static final GetFileLinkInfoResponseProto VOID_GETFILELINKINFO_RESPONSE = 
+  protected static final GetFileLinkInfoResponseProto VOID_GETFILELINKINFO_RESPONSE =
   GetFileLinkInfoResponseProto.newBuilder().build();
 
-  private static final SetQuotaResponseProto VOID_SETQUOTA_RESPONSE = 
+  protected static final SetQuotaResponseProto VOID_SETQUOTA_RESPONSE =
   SetQuotaResponseProto.newBuilder().build();
 
-  private static final FsyncResponseProto VOID_FSYNC_RESPONSE = 
+  protected static final FsyncResponseProto VOID_FSYNC_RESPONSE =
   FsyncResponseProto.newBuilder().build();
 
-  private static final SetTimesResponseProto VOID_SETTIMES_RESPONSE = 
+  protected static final SetTimesResponseProto VOID_SETTIMES_RESPONSE =
   SetTimesResponseProto.newBuilder().build();
 
-  private static final CreateSymlinkResponseProto VOID_CREATESYMLINK_RESPONSE = 
+  protected static final CreateSymlinkResponseProto VOID_CREATESYMLINK_RESPONSE =
   CreateSymlinkResponseProto.newBuilder().build();
 
-  private static final UpdatePipelineResponseProto
+  protected static final UpdatePipelineResponseProto
     VOID_UPDATEPIPELINE_RESPONSE = 
   UpdatePipelineResponseProto.newBuilder().build();
 
-  private static final CancelDelegationTokenResponseProto 
+  protected static final CancelDelegationTokenResponseProto
       VOID_CANCELDELEGATIONTOKEN_RESPONSE = 
           CancelDelegationTokenResponseProto.newBuilder().build();
 
-  private static final SetBalancerBandwidthResponseProto 
+  protected static final SetBalancerBandwidthResponseProto
       VOID_SETBALANCERBANDWIDTH_RESPONSE = 
         SetBalancerBandwidthResponseProto.newBuilder().build();
 
-  private static final SetAclResponseProto
+  protected static final SetAclResponseProto
     VOID_SETACL_RESPONSE = SetAclResponseProto.getDefaultInstance();
 
-  private static final ModifyAclEntriesResponseProto
+  protected static final ModifyAclEntriesResponseProto
     VOID_MODIFYACLENTRIES_RESPONSE = ModifyAclEntriesResponseProto
       .getDefaultInstance();
 
-  private static final RemoveAclEntriesResponseProto
+  protected static final RemoveAclEntriesResponseProto
     VOID_REMOVEACLENTRIES_RESPONSE = RemoveAclEntriesResponseProto
       .getDefaultInstance();
 
-  private static final RemoveDefaultAclResponseProto
+  protected static final RemoveDefaultAclResponseProto
     VOID_REMOVEDEFAULTACL_RESPONSE = RemoveDefaultAclResponseProto
       .getDefaultInstance();
 
-  private static final RemoveAclResponseProto
+  protected static final RemoveAclResponseProto
     VOID_REMOVEACL_RESPONSE = RemoveAclResponseProto.getDefaultInstance();
-  
-  private static final SetXAttrResponseProto
+
+  protected static final SetXAttrResponseProto
     VOID_SETXATTR_RESPONSE = SetXAttrResponseProto.getDefaultInstance();
-  
-  private static final RemoveXAttrResponseProto
+
+  protected static final RemoveXAttrResponseProto
     VOID_REMOVEXATTR_RESPONSE = RemoveXAttrResponseProto.getDefaultInstance();
 
-  private static final CheckAccessResponseProto
+  protected static final CheckAccessResponseProto
     VOID_CHECKACCESS_RESPONSE = CheckAccessResponseProto.getDefaultInstance();
 
-  private static final SatisfyStoragePolicyResponseProto
+  protected static final SatisfyStoragePolicyResponseProto
       VOID_SATISFYSTORAGEPOLICY_RESPONSE = SatisfyStoragePolicyResponseProto
       .getDefaultInstance();
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/NamenodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/NamenodeProtocolServerSideTranslatorPB.java
@@ -73,11 +73,11 @@ public class NamenodeProtocolServerSideTranslatorPB implements
     NamenodeProtocolPB {
   private final NamenodeProtocol impl;
 
-  private final static ErrorReportResponseProto VOID_ERROR_REPORT_RESPONSE = 
-  ErrorReportResponseProto.newBuilder().build();
+  protected final static ErrorReportResponseProto VOID_ERROR_REPORT_RESPONSE =
+      ErrorReportResponseProto.newBuilder().build();
 
-  private final static EndCheckpointResponseProto VOID_END_CHECKPOINT_RESPONSE =
-  EndCheckpointResponseProto.newBuilder().build();
+  protected final static EndCheckpointResponseProto VOID_END_CHECKPOINT_RESPONSE =
+      EndCheckpointResponseProto.newBuilder().build();
 
   public NamenodeProtocolServerSideTranslatorPB(NamenodeProtocol impl) {
     this.impl = impl;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/NamenodeProtocolTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/NamenodeProtocolTranslatorPB.java
@@ -72,18 +72,18 @@ import static org.apache.hadoop.ipc.internal.ShadedProtobufHelper.ipc;
 public class NamenodeProtocolTranslatorPB implements NamenodeProtocol,
     ProtocolMetaInterface, Closeable, ProtocolTranslator {
   /** RpcController is not used and hence is set to null */
-  private final static RpcController NULL_CONTROLLER = null;
+  protected final static RpcController NULL_CONTROLLER = null;
   
   /*
    * Protobuf requests with no parameters instantiated only once
    */
-  private static final GetBlockKeysRequestProto VOID_GET_BLOCKKEYS_REQUEST = 
+  protected static final GetBlockKeysRequestProto VOID_GET_BLOCKKEYS_REQUEST =
       GetBlockKeysRequestProto.newBuilder().build();
-  private static final GetTransactionIdRequestProto VOID_GET_TRANSACTIONID_REQUEST = 
+  protected static final GetTransactionIdRequestProto VOID_GET_TRANSACTIONID_REQUEST =
       GetTransactionIdRequestProto.newBuilder().build();
-  private static final RollEditLogRequestProto VOID_ROLL_EDITLOG_REQUEST = 
+  protected static final RollEditLogRequestProto VOID_ROLL_EDITLOG_REQUEST =
       RollEditLogRequestProto.newBuilder().build();
-  private static final VersionRequestProto VOID_VERSION_REQUEST = 
+  protected static final VersionRequestProto VOID_VERSION_REQUEST =
       VersionRequestProto.newBuilder().build();
 
   final private NamenodeProtocolPB rpcProxy;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
This PR is mainly for your reference. 
Welcome to discuss it. https://issues.apache.org/jira/browse/HDFS-17531

### How was this patch tested?

Currently, I have modified these UTs to use asynchronous router for your reference.

TestNoNamenodesAvailableLongTime
TestObserverWithRouter
TestRouterFederationRename
TestRouterFederationRenamePermission
TestRouterQuota
TestRouterRefreshSuperUserGroupsConfiguration
TestRouterRpc
TestRouterRpcMultiDestination
TestRouterRPCMultipleDestinationMountTableResolver
TestRouterRpcSingleNS
TestRouterRpcStoragePolicySatisfier
TestRouterUserMappings

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

