### PR TITLE
HADOOP-19196. Allow base path to be deleted as well using Bulk Delete.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/BulkDeleteUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/BulkDeleteUtils.java
@@ -54,8 +54,8 @@ public final class BulkDeleteUtils {
    * @return true if the path is under the base path.
    */
   public static boolean validatePathIsUnderParent(Path p, Path basePath) {
-    while (p.getParent() != null) {
-      if (p.getParent().equals(basePath)) {
+    while (p != null) {
+      if (p.equals(basePath)) {
         return true;
       }
       p = p.getParent();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/BulkDeleteUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/BulkDeleteUtils.java
@@ -48,10 +48,10 @@ public final class BulkDeleteUtils {
   }
 
   /**
-   * Check if a path is under a base path.
+   * Check if a given path is the base path or under the base path.
    * @param p path to check.
    * @param basePath base path.
-   * @return true if the path is under the base path.
+   * @return true if the given path is the base path or under the base path.
    */
   public static boolean validatePathIsUnderParent(Path p, Path basePath) {
     while (p != null) {

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/bulkdelete.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/bulkdelete.md
@@ -23,6 +23,7 @@ in an object store or filesystem.
 
 * An API for submitting a list of paths to delete.
 * This list must be no larger than the "page size" supported by the client; This size is also exposed as a method.
+* This list must not have any path outside the base path.
 * Triggers a request to delete files at the specific paths.
 * Returns a list of which paths were reported as delete failures by the store.
 * Does not consider a nonexistent file to be a failure.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractBulkDeleteTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractBulkDeleteTest.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.contract;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -165,6 +166,17 @@ public abstract class AbstractContractBulkDeleteTest extends AbstractFSContractT
     paths.add(pathNotUnderBase);
     intercept(IllegalArgumentException.class,
             () -> bulkDelete_delete(getFileSystem(), basePath, paths));
+  }
+
+  /**
+   * We should be able to delete the base path itself
+   * using bulk delete operation.
+   */
+  @Test
+  public void testDeletePathSameAsBasePath() throws Exception {
+    assertSuccessfulBulkDelete(bulkDelete_delete(getFileSystem(),
+            basePath,
+            Arrays.asList(basePath)));
   }
 
   /**


### PR DESCRIPTION
Follow up on HADOOP-18679.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?
Re-ran all the implementation of AbstractContractBulkDeleteTest

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

