### PR TITLE
HDFS-17560: RBF: When CurrentCall does not include StateId, it can still send requests to the Observer.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/PoolAlignmentContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/PoolAlignmentContext.java
@@ -104,7 +104,11 @@ public class PoolAlignmentContext implements AlignmentContext {
   }
 
   public void advanceClientStateId(Long clientStateId) {
-    poolLocalStateId.accumulate(clientStateId);
+    if (clientStateId == Long.MIN_VALUE){
+      poolLocalStateId.accumulate(sharedGlobalStateId.get());
+    } else {
+      poolLocalStateId.accumulate(clientStateId);
+    }
   }
 
   @VisibleForTesting

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -1787,8 +1787,7 @@ public class RouterRpcClient {
     final List<? extends FederationNamenodeContext> namenodes;
 
     boolean listObserverNamenodesFirst = isObserverRead
-        && isNamespaceStateIdFresh(nsId)
-        && (RouterStateIdContext.getClientStateIdFromCurrentCall(nsId) > Long.MIN_VALUE);
+        && isNamespaceStateIdFresh(nsId);
     namenodes = namenodeResolver.getNamenodesForNameserviceId(nsId, listObserverNamenodesFirst);
     if (!listObserverNamenodesFirst) {
       // Refresh time of last call to active NameNode.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -259,7 +259,7 @@ public class TestObserverWithRouter {
     long rpcCountForActive = routerContext.getRouter().getRpcServer()
         .getRPCMetrics().getActiveProxyOps();
     // Create, complete and getBlockLocations calls should be sent to active
-    assertEquals("Three calls should be sent to active", 2, rpcCountForActive);
+    assertEquals("Two calls should be sent to active", 2, rpcCountForActive);
 
     long rpcCountForObserver = routerContext.getRouter().getRpcServer()
         .getRPCMetrics().getObserverProxyOps();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -259,11 +259,11 @@ public class TestObserverWithRouter {
     long rpcCountForActive = routerContext.getRouter().getRpcServer()
         .getRPCMetrics().getActiveProxyOps();
     // Create, complete and getBlockLocations calls should be sent to active
-    assertEquals("Three calls should be sent to active", 3, rpcCountForActive);
+    assertEquals("Three calls should be sent to active", 2, rpcCountForActive);
 
     long rpcCountForObserver = routerContext.getRouter().getRpcServer()
         .getRPCMetrics().getObserverProxyOps();
-    assertEquals("No call should be sent to observer", 0, rpcCountForObserver);
+    assertEquals("No call should be sent to observer", 1, rpcCountForObserver);
   }
 
   @EnumSource(ConfigSetting.class)

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -263,7 +263,7 @@ public class TestObserverWithRouter {
 
     long rpcCountForObserver = routerContext.getRouter().getRpcServer()
         .getRPCMetrics().getObserverProxyOps();
-    assertEquals("No call should be sent to observer", 1, rpcCountForObserver);
+    assertEquals("One call should be sent to observer", 1, rpcCountForObserver);
   }
 
   @EnumSource(ConfigSetting.class)

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -258,11 +258,12 @@ public class TestObserverWithRouter {
 
     long rpcCountForActive = routerContext.getRouter().getRpcServer()
         .getRPCMetrics().getActiveProxyOps();
-    // Create, complete and getBlockLocations calls should be sent to active
+    // Create and complete calls should be sent to active
     assertEquals("Two calls should be sent to active", 2, rpcCountForActive);
 
     long rpcCountForObserver = routerContext.getRouter().getRpcServer()
         .getRPCMetrics().getObserverProxyOps();
+    // getBlockLocations call should be sent to observer
     assertEquals("One call should be sent to observer", 1, rpcCountForObserver);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestPoolAlignmentContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestPoolAlignmentContext.java
@@ -41,6 +41,9 @@ public class TestPoolAlignmentContext {
     poolContext1.advanceClientStateId(30L);
     assertRequestHeaderStateId(poolContext1, 30L);
     assertRequestHeaderStateId(poolContext2, Long.MIN_VALUE);
+
+    poolContext2.advanceClientStateId(Long.MIN_VALUE);
+    assertRequestHeaderStateId(poolContext2, 20L);
     Assertions.assertEquals(20L, poolContext1.getLastSeenStateId());
     Assertions.assertEquals(20L, poolContext2.getLastSeenStateId());
   }


### PR DESCRIPTION
JIRA: HDFS-17560.
When the size of the federated state propagated to the client exceeds maxSizeOfFederatedStateToPropagate, all requests are forwarded to the active NameNode. I don't think this is very reasonable.When enabling Observer read and there is no FederatedState propagated to the client, advanceClientStateId can use sharedGlobalStateId to assign poolLocalStateId and send the request to the Observer.