### PR TITLE
HADOOP-19184. S3A Fix TestStagingCommitter.testJobCommitFailure

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
@@ -353,7 +353,11 @@ public class MockS3AFileSystem extends S3AFileSystem {
       String key,
       boolean isFile)
       throws SdkException, IOException {
-    deleteObject(key);
+    mock.getS3AInternals()
+            .getAmazonS3Client("test")
+            .deleteObject(getRequestFactory()
+            .newDeleteObjectRequestBuilder(key)
+            .build());
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/StagingTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/StagingTestBase.java
@@ -38,11 +38,15 @@ import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest;
 import software.amazon.awssdk.services.s3.model.ListMultipartUploadsResponse;
 import software.amazon.awssdk.services.s3.model.MultipartUpload;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+
+import org.apache.hadoop.fs.s3a.S3AInternals;
+import org.apache.hadoop.fs.s3a.S3AStore;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 import org.junit.AfterClass;
@@ -129,9 +133,9 @@ public class StagingTestBase {
    * @throws IOException IO problems.
    */
   protected static S3AFileSystem createAndBindMockFSInstance(Configuration conf,
-      Pair<StagingTestBase.ClientResults, StagingTestBase.ClientErrors> outcome)
+      Pair<StagingTestBase.ClientResults, StagingTestBase.ClientErrors> outcome, S3Client mockClient)
       throws IOException {
-    S3AFileSystem mockFs = mockS3AFileSystemRobustly();
+    S3AFileSystem mockFs = mockS3AFileSystemRobustly(mockClient);
     MockS3AFileSystem wrapperFS = new MockS3AFileSystem(mockFs, outcome);
     URI uri = RAW_BUCKET_URI;
     wrapperFS.initialize(uri, conf);
@@ -142,8 +146,13 @@ public class StagingTestBase {
     return mockFs;
   }
 
-  private static S3AFileSystem mockS3AFileSystemRobustly() {
+  private static S3AFileSystem mockS3AFileSystemRobustly(S3Client s3Client) {
     S3AFileSystem mockFS = mock(S3AFileSystem.class);
+    S3AInternals s3AInternals = mock(S3AInternals.class);
+    when(mockFS.getS3AInternals()).thenReturn(s3AInternals);
+    when(s3AInternals.getStore()).thenReturn(mock(S3AStore.class));
+    when(s3AInternals.getAmazonS3Client(anyString()))
+        .thenReturn(s3Client);
     doNothing().when(mockFS).incrementReadOperations();
     doNothing().when(mockFS).incrementWriteOperations();
     doNothing().when(mockFS).incrementWriteOperations();
@@ -350,7 +359,7 @@ public class StagingTestBase {
       this.errors = new StagingTestBase.ClientErrors();
       this.mockClient = newMockS3Client(results, errors);
       this.mockFS = createAndBindMockFSInstance(jobConf,
-          Pair.of(results, errors));
+          Pair.of(results, errors), mockClient);
       this.wrapperFS = lookupWrapperFS(jobConf);
       // and bind the FS
       wrapperFS.setAmazonS3Client(mockClient);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/StagingTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/StagingTestBase.java
@@ -38,7 +38,6 @@ import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest;
 import software.amazon.awssdk.services.s3.model.ListMultipartUploadsResponse;
 import software.amazon.awssdk.services.s3.model.MultipartUpload;
@@ -133,9 +132,10 @@ public class StagingTestBase {
    * @throws IOException IO problems.
    */
   protected static S3AFileSystem createAndBindMockFSInstance(Configuration conf,
-      Pair<StagingTestBase.ClientResults, StagingTestBase.ClientErrors> outcome, S3Client mockClient)
+      Pair<StagingTestBase.ClientResults, StagingTestBase.ClientErrors> outcome,
+                                                             S3Client mockS3Client)
       throws IOException {
-    S3AFileSystem mockFs = mockS3AFileSystemRobustly(mockClient);
+    S3AFileSystem mockFs = mockS3AFileSystemRobustly(mockS3Client);
     MockS3AFileSystem wrapperFS = new MockS3AFileSystem(mockFs, outcome);
     URI uri = RAW_BUCKET_URI;
     wrapperFS.initialize(uri, conf);
@@ -146,13 +146,13 @@ public class StagingTestBase {
     return mockFs;
   }
 
-  private static S3AFileSystem mockS3AFileSystemRobustly(S3Client s3Client) {
+  private static S3AFileSystem mockS3AFileSystemRobustly(S3Client mockS3Client) {
     S3AFileSystem mockFS = mock(S3AFileSystem.class);
     S3AInternals s3AInternals = mock(S3AInternals.class);
     when(mockFS.getS3AInternals()).thenReturn(s3AInternals);
     when(s3AInternals.getStore()).thenReturn(mock(S3AStore.class));
     when(s3AInternals.getAmazonS3Client(anyString()))
-        .thenReturn(s3Client);
+        .thenReturn(mockS3Client);
     doNothing().when(mockFS).incrementReadOperations();
     doNothing().when(mockFS).incrementWriteOperations();
     doNothing().when(mockFS).incrementWriteOperations();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/TestStagingCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/TestStagingCommitter.java
@@ -158,7 +158,7 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
     this.errors = new StagingTestBase.ClientErrors();
     this.mockClient = newMockS3Client(results, errors);
     this.mockFS = createAndBindMockFSInstance(jobConf,
-        Pair.of(results, errors));
+        Pair.of(results, errors), mockClient);
     this.wrapperFS = lookupWrapperFS(jobConf);
     // and bind the FS
     wrapperFS.setAmazonS3Client(mockClient);


### PR DESCRIPTION
Follow up of HADOOP-18679

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

