### PR TITLE
HADOOP-19194:Add test to find unshaded dependencies in the aws sdk

### DIFF
--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
@@ -1141,6 +1141,7 @@ your IDE or via maven.
 1. Run a full AWS-test suite with S3 client-side encryption enabled by
  setting `fs.s3a.encryption.algorithm` to 'CSE-KMS' and setting up AWS-KMS
   Key ID in `fs.s3a.encryption.key`.
+2. Verify that the output of test `TestAWSV2SDK` doesn't contain any unshaded classes.
 
 The dependency chain of the `hadoop-aws` module should be similar to this, albeit
 with different version numbers:

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/sdk/TestAWSV2SDK.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/sdk/TestAWSV2SDK.java
@@ -38,56 +38,57 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class TestAWSV2SDK extends AbstractHadoopTestBase {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TestAWSV2SDK.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(TestAWSV2SDK.class.getName());
 
-    @Test
-    public void testShadedClasses() throws IOException {
-        String allClassPath = System.getProperty("java.class.path");
-        LOG.debug("Current classpath:{}", allClassPath);
-        String[] classPaths = allClassPath.split(File.pathSeparator);
-        String v2ClassPath = null;
-        for(String classPath : classPaths) {
-            //Checking for only version 2.x sdk here
-            if (classPath.contains("awssdk/bundle/2")) {
-                v2ClassPath = classPath;
-                break;
-            }
-        }
-        assertThat(v2ClassPath)
-                .as("AWS V2 SDK should be present on the classpath").isNotNull();
-        List<String> listOfV2SdkClasses = getClassNamesFromJarFile(v2ClassPath);
-        String awsSdkPrefix = "software/amazon/awssdk";
-        List<String> unshadedClasses = new ArrayList<>();
-        for(String awsSdkClass : listOfV2SdkClasses) {
-            if (!awsSdkClass.startsWith(awsSdkPrefix)) {
-                unshadedClasses.add(awsSdkClass);
-            }
-        }
-        if (!unshadedClasses.isEmpty()) {
-            LOG.warn("Unshaded Classes Found :{}", unshadedClasses.size());
-            LOG.warn("List of unshaded classes:{}", unshadedClasses);
-        } else {
-            LOG.info("No Unshaded classes found in the sdk.");
-        }
+  @Test
+  public void testShadedClasses() throws IOException {
+    String allClassPath = System.getProperty("java.class.path");
+    LOG.debug("Current classpath:{}", allClassPath);
+    String[] classPaths = allClassPath.split(File.pathSeparator);
+    String v2ClassPath = null;
+    for (String classPath : classPaths) {
+      //Checking for only version 2.x sdk here
+      if (classPath.contains("awssdk/bundle/2")) {
+        v2ClassPath = classPath;
+        break;
+      }
     }
+    assertThat(v2ClassPath)
+            .as("AWS V2 SDK should be present on the classpath").isNotNull();
+    List<String> listOfV2SdkClasses = getClassNamesFromJarFile(v2ClassPath);
+    String awsSdkPrefix = "software/amazon/awssdk";
+    List<String> unshadedClasses = new ArrayList<>();
+    for (String awsSdkClass : listOfV2SdkClasses) {
+      if (!awsSdkClass.startsWith(awsSdkPrefix)) {
+        unshadedClasses.add(awsSdkClass);
+      }
+    }
+    if (!unshadedClasses.isEmpty()) {
+      LOG.warn("Unshaded Classes Found :{}", unshadedClasses.size());
+      LOG.warn("List of unshaded classes:{}", unshadedClasses);
+    } else {
+      LOG.info("No Unshaded classes found in the sdk.");
+    }
+  }
 
-    /**
-     * Returns the list of classes in a jar file.
-     * @param jarFilePath: the location of the jar file from absolute path
-     * @return a list of classes contained by the jar file
-     * @throws IOException if the file is not present or the path is not readable
-     */
-    private List<String> getClassNamesFromJarFile(String jarFilePath) throws IOException {
-        List<String> classNames = new ArrayList<>();
-        try (JarFile jarFile = new JarFile(new File(jarFilePath))) {
-            Enumeration<JarEntry> jarEntryEnumeration = jarFile.entries();
-            while(jarEntryEnumeration.hasMoreElements()){
-                JarEntry jarEntry = jarEntryEnumeration.nextElement();
-                if (jarEntry.getName().endsWith(".class")) {
-                    classNames.add(jarEntry.getName());
-                }
-            }
+  /**
+   * Returns the list of classes in a jar file.
+   *
+   * @param jarFilePath: the location of the jar file from absolute path
+   * @return a list of classes contained by the jar file
+   * @throws IOException if the file is not present or the path is not readable
+   */
+  private List<String> getClassNamesFromJarFile(String jarFilePath) throws IOException {
+    List<String> classNames = new ArrayList<>();
+    try (JarFile jarFile = new JarFile(new File(jarFilePath))) {
+      Enumeration<JarEntry> jarEntryEnumeration = jarFile.entries();
+      while (jarEntryEnumeration.hasMoreElements()) {
+        JarEntry jarEntry = jarEntryEnumeration.nextElement();
+        if (jarEntry.getName().endsWith(".class")) {
+          classNames.add(jarEntry.getName());
         }
-        return classNames;
+      }
     }
+    return classNames;
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/sdk/TestAWSV2SDK.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/sdk/TestAWSV2SDK.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.fs.sdk;
+import org.junit.Test;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Tests to verify AWS SDK based issues like duplicated shaded classes and others
+ */
+public class TestAWSV2SDK extends AbstractHadoopTestBase {
+
+    Logger LOG = LoggerFactory.getLogger(this.getClass().getName());
+    @Test
+    public void testShadedClasses() throws IOException {
+        String allClassPath = System.getProperty("java.class.path");
+        LOG.debug("Current classpath:{}", allClassPath);
+        String[] classPaths = allClassPath.split(File.pathSeparator);
+        String v2ClassPath = null;
+        for(String classPath : classPaths){
+            //Checking for only version 2.x sdk here
+            if (classPath.contains("awssdk/bundle/2")) {
+                v2ClassPath = classPath;
+                break;
+            }
+        }
+        assertNotEquals("AWS V2 SDK should be present on the classpath",
+                v2ClassPath, null);
+        List<String> listOfV2SdkClasses = getClassNamesFromJarFile(v2ClassPath);
+        String awsSdkPrefix = "software/amazon/awssdk";
+        List<String> unshadedClasses = new ArrayList<>();
+        for(String awsSdkClass : listOfV2SdkClasses){
+            if (!awsSdkClass.startsWith(awsSdkPrefix)) {
+                unshadedClasses.add(awsSdkClass);
+            }
+        }
+        if (!unshadedClasses.isEmpty()) {
+            LOG.warn("Unshaded Classes Found :{}", unshadedClasses.size());
+            LOG.warn("List of unshaded classes:{}", unshadedClasses);
+        } else {
+            LOG.info("No Unshaded classes found in the sdk.");
+        }
+    }
+
+    public List<String> getClassNamesFromJarFile(String jarFilePath) throws IOException {
+        List<String> classNames = new ArrayList<>();
+        try (JarFile jarFile = new JarFile(new File(jarFilePath))) {
+            Enumeration<JarEntry> jarEntryEnumeration = jarFile.entries();
+            while(jarEntryEnumeration.hasMoreElements()){
+                JarEntry jarEntry = jarEntryEnumeration.nextElement();
+                if (jarEntry.getName().endsWith(".class")) {
+                    classNames.add(jarEntry.getName());
+                }
+            }
+        }
+        return classNames;
+    }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/sdk/TestAWSV2SDK.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/sdk/TestAWSV2SDK.java
@@ -73,7 +73,6 @@ public class TestAWSV2SDK extends AbstractHadoopTestBase {
 
   /**
    * Returns the list of classes in a jar file.
-   *
    * @param jarFilePath: the location of the jar file from absolute path
    * @return a list of classes contained by the jar file
    * @throws IOException if the file is not present or the path is not readable

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/sdk/TestAWSV2SDK.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/sdk/TestAWSV2SDK.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests to verify AWS SDK based issues like duplicated shaded classes and others
+ * Tests to verify AWS SDK based issues like duplicated shaded classes and others.
  */
 public class TestAWSV2SDK extends AbstractHadoopTestBase {
 
@@ -53,6 +53,7 @@ public class TestAWSV2SDK extends AbstractHadoopTestBase {
         break;
       }
     }
+    LOG.debug("AWS SDK V2 Classpath:{}", v2ClassPath);
     assertThat(v2ClassPath)
             .as("AWS V2 SDK should be present on the classpath").isNotNull();
     List<String> listOfV2SdkClasses = getClassNamesFromJarFile(v2ClassPath);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?
Local testing via test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

