### PR TITLE
HDFS-17541. Support msync requests to a separate RPC Server

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -69,6 +69,8 @@ public interface HdfsClientConfigKeys {
   String  DFS_NAMESERVICES = "dfs.nameservices";
   String DFS_NAMENODE_RPC_ADDRESS_KEY = "dfs.namenode.rpc-address";
 
+  String DFS_NAMENODE_MSYNC_RPC_ADDRESS_KEY = "dfs.namenode.msync.rpc-address";
+
   String DFS_NAMENODE_RPC_ADDRESS_AUXILIARY_SUFFIX = "auxiliary-ports";
   String DFS_NAMENODE_RPC_ADDRESS_AUXILIARY_KEY = DFS_NAMENODE_RPC_ADDRESS_KEY
       + "." + DFS_NAMENODE_RPC_ADDRESS_AUXILIARY_SUFFIX;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_NAMENODE_MSYNC_RPC_ADDRESS_KEY;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InterruptedIOException;
@@ -195,7 +197,7 @@ public class ObserverReadProxyProvider<T>
   public ObserverReadProxyProvider(
       Configuration conf, URI uri, Class<T> xface, HAProxyFactory<T> factory) {
     this(conf, uri, xface, factory,
-        new ConfiguredFailoverProxyProvider<>(conf, uri, xface, factory));
+        new ConfiguredFailoverProxyProvider<>(conf, uri, xface, factory, DFS_NAMENODE_MSYNC_RPC_ADDRESS_KEY));
   }
 
   @SuppressWarnings("unchecked")

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -219,6 +219,16 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       "dfs.namenode.lifeline.rpc-address";
   public static final String  DFS_NAMENODE_LIFELINE_RPC_BIND_HOST_KEY =
       "dfs.namenode.lifeline.rpc-bind-host";
+  public static final String  DFS_NAMENODE_MSYNC_RPC_ADDRESS_KEY =
+      HdfsClientConfigKeys.DFS_NAMENODE_MSYNC_RPC_ADDRESS_KEY;
+  public static final String  DFS_NAMENODE_MSYNC_RPC_BIND_HOST_KEY =
+    "dfs.namenode.msync.rpc-bind-host";
+  public static final String  DFS_NAMENODE_MSYNC_HANDLER_RATIO_KEY =
+    "dfs.namenode.msync.handler.ratio";
+  public static final float   DFS_NAMENODE_MSYNC_HANDLER_RATIO_DEFAULT =
+    0.1f;
+  public static final String  DFS_NAMENODE_MSYNC_HANDLER_COUNT_KEY =
+    "dfs.namenode.msync.handler.count";
   public static final String  DFS_NAMENODE_MAX_OBJECTS_KEY =
       HdfsClientConfigKeys.DeprecatedKeys.DFS_NAMENODE_MAX_OBJECTS_KEY;
   public static final long    DFS_NAMENODE_MAX_OBJECTS_DEFAULT = 0;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -176,6 +176,8 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_LIFELINE_RPC_ADD
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_LIFELINE_RPC_BIND_HOST_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_METRICS_LOGGER_PERIOD_SECONDS_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_METRICS_LOGGER_PERIOD_SECONDS_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_MSYNC_RPC_ADDRESS_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_MSYNC_RPC_BIND_HOST_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_NAME_DIR_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_OBSERVER_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_OBSERVER_ENABLED_KEY;
@@ -324,6 +326,8 @@ public class NameNode extends ReconfigurableBase implements
     DFS_NAMENODE_CHECKPOINT_EDITS_DIR_KEY,
     DFS_NAMENODE_LIFELINE_RPC_ADDRESS_KEY,
     DFS_NAMENODE_LIFELINE_RPC_BIND_HOST_KEY,
+    DFS_NAMENODE_MSYNC_RPC_ADDRESS_KEY,
+    DFS_NAMENODE_MSYNC_RPC_BIND_HOST_KEY,
     DFS_NAMENODE_SERVICE_RPC_ADDRESS_KEY,
     DFS_NAMENODE_SERVICE_RPC_BIND_HOST_KEY,
     DFS_NAMENODE_HTTP_ADDRESS_KEY,
@@ -703,6 +707,21 @@ public class NameNode extends ReconfigurableBase implements
   }
 
   /**
+   * Given a configuration get the address of the msync RPC server.
+   * If the msync RPC is not configured returns null.
+   *
+   * @param conf configuration
+   * @return address or null
+   */
+  InetSocketAddress getMsyncRpcServerAddress(Configuration conf) {
+    String addr = getTrimmedOrNull(conf, DFS_NAMENODE_MSYNC_RPC_ADDRESS_KEY);
+    if (addr == null) {
+      return null;
+    }
+    return NetUtils.createSocketAddr(addr);
+  }
+
+  /**
    * Given a configuration get the address of the service rpc server
    * If the service rpc is not configured returns null
    */
@@ -723,6 +742,17 @@ public class NameNode extends ReconfigurableBase implements
    */
   String getLifelineRpcServerBindHost(Configuration conf) {
     return getTrimmedOrNull(conf, DFS_NAMENODE_LIFELINE_RPC_BIND_HOST_KEY);
+  }
+
+  /**
+   * Given a configuration get the bind host of the msync RPC server.
+   * If the bind host is not configured returns null.
+   *
+   * @param conf configuration
+   * @return bind host or null
+   */
+  String getMsyncRpcServerBindHost(Configuration conf) {
+    return getTrimmedOrNull(conf, DFS_NAMENODE_MSYNC_RPC_BIND_HOST_KEY);
   }
 
   /** Given a configuration get the bind host of the service rpc server
@@ -765,6 +795,19 @@ public class NameNode extends ReconfigurableBase implements
     LOG.info("Setting lifeline RPC address {}", lifelineRPCAddress);
     conf.set(DFS_NAMENODE_LIFELINE_RPC_ADDRESS_KEY,
         NetUtils.getHostPortString(lifelineRPCAddress));
+  }
+
+  /**
+   * Modifies the configuration to contain the lifeline RPC address setting.
+   *
+   * @param conf configuration to modify
+   * @param msyncRPCAddress lifeline RPC address
+   */
+  void setRpcMsyncServerAddress(Configuration conf,
+                                   InetSocketAddress msyncRPCAddress) {
+    LOG.info("Setting msync RPC address {}", msyncRPCAddress);
+    conf.set(DFS_NAMENODE_MSYNC_RPC_ADDRESS_KEY,
+      NetUtils.getHostPortString(msyncRPCAddress));
   }
 
   /**
@@ -1034,6 +1077,9 @@ public class NameNode extends ReconfigurableBase implements
     }
     if (rpcServer.getLifelineRpcAddress() != null) {
       LOG.info("{} lifeline RPC up at: {}.", getRole(), rpcServer.getLifelineRpcAddress());
+    }
+    if (rpcServer.getMsyncRpcAddress() != null) {
+      LOG.info("{} msync RPC up at: {}.", getRole(), rpcServer.getMsyncRpcAddress());
     }
   }
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -25,6 +25,9 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_IP_PROXY_USERS;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_LIFELINE_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_LIFELINE_HANDLER_RATIO_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_LIFELINE_HANDLER_RATIO_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_MSYNC_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_MSYNC_HANDLER_RATIO_DEFAULT;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_MSYNC_HANDLER_RATIO_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SERVICE_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SERVICE_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_RPC_ADDRESS_AUXILIARY_KEY;
@@ -262,6 +265,10 @@ public class NameNodeRpcServer implements NamenodeProtocols {
   /** The RPC server that listens to lifeline requests */
   private final RPC.Server lifelineRpcServer;
   private final InetSocketAddress lifelineRPCAddress;
+
+  /** The RPC server that listens to msync requests */
+  private final RPC.Server msyncRpcServer;
+  private final InetSocketAddress msyncRPCAddress;
   
   /** The RPC server that listens to requests from clients */
   protected final RPC.Server clientRpcServer;
@@ -444,6 +451,43 @@ public class NameNodeRpcServer implements NamenodeProtocols {
       lifelineRPCAddress = null;
     }
 
+    InetSocketAddress msyncRpcAddr = nn.getMsyncRpcServerAddress(conf);
+    if (msyncRpcAddr != null) {
+      String bindHost = nn.getMsyncRpcServerBindHost(conf);
+      if (bindHost == null) {
+        bindHost = msyncRpcAddr.getHostName();
+      }
+      LOG.info("Msync RPC server is binding to {}:{}", bindHost,
+        msyncRpcAddr.getPort());
+      int msyncHandlerCount = conf.getInt(
+        DFS_NAMENODE_MSYNC_HANDLER_COUNT_KEY, 0);
+      if (msyncHandlerCount <= 0) {
+        float msyncHandlerRatio = conf.getFloat(
+          DFS_NAMENODE_MSYNC_HANDLER_RATIO_KEY,
+          DFS_NAMENODE_MSYNC_HANDLER_RATIO_DEFAULT);
+        msyncHandlerCount = Math.max(
+          (int)(handlerCount * msyncHandlerRatio), 1);
+      }
+      msyncRpcServer = new RPC.Builder(conf)
+        .setProtocol(ClientNamenodeProtocolPB.class)
+        .setInstance(clientNNPbService)
+        .setBindAddress(bindHost)
+        .setPort(msyncRpcAddr.getPort())
+        .setNumHandlers(msyncHandlerCount)
+        .setVerbose(false)
+        .setSecretManager(namesystem.getDelegationTokenSecretManager())
+        .build();
+
+      // Update the address with the correct port
+      InetSocketAddress listenAddr = msyncRpcServer.getListenerAddress();
+      msyncRPCAddress = new InetSocketAddress(msyncRpcAddr.getHostName(),
+        listenAddr.getPort());
+      nn.setRpcMsyncServerAddress(conf, msyncRPCAddress);
+    } else {
+      msyncRpcServer = null;
+      msyncRPCAddress = null;
+    }
+
     InetSocketAddress rpcAddr = nn.getRpcServerAddress(conf);
     String bindHost = nn.getRpcServerBindHost(conf);
     if (bindHost == null) {
@@ -462,8 +506,7 @@ public class NameNodeRpcServer implements NamenodeProtocols {
     }
 
     clientRpcServer = new RPC.Builder(conf)
-        .setProtocol(
-            org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolPB.class)
+        .setProtocol(ClientNamenodeProtocolPB.class)
         .setInstance(clientNNPbService)
         .setBindAddress(bindHost)
         .setPort(rpcAddr.getPort())
@@ -591,6 +634,9 @@ public class NameNodeRpcServer implements NamenodeProtocols {
     if (lifelineRpcServer != null) {
       lifelineRpcServer.start();
     }
+    if (msyncRpcServer != null) {
+      msyncRpcServer.start();
+    }
   }
   
   /**
@@ -603,6 +649,9 @@ public class NameNodeRpcServer implements NamenodeProtocols {
     }
     if (lifelineRpcServer != null) {
       lifelineRpcServer.join();
+    }
+    if (msyncRpcServer != null) {
+      msyncRpcServer.join();
     }
   }
 
@@ -619,10 +668,17 @@ public class NameNodeRpcServer implements NamenodeProtocols {
     if (lifelineRpcServer != null) {
       lifelineRpcServer.stop();
     }
+    if (msyncRpcServer != null ) {
+      msyncRpcServer.stop();
+    }
   }
 
   InetSocketAddress getLifelineRpcAddress() {
     return lifelineRPCAddress;
+  }
+
+  InetSocketAddress getMsyncRpcAddress() {
+    return msyncRPCAddress;
   }
 
   InetSocketAddress getServiceRpcAddress() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -106,6 +106,33 @@
 </property>
 
 <property>
+  <name>dfs.namenode.msync.rpc-address</name>
+  <value></value>
+  <description>
+    NameNode RPC msync address.  This is an optional separate RPC address
+    that can be used to msync requests to protect against
+    resource exhaustion in the main RPC handler pool.  In the case of
+    HA/Federation where multiple NameNodes exist, the name service ID is added
+    to the name e.g. dfs.namenode.msync.rpc-address.ns1.  The value of this
+    property will take the form of nn-host1:rpc-port.  If this property is not
+    defined, then the NameNode will not start a msync RPC server.  By
+    default, the property is not defined.
+  </description>
+</property>
+
+<property>
+  <name>dfs.namenode.msync.rpc-bind-host</name>
+  <value></value>
+  <description>
+    The actual address the msync RPC server will bind to.  If this optional
+    address is set, it overrides only the hostname portion of
+    dfs.namenode.msync.rpc-address.  It can also be specified per name node
+    or name service for HA/Federation.  This is useful for making the name node
+    listen on all interfaces by setting it to 0.0.0.0.
+  </description>
+</property>
+
+<property>
   <name>dfs.namenode.secondary.http-address</name>
   <value>0.0.0.0:9868</value>
   <description>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-17541

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

