### PR TITLE
HADOOP-19205. S3A: initialization/close slower than with v1 SDK

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/FileSystemStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/FileSystemStatisticNames.java
@@ -27,7 +27,10 @@ import org.apache.hadoop.classification.InterfaceStability;
  */
 @InterfaceAudience.Public
 @InterfaceStability.Evolving
-public class FileSystemStatisticNames {
+public final class FileSystemStatisticNames {
+
+  private FileSystemStatisticNames() {
+  }
 
   /**
    * How long did filesystem initialization take?

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/FileSystemStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/FileSystemStatisticNames.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * Common statistic names for Filesystem-level statistics,
+ * including internals.
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public class FileSystemStatisticNames {
+
+  /**
+   * How long did filesystem initialization take?
+   */
+  public static final String FILESYSTEM_INITIALIZATION = "filesystem_initialization";
+
+  /**
+   * How long did filesystem close take?
+   */
+  public static final String FILESYSTEM_CLOSE = "filesystem_close";
+
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StoreStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StoreStatisticNames.java
@@ -176,6 +176,11 @@ public final class StoreStatisticNames {
   public static final String DELEGATION_TOKENS_ISSUED
       = "delegation_tokens_issued";
 
+  /**
+   * How long did any store client creation take?
+   */
+  public static final String STORE_CLIENT_CREATION = "store_client_creation";
+
   /** Probe for store existing: {@value}. */
   public static final String STORE_EXISTS_PROBE
       = "store_exists_probe";
@@ -199,6 +204,7 @@ public final class StoreStatisticNames {
 
   public static final String STORE_IO_RATE_LIMITED_DURATION
       = "store_io_rate_limited_duration";
+
 
   /**
    * A store's equivalent of a paged LIST request was initiated: {@value}.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FunctionalIO.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FunctionalIO.java
@@ -51,33 +51,12 @@ public final class FunctionalIO {
 
   /**
    * Wrap a {@link CallableRaisingIOE} as a {@link Supplier}.
-   * This is similar to {@link CommonCallableSupplier}, except that
-   * only IOExceptions are caught and wrapped; all other exceptions are
-   * propagated unchanged.
-   * @param <T> type of result
-   */
-  private static final class UncheckedIOExceptionSupplier<T> implements Supplier<T> {
-
-    private final CallableRaisingIOE<T> call;
-
-    private UncheckedIOExceptionSupplier(CallableRaisingIOE<T> call) {
-      this.call = call;
-    }
-
-    @Override
-    public T get() {
-      return uncheckIOExceptions(call);
-    }
-  }
-
-  /**
-   * Wrap a {@link CallableRaisingIOE} as a {@link Supplier}.
    * @param call call to wrap
    * @param <T> type of result
    * @return a supplier which invokes the call.
    */
   public static <T> Supplier<T> toUncheckedIOExceptionSupplier(CallableRaisingIOE<T> call) {
-    return new UncheckedIOExceptionSupplier<>(call);
+    return () -> uncheckIOExceptions(call);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FutureIO.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FutureIO.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -353,5 +354,24 @@ public final class FutureIO {
       result.completeExceptionally(tx);
     }
     return result;
+  }
+
+
+  /**
+   * Create a java supplier from a {@link CallableRaisingIOE},
+   * converting IOExceptions to UncheckedIOException.
+   * @param callable callable to invoke.
+   * @return supplier.
+   * @param <T> return type
+   */
+  public static <T> Supplier<T> toSupplier(
+      CallableRaisingIOE<T> callable) {
+    return () -> {
+      try {
+        return callable.apply();
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    };
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FutureIO.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FutureIO.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Supplier;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -354,24 +353,5 @@ public final class FutureIO {
       result.completeExceptionally(tx);
     }
     return result;
-  }
-
-
-  /**
-   * Create a java supplier from a {@link CallableRaisingIOE},
-   * converting IOExceptions to UncheckedIOException.
-   * @param callable callable to invoke.
-   * @return supplier.
-   * @param <T> return type
-   */
-  public static <T> Supplier<T> toSupplier(
-      CallableRaisingIOE<T> callable) {
-    return () -> {
-      try {
-        return callable.apply();
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      }
-    };
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FutureIO.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FutureIO.java
@@ -258,8 +258,7 @@ public final class FutureIO {
    * @param <U> type of builder
    * @return the builder passed in.
    */
-  public static <T, U extends FSBuilder<T, U>>
-  FSBuilder<T, U> propagateOptions(
+  public static <T, U extends FSBuilder<T, U>> FSBuilder<T, U> propagateOptions(
       final FSBuilder<T, U> builder,
       final Configuration conf,
       final String optionalPrefix,

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FutureIO.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/FutureIO.java
@@ -38,9 +38,6 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSBuilder;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Future IO Helper methods.
  * <p>
@@ -62,7 +59,6 @@ import org.slf4j.LoggerFactory;
 @InterfaceStability.Unstable
 public final class FutureIO {
 
-  private static final Logger LOG = LoggerFactory.getLogger(FutureIO.class.getName());
   private FutureIO() {
   }
 
@@ -129,7 +125,6 @@ public final class FutureIO {
    * If any future throws an exception during its execution, this method
    * extracts and rethrows that exception.
    * </p>
-   *
    * @param collection collection of futures to be evaluated
    * @param <T> type of the result.
    * @return the list of future's result, if all went well.
@@ -140,19 +135,10 @@ public final class FutureIO {
   public static <T> List<T> awaitAllFutures(final Collection<Future<T>> collection)
       throws InterruptedIOException, IOException, RuntimeException {
     List<T> results = new ArrayList<>();
-    try {
-      for (Future<T> future : collection) {
-        results.add(future.get());
-      }
-      return results;
-    } catch (InterruptedException e) {
-      LOG.debug("Execution of future interrupted ", e);
-      throw (InterruptedIOException) new InterruptedIOException(e.toString())
-          .initCause(e);
-    } catch (ExecutionException e) {
-      LOG.debug("Execution of future failed with exception", e.getCause());
-      return raiseInnerCause(e);
+    for (Future<T> future : collection) {
+      results.add(awaitFuture(future));
     }
+    return results;
   }
 
   /**
@@ -163,7 +149,6 @@ public final class FutureIO {
    * the timeout expires, whichever happens first. If any future throws an
    * exception during its execution, this method extracts and rethrows that exception.
    * </p>
-   *
    * @param collection collection of futures to be evaluated
    * @param duration timeout duration
    * @param <T> type of the result.
@@ -176,21 +161,12 @@ public final class FutureIO {
   public static <T> List<T> awaitAllFutures(final Collection<Future<T>> collection,
       final Duration duration)
       throws InterruptedIOException, IOException, RuntimeException,
-      TimeoutException {
+             TimeoutException {
     List<T> results = new ArrayList<>();
-    try {
-      for (Future<T> future : collection) {
-        results.add(future.get(duration.toMillis(), TimeUnit.MILLISECONDS));
-      }
-      return results;
-    } catch (InterruptedException e) {
-      LOG.debug("Execution of future interrupted ", e);
-      throw (InterruptedIOException) new InterruptedIOException(e.toString())
-          .initCause(e);
-    } catch (ExecutionException e) {
-      LOG.debug("Execution of future failed with exception", e.getCause());
-      return raiseInnerCause(e);
+    for (Future<T> future : collection) {
+      results.add(awaitFuture(future, duration.toMillis(), TimeUnit.MILLISECONDS));
     }
+    return results;
   }
 
   /**
@@ -199,7 +175,6 @@ public final class FutureIO {
    * This will always raise an exception, either the inner IOException,
    * an inner RuntimeException, or a new IOException wrapping the raised
    * exception.
-   *
    * @param e exception.
    * @param <T> type of return value.
    * @return nothing, ever.
@@ -284,11 +259,11 @@ public final class FutureIO {
    * @return the builder passed in.
    */
   public static <T, U extends FSBuilder<T, U>>
-      FSBuilder<T, U> propagateOptions(
-        final FSBuilder<T, U> builder,
-        final Configuration conf,
-        final String optionalPrefix,
-        final String mandatoryPrefix) {
+  FSBuilder<T, U> propagateOptions(
+      final FSBuilder<T, U> builder,
+      final Configuration conf,
+      final String optionalPrefix,
+      final String mandatoryPrefix) {
     propagateOptions(builder, conf,
         optionalPrefix, false);
     propagateOptions(builder, conf,

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/LazyAtomicReference.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/LazyAtomicReference.java
@@ -40,12 +40,12 @@ public class LazyAtomicReference<T> implements CallableRaisingIOE<T> {
   /**
    * Underlying reference.
    */
-  protected final AtomicReference<T> reference = new AtomicReference<>();
+  private final AtomicReference<T> reference = new AtomicReference<>();
 
   /**
    * Constructor for lazy creation.
    */
-  protected final CallableRaisingIOE<? extends T> constructor;
+  private final CallableRaisingIOE<? extends T> constructor;
 
   /**
    * Constructor for this instance.
@@ -92,7 +92,7 @@ public class LazyAtomicReference<T> implements CallableRaisingIOE<T> {
    * @return the value
    * @throws UncheckedIOException if the constructor raised an IOException.
    */
-  private final T getUnchecked() throws UncheckedIOException {
+  public final T getUnchecked() throws UncheckedIOException {
     return uncheckIOExceptions(this::get);
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/LazyAutoCloseableReference.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/LazyAutoCloseableReference.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.util.functional;
+
+/**
+ * A subclass of {@link LazyAtomicReference} which
+ * holds an {@code AutoCloseable} reference and calls {@code close()}
+ * on ot
+ * @param <T> type of reference.
+ */
+public class LazyAutoCloseableReference<T extends AutoCloseable>
+    extends LazyAtomicReference<T> implements AutoCloseable {
+
+  /**
+   * Constructor for this instance.
+   * @param constructor method to invoke to actually construct the inner object.
+   */
+  public LazyAutoCloseableReference(final CallableRaisingIOE<? extends T> constructor) {
+    super(constructor);
+  }
+
+  /**
+   * Close the reference value if it is non-null.
+   * Sets the reference to null afterwards, even on
+   * a failure.
+   * @throws Exception failure to close.
+   */
+  @Override
+  public synchronized void close() throws Exception {
+    final T v = getReference().get();
+    if (v != null) {
+      try {
+        v.close();
+      } finally {
+        // set the reference to null, even on a failure.
+        getReference().set(null);
+      }
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/LazyAutoCloseableReference.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/functional/LazyAutoCloseableReference.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.util.functional;
 /**
  * A subclass of {@link LazyAtomicReference} which
  * holds an {@code AutoCloseable} reference and calls {@code close()}
- * on ot
+ * when it itself is closed.
  * @param <T> type of reference.
  */
 public class LazyAutoCloseableReference<T extends AutoCloseable>

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/functional/TestLazyReferences.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/functional/TestLazyReferences.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.util.functional;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.UnknownHostException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+import static org.apache.hadoop.test.LambdaTestUtils.verifyCause;
+import static org.apache.hadoop.util.Preconditions.checkState;
+
+/**
+ * Test {@link LazyAtomicReference} and {@link LazyAutoCloseableReference}.
+ */
+public class TestLazyReferences extends AbstractHadoopTestBase {
+
+  /**
+   * Format of exceptions to raise.
+   */
+  private static final String GENERATED = "generated[%d]";
+
+  /**
+   * Invocation counter, can be asserted on in {@link #assertCounterValue(int)}.
+   */
+  private final AtomicInteger counter = new AtomicInteger();
+
+  /**
+   * Assert that {@link #counter} has a specific value.
+   * @param val expected value
+   */
+  private void assertCounterValue(final int val) {
+    assertAtomicIntValue(counter, val);
+  }
+
+  /**
+   * Assert an atomic integer has a specific value.
+   * @param ai atomic integer
+   * @param val expected value
+   */
+  private static void assertAtomicIntValue(
+      final AtomicInteger ai, final int val) {
+    Assertions.assertThat(ai.get())
+        .describedAs("value of atomic integer %s", ai)
+        .isEqualTo(val);
+  }
+
+
+  /**
+   * Test the underlying {@link LazyAtomicReference} integration with java
+   * Supplier API.
+   */
+  @Test
+  public void testLazyAtomicReference() throws Throwable {
+
+    LazyAtomicReference<Integer> ref = new LazyAtomicReference<>(counter::incrementAndGet);
+
+    // constructor does not invoke the supplier
+    assertCounterValue(0);
+
+    assertSetState(ref, false);
+
+    // second invocation does not
+    Assertions.assertThat(ref.eval())
+        .describedAs("first eval()")
+        .isEqualTo(1);
+    assertCounterValue(1);
+    assertSetState(ref, true);
+
+
+    // Callable.apply() returns the same value
+    Assertions.assertThat(ref.apply())
+        .describedAs("second get of %s", ref)
+        .isEqualTo(1);
+    // no new counter increment
+    assertCounterValue(1);
+  }
+
+  /**
+   * Assert that {@link LazyAtomicReference#isSet()} is in the expected state.
+   * @param ref reference
+   * @param expected expected value
+   */
+  private static <T> void assertSetState(final LazyAtomicReference<T> ref,
+      final boolean expected) {
+    Assertions.assertThat(ref.isSet())
+        .describedAs("isSet() of %s", ref)
+        .isEqualTo(expected);
+  }
+
+  /**
+   * Test the underlying {@link LazyAtomicReference} integration with java
+   * Supplier API.
+   */
+  @Test
+  public void testSupplierIntegration() throws Throwable {
+
+    LazyAtomicReference<Integer> ref = LazyAtomicReference.lazyAtomicReferenceFromSupplier(counter::incrementAndGet);
+
+    // constructor does not invoke the supplier
+    assertCounterValue(0);
+    assertSetState(ref, false);
+
+    // second invocation does not
+    Assertions.assertThat(ref.get())
+        .describedAs("first get()")
+        .isEqualTo(1);
+    assertCounterValue(1);
+
+    // Callable.apply() returns the same value
+    Assertions.assertThat(ref.apply())
+        .describedAs("second get of %s", ref)
+        .isEqualTo(1);
+    // no new counter increment
+    assertCounterValue(1);
+  }
+
+  /**
+   * Test failure handling. through the supplier API.
+   */
+  @Test
+  public void testSupplierIntegrationFailureHandling() throws Throwable {
+
+    LazyAtomicReference<Integer> ref = new LazyAtomicReference<>(() -> {
+      throw new UnknownHostException(String.format(GENERATED, counter.incrementAndGet()));
+    });
+
+    // the get() call will wrap the raised exception, which can be extracted
+    // and type checked.
+    verifyCause(UnknownHostException.class,
+        intercept(UncheckedIOException.class, "[1]", ref::get));
+
+    assertSetState(ref, false);
+
+    // counter goes up
+    intercept(UncheckedIOException.class, "[2]", ref::get);
+  }
+
+  @Test
+  public void testAutoCloseable() throws Throwable {
+    final LazyAutoCloseableReference<CloseableClass> ref =
+        LazyAutoCloseableReference.lazyAutoCloseablefromSupplier(CloseableClass::new);
+
+    assertSetState(ref, false);
+    ref.eval();
+    final CloseableClass closeable = ref.get();
+    Assertions.assertThat(closeable.isClosed())
+        .describedAs("closed flag of %s", closeable)
+        .isFalse();
+
+    // first close will close the class.
+    ref.close();
+    Assertions.assertThat(ref.isClosed())
+        .describedAs("closed flag of %s", ref)
+        .isTrue();
+    Assertions.assertThat(closeable.isClosed())
+        .describedAs("closed flag of %s", closeable)
+        .isTrue();
+
+    // second close will not raise an exception
+    ref.close();
+
+    // you cannot eval() a closed reference
+    intercept(IllegalStateException.class, "Reference is closed", ref::eval);
+    intercept(IllegalStateException.class, "Reference is closed", ref::get);
+    intercept(IllegalStateException.class, "Reference is closed", ref::apply);
+
+    Assertions.assertThat(ref.getReference().get())
+        .describedAs("inner referece of %s", ref)
+        .isNull();
+  }
+
+  /**
+   * Not an error to close a reference which was never evaluated.
+   */
+  @Test
+  public void testCloseableUnevaluated() throws Throwable {
+    final LazyAutoCloseableReference<CloseableRaisingException> ref =
+        new LazyAutoCloseableReference<>(CloseableRaisingException::new);
+    ref.close();
+    ref.close();
+  }
+
+  /**
+   * If the close() call fails, that only raises an exception on the first attempt,
+   * and the reference is set to null.
+   */
+  @Test
+  public void testAutoCloseableFailureHandling() throws Throwable {
+    final LazyAutoCloseableReference<CloseableRaisingException> ref =
+        new LazyAutoCloseableReference<>(CloseableRaisingException::new);
+    ref.eval();
+
+    // close reports the failure.
+    intercept(IOException.class, "raised", ref::close);
+
+    // but the reference is set to null
+    assertSetState(ref, false);
+    // second attept does nothing, so will not raise an exception.p
+    ref.close();
+  }
+
+  /**
+   * Closeable which sets the closed flag on close().
+   */
+  private static final class CloseableClass implements AutoCloseable {
+
+    /** closed flag. */
+    private boolean closed;
+
+    /**
+     * Close the resource.
+     * @throws IllegalArgumentException if already closed.
+     */
+    @Override
+    public void close() {
+      checkState(!closed, "Already closed");
+      closed = true;
+    }
+
+    /**
+     * Get the closed flag.
+     * @return the state.
+     */
+    private boolean isClosed() {
+      return closed;
+    }
+
+  }
+  /**
+   * Closeable which raises an IOE in close().
+   */
+  private static final class CloseableRaisingException implements AutoCloseable {
+
+    @Override
+    public void close() throws Exception {
+      throw new IOException("raised");
+    }
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/dev-support/findbugs-exclude.xml
+++ b/hadoop-tools/hadoop-aws/dev-support/findbugs-exclude.xml
@@ -65,11 +65,6 @@
     <Bug pattern="IS2_INCONSISTENT_SYNC"/>
   </Match>
   <Match>
-    <Class name="org.apache.hadoop.fs.s3a.S3AFileSystem"/>
-    <Field name="s3AsyncClient"/>
-    <Bug pattern="IS2_INCONSISTENT_SYNC"/>
-  </Match>
-  <Match>
     <Class name="org.apache.hadoop.fs.s3a.s3guard.S3GuardTool$BucketInfo"/>
     <Method name="run"/>
     <Bug pattern="SF_SWITCH_FALLTHROUGH"/>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -701,7 +701,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       // the FS came with a DT
       // this may do some patching of the configuration (e.g. setting
       // the encryption algorithms)
-      ClientManager clientManager = bindAWSClient(name, delegationTokensEnabled);
+      ClientManager clientManager = createClientManager(name, delegationTokensEnabled);
 
       inputPolicy = S3AInputPolicy.getPolicy(
           conf.getTrimmed(INPUT_FADVISE,
@@ -1061,7 +1061,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * @return the client manager which can generate the clients.
    * @throws IOException failure.
    */
-  private ClientManager bindAWSClient(URI fsURI, boolean dtEnabled) throws IOException {
+  private ClientManager createClientManager(URI fsURI, boolean dtEnabled) throws IOException {
     Configuration conf = getConf();
     credentials = null;
     String uaSuffix = "";

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -1144,7 +1144,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   protected ClientManager createClientManager(
       final S3ClientFactory clientFactory,
       final S3ClientFactory.S3ClientCreationParameters clientCreationParameters,
-      final DurationTrackerFactory durationTrackerFactory) throws IOException {
+      final DurationTrackerFactory durationTrackerFactory) {
     return new ClientManagerImpl(clientFactory,
         clientCreationParameters,
         durationTrackerFactory
@@ -3233,6 +3233,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * @param file the file to be uploaded
    * @param listener the progress listener for the request
    * @return the upload initiated
+   * @throws IOException if transfer manager creation failed.
    */
   @Retries.OnceRaw
   public UploadInfo putObject(PutObjectRequest putObjectRequest, File file,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AStore.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.s3a.api.RequestFactory;
+import org.apache.hadoop.fs.s3a.impl.ClientManager;
 import org.apache.hadoop.fs.s3a.impl.MultiObjectDeleteException;
 import org.apache.hadoop.fs.s3a.impl.StoreContext;
 import org.apache.hadoop.fs.s3a.statistics.S3AStatisticsContext;
@@ -42,10 +43,14 @@ import org.apache.hadoop.fs.statistics.IOStatisticsSource;
  * Interface for the S3A Store;
  * S3 client interactions should be via this; mocking
  * is possible for unit tests.
+ * <p>
+ * The {@link ClientManager} interface is used to create the AWS clients;
+ * the base implementation forwards to the implementation of this interface
+ * passed in at construction time.
  */
 @InterfaceAudience.LimitedPrivate("Extensions")
 @InterfaceStability.Unstable
-public interface S3AStore extends IOStatisticsSource {
+public interface S3AStore extends IOStatisticsSource, ClientManager {
 
   /**
    * Acquire write capacity for operations.
@@ -70,6 +75,8 @@ public interface S3AStore extends IOStatisticsSource {
   S3AStatisticsContext getStatisticsContext();
 
   RequestFactory getRequestFactory();
+
+  ClientManager clientManager();
 
   /**
    * Perform a bulk object delete operation against S3.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
@@ -47,8 +47,6 @@ import static org.apache.hadoop.fs.s3a.Constants.S3EXPRESS_CREATE_SESSION_DEFAUL
  * implementing only the deprecated method will work.
  * See https://github.com/apache/hbase-filesystem
  *
- * @deprecated This interface will be replaced by one which uses the AWS SDK V2 S3 client as part of
- * upgrading S3A to SDK V2. See HADOOP-18073.
  */
 @InterfaceAudience.LimitedPrivate("HBoss")
 @InterfaceStability.Evolving

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.audit.AuditStatisticNames;
 import org.apache.hadoop.fs.s3a.statistics.StatisticTypeEnum;
+import org.apache.hadoop.fs.statistics.FileSystemStatisticNames;
 import org.apache.hadoop.fs.statistics.StoreStatisticNames;
 import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 
@@ -65,6 +66,16 @@ public enum Statistic {
       TYPE_DURATION),
 
   /* FileSystem Level statistics */
+
+  FILESYSTEM_INITIALIZATION(
+      FileSystemStatisticNames.FILESYSTEM_INITIALIZATION,
+      "Filesystem initialization",
+      TYPE_DURATION),
+  FILESYSTEM_CLOSE(
+      FileSystemStatisticNames.FILESYSTEM_CLOSE,
+      "Filesystem close",
+      TYPE_DURATION),
+
   DIRECTORIES_CREATED("directories_created",
       "Total number of directories created through the object store.",
       TYPE_COUNTER),
@@ -532,6 +543,11 @@ public enum Statistic {
       TYPE_DURATION),
 
   /* General Store operations */
+  STORE_CLIENT_CREATION(
+      StoreStatisticNames.STORE_CLIENT_CREATION,
+      "Filesystem close",
+      TYPE_DURATION),
+
   STORE_EXISTS_PROBE(StoreStatisticNames.STORE_EXISTS_PROBE,
       "Store Existence Probe",
       TYPE_DURATION),

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
@@ -545,7 +545,7 @@ public enum Statistic {
   /* General Store operations */
   STORE_CLIENT_CREATION(
       StoreStatisticNames.STORE_CLIENT_CREATION,
-      "Filesystem close",
+      "Store Client Creation",
       TYPE_DURATION),
 
   STORE_EXISTS_PROBE(StoreStatisticNames.STORE_EXISTS_PROBE,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ClientManager.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ClientManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.s3a.impl;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -28,7 +29,7 @@ import software.amazon.awssdk.transfer.s3.S3TransferManager;
  * Interface for on-demand/async creation of AWS clients
  * and extension services.
  */
-public interface ClientManager extends AutoCloseable {
+public interface ClientManager extends Closeable {
 
   /**
    * Get the transfer manager, creating it and any dependencies if needed.
@@ -41,4 +42,9 @@ public interface ClientManager extends AutoCloseable {
   S3Client getOrCreateS3Client() throws IOException;
 
   S3AsyncClient getOrCreateAsyncClient() throws IOException;
+
+  /**
+   * Close operation is required to not raise exceptions.
+   */
+  void close();
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ClientManager.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ClientManager.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.io.IOException;
+
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+
+/**
+ * Interface for on-demand/async creation of AWS clients
+ * and extension services.
+ */
+public interface ClientManager extends AutoCloseable {
+
+  /**
+   * Get the transfer manager, creating it and any dependencies if needed.
+   * @return a transfer manager
+   * @throws IOException on any failure to create the manager
+   */
+  S3TransferManager getOrCreateTransferManager()
+      throws IOException;
+
+  S3Client getOrCreateS3Client() throws IOException;
+
+  S3AsyncClient getOrCreateAsyncClient() throws IOException;
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ClientManagerImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ClientManagerImpl.java
@@ -47,9 +47,7 @@ import static org.apache.hadoop.util.Preconditions.checkState;
  */
 public class ClientManagerImpl implements ClientManager {
 
-  public static final Logger LOG = LoggerFactory.getLogger(
-      ClientManagerImpl.class);
-
+  public static final Logger LOG = LoggerFactory.getLogger(ClientManagerImpl.class);
   /**
    * Client factory to invoke.
    */

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ClientManagerImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ClientManagerImpl.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.io.IOException;
+import java.net.URI;
+
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+
+import org.apache.hadoop.fs.s3a.S3ClientFactory;
+import org.apache.hadoop.fs.statistics.DurationTrackerFactory;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.fs.s3a.Statistic.STORE_CLIENT_CREATION;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.trackDuration;
+
+public class ClientManagerImpl implements ClientManager {
+
+  private final S3ClientFactory clientFactory;
+
+  /**
+   * Parameters to create sync/async clients.
+   */
+  private final S3ClientFactory.S3ClientCreationParameters clientCreationParameters;
+
+  /**
+   * Duration tracker factory for creation.
+   */
+  private final DurationTrackerFactory durationTrackerFactory;
+
+  /**
+   * Core S3 client.
+   */
+  private S3Client s3Client;
+
+  /** Async client is used for transfer manager. */
+  private S3AsyncClient s3AsyncClient;
+
+  /** Transfer manager. */
+  private S3TransferManager transferManager;
+
+  public ClientManagerImpl(
+      final S3ClientFactory clientFactory,
+      final S3ClientFactory.S3ClientCreationParameters clientCreationParameters,
+      final DurationTrackerFactory durationTrackerFactory) throws IOException {
+    this.clientFactory = requireNonNull(clientFactory);
+    this.clientCreationParameters = requireNonNull(clientCreationParameters);
+    this.durationTrackerFactory = requireNonNull(durationTrackerFactory);
+  }
+
+  @Override
+  public synchronized S3Client getOrCreateS3Client() throws IOException {
+    if (s3Client == null) {
+      // demand create the S3 client.
+      s3Client = trackDuration(durationTrackerFactory,
+          STORE_CLIENT_CREATION.getSymbol(), () ->
+              clientFactory.createS3Client(getUri(), clientCreationParameters));
+    }
+    return s3Client;
+  }
+
+  @Override
+  public synchronized S3AsyncClient getOrCreateAsyncClient() throws IOException {
+    if (s3AsyncClient == null) {
+      // demand create the Async S3 client.
+      s3AsyncClient = trackDuration(durationTrackerFactory,
+          STORE_CLIENT_CREATION.getSymbol(), () ->
+              clientFactory.createS3AsyncClient(getUri(), clientCreationParameters));
+    }
+    return s3AsyncClient;
+  }
+
+  @Override
+  public synchronized S3TransferManager getOrCreateTransferManager() throws IOException {
+    if (transferManager == null) {
+
+      final S3AsyncClient asyncClient = getOrCreateAsyncClient();
+
+      transferManager = trackDuration(durationTrackerFactory,
+          STORE_CLIENT_CREATION.getSymbol(), () ->
+              clientFactory.createS3TransferManager(asyncClient));
+    }
+    return transferManager;
+  }
+
+
+  @Override
+  public synchronized void close() throws Exception {
+    if (transferManager != null) {
+      transferManager.close();
+      transferManager = null;
+    }
+    if (s3AsyncClient != null) {
+      s3AsyncClient.close();
+      s3AsyncClient = null;
+    }
+    if (s3Client != null) {
+      s3Client.close();
+      s3Client = null;
+    }
+  }
+
+  /**
+   * Get the URI of the filesystem.
+   * @return URI to use when creating clients.
+   */
+  public URI getUri() {
+    return clientCreationParameters.getPathUri();
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreBuilder.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreBuilder.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.fs.s3a.impl;
 
-import software.amazon.awssdk.services.s3.S3Client;
-
 import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3AStorageStatistics;
 import org.apache.hadoop.fs.s3a.S3AStore;
@@ -59,8 +57,8 @@ public class S3AStoreBuilder {
   }
 
   public S3AStoreBuilder withClientManager(
-          final ClientManager clientManager) {
-    this.clientManager = clientManager;
+          final ClientManager manager) {
+    this.clientManager = manager;
     return this;
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreBuilder.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreBuilder.java
@@ -36,7 +36,7 @@ public class S3AStoreBuilder {
 
   private StoreContextFactory storeContextFactory;
 
-  private S3Client s3Client;
+  private ClientManager clientManager;
 
   private DurationTrackerFactory durationTrackerFactory;
 
@@ -58,9 +58,9 @@ public class S3AStoreBuilder {
     return this;
   }
 
-  public S3AStoreBuilder withS3Client(
-          final S3Client s3ClientValue) {
-    this.s3Client = s3ClientValue;
+  public S3AStoreBuilder withClientManager(
+          final ClientManager clientManager) {
+    this.clientManager = clientManager;
     return this;
   }
 
@@ -107,7 +107,14 @@ public class S3AStoreBuilder {
   }
 
   public S3AStore build() {
-    return new S3AStoreImpl(storeContextFactory, s3Client, durationTrackerFactory, instrumentation,
-        statisticsContext, storageStatistics, readRateLimiter, writeRateLimiter, auditSpanSource);
+    return new S3AStoreImpl(storeContextFactory,
+        clientManager,
+        durationTrackerFactory,
+        instrumentation,
+        statisticsContext,
+        storageStatistics,
+        readRateLimiter,
+        writeRateLimiter,
+        auditSpanSource);
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreImpl.java
@@ -364,7 +364,8 @@ public class S3AStoreImpl implements S3AStore {
               // duration is tracked in the bulk delete counters
               trackDurationOfOperation(getDurationTrackerFactory(),
                   OBJECT_BULK_DELETE_REQUEST.getSymbol(), () -> {
-                    // acquire the write capacity for the number of keys to delete and record the duration.
+                    // acquire the write capacity for the number of keys to delete
+                    // and record the duration.
                     Duration durationToAcquireWriteCapacity = acquireWriteCapacity(keyCount);
                     instrumentation.recordDuration(STORE_IO_RATE_LIMITED,
                         true,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreImpl.java
@@ -138,10 +138,9 @@ public class S3AStoreImpl implements S3AStore {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     clientManager.close();
   }
-
 
   /** Acquire write capacity for rate limiting {@inheritDoc}. */
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.fs.s3a.api.RequestFactory;
 import org.apache.hadoop.fs.s3a.audit.AuditTestSupport;
 import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
 import org.apache.hadoop.fs.s3a.commit.staging.StagingTestBase;
+import org.apache.hadoop.fs.s3a.impl.ClientManager;
 import org.apache.hadoop.fs.s3a.impl.PutObjectOptions;
 import org.apache.hadoop.fs.s3a.impl.RequestFactoryImpl;
 import org.apache.hadoop.fs.s3a.impl.StoreContext;
@@ -118,6 +119,12 @@ public class MockS3AFileSystem extends S3AFileSystem {
   }
 
   private static void prepareRequest(SdkRequest.Builder t) {}
+
+  @Override
+  protected S3AStore createS3AStore(final ClientManager clientManager,
+      final int rateLimitCapacity) {
+    return super.createS3AStore(clientManager, rateLimitCapacity);
+  }
 
   @Override
   public RequestFactory getRequestFactory() {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/StagingTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/StagingTestBase.java
@@ -146,11 +146,18 @@ public class StagingTestBase {
     return mockFs;
   }
 
-  private static S3AFileSystem mockS3AFileSystemRobustly(S3Client mockS3Client) {
+  private static S3AFileSystem mockS3AFileSystemRobustly(S3Client mockS3Client) throws IOException {
+
     S3AFileSystem mockFS = mock(S3AFileSystem.class);
+    S3AStore store = mock(S3AStore.class);
+    when(store.getOrCreateS3Client())
+        .thenReturn(mockS3Client);
+
     S3AInternals s3AInternals = mock(S3AInternals.class);
+
     when(mockFS.getS3AInternals()).thenReturn(s3AInternals);
-    when(s3AInternals.getStore()).thenReturn(mock(S3AStore.class));
+
+    when(s3AInternals.getStore()).thenReturn(store);
     when(s3AInternals.getAmazonS3Client(anyString()))
         .thenReturn(mockS3Client);
     doNothing().when(mockFS).incrementReadOperations();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestClientManager.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestClientManager.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.test.AbstractHadoopTestBase;
 import static java.lang.Thread.sleep;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.apache.hadoop.util.functional.FutureIO.toSupplier;
+import static org.apache.hadoop.util.functional.FunctionalIO.toUncheckedIOExceptionSupplier;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -218,7 +218,7 @@ public class TestClientManager extends AbstractHadoopTestBase {
 
     // execute the first creation in a separate thread.
     final CompletableFuture<S3Client> futureClient =
-        supplyAsync(toSupplier(() -> {
+        supplyAsync(toUncheckedIOExceptionSupplier(() -> {
           LOG.info("creating #1 s3 client");
           sem.release();
           final S3Client client = manager.getOrCreateS3Client();
@@ -263,7 +263,7 @@ public class TestClientManager extends AbstractHadoopTestBase {
 
     // execute the first creation in a separate thread.
     final CompletableFuture<S3TransferManager> futureClient =
-        supplyAsync(toSupplier(() -> {
+        supplyAsync(toUncheckedIOExceptionSupplier(() -> {
           LOG.info("creating #1 instance");
           sem.release();
           final S3TransferManager r = manager.getOrCreateTransferManager();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestClientManager.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestClientManager.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+
+import org.apache.hadoop.fs.s3a.S3ClientFactory;
+import org.apache.hadoop.fs.s3a.test.StubS3ClientFactory;
+import org.apache.hadoop.fs.statistics.impl.StubDurationTrackerFactory;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static java.lang.Thread.sleep;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+import static org.apache.hadoop.util.functional.FutureIO.toSupplier;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test the client manager.
+ */
+public class TestClientManager extends AbstractHadoopTestBase {
+
+  public static final Logger LOG = LoggerFactory.getLogger(TestClientManager.class);
+
+  private S3AsyncClient asyncClient;
+
+  private S3TransferManager transferManager;
+
+  private S3Client s3Client;
+
+  private URI uri;
+
+  @Before
+  public void setUp() throws Exception {
+    asyncClient = mock(S3AsyncClient.class);
+    transferManager = mock(S3TransferManager.class);
+    s3Client = mock(S3Client.class);
+    uri = new URI("https://bucket/");
+  }
+
+  /**
+   * Create a single s3 client.
+   */
+  @Test
+  public void testCreateS3Client() throws Throwable {
+
+    final StubS3ClientFactory factory = factory(Duration.ZERO);
+    final ClientManager manager = manager(factory);
+
+    Assertions.assertThat(manager.getOrCreateS3Client())
+        .describedAs("manager %s", manager)
+        .isSameAs(s3Client);
+    Assertions.assertThat(factory.clientCreationCount())
+        .describedAs("client creation count")
+        .isEqualTo(1);
+
+    // second attempt returns same instance
+    Assertions.assertThat(manager.getOrCreateS3Client())
+        .describedAs("manager %s", manager)
+        .isSameAs(s3Client);
+
+    // and the factory counter is not incremented.
+    Assertions.assertThat(factory.clientCreationCount())
+        .describedAs("client creation count")
+        .isEqualTo(1);
+
+    // now close
+    manager.close();
+
+    // and expect a failure
+    intercept(IllegalStateException.class, () ->
+        manager.getOrCreateS3Client());
+  }
+
+  /**
+   * Create a stub client factory.
+   * @param delay delay when creating a client.
+   * @return the factory
+   */
+  private StubS3ClientFactory factory(final Duration delay) {
+    return new StubS3ClientFactory(s3Client, asyncClient, transferManager,
+        delay);
+  }
+
+  /**
+   * Create a manager instance using the given factory.
+   * @param factory factory for clients.
+   * @return a client manager
+   */
+  private ClientManager manager(final StubS3ClientFactory factory) {
+    return new ClientManagerImpl(
+        factory,
+        new S3ClientFactory.S3ClientCreationParameters()
+            .withPathUri(uri),
+        StubDurationTrackerFactory.STUB_DURATION_TRACKER_FACTORY);
+  }
+
+  /**
+   * Create an async s3 client.
+   */
+  @Test
+  public void testCreateAsyncS3Client() throws Throwable {
+
+    final StubS3ClientFactory factory = factory(Duration.ofMillis(100));
+    final ClientManager manager = manager(factory);
+
+    Assertions.assertThat(manager.getOrCreateAsyncClient())
+        .describedAs("manager %s", manager)
+        .isSameAs(asyncClient);
+
+    manager.getOrCreateAsyncClient();
+    // and the factory counter is not incremented.
+    Assertions.assertThat(factory.asyncClientCreationCount())
+        .describedAs("client creation count")
+        .isEqualTo(1);
+
+    // now close
+    manager.close();
+
+    // and expect a failure
+    intercept(IllegalStateException.class, () ->
+        manager.getOrCreateAsyncClient());
+  }
+
+  /**
+   * Create a transfer manager; this will demand create an async s3 client
+   * if needed.
+   */
+  @Test
+  public void testCreateTransferManagerAndAsyncClient() throws Throwable {
+
+    final StubS3ClientFactory factory = factory(Duration.ZERO);
+    final ClientManager manager = manager(factory);
+
+    Assertions.assertThat(manager.getOrCreateTransferManager())
+        .describedAs("manager %s", manager)
+        .isSameAs(transferManager);
+
+    // and we created an async client
+    Assertions.assertThat(factory.asyncClientCreationCount())
+        .describedAs("client creation count")
+        .isEqualTo(1);
+    Assertions.assertThat(factory.transferManagerCreationCount())
+        .describedAs("client creation count")
+        .isEqualTo(1);
+
+    // now close
+    manager.close();
+
+    // and expect a failure
+    intercept(IllegalStateException.class, () ->
+        manager.getOrCreateTransferManager());
+  }
+
+  /**
+   * Create a transfer manager with the async client already created.
+   */
+  @Test
+  public void testCreateTransferManagerWithAsyncClientAlreadyCreated() throws Throwable {
+    final StubS3ClientFactory factory = factory(Duration.ZERO);
+    final ClientManager manager = manager(factory);
+
+    manager.getOrCreateAsyncClient();
+    Assertions.assertThat(manager.getOrCreateTransferManager())
+        .describedAs("manager %s", manager)
+        .isSameAs(transferManager);
+
+    // no new async client was created.
+    Assertions.assertThat(factory.asyncClientCreationCount())
+        .describedAs("client creation count")
+        .isEqualTo(1);
+  }
+
+  /**
+   * Create clients in parallel and verify that the first one blocks
+   * the others.
+   * There's a bit of ordering complexity which uses a semaphore and a sleep
+   * to block one of the acquisitions until the initial operation has started.
+   * There's then an assertion that the time the first client created
+   */
+  @Test
+  public void testParallelClientCreation() throws Throwable {
+    final StubS3ClientFactory factory = factory(Duration.ofSeconds(5));
+    final ClientManager manager = manager(factory);
+    // time of first client creation in millis
+    final AtomicLong clientCreated = new AtomicLong(0);
+    Semaphore sem = new Semaphore(1);
+    sem.acquire();
+
+    // execute the first creation in a separate thread.
+    final CompletableFuture<S3Client> futureClient =
+        supplyAsync(toSupplier(() -> {
+          LOG.info("creating #1 s3 client");
+          sem.release();
+          final S3Client client = manager.getOrCreateS3Client();
+          clientCreated.set(System.currentTimeMillis());
+          LOG.info("#1 s3 client created");
+          return client;
+        }));
+
+    // wait until the async closure has started
+    sem.acquire();
+
+    sleep(1000);
+    // expect to block.
+    LOG.info("creating #2 s3 client");
+    final S3Client client2 = manager.getOrCreateS3Client();
+    LOG.info("created #2 s3 client");
+
+    // now assert that the #1 client has succeeded, without
+    // even calling futureClient.get() to evaluate the result.
+    Assertions.assertThat(clientCreated.get())
+        .describedAs("time client #1 was created")
+        .isGreaterThan(0);
+
+    final S3Client orig = futureClient.get();
+    Assertions.assertThat(orig)
+        .describedAs("async created client from %s", manager)
+        .isSameAs(client2);
+  }
+
+  /**
+   * Parallel transfer manager creation.
+   * This will force creation of the async client
+   */
+  @Test
+  public void testParallelTransferManagerCreation() throws Throwable {
+    final StubS3ClientFactory factory = factory(Duration.ofSeconds(5));
+    final ClientManager manager = manager(factory);
+    // time of first client creation in millis
+    final AtomicLong clientCreated = new AtomicLong(0);
+    Semaphore sem = new Semaphore(1);
+    sem.acquire();
+
+    // execute the first creation in a separate thread.
+    final CompletableFuture<S3TransferManager> futureClient =
+        supplyAsync(toSupplier(() -> {
+          LOG.info("creating #1 instance");
+          sem.release();
+          final S3TransferManager r = manager.getOrCreateTransferManager();
+          clientCreated.set(System.currentTimeMillis());
+          LOG.info("#1 instance created");
+          return r;
+        }));
+
+    // wait until the async closure has started
+    sem.acquire();
+
+    sleep(1000);
+    // expect to block.
+    LOG.info("creating #2 instance");
+    final S3TransferManager instance2 = manager.getOrCreateTransferManager();
+    LOG.info("created #2 instance");
+
+    // now assert that the #1 mananger has succeeded, without
+    // even calling futureClient.get() to evaluate the result.
+    Assertions.assertThat(clientCreated.get())
+        .describedAs("time client #1 was created")
+        .isGreaterThan(0);
+
+    final S3TransferManager orig = futureClient.get();
+    Assertions.assertThat(orig)
+        .describedAs("async created instance from %s", manager)
+        .isSameAs(instance2);
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestClientManager.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestClientManager.java
@@ -19,10 +19,12 @@
 package org.apache.hadoop.fs.s3a.impl;
 
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
@@ -37,8 +39,8 @@ import org.apache.hadoop.fs.s3a.S3ClientFactory;
 import org.apache.hadoop.fs.s3a.test.StubS3ClientFactory;
 import org.apache.hadoop.fs.statistics.impl.StubDurationTrackerFactory;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
+import org.apache.hadoop.util.functional.InvocationRaisingIOE;
 
-import static java.lang.Thread.sleep;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.apache.hadoop.util.functional.FunctionalIO.toUncheckedIOExceptionSupplier;
@@ -46,16 +48,35 @@ import static org.mockito.Mockito.mock;
 
 /**
  * Test the client manager.
+ * <p>
+ * The tests with "Parallel" in the title generate delays in the second thread
+ * so stress the concurrency logic.
  */
 public class TestClientManager extends AbstractHadoopTestBase {
 
-  public static final Logger LOG = LoggerFactory.getLogger(TestClientManager.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TestClientManager.class);
+
+  /**
+   * Factory delay for the multithreaded operations.
+   */
+  private static final Duration FACTORY_DELAY = Duration.ofSeconds(5);
+
+  /**
+   * How long for the second thread to sleep before it tries to get()
+   * the client.
+   */
+  private static final Duration SECOND_THREAD_DELAY = Duration.ofSeconds(2);
+
+  /**
+   * Format of exceptions raise.
+   */
+  private static final String GENERATED = "generated[%d]";
+
+  private S3Client s3Client;
 
   private S3AsyncClient asyncClient;
 
   private S3TransferManager transferManager;
-
-  private S3Client s3Client;
 
   private URI uri;
 
@@ -65,6 +86,39 @@ public class TestClientManager extends AbstractHadoopTestBase {
     transferManager = mock(S3TransferManager.class);
     s3Client = mock(S3Client.class);
     uri = new URI("https://bucket/");
+  }
+
+  /**
+   * Create a stub client factory where there is a specific delay
+   * @param delay delay when creating a client.
+   * @return the factory
+   */
+  private StubS3ClientFactory factory(final Duration delay) {
+    return factory(() -> sleep(delay));
+  }
+
+  /**
+   * Create a stub client factory. where the the invocation is called before
+   * the operation is executed.
+   * @param invocationRaisingIOE invocation to call before returning a client.
+   * @return the factory
+   */
+  private StubS3ClientFactory factory(final InvocationRaisingIOE invocationRaisingIOE) {
+    return new StubS3ClientFactory(s3Client, asyncClient, transferManager,
+        invocationRaisingIOE);
+  }
+
+  /**
+   * Create a manager instance using the given factory.
+   * @param factory factory for clients.
+   * @return a client manager
+   */
+  private ClientManager manager(final StubS3ClientFactory factory) {
+    return new ClientManagerImpl(
+        factory,
+        new S3ClientFactory.S3ClientCreationParameters()
+            .withPathUri(uri),
+        StubDurationTrackerFactory.STUB_DURATION_TRACKER_FACTORY);
   }
 
   /**
@@ -97,35 +151,23 @@ public class TestClientManager extends AbstractHadoopTestBase {
     manager.close();
 
     // and expect a failure
-    intercept(IllegalStateException.class, () ->
-        manager.getOrCreateS3Client());
+    intercept(IllegalStateException.class, manager::getOrCreateS3Client);
   }
 
   /**
-   * Create a stub client factory.
-   * @param delay delay when creating a client.
-   * @return the factory
+   * Sleep for a given period; interrupts are swallowed.
+   * @param delay delay
    */
-  private StubS3ClientFactory factory(final Duration delay) {
-    return new StubS3ClientFactory(s3Client, asyncClient, transferManager,
-        delay);
+  private static void sleep(final Duration delay) {
+    try {
+      Thread.sleep(delay.toMillis());
+    } catch (InterruptedException e) {
+
+    }
   }
 
   /**
-   * Create a manager instance using the given factory.
-   * @param factory factory for clients.
-   * @return a client manager
-   */
-  private ClientManager manager(final StubS3ClientFactory factory) {
-    return new ClientManagerImpl(
-        factory,
-        new S3ClientFactory.S3ClientCreationParameters()
-            .withPathUri(uri),
-        StubDurationTrackerFactory.STUB_DURATION_TRACKER_FACTORY);
-  }
-
-  /**
-   * Create an async s3 client.
+   * Create an async s3 client, verify it is only invoked once
    */
   @Test
   public void testCreateAsyncS3Client() throws Throwable {
@@ -177,8 +219,7 @@ public class TestClientManager extends AbstractHadoopTestBase {
     manager.close();
 
     // and expect a failure
-    intercept(IllegalStateException.class, () ->
-        manager.getOrCreateTransferManager());
+    intercept(IllegalStateException.class, manager::getOrCreateTransferManager);
   }
 
   /**
@@ -209,28 +250,34 @@ public class TestClientManager extends AbstractHadoopTestBase {
    */
   @Test
   public void testParallelClientCreation() throws Throwable {
-    final StubS3ClientFactory factory = factory(Duration.ofSeconds(5));
-    final ClientManager manager = manager(factory);
-    // time of first client creation in millis
-    final AtomicLong clientCreated = new AtomicLong(0);
+
+    // semaphore
     Semaphore sem = new Semaphore(1);
-    sem.acquire();
+    // reference of thread where the construction took place
+    AtomicReference threadRef = new AtomicReference();
+    // this factory releases the semaphore on its invocation then
+    // sleeps
+    final ClientManager manager = manager(factory(() -> {
+      threadRef.set(Thread.currentThread());
+      sem.release();
+      sleep(FACTORY_DELAY);
+    }));
+
+    // acquire that semaphore.
+    sem.acquire(1);
 
     // execute the first creation in a separate thread.
     final CompletableFuture<S3Client> futureClient =
         supplyAsync(toUncheckedIOExceptionSupplier(() -> {
           LOG.info("creating #1 s3 client");
-          sem.release();
           final S3Client client = manager.getOrCreateS3Client();
-          clientCreated.set(System.currentTimeMillis());
           LOG.info("#1 s3 client created");
           return client;
         }));
 
-    // wait until the async closure has started
+    // wait until the async creation has started
     sem.acquire();
-
-    sleep(1000);
+    sleep(SECOND_THREAD_DELAY);
     // expect to block.
     LOG.info("creating #2 s3 client");
     final S3Client client2 = manager.getOrCreateS3Client();
@@ -238,13 +285,13 @@ public class TestClientManager extends AbstractHadoopTestBase {
 
     // now assert that the #1 client has succeeded, without
     // even calling futureClient.get() to evaluate the result.
-    Assertions.assertThat(clientCreated.get())
-        .describedAs("time client #1 was created")
-        .isGreaterThan(0);
+    Assertions.assertThat(threadRef.get())
+        .describedAs("Thread in which client #1 was created")
+        .isNotSameAs(Thread.currentThread());
 
     final S3Client orig = futureClient.get();
     Assertions.assertThat(orig)
-        .describedAs("async created client from %s", manager)
+        .describedAs("second getOrCreate() call to %s", manager)
         .isSameAs(client2);
   }
 
@@ -254,12 +301,21 @@ public class TestClientManager extends AbstractHadoopTestBase {
    */
   @Test
   public void testParallelTransferManagerCreation() throws Throwable {
-    final StubS3ClientFactory factory = factory(Duration.ofSeconds(5));
-    final ClientManager manager = manager(factory);
-    // time of first client creation in millis
-    final AtomicLong clientCreated = new AtomicLong(0);
+    // semaphore
     Semaphore sem = new Semaphore(1);
-    sem.acquire();
+    // reference of thread where the construction took place
+    AtomicReference threadRef = new AtomicReference();
+    // this factory releases the semaphore on its invocation, then
+    // sleeps
+    final ClientManager manager = manager(factory(() -> {
+      threadRef.set(Thread.currentThread());
+      sem.release();
+      sleep(FACTORY_DELAY);
+    }));
+
+    // acquire that semaphore.
+    sem.acquire(1);
+    sleep(SECOND_THREAD_DELAY);
 
     // execute the first creation in a separate thread.
     final CompletableFuture<S3TransferManager> futureClient =
@@ -267,29 +323,49 @@ public class TestClientManager extends AbstractHadoopTestBase {
           LOG.info("creating #1 instance");
           sem.release();
           final S3TransferManager r = manager.getOrCreateTransferManager();
-          clientCreated.set(System.currentTimeMillis());
           LOG.info("#1 instance created");
           return r;
         }));
 
-    // wait until the async closure has started
+    // wait until the async creation has started
     sem.acquire();
-
-    sleep(1000);
     // expect to block.
-    LOG.info("creating #2 instance");
-    final S3TransferManager instance2 = manager.getOrCreateTransferManager();
-    LOG.info("created #2 instance");
+    LOG.info("creating #2 s3 client");
+    final S3TransferManager client2 = manager.getOrCreateTransferManager();
+    LOG.info("created #2 s3 client");
 
-    // now assert that the #1 mananger has succeeded, without
+    // now assert that the #1 client has succeeded, without
     // even calling futureClient.get() to evaluate the result.
-    Assertions.assertThat(clientCreated.get())
-        .describedAs("time client #1 was created")
-        .isGreaterThan(0);
+    Assertions.assertThat(threadRef.get())
+        .describedAs("Thread in which client #1 was created")
+        .isNotSameAs(Thread.currentThread());
 
-    final S3TransferManager orig = futureClient.get();
-    Assertions.assertThat(orig)
-        .describedAs("async created instance from %s", manager)
-        .isSameAs(instance2);
+    futureClient.get();
+  }
+
+  /**
+   * Verify that if an exception is thrown during creation, the
+   * operation will be repeated -there's no attempt to record
+   * that an exception was raised on the first attempt.
+   */
+  @Test
+  public void testClientCreationFailure() throws Throwable {
+
+    AtomicInteger counter = new AtomicInteger();
+    final ClientManager manager = manager(factory(() -> {
+      throw new UnknownHostException(String.format(GENERATED, counter.incrementAndGet()));
+    }));
+
+    // first attempt fails
+    intercept(UnknownHostException.class,
+        String.format(GENERATED, 1),
+        manager::getOrCreateS3Client);
+
+    // second will retry
+    intercept(UnknownHostException.class, "[2]", manager::getOrCreateS3Client);
+    intercept(UnknownHostException.class, "[3]", manager::getOrCreateAsyncClient);
+    intercept(UnknownHostException.class, "[4]", manager::getOrCreateTransferManager);
+
+    manager.close();
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestClientManager.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestClientManager.java
@@ -89,7 +89,7 @@ public class TestClientManager extends AbstractHadoopTestBase {
   }
 
   /**
-   * Create a stub client factory where there is a specific delay
+   * Create a stub client factory where there is a specific delay.
    * @param delay delay when creating a client.
    * @return the factory
    */
@@ -167,7 +167,7 @@ public class TestClientManager extends AbstractHadoopTestBase {
   }
 
   /**
-   * Create an async s3 client, verify it is only invoked once
+   * Get an async s3 client twice and verify it is only created once.
    */
   @Test
   public void testCreateAsyncS3Client() throws Throwable {
@@ -361,7 +361,8 @@ public class TestClientManager extends AbstractHadoopTestBase {
         String.format(GENERATED, 1),
         manager::getOrCreateS3Client);
 
-    // second will retry
+    // subsequent tests will also retry; the exception message changes each time,
+    // showing that it is regenerated rather than cached
     intercept(UnknownHostException.class, "[2]", manager::getOrCreateS3Client);
     intercept(UnknownHostException.class, "[3]", manager::getOrCreateAsyncClient);
     intercept(UnknownHostException.class, "[4]", manager::getOrCreateTransferManager);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/StubS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/StubS3ClientFactory.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+
+import org.apache.hadoop.fs.s3a.S3ClientFactory;
+
+/**
+ * Stub implementation of {@link S3ClientFactory}.
+ * returns the preconfigured clients.
+ * No checks for null values are made.
+ */
+public final class StubS3ClientFactory implements S3ClientFactory {
+
+  /**
+   * The class name of this factory.
+   */
+  public static final String STUB_FACTORY = StubS3ClientFactory.class.getName();
+
+  private final S3Client client;
+  private final S3AsyncClient asyncClient;
+  private final S3TransferManager transferManager;
+
+  private final Duration creationDelay;
+
+  private AtomicInteger clientCreationCount = new AtomicInteger(0);
+  private AtomicInteger asyncClientCreationCount = new AtomicInteger(0);
+  private AtomicInteger transferManagerCreationCount = new AtomicInteger(0);
+
+  public StubS3ClientFactory(final S3Client client,
+      final S3AsyncClient asyncClient,
+      final S3TransferManager transferManager,
+      final Duration creationDelay) {
+    this.client = client;
+    this.asyncClient = asyncClient;
+    this.transferManager = transferManager;
+    this.creationDelay = creationDelay;
+  }
+
+  private void maybeSleep() {
+    if (creationDelay.isZero()) {
+      return;
+    }
+    try {
+      Thread.sleep(creationDelay.toMillis());
+    } catch (InterruptedException ignored) {
+
+    }
+
+  }
+  @Override
+  public S3Client createS3Client(final URI uri, final S3ClientCreationParameters parameters)
+      throws IOException {
+    maybeSleep();
+    clientCreationCount.incrementAndGet();
+    return client;
+  }
+
+  @Override
+  public S3AsyncClient createS3AsyncClient(final URI uri,
+      final S3ClientCreationParameters parameters)
+      throws IOException {
+    maybeSleep();
+    asyncClientCreationCount.incrementAndGet();
+    return asyncClient;
+  }
+
+  @Override
+  public S3TransferManager createS3TransferManager(final S3AsyncClient s3AsyncClient) {
+    maybeSleep();
+    transferManagerCreationCount.incrementAndGet();
+    return transferManager;
+  }
+
+  public int clientCreationCount() {
+    return clientCreationCount.get();
+  }
+
+  public int asyncClientCreationCount() {
+    return asyncClientCreationCount.get();
+  }
+
+  public int transferManagerCreationCount() {
+    return transferManagerCreationCount.get();
+  }
+
+  @Override
+  public String toString() {
+    return "StubS3ClientFactory{" +
+        "client=" + client +
+        ", asyncClient=" + asyncClient +
+        ", transferManager=" + transferManager +
+        ", clientCreationCount=" + clientCreationCount.get() +
+        ", asyncClientCreationCount=" + asyncClientCreationCount.get() +
+        ", transferManagerCreationCount=" + transferManagerCreationCount.get() +
+        '}';
+  }
+}


### PR DESCRIPTION
HADOOP-19205

Adds new ClientManager interface/impl which provides on-demand creation of sync and async s3 clients, s3 transfer manager, and in close() terminates these.

S3A FS is modified to
* Create one of these and hand off to S3Store
* Use the same ClientManager interface against S3Store to demand-create the services.
* only create the async client as part of the transfer manager creation, during rename.
* stats on client creation count/duration are recorded.
+ statistics on the time to initialize and shutdown the s3afs is collected in IOStatistics for reporting.

The s3client is still created in FileSystem.initialize(), it is the async one which
is on demand.

No attempt to do async creation of the s3 client in initialize, though it could offer marginal benefits, depending on the codepath.

Change-Id: I79a668aacd920048447485afed77df573a38cb37

### How was this patch tested?

Relying on regression tests knowing that this codepath will be tested.

Some other tests will be needed. e.g
- verify recurrent creation always returns same instance.
- behaviour after close()

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

