### PR TITLE
HDFS-17546. Implementing HostsFileReader timeout

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/CombinedHostsFileReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/CombinedHostsFileReader.java
@@ -125,7 +125,8 @@ public final class CombinedHostsFileReader {
     }
     return allDNs;
   }
-      /**
+
+  /**
    * Wrapper to call readFile with timeout via Future Tasks.
    * If timeout is reached, it will throw IOException
    * @param hostsFile the input json file to read from

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/CombinedHostsFileReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/CombinedHostsFileReader.java
@@ -137,12 +137,12 @@ public final class CombinedHostsFileReader {
   public static DatanodeAdminProperties[]
       readFileWithTimeout(final String hostsFile, final int readTimeout) throws IOException {
     FutureTask<DatanodeAdminProperties[]> futureTask = new FutureTask<>(
-      new Callable<DatanodeAdminProperties[]>() {
-        @Override
-        public DatanodeAdminProperties[] call() throws Exception {
-          return readFile(hostsFile);
+        new Callable<DatanodeAdminProperties[]>() {
+          @Override
+          public DatanodeAdminProperties[] call() throws Exception {
+            return readFile(hostsFile);
         }
-    });
+      });
 
     Thread thread = new Thread(futureTask);
     thread.start();

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/CombinedHostsFileReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/CombinedHostsFileReader.java
@@ -33,6 +33,11 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -119,5 +124,36 @@ public final class CombinedHostsFileReader {
       allDNs = all.toArray(new DatanodeAdminProperties[all.size()]);
     }
     return allDNs;
+  }
+      /**
+   * Wrapper to call readFile with timeout via Future Tasks.
+   * If timeout is reached, it will throw IOException
+   * @param hostsFile the input json file to read from
+   * @param readTimeout timeout for FutureTask execution in milliseconds
+   * @return the set of DatanodeAdminProperties
+   * @throws IOException
+   */
+  public static DatanodeAdminProperties[]
+      readFileWithTimeout(final String hostsFile, final int readTimeout) throws IOException {
+    FutureTask<DatanodeAdminProperties[]> futureTask = new FutureTask<>(new Callable<DatanodeAdminProperties[]>() {
+        @Override
+        public DatanodeAdminProperties[] call() throws Exception {
+            return readFile(hostsFile);
+        }
+    });
+
+    Thread thread = new Thread(futureTask);
+    thread.start();
+
+    try {
+        return futureTask.get(readTimeout, TimeUnit.MILLISECONDS);
+    } catch (TimeoutException e) {
+        futureTask.cancel(true);
+        LOG.error("refresh File read operation timed out");
+        throw new IOException("host file read operation timed out");
+    } catch (InterruptedException | ExecutionException e) {
+        LOG.error("File read operation interrupted : " + e.getMessage());
+        throw new IOException("host file read operation timed out");
+    }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/CombinedHostsFileReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/CombinedHostsFileReader.java
@@ -136,10 +136,11 @@ public final class CombinedHostsFileReader {
    */
   public static DatanodeAdminProperties[]
       readFileWithTimeout(final String hostsFile, final int readTimeout) throws IOException {
-    FutureTask<DatanodeAdminProperties[]> futureTask = new FutureTask<>(new Callable<DatanodeAdminProperties[]>() {
+    FutureTask<DatanodeAdminProperties[]> futureTask = new FutureTask<>(
+      new Callable<DatanodeAdminProperties[]>() {
         @Override
         public DatanodeAdminProperties[] call() throws Exception {
-            return readFile(hostsFile);
+          return readFile(hostsFile);
         }
     });
 
@@ -147,14 +148,14 @@ public final class CombinedHostsFileReader {
     thread.start();
 
     try {
-        return futureTask.get(readTimeout, TimeUnit.MILLISECONDS);
+      return futureTask.get(readTimeout, TimeUnit.MILLISECONDS);
     } catch (TimeoutException e) {
-        futureTask.cancel(true);
-        LOG.error("refresh File read operation timed out");
-        throw new IOException("host file read operation timed out");
+      futureTask.cancel(true);
+      LOG.error("refresh File read operation timed out");
+      throw new IOException("host file read operation timed out");
     } catch (InterruptedException | ExecutionException e) {
-        LOG.error("File read operation interrupted : " + e.getMessage());
-        throw new IOException("host file read operation timed out");
+      LOG.error("File read operation interrupted : " + e.getMessage());
+      throw new IOException("host file read operation timed out");
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -757,6 +757,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       "dfs.namenode.hosts.provider.classname";
   public static final String  DFS_HOSTS = "dfs.hosts";
   public static final String  DFS_HOSTS_EXCLUDE = "dfs.hosts.exclude";
+  public static final String  DFS_HOSTS_TIMEOUT = "dfs.hosts.timeout";
+  public static final int     DFS_HOSTS_TIMEOUT_DEFAULT = 0;
   public static final String  DFS_NAMENODE_AUDIT_LOGGERS_KEY = "dfs.namenode.audit.loggers";
   public static final String  DFS_NAMENODE_DEFAULT_AUDIT_LOGGER_NAME = "default";
   public static final String  DFS_NAMENODE_AUDIT_LOG_TOKEN_TRACKING_ID_KEY = "dfs.namenode.audit.log.token.tracking.id";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/CombinedHostFileManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/CombinedHostFileManager.java
@@ -179,12 +179,14 @@ public class CombinedHostFileManager extends HostConfigManager {
 
   @Override
   public void refresh() throws IOException {
-    refresh(conf.get(DFSConfigKeys.DFS_HOSTS, ""));
+    refresh(conf.get(DFSConfigKeys.DFS_HOSTS, ""),
+      conf.getInt(DFSConfigKeys.DFS_HOSTS_TIMEOUT, DFSConfigKeys.DFS_HOSTS_TIMEOUT_DEFAULT)
+    );
   }
-  private void refresh(final String hostsFile) throws IOException {
+  private void refresh(final String hostsFile, final int readTimeout) throws IOException {
     HostProperties hostProps = new HostProperties();
-    DatanodeAdminProperties[] all =
-        CombinedHostsFileReader.readFile(hostsFile);
+    DatanodeAdminProperties[] all = readTimeout != DFSConfigKeys.DFS_HOSTS_TIMEOUT_DEFAULT ?
+    CombinedHostsFileReader.readFileWithTimeout(hostsFile, readTimeout) : CombinedHostsFileReader.readFile(hostsFile);
     for(DatanodeAdminProperties properties : all) {
       InetSocketAddress addr = parseEntry(hostsFile,
           properties.getHostName(), properties.getPort());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/CombinedHostFileManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/CombinedHostFileManager.java
@@ -185,8 +185,9 @@ public class CombinedHostFileManager extends HostConfigManager {
   }
   private void refresh(final String hostsFile, final int readTimeout) throws IOException {
     HostProperties hostProps = new HostProperties();
-    DatanodeAdminProperties[] all = readTimeout != DFSConfigKeys.DFS_HOSTS_TIMEOUT_DEFAULT ?
-    CombinedHostsFileReader.readFileWithTimeout(hostsFile, readTimeout) : CombinedHostsFileReader.readFile(hostsFile);
+    DatanodeAdminProperties[] all = readTimeout != DFSConfigKeys.DFS_HOSTS_TIMEOUT_DEFAULT
+        ? CombinedHostsFileReader.readFileWithTimeout(hostsFile, readTimeout)
+        : CombinedHostsFileReader.readFile(hostsFile);
     for(DatanodeAdminProperties properties : all) {
       InetSocketAddress addr = parseEntry(hostsFile,
           properties.getHostName(), properties.getPort());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/CombinedHostFileManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/CombinedHostFileManager.java
@@ -180,7 +180,7 @@ public class CombinedHostFileManager extends HostConfigManager {
   @Override
   public void refresh() throws IOException {
     refresh(conf.get(DFSConfigKeys.DFS_HOSTS, ""),
-      conf.getInt(DFSConfigKeys.DFS_HOSTS_TIMEOUT, DFSConfigKeys.DFS_HOSTS_TIMEOUT_DEFAULT)
+        conf.getInt(DFSConfigKeys.DFS_HOSTS_TIMEOUT, DFSConfigKeys.DFS_HOSTS_TIMEOUT_DEFAULT)
     );
   }
   private void refresh(final String hostsFile, final int readTimeout) throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -1131,7 +1131,14 @@
   not permitted to connect to the namenode.  The full pathname of the
   file must be specified.  If the value is empty, no hosts are
   excluded.</description>
-</property> 
+</property>
+
+<property>
+  <name>dfs.hosts.timeout</name>
+  <value>0</value>
+  <description>Specifies a timeout (in milliseconds) for reading the dfs.hosts file.
+  A value of zero indicates no timeout to be set.</description>
+</property>
 
 <property>
   <name>dfs.namenode.max.objects</name>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestCombinedHostsFileReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestCombinedHostsFileReader.java
@@ -19,14 +19,24 @@ package org.apache.hadoop.hdfs.util;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
+import java.util.concurrent.Callable;
 
 import org.apache.hadoop.hdfs.protocol.DatanodeAdminProperties;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.After;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 /**
  * Test for JSON based HostsFileReader.
@@ -43,6 +53,12 @@ public class TestCombinedHostsFileReader {
   private final File jsonFile = new File(TESTCACHEDATADIR, "dfs.hosts.json");
   private final File legacyFile =
       new File(TESTCACHEDATADIR, "legacy.dfs.hosts.json");
+
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  @Mock
+  private Callable<DatanodeAdminProperties[]> callable;
 
   @Before
   public void setUp() throws Exception {
@@ -87,4 +103,50 @@ public class TestCombinedHostsFileReader {
         CombinedHostsFileReader.readFile(newFile.getAbsolutePath());
     assertEquals(0, all.length);
   }
+
+  /*
+   * When timeout is enabled, test for success when reading file within timeout limits
+   */
+  @Test
+  public void testReadFileWithTimeoutSuccess() throws Exception {
+
+      DatanodeAdminProperties[] all =
+        CombinedHostsFileReader.readFileWithTimeout(
+          jsonFile.getAbsolutePath(), 1000);
+      assertEquals(7, all.length);
+  }
+
+  /*
+   * When timeout is enabled, test for IOException when reading file exceeds timeout limits
+   */
+  @Test
+  public void testReadFileWithTimeoutTimeoutException() throws Exception {
+    exception.expect(IOException.class);
+    when(callable.call()).thenAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        Thread.sleep(2000);
+        return null;
+      }
+    });
+
+    CombinedHostsFileReader.readFileWithTimeout(
+      jsonFile.getAbsolutePath(), 1);
+  }
+
+  /*
+  * When timeout is enabled, test for IOException when execution is interrupted
+  */
+ @Test(expected = IOException.class)
+ public void testReadFileWithTimeoutInterruptedException() throws Exception {
+   when(callable.call()).thenAnswer(new Answer<Void>() {
+     @Override
+     public Void answer(InvocationOnMock invocation) throws Throwable {
+       throw new InterruptedException();
+     }
+   });
+
+   CombinedHostsFileReader.readFileWithTimeout(
+     jsonFile.getAbsolutePath(), 1);
+ }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestCombinedHostsFileReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestCombinedHostsFileReader.java
@@ -25,12 +25,10 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.hdfs.protocol.DatanodeAdminProperties;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
@@ -52,9 +50,6 @@ public class TestCombinedHostsFileReader {
   private final File jsonFile = new File(TESTCACHEDATADIR, "dfs.hosts.json");
   private final File legacyFile =
       new File(TESTCACHEDATADIR, "legacy.dfs.hosts.json");
-
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
 
   @Mock
   private Callable<DatanodeAdminProperties[]> callable;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestCombinedHostsFileReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestCombinedHostsFileReader.java
@@ -32,6 +32,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
@@ -60,6 +61,7 @@ public class TestCombinedHostsFileReader {
 
   @Before
   public void setUp() throws Exception {
+    callable = Mockito.mock(Callable.class);
   }
 
   @After

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestCombinedHostsFileReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestCombinedHostsFileReader.java
@@ -120,9 +120,8 @@ public class TestCombinedHostsFileReader {
    * When timeout is enabled, test for IOException when reading file exceeds
    * timeout limits
    */
-  @Test
+  @Test(expected = IOException.class)
   public void testReadFileWithTimeoutTimeoutException() throws Exception {
-    exception.expect(IOException.class);
     when(callable.call()).thenAnswer(new Answer<Void>() {
       @Override
       public Void answer(InvocationOnMock invocation) throws Throwable {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestCombinedHostsFileReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestCombinedHostsFileReader.java
@@ -32,8 +32,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
@@ -105,19 +103,20 @@ public class TestCombinedHostsFileReader {
   }
 
   /*
-   * When timeout is enabled, test for success when reading file within timeout limits
+   * When timeout is enabled, test for success when reading file within timeout
+   * limits
    */
   @Test
   public void testReadFileWithTimeoutSuccess() throws Exception {
 
-      DatanodeAdminProperties[] all =
-        CombinedHostsFileReader.readFileWithTimeout(
-          jsonFile.getAbsolutePath(), 1000);
-      assertEquals(7, all.length);
+    DatanodeAdminProperties[] all = CombinedHostsFileReader.readFileWithTimeout(
+        jsonFile.getAbsolutePath(), 1000);
+    assertEquals(7, all.length);
   }
 
   /*
-   * When timeout is enabled, test for IOException when reading file exceeds timeout limits
+   * When timeout is enabled, test for IOException when reading file exceeds
+   * timeout limits
    */
   @Test
   public void testReadFileWithTimeoutTimeoutException() throws Exception {
@@ -131,22 +130,22 @@ public class TestCombinedHostsFileReader {
     });
 
     CombinedHostsFileReader.readFileWithTimeout(
-      jsonFile.getAbsolutePath(), 1);
+        jsonFile.getAbsolutePath(), 1);
   }
 
   /*
-  * When timeout is enabled, test for IOException when execution is interrupted
-  */
- @Test(expected = IOException.class)
- public void testReadFileWithTimeoutInterruptedException() throws Exception {
-   when(callable.call()).thenAnswer(new Answer<Void>() {
-     @Override
-     public Void answer(InvocationOnMock invocation) throws Throwable {
-       throw new InterruptedException();
-     }
-   });
+   * When timeout is enabled, test for IOException when execution is interrupted
+   */
+  @Test(expected = IOException.class)
+  public void testReadFileWithTimeoutInterruptedException() throws Exception {
+    when(callable.call()).thenAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        throw new InterruptedException();
+      }
+    });
 
-   CombinedHostsFileReader.readFileWithTimeout(
-     jsonFile.getAbsolutePath(), 1);
- }
+    CombinedHostsFileReader.readFileWithTimeout(
+        jsonFile.getAbsolutePath(), 1);
+  }
 }


### PR DESCRIPTION
### Description of PR
In hadoop environments that rely on NAS to house dfs.hosts file, during FS hangs (for any reason) the refreshNodes call would infinitely hang (causing a blocked thread) until the FS returns. 
This is due to how Java's Filestream works here:
```
  try (Reader input =
          new InputStreamReader(
              Files.newInputStream(hostFile.toPath()), StandardCharsets.UTF_8)) {
        allDNs = objectMapper.readValue(input, DatanodeAdminProperties[].class);
      } catch (JsonMappingException jme) {
```
In order to fix this we introduce a method  (+ new config value) which (if set) encapsulates the original method in a `Future.Task`. If the Task -- reading the file -- does not complete within `dfs.hosts.timeout` then we raise IOException which would interrupt (close) the thread and return a failure. 

### How was this patch tested?
Updated Unit tests to account for new method, ran through local test suite, and planning to run through remote test suite

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

