### PR TITLE
HADOOP-19208: [ABFS] Fixing logic to determine HNS nature of account to avoid extra getAcl() calls

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -404,9 +404,12 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         // If getAcl fails with anything other than 400, namespace is enabled.
         isNamespaceEnabled = Trilean.getTrilean(true);
         // Continue to throw exception as earlier.
+        LOG.debug("Failed to get ACL status with non 400. Inferring namespace enabled", ex);
         throw ex;
       }
       // If getAcl fails with 400, namespace is disabled.
+      LOG.debug("Failed to get ACL status with 400. "
+          + "Inferring namespace disabled and ignoring error", ex);
       isNamespaceEnabled = Trilean.getTrilean(false);
     } catch (AzureBlobFileSystemException ex) {
       throw ex;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -399,17 +399,15 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       isNamespaceEnabled = Trilean.getTrilean(true);
     } catch (AbfsRestOperationException ex) {
       // Get ACL status is a HEAD request, its response doesn't contain errorCode
-      // So can only rely on its status code to determine its account type.
-      if (HttpURLConnection.HTTP_BAD_REQUEST == ex.getStatusCode()) {
-        // If getAcl fails with 400, namespace is disabled.
-        isNamespaceEnabled = Trilean.getTrilean(false);
-      } else if (HttpURLConnection.HTTP_NOT_FOUND == ex.getStatusCode()) {
-        // If getAcl fails with 404, namespace is enabled.
+      // So can only rely on its status code to determine account type.
+      if (HttpURLConnection.HTTP_BAD_REQUEST != ex.getStatusCode()) {
+        // If getAcl fails with anything other than 400, namespace is enabled.
         isNamespaceEnabled = Trilean.getTrilean(true);
-      } else {
-        // Any other server error, throw exception.
+        // Continue to throw exception as earlier.
         throw ex;
       }
+      // If getAcl fails with 400, namespace is disabled.
+      isNamespaceEnabled = Trilean.getTrilean(false);
     } catch (AzureBlobFileSystemException ex) {
       throw ex;
     }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.fs.azurebfs;
 
 import java.io.FileNotFoundException;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -33,9 +32,6 @@ import org.apache.hadoop.fs.azurebfs.enums.Trilean;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
-
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_IS_HNS_ENABLED;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.accountProperty;
 
 /**
  * Test filesystem initialization and creation.

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.azurebfs;
 
 import java.io.FileNotFoundException;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -28,9 +29,13 @@ import org.mockito.Mockito;
 
 import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.TrileanConversionException;
+import org.apache.hadoop.fs.azurebfs.enums.Trilean;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
+
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_IS_HNS_ENABLED;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.accountProperty;
 
 /**
  * Test filesystem initialization and creation.
@@ -67,6 +72,7 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
     Mockito.doThrow(TrileanConversionException.class)
         .when(store)
         .isNamespaceEnabled();
+    store.setNamespaceEnabled(Trilean.UNKNOWN);
 
     TracingContext tracingContext = getSampleTracingContext(fs, true);
     Mockito.doReturn(Mockito.mock(AbfsRestOperation.class))

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestGetNameSpaceEnabled.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestGetNameSpaceEnabled.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.fs.azurebfs;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.util.UUID;
 
 import org.junit.Assume;
@@ -35,8 +36,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.enums.Trilean;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
-import org.apache.kerby.config.Conf;
 
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_SERVER_ERROR;
+import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -52,7 +57,6 @@ import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_CR
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_IS_HNS_ENABLED;
 import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.FS_AZURE_TEST_NAMESPACE_ENABLED_ACCOUNT;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.mockito.Mockito.when;
 
 /**
  * Test getIsNamespaceEnabled call.
@@ -224,10 +228,10 @@ public class ITestGetNameSpaceEnabled extends AbstractAbfsIntegrationTest {
 
   @Test
   public void ensureGetAclDetermineHnsStatusAccurately() throws Exception {
-    ensureGetAclDetermineHnsStatusAccuratelyInternal(400, false);
-    ensureGetAclDetermineHnsStatusAccuratelyInternal(404, true);
-    ensureGetAclDetermineHnsStatusAccuratelyInternal(500, false);
-    ensureGetAclDetermineHnsStatusAccuratelyInternal(503, false);
+    ensureGetAclDetermineHnsStatusAccuratelyInternal(HTTP_BAD_REQUEST, false);
+    ensureGetAclDetermineHnsStatusAccuratelyInternal(HTTP_NOT_FOUND, true);
+    ensureGetAclDetermineHnsStatusAccuratelyInternal(HTTP_INTERNAL_ERROR, false);
+    ensureGetAclDetermineHnsStatusAccuratelyInternal(HTTP_UNAVAILABLE, false);
   }
 
   private void ensureGetAclDetermineHnsStatusAccuratelyInternal(int statusCode,


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/HADOOP-19208

### Description of PR
ABFS driver needs to know the type of account being used. It relies on the user to inform the account type using the config `fs.azure.account.hns.enabled`. If not configured, driver makes a [GetAcl Head Call](https://learn.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/get-properties) call to determine the account type.
Expectation is getAcl() will fail with 400 Bad Request if made on the FNS Account.
If succeeded or fails with any other error code, it means it's an HNS Account.

#### Current Implementation:
Today when someone tries to create a new file system, getAcl is called to determine HNS/FNS account. This call fails with 404 as file system is not yet created. Then another getAcl is needed to determine HNS/FNS post filesystem creation. Leading to redundant getAcl calls.

#### New Implementation
1. If getAcl fails with 400 then only we will determine the account as HNS disabled. For any other error code including 404, we will infer the account as HNS enabled. getAcl call will continue to throw exception in cases where it fails with non 400 error code as earlier.
2. In case of 404, getAcl() will still fail as always but store will capture the HNS enabled/disabled to avoid further calls. File system init will not fail for 404 as per the design.
3. In case of error apart from 400, 404 like 5xx or others, getAcl() will still fail leading to file system initialization failure. Any inference made on account type here won't be used further.

This PR also fixes a test case failing on trunk. `testGetAclCallOnHnsConfigAbsence(org.apache.hadoop.fs.azurebfs.ITestAzureBlobFileSystemInitAndCreate)`

### How was this patch tested?
New test around the production code changes, and existing test suite ran to validate the patch.

### Test Suite Results
Metric related tests are fixed in the the https://github.com/apache/hadoop/pull/6847

:::: AGGREGATED TEST RESULT ::::

============================================================
HNS-OAuth
============================================================

[ERROR] testBackoffRetryMetrics(org.apache.hadoop.fs.azurebfs.services.TestAbfsRestOperation)  Time elapsed: 3.719 s  <<< ERROR!
[ERROR] testReadFooterMetrics(org.apache.hadoop.fs.azurebfs.ITestAbfsReadFooterMetrics)  Time elapsed: 1.167 s  <<< ERROR!
[ERROR] testMetricWithIdlePeriod(org.apache.hadoop.fs.azurebfs.ITestAbfsReadFooterMetrics)  Time elapsed: 1.165 s  <<< ERROR!
[ERROR] testReadFooterMetricsWithParquetAndNonParquet(org.apache.hadoop.fs.azurebfs.ITestAbfsReadFooterMetrics)  Time elapsed: 1.159 s  <<< ERROR!

[ERROR] Tests run: 142, Failures: 0, Errors: 1, Skipped: 2
[ERROR] Tests run: 626, Failures: 0, Errors: 3, Skipped: 76
[WARNING] Tests run: 412, Failures: 0, Errors: 0, Skipped: 57

============================================================
HNS-SharedKey
============================================================

[ERROR] testBackoffRetryMetrics(org.apache.hadoop.fs.azurebfs.services.TestAbfsRestOperation)  Time elapsed: 3.166 s  <<< ERROR!
[ERROR] testReadFooterMetrics(org.apache.hadoop.fs.azurebfs.ITestAbfsReadFooterMetrics)  Time elapsed: 0.946 s  <<< ERROR!
[ERROR] testMetricWithIdlePeriod(org.apache.hadoop.fs.azurebfs.ITestAbfsReadFooterMetrics)  Time elapsed: 0.891 s  <<< ERROR!
[ERROR] testReadFooterMetricsWithParquetAndNonParquet(org.apache.hadoop.fs.azurebfs.ITestAbfsReadFooterMetrics)  Time elapsed: 0.914 s  <<< ERROR!

[ERROR] Tests run: 142, Failures: 0, Errors: 1, Skipped: 3
[ERROR] Tests run: 626, Failures: 0, Errors: 3, Skipped: 28
[WARNING] Tests run: 412, Failures: 0, Errors: 0, Skipped: 44

============================================================
NonHNS-SharedKey
============================================================

[ERROR] testBackoffRetryMetrics(org.apache.hadoop.fs.azurebfs.services.TestAbfsRestOperation)  Time elapsed: 3.521 s  <<< ERROR!
[ERROR] testReadFooterMetrics(org.apache.hadoop.fs.azurebfs.ITestAbfsReadFooterMetrics)  Time elapsed: 1.003 s  <<< ERROR!
[ERROR] testMetricWithIdlePeriod(org.apache.hadoop.fs.azurebfs.ITestAbfsReadFooterMetrics)  Time elapsed: 0.997 s  <<< ERROR!
[ERROR] testReadFooterMetricsWithParquetAndNonParquet(org.apache.hadoop.fs.azurebfs.ITestAbfsReadFooterMetrics)  Time elapsed: 0.954 s  <<< ERROR!

[ERROR] Tests run: 142, Failures: 0, Errors: 1, Skipped: 9
[ERROR] Tests run: 610, Failures: 0, Errors: 3, Skipped: 268
[WARNING] Tests run: 412, Failures: 0, Errors: 0, Skipped: 47

============================================================
AppendBlob-HNS-OAuth
============================================================

[ERROR] testBackoffRetryMetrics(org.apache.hadoop.fs.azurebfs.services.TestAbfsRestOperation)  Time elapsed: 3.712 s  <<< ERROR!
[ERROR] testReadFooterMetrics(org.apache.hadoop.fs.azurebfs.ITestAbfsReadFooterMetrics)  Time elapsed: 1.147 s  <<< ERROR!
[ERROR] testMetricWithIdlePeriod(org.apache.hadoop.fs.azurebfs.ITestAbfsReadFooterMetrics)  Time elapsed: 1.146 s  <<< ERROR!
[ERROR] testReadFooterMetricsWithParquetAndNonParquet(org.apache.hadoop.fs.azurebfs.ITestAbfsReadFooterMetrics)  Time elapsed: 1.199 s  <<< ERROR!

[ERROR] Tests run: 142, Failures: 0, Errors: 1, Skipped: 2
[ERROR] Tests run: 626, Failures: 0, Errors: 3, Skipped: 78
[WARNING] Tests run: 412, Failures: 0, Errors: 0, Skipped: 81

Time taken: 54 mins 49 secs.
