### PR TITLE
HDFS-16690. Automatically format unformatted JNs with JournalNodeSyncer

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1471,6 +1471,9 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final String DFS_JOURNALNODE_SYNC_INTERVAL_KEY =
       "dfs.journalnode.sync.interval";
   public static final long DFS_JOURNALNODE_SYNC_INTERVAL_DEFAULT = 2*60*1000L;
+  public static final String DFS_JOURNALNODE_ENABLE_SYNC_FORMAT_KEY =
+      "dfs.journalnode.enable.sync.format";
+  public static final boolean DFS_JOURNALNODE_ENABLE_SYNC_FORMAT_DEFAULT = false;
   public static final String DFS_JOURNALNODE_EDIT_CACHE_SIZE_KEY =
       "dfs.journalnode.edit-cache-size.bytes";
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/protocol/InterQJournalProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/protocol/InterQJournalProtocol.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdfs.qjournal.protocol;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.protocol.proto.HdfsServerProtos.StorageInfoProto;
 import org.apache.hadoop.hdfs.qjournal.server.JournalNode;
 import org.apache.hadoop.hdfs.qjournal.protocol.QJournalProtocolProtos.GetEditLogManifestResponseProto;
 import org.apache.hadoop.security.KerberosInfo;
@@ -49,6 +50,15 @@ public interface InterQJournalProtocol {
    */
   GetEditLogManifestResponseProto getEditLogManifestFromJournal(
       String jid, String nameServiceId, long sinceTxId, boolean inProgressOk)
+      throws IOException;
+
+  /**
+   * Get the storage info for the specified journal.
+   * @param jid the journal identifier
+   * @param nameServiceId the name service id
+   * @return the storage info object
+   */
+  StorageInfoProto getStorageInfo(String jid, String nameServiceId)
       throws IOException;
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/protocolPB/InterQJournalProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/protocolPB/InterQJournalProtocolServerSideTranslatorPB.java
@@ -24,6 +24,8 @@ import org.apache.hadoop.thirdparty.protobuf.ServiceException;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.hdfs.qjournal.protocol.InterQJournalProtocol;
+import org.apache.hadoop.hdfs.protocol.proto.HdfsServerProtos.StorageInfoProto;
+import org.apache.hadoop.hdfs.qjournal.protocol.InterQJournalProtocolProtos.GetStorageInfoRequestProto;
 import org.apache.hadoop.hdfs.qjournal.protocol.QJournalProtocolProtos.GetEditLogManifestRequestProto;
 import org.apache.hadoop.hdfs.qjournal.protocol.QJournalProtocolProtos.GetEditLogManifestResponseProto;
 
@@ -56,6 +58,20 @@ public class InterQJournalProtocolServerSideTranslatorPB implements
           request.hasNameServiceId() ? request.getNameServiceId() : null,
           request.getSinceTxId(),
           request.getInProgressOk());
+    } catch (IOException e) {
+      throw new ServiceException(e);
+    }
+  }
+
+  @Override
+  public StorageInfoProto getStorageInfo(
+      RpcController controller, GetStorageInfoRequestProto request)
+      throws ServiceException {
+    try {
+      return impl.getStorageInfo(
+          request.getJid().getIdentifier(),
+          request.hasNameServiceId() ? request.getNameServiceId() : null
+      );
     } catch (IOException e) {
       throw new ServiceException(e);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/protocolPB/InterQJournalProtocolTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/protocolPB/InterQJournalProtocolTranslatorPB.java
@@ -19,6 +19,8 @@
 
 package org.apache.hadoop.hdfs.qjournal.protocolPB;
 
+import org.apache.hadoop.hdfs.protocol.proto.HdfsServerProtos.StorageInfoProto;
+import org.apache.hadoop.hdfs.qjournal.protocol.InterQJournalProtocolProtos;
 import org.apache.hadoop.thirdparty.protobuf.RpcController;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -73,6 +75,18 @@ public class InterQJournalProtocolTranslatorPB implements ProtocolMetaInterface,
     }
     return ipc(() -> rpcProxy.getEditLogManifestFromJournal(NULL_CONTROLLER,
         req.build()));
+  }
+
+  @Override
+  public StorageInfoProto getStorageInfo(String jid, String nameServiceId)
+      throws IOException {
+    InterQJournalProtocolProtos.GetStorageInfoRequestProto.Builder req =
+        InterQJournalProtocolProtos.GetStorageInfoRequestProto.newBuilder()
+            .setJid(convertJournalId(jid));
+    if (nameServiceId != null) {
+      req.setNameServiceId(nameServiceId);
+    }
+    return ipc(() -> rpcProxy.getStorageInfo(NULL_CONTROLLER, req.build()));
   }
 
   private QJournalProtocolProtos.JournalIdProto convertJournalId(String jid) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeRpcServer.java
@@ -260,7 +260,7 @@ public class JournalNodeRpcServer implements QJournalProtocol,
   @Override
   public StorageInfoProto getStorageInfo(String jid,
       String nameServiceId) throws IOException {
-    StorageInfo storage = jn.getOrCreateJournal(jid).getStorage();
+    StorageInfo storage = jn.getOrCreateJournal(jid, nameServiceId).getStorage();
     return PBHelper.convert(storage);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeRpcServer.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs.qjournal.server;
 
 import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.hdfs.protocol.proto.HdfsServerProtos.StorageInfoProto;
 import org.apache.hadoop.thirdparty.protobuf.BlockingService;
 import org.slf4j.Logger;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -71,14 +72,14 @@ public class JournalNodeRpcServer implements QJournalProtocol,
 
   JournalNodeRpcServer(Configuration conf, JournalNode jn) throws IOException {
     this.jn = jn;
-    
+
     Configuration confCopy = new Configuration(conf);
-    
+
     // Ensure that nagling doesn't kick in, which could cause latency issues.
     confCopy.setBoolean(
         CommonConfigurationKeysPublic.IPC_SERVER_TCPNODELAY_KEY,
         true);
-    
+
     InetSocketAddress addr = getAddress(confCopy);
     String bindHost = conf.getTrimmed(DFS_JOURNALNODE_RPC_BIND_HOST_KEY, null);
     if (bindHost == null) {
@@ -104,7 +105,7 @@ public class JournalNodeRpcServer implements QJournalProtocol,
     this.handlerCount = confHandlerCount;
     LOG.info("The number of JournalNodeRpcServer handlers is {}.",
         this.handlerCount);
-    
+
     this.server = new RPC.Builder(confCopy)
         .setProtocol(QJournalProtocolPB.class)
         .setInstance(service)
@@ -149,15 +150,15 @@ public class JournalNodeRpcServer implements QJournalProtocol,
   public InetSocketAddress getAddress() {
     return server.getListenerAddress();
   }
-  
+
   void join() throws InterruptedException {
     this.server.join();
   }
-  
+
   void stop() {
     this.server.stop();
   }
-  
+
   static InetSocketAddress getAddress(Configuration conf) {
     String addr = conf.get(
         DFSConfigKeys.DFS_JOURNALNODE_RPC_ADDRESS_KEY,
@@ -211,7 +212,7 @@ public class JournalNodeRpcServer implements QJournalProtocol,
     jn.getOrCreateJournal(reqInfo.getJournalId(), reqInfo.getNameServiceId())
        .journal(reqInfo, segmentTxId, firstTxnId, numTxns, records);
   }
-  
+
   @Override
   public void heartbeat(RequestInfo reqInfo) throws IOException {
     jn.getOrCreateJournal(reqInfo.getJournalId(), reqInfo.getNameServiceId())
@@ -245,15 +246,22 @@ public class JournalNodeRpcServer implements QJournalProtocol,
       String jid, String nameServiceId,
       long sinceTxId, boolean inProgressOk)
       throws IOException {
-    
+
     RemoteEditLogManifest manifest = jn.getOrCreateJournal(jid, nameServiceId)
         .getEditLogManifest(sinceTxId, inProgressOk);
-    
+
     return GetEditLogManifestResponseProto.newBuilder()
         .setManifest(PBHelper.convert(manifest))
         .setHttpPort(jn.getBoundHttpAddress().getPort())
         .setFromURL(jn.getHttpServerURI())
         .build();
+  }
+
+  @Override
+  public StorageInfoProto getStorageInfo(String jid,
+      String nameServiceId) throws IOException {
+    StorageInfo storage = jn.getOrCreateJournal(jid).getStorage();
+    return PBHelper.convert(storage);
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeSyncer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeSyncer.java
@@ -251,6 +251,7 @@ public class JournalNodeSyncer {
           storage = PBHelper.convert(storageInfoResponse, HdfsServerConstants.NodeType.JOURNAL_NODE);
           if (storage.getNamespaceID() == 0) {
             LOG.error("Got invalid StorageInfo from " + jnProxy);
+            storage = null;
             continue;
           }
           LOG.info("Got StorageInfo " + storage + " from " + jnProxy);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeSyncer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeSyncer.java
@@ -267,7 +267,7 @@ public class JournalNodeSyncer {
         }
         try {
           HdfsServerProtos.StorageInfoProto storageInfoResponse =
-              jnProxy.jnProxy.getStorageInfo(jid, null);
+              jnProxy.jnProxy.getStorageInfo(jid, nameServiceId);
           storage = PBHelper.convert(
               storageInfoResponse, HdfsServerConstants.NodeType.JOURNAL_NODE
           );

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeSyncer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeSyncer.java
@@ -175,13 +175,11 @@ public class JournalNodeSyncer {
 
   private void startSyncJournalsDaemon() {
     syncJournalDaemon = new Daemon(() -> {
-      // Format the journal with namespace info from the other JNs if it is not formatted
-      if (!journal.isFormatted()) {
-        formatWithSyncer();
-      }
       // Wait for journal to be formatted to create edits.sync directory
       while(!journal.isFormatted()) {
         try {
+          // Format the journal with namespace info from the other JNs if it is not formatted
+          formatWithSyncer();
           Thread.sleep(journalSyncInterval);
         } catch (InterruptedException e) {
           LOG.error("JournalNodeSyncer daemon received Runtime exception.", e);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/InterQJournalProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/InterQJournalProtocol.proto
@@ -31,8 +31,15 @@ package hadoop.hdfs.qjournal;
 import "HdfsServer.proto";
 import "QJournalProtocol.proto";
 
+message GetStorageInfoRequestProto {
+    required JournalIdProto jid = 1;
+    optional string nameServiceId = 2;
+}
 
 service InterQJournalProtocolService {
     rpc getEditLogManifestFromJournal(GetEditLogManifestRequestProto)
     returns (GetEditLogManifestResponseProto);
+
+    rpc getStorageInfo(GetStorageInfoRequestProto)
+    returns (StorageInfoProto);
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -5063,6 +5063,16 @@
 </property>
 
 <property>
+  <name>dfs.journalnode.enable.sync.format</name>
+  <value>false</value>
+  <description>
+    If true, the journal node syncer daemon that tries to sync edit
+    logs between journal nodes will try to format its journal if it is not.
+    It will query the other journal nodes for the storage info required to format.
+  </description>
+</property>
+
+<property>
   <name>dfs.journalnode.edit-cache-size.bytes</name>
   <value></value>
   <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
@@ -480,7 +480,7 @@ public class TestJournalNodeSync {
     }
   }
 
-  @Test(timeout=300_000)
+  @Test(timeout=900_000)
   public void testFormatWithSyncer() throws Exception {
     File firstJournalDir = jCluster.getJournalDir(0, jid);
     File firstJournalCurrentDir = new StorageDirectory(firstJournalDir)
@@ -499,11 +499,11 @@ public class TestJournalNodeSync {
     jCluster.getJournalNode(0).getOrCreateJournal(jid).getStorage().analyzeStorage();
 
     // Wait for JN formatting with Syncer
-    GenericTestUtils.waitFor(jnFormatted(0), 500, 30000);
+    GenericTestUtils.waitFor(jnFormatted(0), 500, 90000);
     // Generate some more edit log so that the JN updates its committed tx id
     generateEditLog();
     // Check that the missing edit logs have been synced
-    GenericTestUtils.waitFor(editLogExists(missingLogs), 500, 30000);
+    GenericTestUtils.waitFor(editLogExists(missingLogs), 500, 90000);
   }
 
   private File deleteEditLog(File currentDir, long startTxId)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
@@ -480,7 +480,7 @@ public class TestJournalNodeSync {
     }
   }
 
-  @Test(timeout=900_000)
+  @Test(timeout=300_000)
   public void testFormatWithSyncer() throws Exception {
     File firstJournalDir = jCluster.getJournalDir(0, jid);
     File firstJournalCurrentDir = new StorageDirectory(firstJournalDir)
@@ -493,17 +493,18 @@ public class TestJournalNodeSync {
     List<File> missingLogs = Lists.newArrayList();
     missingLogs.add(deleteEditLog(firstJournalCurrentDir, firstTxId));
 
-    // Delete the storage directory itself to simulate a disk wipe
+    // Wait to ensure sync starts, delete the storage directory itself to simulate a disk wipe
     // and ensure that the in-memory formatting state of JNStorage gets updated
+    Thread.sleep(2000);
     FileUtils.deleteDirectory(firstJournalDir);
     jCluster.getJournalNode(0).getOrCreateJournal(jid).getStorage().analyzeStorage();
 
     // Wait for JN formatting with Syncer
-    GenericTestUtils.waitFor(jnFormatted(0), 500, 90000);
+    GenericTestUtils.waitFor(jnFormatted(0), 500, 30000);
     // Generate some more edit log so that the JN updates its committed tx id
     generateEditLog();
     // Check that the missing edit logs have been synced
-    GenericTestUtils.waitFor(editLogExists(missingLogs), 500, 90000);
+    GenericTestUtils.waitFor(editLogExists(missingLogs), 500, 30000);
   }
 
   private File deleteEditLog(File currentDir, long startTxId)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdfs.qjournal.server;
 import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
 import java.util.function.Supplier;
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
@@ -82,6 +83,9 @@ public class TestJournalNodeSync {
     if (testName.getMethodName().equals("testSyncDuringRollingUpgrade")) {
       conf.setInt(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY,
           DFS_HA_TAILEDITS_PERIOD_SECONDS);
+    }
+    if (testName.getMethodName().equals("testFormatWithSyncer")) {
+      conf.setBoolean(DFSConfigKeys.DFS_JOURNALNODE_ENABLE_SYNC_FORMAT_KEY, true);
     }
     qjmhaCluster = new MiniQJMHACluster.Builder(conf).setNumNameNodes(2)
       .build();
@@ -478,6 +482,32 @@ public class TestJournalNodeSync {
     }
   }
 
+  @Test(timeout=300_000)
+  public void testFormatWithSyncer() throws Exception {
+    File firstJournalDir = jCluster.getJournalDir(0, jid);
+    File firstJournalCurrentDir = new StorageDirectory(firstJournalDir)
+        .getCurrentDir();
+
+    // Generate some edit logs
+    long firstTxId = generateEditLog();
+
+    // Delete them from the JN01
+    List<File> missingLogs = Lists.newArrayList();
+    missingLogs.add(deleteEditLog(firstJournalCurrentDir, firstTxId));
+
+    // Delete the storage directory itself to simulate a disk wipe
+    // and ensure that the in-memory formatting state of JNStorage gets updated
+    FileUtils.deleteDirectory(firstJournalDir);
+    jCluster.getJournalNode(0).getOrCreateJournal(jid).getStorage().analyzeStorage();
+
+    // Wait for JN formatting with Syncer
+    GenericTestUtils.waitFor(jnFormatted(0), 500, 30000);
+    // Generate some more edit log so that the JN updates its committed tx id
+    generateEditLog();
+    // Check that the missing edit logs have been synced
+    GenericTestUtils.waitFor(editLogExists(missingLogs), 500, 30000);
+  }
+
   private File deleteEditLog(File currentDir, long startTxId)
       throws IOException {
     EditLogFile logFile = getLogFile(currentDir, startTxId);
@@ -577,6 +607,21 @@ public class TestJournalNodeSync {
           }
         }
         return true;
+      }
+    };
+    return supplier;
+  }
+
+  private Supplier<Boolean> jnFormatted(int jnIndex) throws Exception {
+    Supplier<Boolean> supplier = new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        try {
+          return jCluster.getJournalNode(jnIndex).getOrCreateJournal(jid)
+              .isFormatted();
+        } catch (Exception e) {
+          return false;
+        }
       }
     };
     return supplier;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
@@ -76,6 +76,7 @@ public class TestJournalNodeSync {
     conf = new HdfsConfiguration();
     conf.setBoolean(DFSConfigKeys.DFS_JOURNALNODE_ENABLE_SYNC_KEY, true);
     conf.setLong(DFSConfigKeys.DFS_JOURNALNODE_SYNC_INTERVAL_KEY, 1000L);
+    conf.setBoolean(DFSConfigKeys.DFS_JOURNALNODE_ENABLE_SYNC_FORMAT_KEY, true);
     if (testName.getMethodName().equals(
         "testSyncAfterJNdowntimeWithoutQJournalQueue")) {
       conf.setInt(DFSConfigKeys.DFS_QJOURNAL_QUEUE_SIZE_LIMIT_KEY, 0);
@@ -83,9 +84,6 @@ public class TestJournalNodeSync {
     if (testName.getMethodName().equals("testSyncDuringRollingUpgrade")) {
       conf.setInt(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY,
           DFS_HA_TAILEDITS_PERIOD_SECONDS);
-    }
-    if (testName.getMethodName().equals("testFormatWithSyncer")) {
-      conf.setBoolean(DFSConfigKeys.DFS_JOURNALNODE_ENABLE_SYNC_FORMAT_KEY, true);
     }
     qjmhaCluster = new MiniQJMHACluster.Builder(conf).setNumNameNodes(2)
       .build();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
If an unformatted JournalNode is added to an existing JournalNode set --
1. JournalNodeSyncer is unable to sync from the other JNs to this new JN
2. Namenode is unable to flush edit logs to the the new JN

This scenario can arise in different situations like 
- OS upgrade maintenance of the JN host (with a data disk wipe) 
- Moving the JN application to a new host due to h/w issues
- Installing additional JNs (3 -> 5) for better HA during maintenance operations

Manually fixing this involves rsyncing the VERSION file to the edit log root directory from the other healthy JNs. A similar issue concerning the paxos directory was solved in [HDFS-10659](https://issues.apache.org/jira/browse/HDFS-10659). 

This PR tries to leverage the already existing JournalNodeSyncer daemon to format the JournalNode on which it is running when it discovers that syncs can't happen due to the `JournalNotFormattedException`. JournalNodeSyncer calls the `formatWithSyncer` method if it sees that the JN is unformatted. `formatWithSyncer` will loop over the other JN proxies, trying to fetch the `StorageInfo` object from them. The StorageInfo object is then used to format the JN by calling `JNStorage.format()`. 

### How was this patch tested?
Unit tests have been added for the change:
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.hdfs.qjournal.server.TestJournalNodeSync
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 82.394 s - in org.apache.hadoop.hdfs.qjournal.server.TestJournalNodeSync
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
```
Build is also successful:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  47:38 min
[INFO] Finished at: 2024-07-04T16:05:40+05:30
[INFO] ------------------------------------------------------------------------
```

**I've tested the changes manually in a K8S cluster with 3 JNs:**

JN root dir before testing:
```
[root@asprabhu-hadoop-hdfs-jn-0 current]# ls
VERSION         edits_0000000000000000001-0000000000000000042  last-promised-epoch  paxos
committed-txid  edits_inprogress_0000000000000000043           last-writer-epoch
[root@asprabhu-hadoop-hdfs-jn-0 current]# pwd 
/grid/edits/journal/data/asprabhu-hadoop/current
```
Logs show that JN can receive edit logs: `2024-07-04 08:50:55,242 INFO org.apache.hadoop.hdfs.server.namenode.FileJournalManager: Finalizing edits file /grid/edits/journal/d
ata/asprabhu-hadoop/current/edits_inprogress_0000000000000000001 -> /grid/edits/journal/data/asprabhu-hadoop/current/edits_00000000
00000000001-0000000000000000042` 

Killed the JN process and deleted the edit logs root dir:
```
[root@asprabhu-hadoop-hdfs-jn-0 data]# kill -9 67
[root@asprabhu-hadoop-hdfs-jn-0 data]# rm -rf *
[root@asprabhu-hadoop-hdfs-jn-0 data]# ls
[root@asprabhu-hadoop-hdfs-jn-0 data]# pwd
/grid/edits/journal/data
```

Started the JN process. The syncer formatted the JN. Some relevant log lines:
```
2024-07-04 09:15:44,437 INFO org.apache.hadoop.hdfs.qjournal.server.JournalNodeSyncer: Starting SyncJournal daemon for journal aspr
abhu-hadoop
2024-07-04 09:15:44,527 INFO org.apache.hadoop.hdfs.qjournal.server.JournalNodeSyncer: Trying to format the journal with the syncer
2024-07-04 09:15:44,639 ERROR org.apache.hadoop.hdfs.qjournal.server.JournalNodeSyncer: Got invalid StorageInfo from asprabhu-hadoop-hdfs-jn-0.asprabhu-hadoop-hdfs-jn-svc.grid-integration-testing.svc.kube.grid.linkedin.com/100.104.107.156:8485
2024-07-04 09:15:44,723 INFO org.apache.hadoop.hdfs.qjournal.server.JournalNodeSyncer: Got StorageInfo lv=-63;cid=CID-613cdcfb-9a6e-4b3b-a3f6-a33ddc7a6ca5;nsid=613335273;c=1720082854169 from asprabhu-hadoop-hdfs-jn-1.asprabhu-hadoop-hdfs-jn-svc.grid-integration-testing.svc.kube.grid.linkedin.com/100.98.128.215:8485
2024-07-04 09:15:44,725 INFO org.apache.hadoop.hdfs.qjournal.server.Journal: Formatting journal id : asprabhu-hadoop with namespace
 info: lv=-63;cid=CID-613cdcfb-9a6e-4b3b-a3f6-a33ddc7a6ca5;nsid=613335273;c=1720082854169;bpid=null
2024-07-04 09:15:44,726 INFO org.apache.hadoop.hdfs.server.common.Storage: /grid/edits/journal/data/asprabhu-hadoop does not exist.
 Creating ...
        at org.apache.hadoop.ipc.Server$Listener$Reader.run(Server.java:1241)
2024-07-04 09:15:44,727 INFO org.apache.hadoop.hdfs.server.common.Storage: Lock on /grid/edits/journal/data/asprabhu-hadoop/in_use.
lock acquired by nodename 920@asprabhu-hadoop-hdfs-jn-0.asprabhu-hadoop-hdfs-jn-svc.grid-integration-testing.svc.kube.grid.linkedin
.com
2024-07-04 09:15:44,728 INFO org.apache.hadoop.hdfs.server.common.Storage: Formatting journal Storage Directory /grid/edits/journal
/data/asprabhu-hadoop with nsid: 613335273
2024-07-04 09:15:44,735 INFO org.apache.hadoop.hdfs.server.common.Storage: Creating paxos dir: /grid/edits/journal/data/asprabhu-ha
doop/current/paxos
2024-07-04 09:15:44,735 INFO org.apache.hadoop.hdfs.server.common.Storage: Lock on /grid/edits/journal/data/asprabhu-hadoop/in_use.
lock acquired by nodename 920@asprabhu-hadoop-hdfs-jn-0.asprabhu-hadoop-hdfs-jn-svc.grid-integration-testing.svc.kube.grid.linkedin
.com
2024-07-04 09:15:44,735 INFO org.apache.hadoop.hdfs.qjournal.server.Journal: Enabling the journaled edits cache with a capacity of 
bytes: 1048576
```

Syncer was also able to fill the holes from other JNs:
```
2024-07-04 09:23:44,844 INFO org.apache.hadoop.hdfs.qjournal.server.JournalNodeSyncer: Syncing Journal /0.0.0.0:8485 with asprabhu-
hadoop-hdfs-jn-2.asprabhu-hadoop-hdfs-jn-svc.grid-integration-testing.svc.kube.grid.linkedin.com/100.98.113.190:8485, journal id: a
sprabhu-hadoop
2024-07-04 09:23:44,867 INFO org.apache.hadoop.hdfs.qjournal.server.JournalNodeSyncer: Downloading missing Edit Log from http://asp/
rabhu-hadoop-hdfs-jn-2.asprabhu-hadoop-hdfs-jn-svc.grid-integration-testing.svc.kube.grid.linkedin.com:8480/getJournal?jid=asprabhu
-hadoop&segmentTxId=1&storageInfo=-63%3A613335273%3A1720082854169%3ACID-613cdcfb-9a6e-4b3b-a3f6-a33ddc7a6ca5&inProgressOk=false to 
/grid/edits/journal/data/asprabhu-hadoop
2024-07-04 09:23:44,929 INFO org.apache.hadoop.hdfs.server.common.Util: Combined time for file download and fsync to all disks took
 0.00s. The file download took 0.00s at 2000.00 KB/s. Synchronous (fsync) write to disk of /grid/edits/journal/data/asprabhu-hadoop
/edits.sync/edits_0000000000000000001-0000000000000000042 took 0.00s.
2024-07-04 09:23:44,929 INFO org.apache.hadoop.hdfs.qjournal.server.JournalNodeSyncer: Downloaded file edits_0000000000000000001-00
00000000000000042 of size 2487 bytes
```

JN root dir after the testing:
```
[root@asprabhu-hadoop-hdfs-jn-0 current]# ls
VERSION                                        edits_0000000000000000057-0000000000000000058
committed-txid                                 edits_0000000000000000059-0000000000000000060
edits_0000000000000000001-0000000000000000042  edits_0000000000000000061-0000000000000000062
edits_0000000000000000043-0000000000000000046  edits_0000000000000000063-0000000000000000064
edits_0000000000000000047-0000000000000000048  edits_0000000000000000065-0000000000000000066
edits_0000000000000000049-0000000000000000050  edits_inprogress_0000000000000000067
edits_0000000000000000051-0000000000000000052  last-promised-epoch
edits_0000000000000000053-0000000000000000054  last-writer-epoch
edits_0000000000000000055-0000000000000000056  paxos
[root@asprabhu-hadoop-hdfs-jn-0 current]# pwd
/grid/edits/journal/data/asprabhu-hadoop/current
```



### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

