### PR TITLE
fix variable name incorrect

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/main/java/org/apache/hadoop/yarn/applications/distributedshell/ApplicationMaster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/main/java/org/apache/hadoop/yarn/applications/distributedshell/ApplicationMaster.java
@@ -323,7 +323,7 @@ public class ApplicationMaster {
       ContainerRetryPolicy.NEVER_RETRY;
   private Set<Integer> containerRetryErrorCodes = null;
   private int containerMaxRetries = 0;
-  private int containrRetryInterval = 0;
+  private int containerRetryInterval = 0;
   private long containerFailuresValidityInterval = -1;
 
   private List<String> localizableFiles = new ArrayList<>();
@@ -722,7 +722,7 @@ public class ApplicationMaster {
     }
     containerMaxRetries = Integer.parseInt(
         cliParser.getOptionValue("container_max_retries", "0"));
-    containrRetryInterval = Integer.parseInt(cliParser.getOptionValue(
+    containerRetryInterval = Integer.parseInt(cliParser.getOptionValue(
         "container_retry_interval", "0"));
     containerFailuresValidityInterval = Long.parseLong(
         cliParser.getOptionValue("container_failures_validity_interval", "-1"));
@@ -1555,7 +1555,7 @@ public class ApplicationMaster {
       ContainerRetryContext containerRetryContext =
           ContainerRetryContext.newInstance(
               containerRetryPolicy, containerRetryErrorCodes,
-              containerMaxRetries, containrRetryInterval,
+              containerMaxRetries, containerRetryInterval,
               containerFailuresValidityInterval);
       ContainerLaunchContext ctx = ContainerLaunchContext.newInstance(
         localResources, myShellEnv, commands, null, allTokens.duplicate(),


### PR DESCRIPTION
### Description of PR

 containrRetryInterval should be containerRetryInterval

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

