### PR TITLE
HADOOP-19203. WrappedIO BulkDelete API to raise IOEs as UncheckedIOExceptions

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/CommonCallableSupplier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/CommonCallableSupplier.java
@@ -41,7 +41,7 @@ import static org.apache.hadoop.util.functional.FutureIO.raiseInnerCause;
  * raised by the callable and wrapping them as appropriate.
  * @param <T> return type.
  */
-public final class CommonCallableSupplier<T> implements Supplier {
+public final class CommonCallableSupplier<T> implements Supplier<T> {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(CommonCallableSupplier.class);
@@ -57,7 +57,7 @@ public final class CommonCallableSupplier<T> implements Supplier {
   }
 
   @Override
-  public Object get() {
+  public T get() {
     try {
       return call.call();
     } catch (RuntimeException e) {
@@ -155,4 +155,5 @@ public final class CommonCallableSupplier<T> implements Supplier {
       waitForCompletion(future);
     }
   }
+
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FunctionalIO.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FunctionalIO.java
@@ -22,17 +22,23 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.function.Supplier;
 
+import org.apache.hadoop.classification.InterfaceAudience;
+
 /**
  * Functional utilities for IO operations.
  */
+@InterfaceAudience.Private
 public final class FunctionalIO {
+
+  private FunctionalIO() {
+  }
 
   /**
    * Invoke any operation, wrapping IOExceptions with
    * {@code UncheckedIOException}.
    * @param call callable
-   * @return result
    * @param <T> type of result
+   * @return result
    * @throws UncheckedIOException if an IOE was raised.
    */
   public static <T> T uncheckIOExceptions(CallableRaisingIOE<T> call) {
@@ -48,10 +54,10 @@ public final class FunctionalIO {
    * This is similar to {@link CommonCallableSupplier}, except that
    * only IOExceptions are caught and wrapped; all other exceptions are
    * propagated unchanged.
-   *
    * @param <T> type of result
    */
   private static final class UncheckedIOExceptionSupplier<T> implements Supplier<T> {
+
     private final CallableRaisingIOE<T> call;
 
     private UncheckedIOExceptionSupplier(CallableRaisingIOE<T> call) {
@@ -78,8 +84,8 @@ public final class FunctionalIO {
    * Invoke the supplier, catching any {@code UncheckedIOException} raised,
    * extracting the inner IOException and rethrowing it.
    * @param call call to invoke
-   * @return result
    * @param <T> type of result
+   * @return result
    * @throws IOException if the call raised an IOException wrapped by an UncheckedIOException.
    */
   public static <T> T extractIOExceptions(Supplier<T> call) throws IOException {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FunctionalIO.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FunctionalIO.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.util.functional;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.function.Supplier;
+
+/**
+ * Functional utilities for IO operations.
+ */
+public final class FunctionalIO {
+
+  /**
+   * Invoke any operation, wrapping IOExceptions with
+   * {@code UncheckedIOException}.
+   * @param call callable
+   * @return result
+   * @param <T> type of result
+   * @throws UncheckedIOException if an IOE was raised.
+   */
+  public static <T> T uncheckIOExceptions(CallableRaisingIOE<T> call) {
+    try {
+      return call.apply();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /**
+   * Wrap a {@link CallableRaisingIOE} as a {@link Supplier}.
+   * This is similar to {@link CommonCallableSupplier}, except that
+   * only IOExceptions are caught and wrapped; all other exceptions are
+   * propagated unchanged.
+   *
+   * @param <T> type of result
+   */
+  private static final class UncheckedIOExceptionSupplier<T> implements Supplier<T> {
+    private final CallableRaisingIOE<T> call;
+
+    private UncheckedIOExceptionSupplier(CallableRaisingIOE<T> call) {
+      this.call = call;
+    }
+
+    @Override
+    public T get() {
+      return uncheckIOExceptions(call);
+    }
+  }
+
+  /**
+   * Wrap a {@link CallableRaisingIOE} as a {@link Supplier}.
+   * @param call call to wrap
+   * @param <T> type of result
+   * @return a supplier which invokes the call.
+   */
+  public static <T> Supplier<T> toUncheckedIOExceptionSupplier(CallableRaisingIOE<T> call) {
+    return new UncheckedIOExceptionSupplier<>(call);
+  }
+
+  /**
+   * Invoke the supplier, catching any {@code UncheckedIOException} raised,
+   * extracting the inner IOException and rethrowing it.
+   * @param call call to invoke
+   * @return result
+   * @param <T> type of result
+   * @throws IOException if the call raised an IOException wrapped by an UncheckedIOException.
+   */
+  public static <T> T extractIOExceptions(Supplier<T> call) throws IOException {
+    try {
+      return call.get();
+    } catch (UncheckedIOException e) {
+      throw e.getCause();
+    }
+  }
+
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FutureIO.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FutureIO.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -354,4 +355,5 @@ public final class FutureIO {
     }
     return result;
   }
+
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FutureIO.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FutureIO.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Supplier;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -355,5 +354,4 @@ public final class FutureIO {
     }
     return result;
   }
-
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/functional/TestFunctionalIO.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/functional/TestFunctionalIO.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.util.functional;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+import static org.apache.hadoop.util.functional.FunctionalIO.extractIOExceptions;
+import static org.apache.hadoop.util.functional.FunctionalIO.toUncheckedIOExceptionSupplier;
+import static org.apache.hadoop.util.functional.FunctionalIO.uncheckIOExceptions;
+
+/**
+ * Test the functional IO class.
+ */
+public class TestFunctionalIO extends AbstractHadoopTestBase {
+
+  /**
+   * Verify that IOEs are caught and wrapped.
+   */
+  @Test
+  public void testUncheckIOExceptions() throws Throwable {
+    final IOException raised = new IOException("text");
+    final UncheckedIOException ex = intercept(UncheckedIOException.class, "text", () ->
+        uncheckIOExceptions(() -> {
+          throw raised;
+        }));
+    Assertions.assertThat(ex.getCause())
+        .describedAs("Cause of %s", ex)
+        .isSameAs(raised);
+  }
+
+  /**
+   * Verify that UncheckedIOEs are not double wrapped.
+   */
+  @Test
+  public void testUncheckIOExceptionsUnchecked() throws Throwable {
+    final UncheckedIOException raised = new UncheckedIOException(
+        new IOException("text"));
+    final UncheckedIOException ex = intercept(UncheckedIOException.class, "text", () ->
+        uncheckIOExceptions(() -> {
+          throw raised;
+        }));
+    Assertions.assertThat(ex)
+        .describedAs("Propagated Exception %s", ex)
+        .isSameAs(raised);
+  }
+
+  /**
+   * Supplier will also wrap IOEs.
+   */
+  @Test
+  public void testUncheckedSupplier() throws Throwable {
+    intercept(UncheckedIOException.class, "text", () ->
+        toUncheckedIOExceptionSupplier(() -> {
+          throw new IOException("text");
+        }).get());
+  }
+
+  /**
+   * The wrap/unwrap code which will be used to invoke operations
+   * through reflection.
+   */
+  @Test
+  public void testUncheckAndExtract() throws Throwable {
+    final IOException raised = new IOException("text");
+    final IOException ex = intercept(IOException.class, "text", () ->
+        extractIOExceptions(toUncheckedIOExceptionSupplier(() -> {
+          throw raised;
+        })));
+    Assertions.assertThat(ex)
+        .describedAs("Propagated Exception %s", ex)
+        .isSameAs(raised);
+  }
+
+}


### PR DESCRIPTION

-WrappedIO methods raise UncheckedIOEs
-new class org.apache.hadoop.util.functional.FunctionalIO
 with wrap/unwrap and the ability to generate a
 java.util.function.Supplier around a CallableRaisingIOE.
-Tests


### How was this patch tested?

* New test for the wrapping logic
* bulk delete contract tests against s3 and abfs

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

