### PR TITLE
fix WebHDFS unknown host error  when the client is not properly confi…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/web/resources/NamenodeWebHdfsMethods.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/web/resources/NamenodeWebHdfsMethods.java
@@ -464,7 +464,7 @@ public class NamenodeWebHdfsMethods {
 
     int port = "http".equals(scheme) ? dn.getInfoPort() : dn
         .getInfoSecurePort();
-    final URI uri = new URI(scheme, null, dn.getHostName(), port, uripath,
+    final URI uri = new URI(scheme, null, dn.getIpAddr(), port, uripath,
         queryBuilder.toString(), null);
 
     if (LOG.isTraceEnabled()) {


### PR DESCRIPTION
### Description of PR
when client is not configured the relationship of the hostname and IP of DataNode correctly, the UnKnownHost error occur once user want to acquire file by WebHDFS url, to fix this issue, the WebHDFS server should returns the real IP instead of hostname

### How was this patch tested?
by test by using curl request to fetch a file

### For code changes:

- [√] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [√] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [√] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [√] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

