### PR TITLE
HADOOP-19210. S3A: Speed up some slow unit tests

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3AMockTest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3AMockTest.java
@@ -80,6 +80,15 @@ public abstract class AbstractS3AMockTest {
     conf.setInt(ASYNC_DRAIN_THRESHOLD, Integer.MAX_VALUE);
     // set the region to avoid the getBucketLocation on FS init.
     conf.set(AWS_REGION, "eu-west-1");
+
+    // tight retry logic as all failures are simulated
+    final String interval = "1ms";
+    final int limit = 3;
+    conf.set(RETRY_THROTTLE_INTERVAL, interval);
+    conf.setInt(RETRY_THROTTLE_LIMIT, limit);
+    conf.set(RETRY_INTERVAL, interval);
+    conf.setInt(RETRY_LIMIT, limit);
+
     return conf;
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AAWSCredentialsProvider.java
@@ -237,7 +237,7 @@ public class TestS3AAWSCredentialsProvider extends AbstractS3ATestBase {
     Assertions
         .assertThat(credentials.size())
         .describedAs("List of Credentials providers")
-        .isEqualTo(TERMINATION_TIMEOUT);
+        .isEqualTo(3);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AAWSCredentialsProvider.java
@@ -86,6 +86,8 @@ public class TestS3AAWSCredentialsProvider extends AbstractS3ATestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestS3AAWSCredentialsProvider.class);
 
+  public static final int TERMINATION_TIMEOUT = 3;
+
   @Test
   public void testProviderWrongClass() throws Exception {
     expectProviderInstantiationFailure(this.getClass(),
@@ -235,7 +237,7 @@ public class TestS3AAWSCredentialsProvider extends AbstractS3ATestBase {
     Assertions
         .assertThat(credentials.size())
         .describedAs("List of Credentials providers")
-        .isEqualTo(3);
+        .isEqualTo(TERMINATION_TIMEOUT);
   }
 
   /**
@@ -579,7 +581,7 @@ public class TestS3AAWSCredentialsProvider extends AbstractS3ATestBase {
     }
   }
 
-  private static final int CONCURRENT_THREADS = 10;
+  private static final int CONCURRENT_THREADS = 4;
 
   @Test
   public void testConcurrentAuthentication() throws Throwable {
@@ -619,7 +621,7 @@ public class TestS3AAWSCredentialsProvider extends AbstractS3ATestBase {
             "expectedSecret", credentials.secretAccessKey());
       }
     } finally {
-      pool.awaitTermination(10, TimeUnit.SECONDS);
+      pool.awaitTermination(TERMINATION_TIMEOUT, TimeUnit.SECONDS);
       pool.shutdown();
     }
 
@@ -685,7 +687,7 @@ public class TestS3AAWSCredentialsProvider extends AbstractS3ATestBase {
         );
       }
     } finally {
-      pool.awaitTermination(10, TimeUnit.SECONDS);
+      pool.awaitTermination(TERMINATION_TIMEOUT, TimeUnit.SECONDS);
       pool.shutdown();
     }
 


### PR DESCRIPTION

HADOOP-19210

Speed up slow tests
* TestS3AAWSCredentialsProvider: decrease thread pool shutdown time
* TestS3AInputStreamRetry: reduce retry limit and intervals

On a test run with -Dparallel-tests -DtestsThreadCount=10 this reduces test execution time from 03:00 min to 02:26 min.



### How was this patch tested?

reran old tests and measured time difference.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

