### PR TITLE
HADOOP-19218 Avoid DNS lookup while creating IPC Connection object

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -2034,11 +2034,7 @@ public abstract class Server {
      * Address to which the socket is connected to.
      */
     private final InetAddress addr;
-    /**
-     * Client Host address from where the socket connection is being established to the Server.
-     */
-    private final String hostName;
-    
+
     IpcConnectionContextProto connectionContext;
     String protocolName;
     SaslServer saslServer;
@@ -2081,12 +2077,9 @@ public abstract class Server {
       this.isOnAuxiliaryPort = isOnAuxiliaryPort;
       if (addr == null) {
         this.hostAddress = "*Unknown*";
-        this.hostName = this.hostAddress;
       } else {
         // host IP address
         this.hostAddress = addr.getHostAddress();
-        // host name for the IP address
-        this.hostName = addr.getHostName();
       }
       this.remotePort = socket.getPort();
       this.responseQueue = new LinkedList<RpcCall>();
@@ -2102,7 +2095,7 @@ public abstract class Server {
 
     @Override
     public String toString() {
-      return hostName + ":" + remotePort + " / " + hostAddress + ":" + remotePort;
+      return hostAddress + ":" + remotePort;
     }
 
     boolean setShouldClose() {
@@ -2516,6 +2509,7 @@ public abstract class Server {
           }
 
           if (!RpcConstants.HEADER.equals(dataLengthBuffer)) {
+            final String hostName = addr == null ? this.hostAddress : addr.getHostName();
             LOG.warn("Incorrect RPC Header length from {}:{} / {}:{}. Expected: {}. Actual: {}",
                 hostName, remotePort, hostAddress, remotePort, RpcConstants.HEADER,
                 dataLengthBuffer);
@@ -2523,6 +2517,7 @@ public abstract class Server {
             return -1;
           }
           if (version != CURRENT_VERSION) {
+            final String hostName = addr == null ? this.hostAddress : addr.getHostName();
             //Warning is ok since this is not supposed to happen.
             LOG.warn("Version mismatch from {}:{} / {}:{}. "
                     + "Expected version: {}. Actual version: {} ", hostName,

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
@@ -1177,7 +1177,7 @@ public class TestIPC {
     Connection connection = server.getConnections()[0];
     LOG.info("Connection is from: {}", connection);
     assertEquals(
-        "Connection string representation should include both IP address and Host name", 2,
+        "Connection string representation should include only IP address for healthy connection", 1,
         connection.toString().split(" / ").length);
     int serviceClass2 = connection.getServiceClass();
     assertFalse(noChanged ^ serviceClass == serviceClass2);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -1941,8 +1941,8 @@ public class TestRPC extends TestRpcBase {
           String connectionInfo = conns[0].toString();
           LOG.info("Connection is from: {}", connectionInfo);
           assertEquals(
-              "Connection string representation should include only IP address for healthy connection",
-              1, connectionInfo.split(" / ").length);
+              "Connection string representation should include only IP address for healthy "
+                  + "connection", 1, connectionInfo.split(" / ").length);
           // verify whether the connection should have been reused.
           if (isDisconnected) {
             assertNotSame(reqName, lastConn, conns[0]);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -1941,8 +1941,8 @@ public class TestRPC extends TestRpcBase {
           String connectionInfo = conns[0].toString();
           LOG.info("Connection is from: {}", connectionInfo);
           assertEquals(
-              "Connection string representation should include both IP address and Host name", 2,
-              connectionInfo.split(" / ").length);
+              "Connection string representation should include only IP address for healthy connection",
+              1, connectionInfo.split(" / ").length);
           // verify whether the connection should have been reused.
           if (isDisconnected) {
             assertNotSame(reqName, lastConn, conns[0]);


### PR DESCRIPTION
### Description of PR
Jira: HADOOP-19218

### How was this patch tested?
Manual testing + UT

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
