### PR TITLE
HDFS-17564. EC: Fix the issue of inaccurate metrics when decommission mark busy DN.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -2396,7 +2396,9 @@ public class BlockManager implements BlockStatsMXBean {
     }
 
     // Add block to the datanode's task list
-    rw.addTaskToDatanode(numReplicas);
+    if (!rw.addTaskToDatanode(numReplicas)) {
+      return false;
+    }
     DatanodeStorageInfo.incrementBlocksScheduled(targets);
 
     // Move the block-replication into a "pending" state.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockReconstructionWork.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockReconstructionWork.java
@@ -145,5 +145,5 @@ abstract class BlockReconstructionWork {
    *
    * @param numberReplicas replica details
    */
-  abstract void addTaskToDatanode(NumberReplicas numberReplicas);
+  abstract boolean addTaskToDatanode(NumberReplicas numberReplicas);
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/ErasureCodingWork.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/ErasureCodingWork.java
@@ -136,11 +136,11 @@ class ErasureCodingWork extends BlockReconstructionWork {
   }
 
   @Override
-  void addTaskToDatanode(NumberReplicas numberReplicas) {
+  boolean addTaskToDatanode(NumberReplicas numberReplicas) {
     final DatanodeStorageInfo[] targets = getTargets();
     assert targets.length > 0;
     BlockInfoStriped stripedBlk = (BlockInfoStriped) getBlock();
-
+    boolean flag = true;
     if (hasNotEnoughRack()) {
       // if we already have all the internal blocks, but not enough racks,
       // we only need to replicate one internal block to a new rack
@@ -152,6 +152,9 @@ class ErasureCodingWork extends BlockReconstructionWork {
       List<Integer> leavingServiceSources = findLeavingServiceSources();
       // decommissioningSources.size() should be >= targets.length
       final int num = Math.min(leavingServiceSources.size(), targets.length);
+      if (num == 0) {
+        flag = false;
+      }
       for (int i = 0; i < num; i++) {
         createReplicationWork(leavingServiceSources.get(i), targets[i]);
       }
@@ -160,6 +163,7 @@ class ErasureCodingWork extends BlockReconstructionWork {
           new ExtendedBlock(blockPoolId, stripedBlk), getSrcNodes(), targets,
           liveBlockIndices, excludeReconstructedIndices, stripedBlk.getErasureCodingPolicy());
     }
+    return flag;
   }
 
   private void createReplicationWork(int sourceIndex,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/ReplicationWork.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/ReplicationWork.java
@@ -61,7 +61,8 @@ class ReplicationWork extends BlockReconstructionWork {
   }
 
   @Override
-  void addTaskToDatanode(NumberReplicas numberReplicas) {
+  boolean addTaskToDatanode(NumberReplicas numberReplicas) {
     getSrcNodes()[0].addBlockToBeReplicated(getBlock(), getTargets());
+    return true;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithStriped.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithStriped.java
@@ -468,15 +468,15 @@ public class TestDecommissionWithStriped {
    */
   @Test(timeout = 120000)
   public void testBusyAfterDecommissionNode() throws Exception {
-    byte busyDNIndex = 0;
-    //1. create EC file
+    int busyDNIndex = 0;
+    //1. create EC file.
     final Path ecFile = new Path(ecDir, "testBusyAfterDecommissionNode");
     int writeBytes = cellSize * dataBlocks;
     writeStripedFile(dfs, ecFile, writeBytes);
     Assert.assertEquals(0, bm.numOfUnderReplicatedBlocks());
     FileChecksum fileChecksum1 = dfs.getFileChecksum(ecFile, writeBytes);
 
-    //2. make once DN busy
+    //2. make once DN busy.
     final INodeFile fileNode = cluster.getNamesystem().getFSDirectory()
         .getINode4Write(ecFile.toString()).asFile();
     BlockInfo firstBlock = fileNode.getBlocks()[0];
@@ -487,7 +487,7 @@ public class TestDecommissionWithStriped {
       busyNode.incrementPendingReplicationWithoutTargets();
     }
 
-    //3. decomission one node
+    //3. decomission one node.
     List<DatanodeInfo> decommisionNodes = new ArrayList<>();
     decommisionNodes.add(busyNode);
     decommissionNode(0, decommisionNodes, AdminStates.DECOMMISSION_INPROGRESS);
@@ -500,8 +500,9 @@ public class TestDecommissionWithStriped {
     }
     assertEquals(decommisionNodes.size(), liveDecommissioning);
 
-    //4. wait for decommission block to replicate
-    Thread.sleep(3000);
+    //4. wait for decommission block to replicate.
+    GenericTestUtils.waitFor(() -> bm.getLowRedundancyBlocksCount() == 1,
+        100, 3000);
 
     int blocksScheduled = 0;
     final List<DatanodeDescriptor> dnList = new ArrayList<>();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithStriped.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithStriped.java
@@ -462,6 +462,59 @@ public class TestDecommissionWithStriped {
         fileChecksum1.equals(fileChecksum2));
   }
 
+  /**
+   * Test decommission when DN marked as busy.
+   * @throwsException
+   */
+  @Test(timeout = 120000)
+  public void testBusyAfterDecommissionNode() throws Exception {
+    byte busyDNIndex = 0;
+    //1. create EC file
+    final Path ecFile = new Path(ecDir, "testBusyAfterDecommissionNode");
+    int writeBytes = cellSize * dataBlocks;
+    writeStripedFile(dfs, ecFile, writeBytes);
+    Assert.assertEquals(0, bm.numOfUnderReplicatedBlocks());
+    FileChecksum fileChecksum1 = dfs.getFileChecksum(ecFile, writeBytes);
+
+    //2. make once DN busy
+    final INodeFile fileNode = cluster.getNamesystem().getFSDirectory()
+        .getINode4Write(ecFile.toString()).asFile();
+    BlockInfo firstBlock = fileNode.getBlocks()[0];
+    DatanodeStorageInfo[] dnStorageInfos = bm.getStorages(firstBlock);
+    DatanodeDescriptor busyNode =
+        dnStorageInfos[busyDNIndex].getDatanodeDescriptor();
+    for (int j = 0; j < replicationStreamsHardLimit; j++) {
+      busyNode.incrementPendingReplicationWithoutTargets();
+    }
+
+    //3. decomission one node
+    List<DatanodeInfo> decommisionNodes = new ArrayList<>();
+    decommisionNodes.add(busyNode);
+    decommissionNode(0, decommisionNodes, AdminStates.DECOMMISSION_INPROGRESS);
+
+    final List<DatanodeDescriptor> live = new ArrayList<DatanodeDescriptor>();
+    bm.getDatanodeManager().fetchDatanodes(live, null, false);
+    int liveDecommissioning = 0;
+    for (DatanodeDescriptor node : live) {
+      liveDecommissioning += node.isDecommissionInProgress() ? 1 : 0;
+    }
+    assertEquals(decommisionNodes.size(), liveDecommissioning);
+
+    //4. wait for decommission block to replicate
+    Thread.sleep(3000);
+
+    int blocksScheduled = 0;
+    final List<DatanodeDescriptor> dnList = new ArrayList<>();
+    fsn.getBlockManager().getDatanodeManager().fetchDatanodes(dnList, null,
+        false);
+    for (DatanodeDescriptor dn : dnList) {
+      blocksScheduled += dn.getBlocksScheduled();
+    }
+    assertEquals(0, blocksScheduled);
+    assertEquals(0, bm.getPendingReconstructionBlocksCount());
+    assertEquals(1, bm.getLowRedundancyBlocksCount());
+  }
+
   private void testDecommission(int writeBytes, int storageCount,
       int decomNodeCount, String filename) throws IOException, Exception {
     Path ecFile = new Path(ecDir, filename);


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17564

If DataNode is marked as busy and contains many EC blocks, when running decommission DataNode, when execute ErasureCodingWork#addTaskToDatanode, here will no replication work will be generated for ecBlocksToBeReplicated, but related metrics (such as DatanodeDescriptor#currApproxBlocksScheduled, pendingReconstruction and needReconstruction) will still updated.

Specific code：
BlockManager#scheduleReconstruction -> BlockManager#chooseSourceDatanodes [2628~2650]
If DataNode is marked as busy and contains many EC blocks here will not add to srcNodes.
```
@VisibleForTesting
DatanodeDescriptor[] chooseSourceDatanodes(BlockInfo block,
    List<DatanodeDescriptor> containingNodes,
    List<DatanodeStorageInfo> nodesContainingLiveReplicas,
    NumberReplicas numReplicas, List<Byte> liveBlockIndices,
    List<Byte> liveBusyBlockIndices, List<Byte> excludeReconstructed, int priority) {
  containingNodes.clear();
  nodesContainingLiveReplicas.clear();
  List<DatanodeDescriptor> srcNodes = new ArrayList<>();
 ...

  for (DatanodeStorageInfo storage : blocksMap.getStorages(block)) {
    final DatanodeDescriptor node = getDatanodeDescriptorFromStorage(storage);
    final StoredReplicaState state = checkReplicaOnStorage(numReplicas, block,
        storage, corruptReplicas.getNodes(block), false);
    ...
    // for EC here need to make sure the numReplicas replicates state correct
    // because in the scheduleReconstruction it need the numReplicas to check
    // whether need to reconstruct the ec internal block
    byte blockIndex = -1;
    if (isStriped) {
      blockIndex = ((BlockInfoStriped) block)
          .getStorageBlockIndex(storage);
      countLiveAndDecommissioningReplicas(numReplicas, state,
          liveBitSet, decommissioningBitSet, blockIndex);
    }

    if (priority != LowRedundancyBlocks.QUEUE_HIGHEST_PRIORITY
&& (!node.isDecommissionInProgress() && !node.isEnteringMaintenance())
        && node.getNumberOfBlocksToBeReplicated() +
        node.getNumberOfBlocksToBeErasureCoded() >= maxReplicationStreams) {
      if (isStriped && (state == StoredReplicaState.LIVE
|| state == StoredReplicaState.DECOMMISSIONING)) {
        liveBusyBlockIndices.add(blockIndex);
        //HDFS-16566 ExcludeReconstructed won't be reconstructed.
        excludeReconstructed.add(blockIndex);
      }
      continue; // already reached replication limit
    }

    if (node.getNumberOfBlocksToBeReplicated() +
        node.getNumberOfBlocksToBeErasureCoded() >= replicationStreamsHardLimit) {
      if (isStriped && (state == StoredReplicaState.LIVE
|| state == StoredReplicaState.DECOMMISSIONING)) {
        liveBusyBlockIndices.add(blockIndex);
        //HDFS-16566 ExcludeReconstructed won't be reconstructed.
        excludeReconstructed.add(blockIndex);
      }
      continue;
    }

    if(isStriped || srcNodes.isEmpty()) {
      srcNodes.add(node);
      if (isStriped) {
        liveBlockIndices.add(blockIndex);
      }
      continue;
    }
   ...
```

ErasureCodingWork#addTaskToDatanode[149~157]
```
@Override
void addTaskToDatanode(NumberReplicas numberReplicas) {
  final DatanodeStorageInfo[] targets = getTargets();
  assert targets.length > 0;
  BlockInfoStriped stripedBlk = (BlockInfoStriped) getBlock();

  ...
  } else if ((numberReplicas.decommissioning() > 0 ||
      numberReplicas.liveEnteringMaintenanceReplicas() > 0) &&
      hasAllInternalBlocks()) {
    List<Integer> leavingServiceSources = findLeavingServiceSources();
    // decommissioningSources.size() should be >= targets.length
    // if the leavingServiceSources size is 0,  here will not to createReplicationWork
    final int num = Math.min(leavingServiceSources.size(), targets.length);
    for (int i = 0; i < num; i++) {
      createReplicationWork(leavingServiceSources.get(i), targets[i]);
    }
  ...
}

// Since there is no decommission busy datanode in srcNodes, here return the set size of srcIndices as 0.
private List<Integer> findLeavingServiceSources() {
    // Mark the block in normal node.
    BlockInfoStriped block = (BlockInfoStriped)getBlock();
    BitSet bitSet = new BitSet(block.getRealTotalBlockNum());
    for (int i = 0; i < getSrcNodes().length; i++) {
      if (getSrcNodes()[i].isInService()) {
        bitSet.set(liveBlockIndices[i]);
      }
    }
    // If the block is on the node which is decommissioning or
    // entering_maintenance, and it doesn't exist on other normal nodes,
    // we just add the node into source list.
    List<Integer> srcIndices = new ArrayList<>();
    for (int i = 0; i < getSrcNodes().length; i++) {
      if ((getSrcNodes()[i].isDecommissionInProgress() ||
          (getSrcNodes()[i].isEnteringMaintenance() &&
          getSrcNodes()[i].isAlive())) &&
          !bitSet.get(liveBlockIndices[i])) {
        srcIndices.add(i);
      }
    }
    return srcIndices;
  }
```
so we need to fix this logic to avoid inaccurate metrics.


