### PR TITLE
HDFS-17557. Fix bug for TestRedundancyMonitor#testChooseTargetWhenAllDataNodesStop

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestRedundancyMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestRedundancyMonitor.java
@@ -72,7 +72,7 @@ public class TestRedundancyMonitor {
       NetworkTopology clusterMap = replicator.clusterMap;
       NetworkTopology spyClusterMap = spy(clusterMap);
       replicator.clusterMap = spyClusterMap;
-      doAnswer(delayer).when(spyClusterMap).getNumOfRacks();
+      doAnswer(delayer).when(spyClusterMap).getNumOfNonEmptyRacks();
 
       ExecutorService pool = Executors.newFixedThreadPool(2);
 


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17557
Due to the modification in [HDFS-16456](https://issues.apache.org/jira/browse/HDFS-16456), the current UT has not been able to run successfully, so we need to fix it.