### PR TITLE
HDFS-17556. Avoid adding block to neededReconstruction repeatedly in decommission

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminBackoffMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminBackoffMonitor.java
@@ -766,6 +766,7 @@ public class DatanodeAdminBackoffMonitor extends DatanodeAdminMonitorBase
     if (neededReconstruction && scheduleReconStruction) {
       if (!blockManager.neededReconstruction.contains(block) &&
           blockManager.pendingReconstruction.getNumReplicas(block) == 0 &&
+          !blockManager.pendingReconstruction.hasTimeOutBlock(block) &&
           blockManager.isPopulatingReplQueues()) {
         // Process these blocks only when active NN is out of safe mode.
         blockManager.neededReconstruction.add(block,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
@@ -470,6 +470,7 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
       if (neededReconstruction) {
         if (!blockManager.neededReconstruction.contains(block) &&
             blockManager.pendingReconstruction.getNumReplicas(block) == 0 &&
+            !blockManager.pendingReconstruction.hasTimeOutBlock(block) &&
             blockManager.isPopulatingReplQueues()) {
           // Process these blocks only when active NN is out of safe mode.
           blockManager.neededReconstruction.add(block,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingReconstructionBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingReconstructionBlocks.java
@@ -25,9 +25,11 @@ import java.sql.Time;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.hdfs.protocol.Block;
@@ -50,7 +52,7 @@ class PendingReconstructionBlocks {
   private static final Logger LOG = BlockManager.LOG;
 
   private final Map<BlockInfo, PendingBlockInfo> pendingReconstructions;
-  private final ArrayList<BlockInfo> timedOutItems;
+  private final Set<BlockInfo> timedOutItems;
   Daemon timerThread = null;
   private volatile boolean fsRunning = true;
   private long timedOutCount = 0L;
@@ -68,7 +70,7 @@ class PendingReconstructionBlocks {
       this.timeout = timeoutPeriod;
     }
     pendingReconstructions = new HashMap<>();
-    timedOutItems = new ArrayList<>();
+    timedOutItems = new HashSet<>();
   }
 
   void start() {
@@ -168,6 +170,16 @@ class PendingReconstructionBlocks {
       }
     }
     return 0;
+  }
+
+  /**
+   * Check if block in timedOutItems.
+   * @return true if the block is in timedOutItems.
+   */
+  boolean hasTimeOutBlock(BlockInfo block) {
+    synchronized (timedOutItems) {
+      return timedOutItems.contains(block);
+    }
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingReconstruction.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingReconstruction.java
@@ -175,6 +175,7 @@ public class TestPendingReconstruction {
     //
     assertEquals("Size of pendingReconstructions ", 0, pendingReconstructions.size());
     assertEquals(15L, pendingReconstructions.getNumTimedOuts());
+    assertTrue(pendingReconstructions.hasTimeOutBlock(blk));
     Block[] timedOut = pendingReconstructions.getTimedOutBlocks();
     assertNotNull(timedOut);
     assertEquals(15, timedOut.length);


### PR DESCRIPTION
[HDFS-17556](https://issues.apache.org/jira/browse/HDFS-17556)
In decommission and maintenance process, before added to BlockManager::neededReconstruction block will be check if it has been added. The check contains if block is in BlockManager::neededReconstruction or in PendingReconstructionBlocks::pendingReconstructions as below code.
But it also need to check if it is in PendingReconstructionBlocks::timedOutItems. Or else DatanodeAdminDefaultMonitor will add block to BlockManager::neededReconstruction repeatedly if block time out in PendingReconstructionBlocks::pendingReconstructions.
`
if (!blockManager.neededReconstruction.contains(block) &&
    blockManager.pendingReconstruction.getNumReplicas(block) == 0 &&
    blockManager.isPopulatingReplQueues()) {
  // Process these blocks only when active NN is out of safe mode.
  blockManager.neededReconstruction.add(block,
      liveReplicas, num.readOnlyReplicas(),
      num.outOfServiceReplicas(),
      blockManager.getExpectedRedundancyNum(block));
} 
`