### PR TITLE
HADOOP-19215.  Fix unit tests testSlowConnection and testBadSetup failed in TestRPC

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -1038,7 +1038,7 @@ public class TestRPC extends TestRpcBase {
     // disable ping & timeout to minimize traffic
     clientConf.setBoolean(CommonConfigurationKeys.IPC_CLIENT_PING_KEY, false);
     clientConf.setInt(CommonConfigurationKeys.IPC_CLIENT_RPC_TIMEOUT_KEY, 0);
-    RPC.setProtocolEngine(clientConf, TestRpcService.class, ProtobufRpcEngine.class);
+    RPC.setProtocolEngine(clientConf, TestRpcService.class, ProtobufRpcEngine2.class);
     // set async mode so that we don't need to implement the input stream
     final boolean wasAsync = Client.isAsynchronousMode();
     TestRpcService client = null;
@@ -1165,7 +1165,7 @@ public class TestRPC extends TestRpcBase {
     clientConf.set(CommonConfigurationKeys.IPC_MAXIMUM_RESPONSE_LENGTH,
         "xxx");
     RPC.setProtocolEngine(clientConf, TestRpcService.class,
-        ProtobufRpcEngine.class);
+        ProtobufRpcEngine2.class);
     TestRpcService client = null;
     int threadCount = Thread.getAllStackTraces().size();
     try {


### PR DESCRIPTION
### Description of PR
Fix unit tests testSlowConnection and testBadSetup failed in TestRPC.
When we invoke testSlowConnection or testBadSetup individually.  we will get below exception result:

```plain
java.lang.ClassCastException: org.apache.hadoop.ipc.protobuf.TestProtos$EmptyRequestProto cannot be cast to com.google.protobuf.Message

	at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:247)
	at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:132)
	at com.sun.proxy.$Proxy21.ping(Unknown Source)
	at org.apache.hadoop.ipc.TestRPC.testSlowConnection(TestRPC.java:1055)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:750)
```

### How to re-produce ?
We run testSlowConnection or testBadSetup individually. 

![image](https://github.com/apache/hadoop/assets/25115709/de5fd61a-f35d-4cfb-9278-c8c2771d6c43)
