### PR TITLE
HDFS-17537 : Last block report is incorrect in Federationhealth.html

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NamenodeBeanMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NamenodeBeanMetrics.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs.server.federation.metrics;
 
 import static org.apache.hadoop.util.Time.now;
+import static org.apache.hadoop.util.Time.monotonicNow;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -188,6 +189,10 @@ public class NamenodeBeanMetrics
   @Override
   public String getSoftwareVersion() {
     return VersionInfo.getVersion();
+  }
+
+  private Object getLastBlockReport(DatanodeInfo node) {
+    return (monotonicNow() - node.getLastBlockReportMonotonic()) / 60000;
   }
 
   @Override
@@ -460,6 +465,7 @@ public class NamenodeBeanMetrics
         innerinfo.put("blockScheduled", -1); // node.getBlocksScheduled()
         innerinfo.put("blockPoolUsed", node.getBlockPoolUsed());
         innerinfo.put("blockPoolUsedPercent", node.getBlockPoolUsedPercent());
+        innerInfo.put("lastBlockReport", getLastBlockReport(node));
         innerinfo.put("volfails", -1); // node.getVolumeFailures()
         info.put(node.getHostName() + ":" + node.getXferPort(),
             Collections.unmodifiableMap(innerinfo));


### PR DESCRIPTION
### Description of PR
The last block report in datanode tab for Router UI is not correct. Adding code to show it similarly as in Namenode UI.


