### PR TITLE
HDFS-17561. Make HeartbeatManager.Monitor use up-to-date heartbeatRecheckInterval

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -89,7 +89,7 @@ public class DatanodeManager {
 
   private volatile long heartbeatIntervalSeconds;
   private volatile int heartbeatRecheckInterval;
-  /** Used by {@link HeartbeatManager} */
+  /** Used by {@link HeartbeatManager}. */
   private volatile int heartbeatRecheckIntervalForMonitor;
   /**
    * Stores the datanode -> block map.  
@@ -2193,7 +2193,8 @@ public class DatanodeManager {
     refreshHeartbeatRecheckIntervalForMonitor();
   }
 
-  private void refreshHeartbeatRecheckIntervalForMonitor() {
+  @VisibleForTesting
+  public void refreshHeartbeatRecheckIntervalForMonitor() {
     if (avoidStaleDataNodesForWrite && staleInterval < heartbeatRecheckInterval) {
       heartbeatRecheckIntervalForMonitor = (int) staleInterval;
       LOG.info("Setting heartbeat recheck interval to " + staleInterval

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -89,6 +89,8 @@ public class DatanodeManager {
 
   private volatile long heartbeatIntervalSeconds;
   private volatile int heartbeatRecheckInterval;
+  /** Used by {@link HeartbeatManager} */
+  private volatile int heartbeatRecheckIntervalForMonitor;
   /**
    * Stores the datanode -> block map.  
    * <p>
@@ -343,6 +345,7 @@ public class DatanodeManager {
         DFSConfigKeys.DFS_NAMENODE_AVOID_STALE_DATANODE_FOR_WRITE_KEY,
         DFSConfigKeys.DFS_NAMENODE_AVOID_STALE_DATANODE_FOR_WRITE_DEFAULT);
     this.staleInterval = getStaleIntervalFromConf(conf, heartbeatExpireInterval);
+    refreshHeartbeatRecheckIntervalForMonitor();
     this.ratioUseStaleDataNodesForWrite = conf.getFloat(
         DFSConfigKeys.DFS_NAMENODE_USE_STALE_DATANODE_FOR_WRITE_RATIO_KEY,
         DFSConfigKeys.DFS_NAMENODE_USE_STALE_DATANODE_FOR_WRITE_RATIO_DEFAULT);
@@ -2187,6 +2190,18 @@ public class DatanodeManager {
     this.heartbeatExpireInterval = 2L * recheckInterval + 10 * 1000
         * intervalSeconds;
     this.blockInvalidateLimit = getBlockInvalidateLimit(blockInvalidateLimit);
+    refreshHeartbeatRecheckIntervalForMonitor();
+  }
+
+  private void refreshHeartbeatRecheckIntervalForMonitor() {
+    if (avoidStaleDataNodesForWrite && staleInterval < heartbeatRecheckInterval) {
+      heartbeatRecheckIntervalForMonitor = (int) staleInterval;
+      LOG.info("Setting heartbeat recheck interval to " + staleInterval
+          + " since " + DFSConfigKeys.DFS_NAMENODE_STALE_DATANODE_INTERVAL_KEY
+          + " is less than " + heartbeatRecheckInterval);
+    } else {
+      heartbeatRecheckIntervalForMonitor = heartbeatRecheckInterval;
+    }
   }
 
   private int getBlockInvalidateLimitFromHBInterval() {
@@ -2327,5 +2342,9 @@ public class DatanodeManager {
   @VisibleForTesting
   public long getSlowPeerCollectionInterval() {
     return slowPeerCollectionInterval;
+  }
+
+  public int getHeartbeatRecheckIntervalForMonitor() {
+    return heartbeatRecheckIntervalForMonitor;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -90,7 +90,7 @@ public class DatanodeManager {
   private volatile long heartbeatIntervalSeconds;
   private volatile int heartbeatRecheckInterval;
   /** Used by {@link HeartbeatManager}. */
-  private volatile int heartbeatRecheckIntervalForMonitor;
+  private volatile long heartbeatRecheckIntervalForMonitor;
   /**
    * Stores the datanode -> block map.  
    * <p>
@@ -2196,7 +2196,7 @@ public class DatanodeManager {
   @VisibleForTesting
   public void refreshHeartbeatRecheckIntervalForMonitor() {
     if (avoidStaleDataNodesForWrite && staleInterval < heartbeatRecheckInterval) {
-      heartbeatRecheckIntervalForMonitor = (int) staleInterval;
+      heartbeatRecheckIntervalForMonitor = staleInterval;
       LOG.info("Setting heartbeat recheck interval to " + staleInterval
           + " since " + DFSConfigKeys.DFS_NAMENODE_STALE_DATANODE_INTERVAL_KEY
           + " is less than " + heartbeatRecheckInterval);
@@ -2345,7 +2345,7 @@ public class DatanodeManager {
     return slowPeerCollectionInterval;
   }
 
-  public int getHeartbeatRecheckIntervalForMonitor() {
+  public long getHeartbeatRecheckIntervalForMonitor() {
     return heartbeatRecheckIntervalForMonitor;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestHeartbeatHandling.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestHeartbeatHandling.java
@@ -264,24 +264,23 @@ public class TestHeartbeatHandling {
 
   @Test
   public void testHeartbeatStopWatch() throws Exception {
-   Namesystem ns = Mockito.mock(Namesystem.class);
-   BlockManager bm = Mockito.mock(BlockManager.class);
-   Configuration conf = new Configuration();
-   long recheck = 2000;
-   conf.setLong(
-       DFSConfigKeys.DFS_NAMENODE_HEARTBEAT_RECHECK_INTERVAL_KEY, recheck);
-   HeartbeatManager monitor = new HeartbeatManager(ns, bm, conf);
-   monitor.restartHeartbeatStopWatch();
-   assertFalse(monitor.shouldAbortHeartbeatCheck(0));
-   // sleep shorter than recheck and verify shouldn't abort
-   Thread.sleep(100);
-   assertFalse(monitor.shouldAbortHeartbeatCheck(0));
-   // sleep longer than recheck and verify should abort unless ignore delay
-   Thread.sleep(recheck);
-   assertTrue(monitor.shouldAbortHeartbeatCheck(0));
-   assertFalse(monitor.shouldAbortHeartbeatCheck(-recheck*3));
-   // ensure it resets properly
-   monitor.restartHeartbeatStopWatch();
-   assertFalse(monitor.shouldAbortHeartbeatCheck(0));
+    Namesystem ns = Mockito.mock(Namesystem.class);
+    Configuration conf = new Configuration();
+    long recheck = 2000;
+    conf.setLong(DFSConfigKeys.DFS_NAMENODE_HEARTBEAT_RECHECK_INTERVAL_KEY, recheck);
+    BlockManager bm = new BlockManager(ns, false, conf);
+    HeartbeatManager monitor = new HeartbeatManager(ns, bm, conf);
+    monitor.restartHeartbeatStopWatch();
+    assertFalse(monitor.shouldAbortHeartbeatCheck(0));
+    // sleep shorter than recheck and verify shouldn't abort
+    Thread.sleep(100);
+    assertFalse(monitor.shouldAbortHeartbeatCheck(0));
+    // sleep longer than recheck and verify should abort unless ignore delay
+    Thread.sleep(recheck);
+    assertTrue(monitor.shouldAbortHeartbeatCheck(0));
+    assertFalse(monitor.shouldAbortHeartbeatCheck(-recheck * 3));
+    // ensure it resets properly
+    monitor.restartHeartbeatStopWatch();
+    assertFalse(monitor.shouldAbortHeartbeatCheck(0));
   }
 }


### PR DESCRIPTION
### Description of PR

DatanodeManager can changes heartbeatRecheckInterval via reconf API but HeartbeatManager's copy of heartbeatRecheckInterval is fixed at initialization and won't update when DatanodeManager updates with a new config.