### PR TITLE
HADOOP-19193. Create orphan commit for website deployment

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -56,4 +56,5 @@ jobs:
           publish_dir: ./staging/hadoop-project
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
+          force_orphan: true
 


### PR DESCRIPTION
### Description of PR

Currently, the gh-pages deployment always creates new commits based on the previous one, which causes the git repo size to grow fast.

According to https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-force-orphan-force_orphan, we can use `force_orphan: true` to create an orphan commit which is sufficient for website deployment cases, as it is some kinds of compilation outputs, we don't need to keep all history commits.

### How was this patch tested?

Review.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

