### PR TITLE
HADOOP-19204. VectorIO regression: empty ranges are now rejected

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/VectoredReadUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/VectoredReadUtils.java
@@ -294,7 +294,14 @@ public final class VectoredReadUtils {
       final Optional<Long> fileLength) throws EOFException {
 
     requireNonNull(input, "Null input list");
-    checkArgument(!input.isEmpty(), "Empty input list");
+
+    if (input.isEmpty()) {
+      // this may seem a pathological case, but it was valid
+      // before and somehow Spark can call it through parquet.
+      LOG.debug("Empty input list");
+      return input;
+    }
+
     final List<? extends FileRange> sortedRanges;
 
     if (input.size() == 1) {

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/fsdatainputstream.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/fsdatainputstream.md
@@ -474,7 +474,6 @@ No empty lists.
 
 ```python
 if ranges = null raise NullPointerException
-if ranges.len() = 0 raise IllegalArgumentException
 if allocate = null raise NullPointerException
 ```
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractVectoredReadTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractVectoredReadTest.java
@@ -340,6 +340,17 @@ public abstract class AbstractContractVectoredReadTest extends AbstractFSContrac
     }
   }
 
+  @Test
+  public void testEmptyRanges() throws Exception {
+    List<FileRange> fileRanges = new ArrayList<>();
+    try (FSDataInputStream in = openVectorFile()) {
+      in.readVectored(fileRanges, allocate);
+      Assertions.assertThat(fileRanges)
+          .describedAs("Empty ranges must stay empty")
+          .isEmpty();
+    }
+  }
+
   /**
    * Test to validate EOF ranges.
    * <p>

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/impl/TestVectoredReadUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/impl/TestVectoredReadUtils.java
@@ -702,12 +702,11 @@ public class TestVectoredReadUtils extends HadoopTestBase {
   }
 
   /**
-   * Empty ranges cannot be sorted.
+   * Empty ranges are allowed.
    */
   @Test
-  public void testEmptyRangesRaisesIllegalArgument() throws Throwable {
-    intercept(IllegalArgumentException.class,
-        () -> validateAndSortRanges(Collections.emptyList(), Optional.empty()));
+  public void testEmptyRangesAllowed() throws Throwable {
+    validateAndSortRanges(Collections.emptyList(), Optional.empty());
   }
 
   /**


### PR DESCRIPTION

- restore out outcome: no-op
- test this


### How was this patch tested?


new test case in AbstractContractVectoredReadTest; tested on
* local
* s3 london
* abfs cardiff

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

