### PR TITLE
HADOOP-18679. Followup: rename WrappedIO.bulkDelete_PageSize to bulkDelete_PageSize

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/wrappedio/WrappedIO.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/wrappedio/WrappedIO.java
@@ -54,7 +54,7 @@ public final class WrappedIO {
    * @throws IllegalArgumentException path not valid.
    * @throws IOException problems resolving paths
    */
-  public static int bulkDelete_PageSize(FileSystem fs, Path path) throws IOException {
+  public static int bulkDelete_pageSize(FileSystem fs, Path path) throws IOException {
     try (BulkDelete bulk = fs.createBulkDelete(path)) {
       return bulk.pageSize();
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractBulkDeleteTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractBulkDeleteTest.java
@@ -69,7 +69,7 @@ public abstract class AbstractContractBulkDeleteTest extends AbstractFSContractT
   public void setUp() throws Exception {
     fs = getFileSystem();
     basePath = path(getClass().getName());
-    pageSize = WrappedIO.bulkDelete_PageSize(getFileSystem(), basePath);
+    pageSize = WrappedIO.bulkDelete_pageSize(getFileSystem(), basePath);
     fs.mkdirs(basePath);
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
@@ -735,7 +735,7 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
 
     bindReadOnlyRolePolicy(assumedRoleConfig, readOnlyDir);
     roleFS = (S3AFileSystem) destDir.getFileSystem(assumedRoleConfig);
-    int bulkDeletePageSize = WrappedIO.bulkDelete_PageSize(roleFS, destDir);
+    int bulkDeletePageSize = WrappedIO.bulkDelete_pageSize(roleFS, destDir);
     int range = bulkDeletePageSize == 1 ? bulkDeletePageSize : 10;
     touchFiles(fs, readOnlyDir, range);
     touchFiles(roleFS, destDir, range);
@@ -769,7 +769,7 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
     bindReadOnlyRolePolicy(assumedRoleConfig, readOnlyDir);
     roleFS = (S3AFileSystem) destDir.getFileSystem(assumedRoleConfig);
     S3AFileSystem fs = getFileSystem();
-    if (WrappedIO.bulkDelete_PageSize(fs, destDir) == 1) {
+    if (WrappedIO.bulkDelete_pageSize(fs, destDir) == 1) {
       String msg = "Skipping as this test requires more than one path to be deleted in bulk";
       LOG.debug(msg);
       skip(msg);


### PR DESCRIPTION

WrappedIO.bulkDelete_PageSize() => bulkDelete_pageSize()

Makes it consistent with the HADOOP-19131 naming scheme. The name needs to be fixed before invoking it through reflection, as once that is attempted the binding won't work at run time, though compilation will be happy.

Change-Id: Ie68f6515ff03d1fa6e7b5e113fc3f68ce8525570

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

