### PR TITLE
HDFS-17567. Return value of method RouterRpcClient#invokeSequential is not accurate.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -1116,6 +1116,7 @@ public class RouterRpcClient {
     final Method m = remoteMethod.getMethod();
     List<IOException> thrownExceptions = new ArrayList<>();
     Object firstResult = null;
+    Object firstLocation = null;
     // Invoke in priority order
     for (final RemoteLocationContext loc : locations) {
       String ns = loc.getNameserviceId();
@@ -1138,6 +1139,7 @@ public class RouterRpcClient {
         }
         if (firstResult == null) {
           firstResult = result;
+          firstLocation = loc;
         }
       } catch (IOException ioe) {
         // Localize the exception
@@ -1175,6 +1177,7 @@ public class RouterRpcClient {
     }
     // Return the first result, whether it is the value or not
     @SuppressWarnings("unchecked") T ret = (T) firstResult;
+    @SuppressWarnings("unchecked") R loc = (R) firstLocation;
     return new RemoteResult<>(locations.get(0), ret);
   }
 


### PR DESCRIPTION
### Description of PR
Below code is the return value in method RouterRpcClient#invokeSequential.

```java
// Return the first result, whether it is the value or not
@SuppressWarnings("unchecked") T ret = (T) firstResult;
return new RemoteResult<>(locations.get(0), ret); 
 ```

`locations.get(0)` is not accurate, because it may not be the remote location where ret was returned.