### PR TITLE
HADOOP-19182. Upgrade kafka to 3.4.0

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -356,7 +356,7 @@ org.eclipse.jetty.websocket:javax-websocket-client-impl:9.4.53.v20231009
 org.eclipse.jetty.websocket:javax-websocket-server-impl:9.4.53.v20231009
 org.ehcache:ehcache:3.8.2
 org.ini4j:ini4j:0.5.4
-org.lz4:lz4-java:1.8.0
+org.lz4:lz4-java:1.7.1
 org.objenesis:objenesis:2.6
 org.xerial.snappy:snappy-java:1.1.10.4
 org.yaml:snakeyaml:2.0

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -317,7 +317,7 @@ org.apache.htrace:htrace-core:3.1.0-incubating
 org.apache.htrace:htrace-core4:4.1.0-incubating
 org.apache.httpcomponents:httpclient:4.5.13
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.kafka:kafka-clients:2.8.2
+org.apache.kafka:kafka-clients:3.4.0
 org.apache.kerby:kerb-admin:2.0.3
 org.apache.kerby:kerb-client:2.0.3
 org.apache.kerby:kerb-common:2.0.3
@@ -356,7 +356,7 @@ org.eclipse.jetty.websocket:javax-websocket-client-impl:9.4.53.v20231009
 org.eclipse.jetty.websocket:javax-websocket-server-impl:9.4.53.v20231009
 org.ehcache:ehcache:3.8.2
 org.ini4j:ini4j:0.5.4
-org.lz4:lz4-java:1.7.1
+org.lz4:lz4-java:1.8.0
 org.objenesis:objenesis:2.6
 org.xerial.snappy:snappy-java:1.1.10.4
 org.yaml:snakeyaml:2.0
@@ -377,7 +377,7 @@ hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/io/com
 hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/util/tree.h
 hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/compat/{fstatat|openat|unlinkat}.h
 
-com.github.luben:zstd-jni:1.4.9-1
+com.github.luben:zstd-jni:1.5.2-1
 dnsjava:dnsjava:2.1.7
 org.codehaus.woodstox:stax2-api:4.2.1
 

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -50,7 +50,7 @@
     <!-- Version number for xerces used by JDiff -->
     <xerces.jdiff.version>2.12.2</xerces.jdiff.version>
 
-    <kafka.version>2.8.2</kafka.version>
+    <kafka.version>3.4.0</kafka.version>
 
     <commons-daemon.version>1.0.13</commons-daemon.version>
 


### PR DESCRIPTION
JIRA: HADOOP-19182.
Upgrade kafka to 3.4.0 to resolve CVE-2023-25194