### PR TITLE
HADOOP-19199

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -987,6 +987,17 @@ public abstract class FileSystem extends Configured
   public abstract FSDataInputStream open(Path f, int bufferSize)
     throws IOException;
 
+ /**
+   * Opens an FSDataInputStream at the indicated FileStatus.
+   * @param f the FileStatus to open
+   * @throws IOException IO failure
+   * @return input stream.
+   */
+  public FSDataInputStream open(FileStatus f) throws IOException {
+    return open(f.getPath(), getConf().getInt(IO_FILE_BUFFER_SIZE_KEY,
+        IO_FILE_BUFFER_SIZE_DEFAULT));
+  }
+        
   /**
    * Opens an FSDataInputStream at the indicated Path.
    * @param f the file to open

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -997,8 +997,8 @@ public abstract class FileSystem extends Configured
     return open(f.getPath(), getConf().getInt(IO_FILE_BUFFER_SIZE_KEY,
         IO_FILE_BUFFER_SIZE_DEFAULT));
   }
-        
-  /**
+
+ /**
    * Opens an FSDataInputStream at the indicated Path.
    * @param f the file to open
    * @throws IOException IO failure

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFilterFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFilterFileSystem.java
@@ -78,6 +78,7 @@ public class TestFilterFileSystem {
         Progressable progress) throws IOException;
 
     public FSDataInputStream open(Path f);
+    public FSDataInputStream open(FileStatus f);
     public FSDataInputStream open(PathHandle f);
     public FSDataOutputStream create(Path f);
     public FSDataOutputStream create(Path f, boolean overwrite);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHarFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHarFileSystem.java
@@ -82,6 +82,7 @@ public class TestHarFileSystem {
 
     public boolean mkdirs(Path f);
     public FSDataInputStream open(Path f);
+    public FSDataInputStream open(FileStatus f);
     public FSDataInputStream open(PathHandle f);
     public FSDataOutputStream create(Path f);
     public FSDataOutputStream create(Path f, boolean overwrite);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalFileSystem.java
@@ -642,6 +642,33 @@ public class TestLocalFileSystem {
       in.close();
     }
   }
+  @Test
+  public void testFSOpenFileOneFileStatus() throws Exception {
+    Path path = new Path(TEST_ROOT_DIR, "testOpenFileStatus");
+
+    try {
+      FSDataOutputStreamBuilder builder =
+              fileSys.createFile(path).recursive();
+      FSDataOutputStream out = builder.build();
+      String content = "Create with a generic type of createFile!";
+      byte[] contentOrigin = content.getBytes(StandardCharsets.UTF_8);
+      out.write(contentOrigin);
+      out.close();
+
+      FileStatus fstatus = fileSys.getFileStatus(path);
+
+      FSDataInputStream input = fileSys.open(fstatus);
+      byte[] buffer =
+              new byte[(int) (fstatus.getLen())];
+      input.readFully(0, buffer);
+      input.close();
+      Assert.assertArrayEquals("The data be read should equals with the "
+              + "data written.", contentOrigin, buffer);
+    } catch (IOException e) {
+      throw e;
+    }
+  }
+
 
   @Test
   public void testFileStatusPipeFile() throws Exception {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalFileSystem.java
@@ -651,7 +651,7 @@ public class TestLocalFileSystem {
               fileSys.createFile(path).recursive();
       FSDataOutputStream out = builder.build();
       String content = "Create with a generic type of createFile!";
-      byte[] contentOrigin = content.getBytes(StandardCharsets.UTF_8);
+      byte[] contentOrigin = content.getBytes("UTF_8");
       out.write(contentOrigin);
       out.close();
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalFileSystem.java
@@ -651,7 +651,7 @@ public class TestLocalFileSystem {
               fileSys.createFile(path).recursive();
       FSDataOutputStream out = builder.build();
       String content = "Create with a generic type of createFile!";
-      byte[] contentOrigin = content.getBytes("UTF_8");
+      byte[] contentOrigin = content.getBytes("UTF8");
       out.write(contentOrigin);
       out.close();
 


### PR DESCRIPTION
HADOOP-19199

### Description of PR

Although to create the implementation you had to consult the file to know its FileStatus, when opening it only the path is included, since the FileSystem implementation is the only thing it allows you to do. This implies that the implementation will surely, in its open function, verify that the file exists or what information the file has and perform the same operation again to collect the FileStatus.

### How was this patch tested?

Local system

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?

HADOOP-19199

- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?

No

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

