### PR TITLE
HDFS-17546. Follow-up backport from branch3.3

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestCombinedHostsFileReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestCombinedHostsFileReader.java
@@ -30,10 +30,10 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
+import org.mockito.MockitoAnnotations;
 
 /**
  * Test for JSON based HostsFileReader.
@@ -56,7 +56,7 @@ public class TestCombinedHostsFileReader {
 
   @Before
   public void setUp() throws Exception {
-    callable = Mockito.mock(Callable.class);
+    MockitoAnnotations.initMocks(this);
   }
 
   @After


### PR DESCRIPTION
### Description of PR
Some minor revisions between the [trunk](https://github.com/apache/hadoop/pull/6873) and [branch-3.3](https://github.com/apache/hadoop/pull/6891) changes for HDFS-17546.
So we are backporting the minor changes in the unit test file for javac/linting fixes. 

### How was this patch tested?
Ran checkstyles + mavent tests

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

