### PR TITLE
HADOOP-19201 S3A. Support external-id in assume role

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1458,14 +1458,6 @@
 </property>
 
 <property>
-  <name>fs.s3a.assumed.role.external.id</name>
-  <value />
-  <description>
-    External id for assumed role, it's an optional configuration.
-  </description>
-</property>
-
-<property>
   <name>fs.s3a.assumed.role.policy</name>
   <value/>
   <description>

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1458,6 +1458,14 @@
 </property>
 
 <property>
+  <name>fs.s3a.assumed.role.external.id</name>
+  <value />
+  <description>
+    External id for assumed role, it's an optional configuration.
+  </description>
+</property>
+
+<property>
   <name>fs.s3a.assumed.role.policy</name>
   <value/>
   <description>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -95,6 +95,11 @@ public final class Constants {
       "fs.s3a.assumed.role.arn";
 
   /**
+   * external id for assume role request: {@value}.
+   */
+  public static final String ASSUMED_ROLE_EXTERNAL_ID = "fs.s3a.assumed.role.external.id";
+
+  /**
    * Session name for the assumed role, must be valid characters according
    * to the AWS APIs: {@value}.
    * If not set, one is generated from the current Hadoop/Kerberos username.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/AssumedRoleCredentialProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/AssumedRoleCredentialProvider.java
@@ -125,12 +125,17 @@ public final class AssumedRoleCredentialProvider implements AwsCredentialsProvid
     duration = conf.getTimeDuration(ASSUMED_ROLE_SESSION_DURATION,
         ASSUMED_ROLE_SESSION_DURATION_DEFAULT, TimeUnit.SECONDS);
     String policy = conf.getTrimmed(ASSUMED_ROLE_POLICY, "");
+    String externalId = conf.getTrimmed(ASSUMED_ROLE_EXTERNAL_ID, "");
 
     LOG.debug("{}", this);
 
     AssumeRoleRequest.Builder requestBuilder =
         AssumeRoleRequest.builder().roleArn(arn).roleSessionName(sessionName)
             .durationSeconds((int) duration);
+
+    if (StringUtils.isNotEmpty(externalId)) {
+      requestBuilder.externalId(externalId);
+    }
 
     if (StringUtils.isNotEmpty(policy)) {
       LOG.debug("Scope down policy {}", policy);

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/assumed_roles.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/assumed_roles.md
@@ -157,7 +157,7 @@ Here are the full set of configuration options.
   <name>fs.s3a.assumed.role.external.id</name>
   <value />
   <description>
-    External id for assumed role, it's an optional configuration. <a href="https://aws.amazon.com/cn/blogs/security/how-to-use-external-id-when-granting-access-to-your-aws-resources/">How to Use External ID When Granting Access to Your AWS Resources</a>
+    External id for assumed role, it's an optional configuration. "https://aws.amazon.com/cn/blogs/security/how-to-use-external-id-when-granting-access-to-your-aws-resources/"
   </description>
 </property>
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/assumed_roles.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/assumed_roles.md
@@ -154,6 +154,14 @@ Here are the full set of configuration options.
 </property>
 
 <property>
+  <name>fs.s3a.assumed.role.external.id</name>
+  <value />
+  <description>
+    External id for assumed role, it's an optional configuration.
+  </description>
+</property>
+
+<property>
   <name>fs.s3a.assumed.role.policy</name>
   <value/>
   <description>

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/assumed_roles.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/assumed_roles.md
@@ -157,7 +157,7 @@ Here are the full set of configuration options.
   <name>fs.s3a.assumed.role.external.id</name>
   <value />
   <description>
-    External id for assumed role, it's an optional configuration.
+    External id for assumed role, it's an optional configuration. <a href="https://aws.amazon.com/cn/blogs/security/how-to-use-external-id-when-granting-access-to-your-aws-resources/">How to Use External ID When Granting Access to Your AWS Resources</a>
   </description>
 </property>
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/assumed_roles.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/assumed_roles.md
@@ -155,7 +155,7 @@ Here are the full set of configuration options.
 
 <property>
   <name>fs.s3a.assumed.role.external.id</name>
-  <value />
+  <value>arbitrary value, specific by user in AWS console</value>
   <description>
     External id for assumed role, it's an optional configuration. "https://aws.amazon.com/cn/blogs/security/how-to-use-external-id-when-granting-access-to-your-aws-resources/"
   </description>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Support external id in AssumedRoleCredentialProvider.java

https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html


### How was this patch tested?

tested in my env


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

