### PR TITLE
HDFS-17559. Fix the uuid as null in NameNodeMXBean

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/DatanodeID.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/DatanodeID.java
@@ -149,14 +149,6 @@ public class DatanodeID implements Comparable<DatanodeID> {
     return datanodeUuid;
   }
 
-  /**
-   * @return data node ID for metrics.
-   * @since HDFS-17559.
-   */
-  public String getDatanodeUuidForMetric() {
-    return datanodeUuid != null ? datanodeUuid : "";
-  }
-
   public ByteString getDatanodeUuidBytes() {
     return datanodeUuidBytes;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/DatanodeID.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/DatanodeID.java
@@ -149,6 +149,14 @@ public class DatanodeID implements Comparable<DatanodeID> {
     return datanodeUuid;
   }
 
+  /**
+   * @return data node ID for metrics.
+   * @since HDFS-17559.
+   */
+  public String getDatanodeUuidForMetric() {
+    return datanodeUuid != null ? datanodeUuid : "";
+  }
+
   public ByteString getDatanodeUuidBytes() {
     return datanodeUuidBytes;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -97,6 +97,7 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SNAPSHOT_DIFF_LI
 import static org.apache.hadoop.hdfs.DFSUtil.isParentEntry;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.text.CaseUtils;
@@ -6674,7 +6675,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
           .put("infoSecureAddr", node.getInfoSecureAddr())
           .put("xferaddr", node.getXferAddr())
           .put("location", node.getNetworkLocation())
-          .put("uuid", node.getDatanodeUuidForMetric())
+          .put("uuid", Optional.ofNullable(node.getDatanodeUuid()).orElse(""))
           .put("lastContact", getLastContact(node))
           .put("usedSpace", getDfsUsed(node))
           .put("adminState", node.getAdminState().toString())
@@ -6728,7 +6729,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
           .put("adminState", node.getAdminState().toString())
           .put("xferaddr", node.getXferAddr())
           .put("location", node.getNetworkLocation())
-          .put("uuid", node.getDatanodeUuidForMetric())
+          .put("uuid", Optional.ofNullable(node.getDatanodeUuid()).orElse(""))
           .build();
       info.put(node.getXferAddrWithHostname(), innerinfo);
     }
@@ -6751,7 +6752,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
           .<String, Object> builder()
           .put("xferaddr", node.getXferAddr())
           .put("location", node.getNetworkLocation())
-          .put("uuid", node.getDatanodeUuidForMetric())
+          .put("uuid", Optional.ofNullable(node.getDatanodeUuid()).orElse(""))
           .put("underReplicatedBlocks",
           node.getLeavingServiceStatus().getUnderReplicatedBlocks())
           .put("decommissionOnlyReplicas",
@@ -6782,7 +6783,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
           .<String, Object> builder()
           .put("xferaddr", node.getXferAddr())
           .put("location", node.getNetworkLocation())
-          .put("uuid", node.getDatanodeUuidForMetric())
+          .put("uuid", Optional.ofNullable(node.getDatanodeUuid()).orElse(""))
           .put("underReplicatedBlocks",
               node.getLeavingServiceStatus().getUnderReplicatedBlocks())
           .put("maintenanceOnlyReplicas",

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -6674,7 +6674,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
           .put("infoSecureAddr", node.getInfoSecureAddr())
           .put("xferaddr", node.getXferAddr())
           .put("location", node.getNetworkLocation())
-          .put("uuid", node.getDatanodeUuid())
+          .put("uuid", node.getDatanodeUuidForMetric())
           .put("lastContact", getLastContact(node))
           .put("usedSpace", getDfsUsed(node))
           .put("adminState", node.getAdminState().toString())
@@ -6728,7 +6728,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
           .put("adminState", node.getAdminState().toString())
           .put("xferaddr", node.getXferAddr())
           .put("location", node.getNetworkLocation())
-          .put("uuid", node.getDatanodeUuid())
+          .put("uuid", node.getDatanodeUuidForMetric())
           .build();
       info.put(node.getXferAddrWithHostname(), innerinfo);
     }
@@ -6751,7 +6751,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
           .<String, Object> builder()
           .put("xferaddr", node.getXferAddr())
           .put("location", node.getNetworkLocation())
-          .put("uuid", node.getDatanodeUuid())
+          .put("uuid", node.getDatanodeUuidForMetric())
           .put("underReplicatedBlocks",
           node.getLeavingServiceStatus().getUnderReplicatedBlocks())
           .put("decommissionOnlyReplicas",
@@ -6782,7 +6782,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
           .<String, Object> builder()
           .put("xferaddr", node.getXferAddr())
           .put("location", node.getNetworkLocation())
-          .put("uuid", node.getDatanodeUuid())
+          .put("uuid", node.getDatanodeUuidForMetric())
           .put("underReplicatedBlocks",
               node.getLeavingServiceStatus().getUnderReplicatedBlocks())
           .put("maintenanceOnlyReplicas",

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMXBean.java
@@ -1170,13 +1170,13 @@ public class TestNameNodeMXBean {
       fsn.getBlockManager().getDatanodeManager().refreshNodes(conf);
       DatanodeManager dm = cluster.getNameNode().getNamesystem().
           getBlockManager().getDatanodeManager();
-      LOG.info("Get all include nodes: {}",dm.getHostConfigManager().getIncludes());
+      LOG.info("Get all include nodes: {}", dm.getHostConfigManager().getIncludes());
 
       // get attribute DeadNodes
       String deadNodeInfo = (String) (mbs.getAttribute(mxbeanName,
           "DeadNodes"));
       assertEquals(fsn.getDeadNodes(), deadNodeInfo);
-      LOG.info("Get deadNode info: {}",deadNodeInfo);
+      LOG.info("Get deadNode info: {}", deadNodeInfo);
       Map<String, Map<String, Object>> deadNodes =
           (Map<String, Map<String, Object>>) JSON.parse(deadNodeInfo);
       assertEquals(1, deadNodes.size());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMXBean.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.hdfs.server.namenode;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.apache.hadoop.hdfs.protocol.DatanodeID;
@@ -1163,7 +1165,7 @@ public class TestNameNodeMXBean {
           new DatanodeID("127.0.0.2", "127.0.0.2", "",
               5000, 5001, 5002, 5003));
 
-      assertEquals("", mockNode.getDatanodeUuidForMetric());
+      assertEquals("", Optional.ofNullable(mockNode.getDatanodeUuid()).orElse(""));
       hosts.add(mockNode.getXferAddrWithHostname());
       hostsFileWriter.initIncludeHosts(hosts.toArray(
           new String[hosts.size()]));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMXBean.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hdfs.server.namenode;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.function.Supplier;
+
+import org.apache.hadoop.hdfs.protocol.DatanodeID;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -1129,6 +1131,66 @@ public class TestNameNodeMXBean {
       if (cluster != null) {
         cluster.shutdown();
       }
+    }
+  }
+
+  @SuppressWarnings({ "unchecked" })
+  @Test
+  public void testDeadNodesInNameNodeMXBean() throws Exception {
+    Configuration conf = new Configuration();
+    conf.setInt(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY, 1);
+    conf.setInt(DFSConfigKeys.DFS_NAMENODE_HEARTBEAT_RECHECK_INTERVAL_KEY, 1);
+    MiniDFSCluster cluster = null;
+    HostsFileWriter hostsFileWriter = new HostsFileWriter();
+    hostsFileWriter.initialize(conf, "temp/TestNameNodeMXBean");
+
+    try {
+      cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot()).numDataNodes(3).build();
+      cluster.waitActive();
+
+      FSNamesystem fsn = cluster.getNameNode().namesystem;
+
+      MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+      ObjectName mxbeanName = new ObjectName(
+          "Hadoop:service=NameNode,name=NameNodeInfo");
+
+      List<String> hosts = new ArrayList<>();
+      for(DataNode dn : cluster.getDataNodes()) {
+        hosts.add(dn.getDisplayName());
+      }
+
+      DatanodeDescriptor mockNode = new DatanodeDescriptor(
+          new DatanodeID("127.0.0.2", "127.0.0.2", "",
+              5000, 5001, 5002, 5003));
+
+      assertEquals("", mockNode.getDatanodeUuidForMetric());
+      hosts.add(mockNode.getXferAddrWithHostname());
+      hostsFileWriter.initIncludeHosts(hosts.toArray(
+          new String[hosts.size()]));
+      fsn.getBlockManager().getDatanodeManager().refreshNodes(conf);
+      DatanodeManager dm = cluster.getNameNode().getNamesystem().
+          getBlockManager().getDatanodeManager();
+      LOG.info("Get all include nodes: {}",dm.getHostConfigManager().getIncludes());
+
+      // get attribute DeadNodes
+      String deadNodeInfo = (String) (mbs.getAttribute(mxbeanName,
+          "DeadNodes"));
+      assertEquals(fsn.getDeadNodes(), deadNodeInfo);
+      LOG.info("Get deadNode info: {}",deadNodeInfo);
+      Map<String, Map<String, Object>> deadNodes =
+          (Map<String, Map<String, Object>>) JSON.parse(deadNodeInfo);
+      assertEquals(1, deadNodes.size());
+      for (Map<String, Object> deadNode : deadNodes.values()) {
+        assertTrue(deadNode.containsKey("lastContact"));
+        assertTrue(deadNode.containsKey("adminState"));
+        assertTrue(deadNode.containsKey("xferaddr"));
+        assertEquals("", deadNode.get("uuid"));
+      }
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+      hostsFileWriter.cleanup();
     }
   }
 


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17559

If there is datanode info in includes, but the datanode service is not currently started, the uuid of the datanode will be null.
when get the DeadNodes DeadNodes metric, the following exception will occur:
```

2024-06-26 17:06:49,698 ERROR jmx.JMXJsonServlet (JMXJsonServlet.java:writeAttribute(345)) [qtp1107412069-7704] - getting attribute DeadNodes of Hadoop:service=NameNode,name=NameNodeInfo threw an exception javax.management.RuntimeMBeanException: java.lang.NullPointerException: null value in entry: uuid=null
        at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.rethrow(DefaultMBeanServerInterceptor.java:839)
        at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.rethrowMaybeMBeanException(DefaultMBeanServerInterceptor.java:852)
        at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.getAttribute(DefaultMBeanServerInterceptor.java:651)
        at com.sun.jmx.mbeanserver.JmxMBeanServer.getAttribute(JmxMBeanServer.java:678)
        at org.apache.hadoop.jmx.JMXJsonServlet.writeAttribute(JMXJsonServlet.java:338)
```
