### PR TITLE
YARN-11698. Store pending log aggregators in the NM State Store

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeStatusUpdaterImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeStatusUpdaterImpl.java
@@ -783,15 +783,11 @@ public class NodeStatusUpdaterImpl extends AbstractService implements
           break;
         }
         if (!context.getContainers().containsKey(cid)) {
-          ApplicationId appId =
-              cid.getApplicationAttemptId().getApplicationId();
-          if (isApplicationStopped(appId)) {
-            i.remove();
-            try {
-              context.getNMStateStore().removeContainer(cid);
-            } catch (IOException e) {
-              LOG.error("Unable to remove container {} in store.", cid, e);
-            }
+          i.remove();
+          try {
+            context.getNMStateStore().removeContainer(cid);
+          } catch (IOException e) {
+            LOG.error("Unable to remove container {} in store.", cid, e);
           }
         }
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/AppLogAggregator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/AppLogAggregator.java
@@ -20,11 +20,14 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.logaggregatio
 
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.server.api.ContainerLogContext;
 
 public interface AppLogAggregator extends Runnable {
 
   void startContainerLogAggregation(ContainerLogContext logContext);
+
+  void recoverContainerLogAggregation(ContainerId containerId);
 
   void abortLogAggregation();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/AppLogAggregatorImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/AppLogAggregatorImpl.java
@@ -383,6 +383,11 @@ public class AppLogAggregatorImpl implements AppLogAggregator {
         // remove it from containerLogAggregators.
         if (finishedContainers.contains(container)) {
           containerLogAggregators.remove(container);
+          try {
+            context.getNMStateStore().removeLogAggregator(container);
+          } catch (IOException e) {
+            LOG.error("Unable to remove log aggregator {} from store.", container, e);
+          }
         }
       }
 
@@ -616,8 +621,18 @@ public class AppLogAggregatorImpl implements AppLogAggregator {
     if (shouldUploadLogs(logContext)) {
       LOG.info("Considering container " + logContext.getContainerId()
           + " for log-aggregation");
+      try {
+        context.getNMStateStore().storeLogAggregator(logContext.getContainerId());
+      } catch (IOException e) {
+        LOG.error("Unable to add log aggregator {} to store.", logContext.getContainerId(), e);
+      }
       this.pendingContainers.add(logContext.getContainerId());
     }
+  }
+
+  @Override
+  public void recoverContainerLogAggregation(ContainerId containerId) {
+    this.pendingContainers.add(containerId);
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/loghandler/event/LogHandlerContainerRecoveredEvent.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/loghandler/event/LogHandlerContainerRecoveredEvent.java
@@ -18,10 +18,18 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.loghandler.event;
 
-public enum LogHandlerEventType {
-  APPLICATION_STARTED,
-  CONTAINER_FINISHED,
-  APPLICATION_FINISHED,
-  CONTAINER_RECOVERED,
-  LOG_AGG_TOKEN_UPDATE
+import org.apache.hadoop.yarn.api.records.ContainerId;
+
+public class LogHandlerContainerRecoveredEvent extends LogHandlerEvent {
+
+  private final ContainerId containerId;
+
+  public LogHandlerContainerRecoveredEvent(ContainerId containerId) {
+    super(LogHandlerEventType.CONTAINER_RECOVERED);
+    this.containerId = containerId;
+  }
+
+  public ContainerId getContainerId() {
+    return this.containerId;
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMNullStateStoreService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMNullStateStoreService.java
@@ -245,6 +245,22 @@ public class NMNullStateStoreService extends NMStateStoreService {
   }
 
   @Override
+  public RecoveredLogAggregatorState loadLogAggregatorState() throws IOException {
+    throw new UnsupportedOperationException(
+        "Recovery not supported by this state store");
+  }
+
+  @Override
+  public void storeLogAggregator(ContainerId containerId)
+      throws IOException {
+  }
+
+  @Override
+  public void removeLogAggregator(ContainerId containerId)
+      throws IOException {
+  }
+
+  @Override
   public RecoveredAMRMProxyState loadAMRMProxyState() throws IOException {
     throw new UnsupportedOperationException(
         "Recovery not supported by this state store");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMStateStoreService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMStateStoreService.java
@@ -325,6 +325,14 @@ public abstract class NMStateStoreService extends AbstractService {
     }
   }
 
+  public static class RecoveredLogAggregatorState {
+    List<ContainerId> logAggregators;
+
+    public List<ContainerId> getLogAggregators() {
+      return logAggregators;
+    }
+  }
+
   /**
    * Recovered states for AMRMProxy.
    */
@@ -720,6 +728,30 @@ public abstract class NMStateStoreService extends AbstractService {
    * @throws IOException
    */
   public abstract void removeLogDeleter(ApplicationId appId)
+      throws IOException;
+
+  /**
+   * Load the state of the log aggregators
+   * @return recovered log aggregator state
+   * @throws IOException if fails
+   */
+  public abstract RecoveredLogAggregatorState loadLogAggregatorState()
+      throws IOException;
+
+  /**
+   * Store the state of a log aggregator
+   * @param containerId the container ID for the log aggregator
+   * @throws IOException if fails
+   */
+  public abstract void storeLogAggregator(ContainerId containerId)
+      throws IOException;
+
+  /**
+   * Remove the state of a log aggregator
+   * @param containerId the container ID for the log aggregator
+   * @throws IOException if fails
+   */
+  public abstract void removeLogAggregator(ContainerId containerId)
       throws IOException;
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestNodeStatusUpdater.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestNodeStatusUpdater.java
@@ -965,18 +965,6 @@ public class TestNodeStatusUpdater extends NodeManagerTestBase {
 
     nodeStatusUpdater.addCompletedContainer(cId);
     assertTrue(nodeStatusUpdater.isContainerRecentlyStopped(cId));
-
-    // verify container remains even after expiration if app
-    // is still active
-    nm.getNMContext().getContainers().remove(cId);
-    Thread.sleep(10);
-    nodeStatusUpdater.removeVeryOldStoppedContainersFromCache();
-    assertTrue(nodeStatusUpdater.isContainerRecentlyStopped(cId));
-
-    // complete the application and verify container is removed
-    nm.getNMContext().getApplications().remove(appId);
-    nodeStatusUpdater.removeVeryOldStoppedContainersFromCache();
-    assertFalse(nodeStatusUpdater.isContainerRecentlyStopped(cId));
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
@@ -144,6 +144,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.loghandler.Tes
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.loghandler.event.LogHandlerAppFinishedEvent;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.loghandler.event.LogHandlerAppStartedEvent;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.loghandler.event.LogHandlerContainerFinishedEvent;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.loghandler.event.LogHandlerContainerRecoveredEvent;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.loghandler.event.LogHandlerTokenUpdatedEvent;
 import org.apache.hadoop.yarn.server.nodemanager.executor.DeletionAsUserContext;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
@@ -2862,5 +2863,45 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
 
     long interval = logAggregationService.getRollingMonitorInterval();
     assertEquals(1800L, interval);
+  }
+
+  @Test
+  public void testLogAggregationRecovery() throws Exception {
+    LogAggregationService logAggregationService =
+            new LogAggregationService(dispatcher, this.context, this.delSrvc,
+                    super.dirsHandler);
+    logAggregationService.init(this.conf);
+    logAggregationService.start();
+
+    ApplicationId application = BuilderUtils.newApplicationId(1234, 1);
+
+    ApplicationAttemptId appAttemptId =
+        BuilderUtils.newApplicationAttemptId(application, 1);
+    ContainerId containerId = ContainerId.newContainerId(appAttemptId, 1);
+
+    File appLogDir1 =
+        new File(localLogDir, application.toString());
+    appLogDir1.mkdir();
+
+    // Simulate log-file creation
+    writeContainerLogs(appLogDir1, containerId, new String[] { "stdout",
+        "syslog" }, new String[] {});
+
+    LogAggregationContext logAggregationContext =
+        Records.newRecord(LogAggregationContext.class);
+
+    logAggregationService.handle(new LogHandlerAppStartedEvent(application,
+      this.user, null, this.acls,
+      logAggregationContext));
+
+    logAggregationService.handle(new LogHandlerContainerRecoveredEvent(containerId));
+
+    logAggregationService.handle(new LogHandlerAppFinishedEvent(application));
+    logAggregationService.stop();
+    assertEquals(0, logAggregationService.getNumAggregators());
+
+    String[] logFiles = new String[] { "stdout", "syslog" };
+    verifyContainerLogs(logAggregationService, application,
+        new ContainerId[] {containerId}, logFiles, 2, false, new String[] {});
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMMemoryStateStoreService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMMemoryStateStoreService.java
@@ -23,9 +23,11 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -60,6 +62,7 @@ public class NMMemoryStateStoreService extends NMStateStoreService {
   private Map<ApplicationAttemptId, MasterKey> applicationMasterKeys;
   private Map<ContainerId, Long> activeTokens;
   private Map<ApplicationId, LogDeleterProto> logDeleterState;
+  private Set<ContainerId> logAggregatorState;
   private RecoveredAMRMProxyState amrmProxyState;
 
   public NMMemoryStateStoreService() {
@@ -77,6 +80,7 @@ public class NMMemoryStateStoreService extends NMStateStoreService {
     trackerStates = new HashMap<TrackerKey, TrackerState>();
     deleteTasks = new HashMap<Integer, DeletionServiceDeleteTaskProto>();
     logDeleterState = new HashMap<ApplicationId, LogDeleterProto>();
+    logAggregatorState = new HashSet<ContainerId>();
     amrmProxyState = new RecoveredAMRMProxyState();
   }
 
@@ -511,6 +515,26 @@ public class NMMemoryStateStoreService extends NMStateStoreService {
   public synchronized void removeLogDeleter(ApplicationId appId)
       throws IOException {
     logDeleterState.remove(appId);
+  }
+
+  @Override
+  public synchronized RecoveredLogAggregatorState loadLogAggregatorState()
+      throws IOException {
+    RecoveredLogAggregatorState state = new RecoveredLogAggregatorState();
+    state.logAggregators = new ArrayList<>(logAggregatorState);
+    return state;
+  }
+
+  @Override
+  public synchronized void storeLogAggregator(ContainerId containerId)
+      throws IOException {
+    logAggregatorState.add(containerId);
+  }
+
+  @Override
+  public synchronized void removeLogAggregator(ContainerId containerId)
+      throws IOException {
+        logAggregatorState.remove(containerId);
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/recovery/TestNMLeveldbStateStoreService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/recovery/TestNMLeveldbStateStoreService.java
@@ -90,6 +90,7 @@ import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService.Re
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService.RecoveredContainerType;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService.RecoveredDeletionServiceState;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService.RecoveredLocalizationState;
+import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService.RecoveredLogAggregatorState;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService.RecoveredLogDeleterState;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService.RecoveredNMTokensState;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService.RecoveredUserResources;
@@ -1545,6 +1546,49 @@ public class TestNMLeveldbStateStoreService {
     restartStateStore();
     state = stateStore.loadLogDeleterState();
     assertTrue(state.getLogDeleterMap().isEmpty());
+  }
+
+  @Test
+  public void testLogAggregatorStorage() throws IOException {
+    // test empty when no state
+    RecoveredLogAggregatorState state = stateStore.loadLogAggregatorState();
+    assertTrue(state.getLogAggregators().isEmpty());
+
+    // store log deleter state
+    final ApplicationId appId1 = ApplicationId.newInstance(1, 1);
+    ApplicationAttemptId appAttemptId1 = ApplicationAttemptId.newInstance(appId1, 1);
+    final ContainerId containerId1 = ContainerId.newContainerId(appAttemptId1, 1);
+    stateStore.storeLogAggregator(containerId1);
+
+    // restart state store and verify recovered
+    restartStateStore();
+    state = stateStore.loadLogAggregatorState();
+    assertEquals(1, state.getLogAggregators().size());
+    assertEquals(containerId1, state.getLogAggregators().get(0));
+
+    // store another log aggregator
+    final ApplicationId appId2 = ApplicationId.newInstance(2, 2);
+    ApplicationAttemptId appAttemptId2 = ApplicationAttemptId.newInstance(appId2, 1);
+    final ContainerId containerId2 = ContainerId.newContainerId(appAttemptId2, 1);
+    stateStore.storeLogAggregator(containerId2);
+
+    // restart state store and verify recovered
+    restartStateStore();
+    state = stateStore.loadLogAggregatorState();
+    assertEquals(2, state.getLogAggregators().size());
+
+    // remove a deleter and verify removed after restart and recovery
+    stateStore.removeLogAggregator(containerId1);
+    restartStateStore();
+    state = stateStore.loadLogAggregatorState();
+    assertEquals(1, state.getLogAggregators().size());
+    assertEquals(containerId2, state.getLogAggregators().get(0));
+
+    // remove last deleter and verify empty after restart and recovery
+    stateStore.removeLogAggregator(containerId2);
+    restartStateStore();
+    state = stateStore.loadLogAggregatorState();
+    assertTrue(state.getLogAggregators().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Stores containers pending log aggregation in the NodeManager state store so logs can still be aggregated for complete containers after a Node Manager restart. This undoes and replaces https://issues.apache.org/jira/browse/YARN-4771 with a finer-grained approach that doesn't involve storing containers indefinitely until the application finishes. 

The original approach has several issues, some of which were mentioned in the JIRA but decided it was ok:
- Long running applications can lead to a large number of containers being stored indefinitely in the state store as well as in memory on the Node Manager
- On restarts, the Node Manager has to do a lot of work fully recovering all of these complete containers just so they can be registered for log aggregation again
- This leads to large heartbeat messages to the Resource Manager that can DoS or OOM it
- This ignores the fact that users may not have log aggregation enabled or may have rolling log aggregation enabled, meaning containers are stored even after there is no need to worry about aggregating the logs in the future

Instead, this adds a new state store entry for containers pending log aggregation. This solves all the above issues, while still providing the same guarantees about logs being aggregated after a Node Manager restart.

### How was this patch tested?
New UTs added

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

