### PR TITLE
Revert "Bump org.apache.derby:derby from 10.14.2.0 to 10.17.1.0 in /hadoop-project"

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -135,7 +135,7 @@
     <ehcache.version>3.8.2</ehcache.version>
     <cache.api.version>1.1.1</cache.api.version>
     <hikari.version>4.0.3</hikari.version>
-    <derby.version>10.17.1.0</derby.version>
+    <derby.version>10.14.2.0</derby.version>
     <mssql.version>6.2.1.jre7</mssql.version>
     <okhttp3.version>4.11.0</okhttp3.version>
     <kotlin-stdlib.version>1.6.20</kotlin-stdlib.version>


### PR DESCRIPTION
Reverts apache/hadoop#6816

We have founed some HDFS RBF errors.  We can refer to this issue https://issues.apache.org/jira/browse/HDFS-17533.