### PR TITLE
HDFS-16739. EC: Reconstruction failed when file has specified storage policy

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedWriter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedWriter.java
@@ -83,11 +83,8 @@ class StripedWriter {
 
     writers = new StripedBlockWriter[targets.length];
     targetIndices = new short[targets.length];
-    Preconditions.checkArgument(
-            targetIndices.length <= dataBlkNum + parityBlkNum - reconstructor.getNumLiveBlocks(),
-            "Reconstruction work gets too much targets.");
-    Preconditions.checkArgument(targetIndices.length <= parityBlkNum,
-        "Too much missed striped blocks.");
+    Preconditions.checkArgument(targetIndices.length - reconstructor.getNumLiveBlocks()
+        <= parityBlkNum, "Too much missed striped blocks.");
     initTargetIndices();
     long maxTargetLength = 0L;
     for (short targetIndex : targetIndices) {


### PR DESCRIPTION
JIRA: HDFS-16739.

As mentioned in [HDFS-16739](https://issues.apache.org/jira/browse/HDFS-16739), in order to satisfy the storage policy, the length of targetIndices will be more than the actual number of blocks that need to be reconstructed.

HDFS-16776 may cause the reconstruction task to never succeed to satisfy the storage policy (unless the mover is manually triggered to make the block satisfy the storage policy).