### PR TITLE
HDFS-17536. RBF: Format safe-mode related logic and fix a race

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAdminServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAdminServer.java
@@ -527,8 +527,7 @@ public class RouterAdminServer extends AbstractService
     boolean success = false;
     RouterSafemodeService safeModeService = this.router.getSafemodeService();
     if (safeModeService != null) {
-      this.router.updateRouterState(RouterServiceState.SAFEMODE);
-      safeModeService.setManualSafeMode(true);
+      safeModeService.enter(true);
       success = verifySafeMode(true);
       if (success) {
         LOG.info("STATE* Safe mode is ON.\n" + "It was turned on manually. "
@@ -548,8 +547,7 @@ public class RouterAdminServer extends AbstractService
     boolean success = false;
     RouterSafemodeService safeModeService = this.router.getSafemodeService();
     if (safeModeService != null) {
-      this.router.updateRouterState(RouterServiceState.RUNNING);
-      safeModeService.setManualSafeMode(false);
+      safeModeService.leave();
       success = verifySafeMode(false);
       if (success) {
         LOG.info("STATE* Safe mode is OFF.\n" + "It was turned off manually.");

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterSafemodeService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterSafemodeService.java
@@ -95,18 +95,18 @@ public class RouterSafemodeService extends PeriodicService {
   /**
    * Enter safe mode.
    */
-  synchronized void enter(boolean isSafeModeSetManually) {
+  void enter(boolean manualSetmode) {
     LOG.info("Entering safe mode");
     enterSafeModeTime = monotonicNow();
     safeMode = true;
     router.updateRouterState(RouterServiceState.SAFEMODE);
-    this.isSafeModeSetManually = isSafeModeSetManually;
+    this.isSafeModeSetManually = manualSetmode;
   }
 
   /**
    * Leave safe mode.
    */
-  synchronized void leave() {
+  void leave() {
     // Cache recently updated, leave safemode
     long timeInSafemode = monotonicNow() - enterSafeModeTime;
     LOG.info("Leaving safe mode after {} milliseconds", timeInSafemode);
@@ -152,7 +152,7 @@ public class RouterSafemodeService extends PeriodicService {
   }
 
   @Override
-  public synchronized void periodicInvoke() {
+  public void periodicInvoke() {
     long now = monotonicNow();
     long delta = now - startupTime;
     if (delta < startupInterval) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterSafemodeService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterSafemodeService.java
@@ -93,28 +93,20 @@ public class RouterSafemodeService extends PeriodicService {
   }
 
   /**
-   * Set the flag to indicate that the safe mode for this Router is set manually
-   * via the Router admin command.
-   */
-  void setManualSafeMode(boolean mode) {
-    this.safeMode = mode;
-    this.isSafeModeSetManually = mode;
-  }
-
-  /**
    * Enter safe mode.
    */
-  private void enter() {
+  synchronized void enter(boolean isSafeModeSetManually) {
     LOG.info("Entering safe mode");
     enterSafeModeTime = monotonicNow();
     safeMode = true;
     router.updateRouterState(RouterServiceState.SAFEMODE);
+    this.isSafeModeSetManually = isSafeModeSetManually;
   }
 
   /**
    * Leave safe mode.
    */
-  private void leave() {
+  synchronized void leave() {
     // Cache recently updated, leave safemode
     long timeInSafemode = monotonicNow() - enterSafeModeTime;
     LOG.info("Leaving safe mode after {} milliseconds", timeInSafemode);
@@ -126,6 +118,7 @@ public class RouterSafemodeService extends PeriodicService {
     }
     safeMode = false;
     router.updateRouterState(RouterServiceState.RUNNING);
+    this.isSafeModeSetManually = false;
   }
 
   @Override
@@ -153,13 +146,13 @@ public class RouterSafemodeService extends PeriodicService {
     this.startupTime = monotonicNow();
 
     // Initializing the RPC server in safe mode, it will disable it later
-    enter();
+    enter(false);
 
     super.serviceInit(conf);
   }
 
   @Override
-  public void periodicInvoke() {
+  public synchronized void periodicInvoke() {
     long now = monotonicNow();
     long delta = now - startupTime;
     if (delta < startupInterval) {
@@ -174,7 +167,7 @@ public class RouterSafemodeService extends PeriodicService {
     // Always update to indicate our cache was updated
     if (isCacheStale) {
       if (!safeMode) {
-        enter();
+        enter(false);
       }
     } else if (safeMode && !isSafeModeSetManually) {
       // Cache recently updated, leave safe mode


### PR DESCRIPTION
Both `RouterAdminServer#enterSafeMode()` and `RouterSafemodeService#periodicInvoke()#leave` can change the router state at the same time. 

Safe-mode change logic should be condensed into one method. And some races may happen in the current implementation, such as:

1. `RouterAdminServer#enterSafeMode()` set router stat to `RouterServiceState.SAFEMODE`
2. `RouterSafemodeService#periodicInvoke()#leave` got true when checking `safeMode && !isSafeModeSetManually`
3. `RouterAdminServer#enterSafeMode()` set `safeMode` and `isSafeModeSetManually` to `true`
4. `RouterAdminServer#enterSafeMode()` get `true` when checking safe-mode 
5. `RouterSafemodeService#periodicInvoke()#leave` call `leave()` to leave safe-mode.

This RBF is not in safe-mode and `safeMode` is `false`, but `isSafeModeSetManually` is `true`.