### PR TITLE
YARN-11699. Diagnostics lacks userlimit info when user capacity has reached its maximum limit

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractLeafQueue.java
@@ -1278,8 +1278,6 @@ public class AbstractLeafQueue extends AbstractCSQueue {
             "User capacity has reached its maximum limit." +
                 " User limit is " + userLimit + "Resource used by " +
                 userName + " is " + usedResourceByUser + ".");
-        application.updateAMContainerDiagnostics(AMState.ACTIVATED,
-            "User capacity has reached its maximum limit.");
         ActivitiesLogger.APP.recordRejectedAppActivityFromLeafQueue(
             activitiesManager, node, application, application.getPriority(),
             ActivityDiagnosticConstant.QUEUE_HIT_USER_MAX_CAPACITY_LIMIT);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractLeafQueue.java
@@ -1275,8 +1275,8 @@ public class AbstractLeafQueue extends AbstractCSQueue {
         Resource usedResourceByUser =
             user == null ? null : user.getUsed(candidates.getPartition());
         application.updateAMContainerDiagnostics(AMState.ACTIVATED,
-            "User capacity has reached its maximum limit." +
-                " User limit is " + userLimit + "Resource used by " +
+            "User capacity has reached its maximum limit," +
+                " user limit is " + userLimit + ", resource used by " +
                 userName + " is " + usedResourceByUser + ".");
         ActivitiesLogger.APP.recordRejectedAppActivityFromLeafQueue(
             activitiesManager, node, application, application.getPriority(),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractLeafQueue.java
@@ -1270,6 +1270,14 @@ public class AbstractLeafQueue extends AbstractCSQueue {
         }
       }
       if (!userAssignable) {
+        String userName = application.getUser();
+        User user = getUser(userName);
+        Resource usedResourceByUser =
+            user == null ? null : user.getUsed(candidates.getPartition());
+        application.updateAMContainerDiagnostics(AMState.ACTIVATED,
+            "User capacity has reached its maximum limit." +
+                " User limit is " + userLimit + "Resource used by " +
+                userName + " is " + usedResourceByUser + ".");
         application.updateAMContainerDiagnostics(AMState.ACTIVATED,
             "User capacity has reached its maximum limit.");
         ActivitiesLogger.APP.recordRejectedAppActivityFromLeafQueue(


### PR DESCRIPTION
Diagnostics lacks userlimit info when user capacity has reached its maximum limit

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11699. Diagnostics lacks userlimit info when user capacity has reached its maximum limit.

Capacity scheduler supports user limit to avoid a single user use the whole queue resource. but when resource used by a user reached its user limit, it lacks related info in diagnostics in web page, just as shown in the figure below. We may need add user limit and resource used by the user to help debug.
![image](https://github.com/apache/hadoop/assets/1585737/30cf2f71-d47c-45a1-930c-8f9ba6d91297)

### How was this patch tested?
Current uts are ok.



