### PR TITLE
HDFS-17565. EC: dfs.datanode.ec.reconstruction.threads should support…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -1090,7 +1090,7 @@ public class DataNode extends ReconfigurableBase
     try {
       int size = (newVal == null ? DFS_DN_EC_RECONSTRUCTION_THREADS_DEFAULT :
           Integer.parseInt(newVal));
-      result = Long.toString(size);
+      result = Integer.toString(size);
       ecWorker.setStripedReconstructionPoolSize(size);
       return result;
     } catch (IllegalArgumentException e) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -89,6 +89,8 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DISK_BALANCER_ENABLED;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DISK_BALANCER_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DISK_BALANCER_PLAN_VALID_INTERVAL;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DISK_BALANCER_PLAN_VALID_INTERVAL_DEFAULT;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DN_EC_RECONSTRUCTION_THREADS_DEFAULT;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DN_EC_RECONSTRUCTION_THREADS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_MAX_NUM_BLOCKS_TO_LOG_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_MAX_NUM_BLOCKS_TO_LOG_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_METRICS_LOGGER_PERIOD_SECONDS_DEFAULT;
@@ -374,7 +376,8 @@ public class DataNode extends ReconfigurableBase
               DFS_DATANODE_DATA_TRANSFER_BANDWIDTHPERSEC_KEY,
               DFS_DATANODE_DATA_WRITE_BANDWIDTHPERSEC_KEY,
               DFS_DATANODE_DATA_READ_BANDWIDTHPERSEC_KEY,
-              DFS_DATANODE_SLOW_IO_WARNING_THRESHOLD_KEY));
+              DFS_DATANODE_SLOW_IO_WARNING_THRESHOLD_KEY,
+              DFS_DN_EC_RECONSTRUCTION_THREADS_KEY));
 
   public static final String METRICS_LOG_NAME = "DataNodeMetricsLog";
 
@@ -740,6 +743,8 @@ public class DataNode extends ReconfigurableBase
       return reconfDiskBalancerParameters(property, newVal);
     case DFS_DATANODE_SLOW_IO_WARNING_THRESHOLD_KEY:
       return reconfSlowIoWarningThresholdParameters(property, newVal);
+    case DFS_DN_EC_RECONSTRUCTION_THREADS_KEY:
+      return reconfStripedReconstructionParameters(property, newVal);
     default:
       break;
     }
@@ -1073,6 +1078,22 @@ public class DataNode extends ReconfigurableBase
       result = Long.toString(slowIoWarningThreshold);
       dnConf.setDatanodeSlowIoWarningThresholdMs(slowIoWarningThreshold);
       LOG.info("RECONFIGURE* changed {} to {}", property, newVal);
+      return result;
+    } catch (IllegalArgumentException e) {
+      throw new ReconfigurationException(property, newVal, getConf().get(property), e);
+    }
+  }
+
+  private String reconfStripedReconstructionParameters(String property, String newVal)
+      throws ReconfigurationException {
+    String result = null;
+    try {
+      if (property.equals(DFS_DN_EC_RECONSTRUCTION_THREADS_KEY)) {
+        int size = (newVal == null ? DFS_DN_EC_RECONSTRUCTION_THREADS_DEFAULT :
+            Integer.parseInt(newVal));
+        result = Long.toString(size);
+        ecWorker.setStripedReconstructionPoolSize(size);
+      }
       return result;
     } catch (IllegalArgumentException e) {
       throw new ReconfigurationException(property, newVal, getConf().get(property), e);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -1088,12 +1088,10 @@ public class DataNode extends ReconfigurableBase
       throws ReconfigurationException {
     String result = null;
     try {
-      if (property.equals(DFS_DN_EC_RECONSTRUCTION_THREADS_KEY)) {
-        int size = (newVal == null ? DFS_DN_EC_RECONSTRUCTION_THREADS_DEFAULT :
-            Integer.parseInt(newVal));
-        result = Long.toString(size);
-        ecWorker.setStripedReconstructionPoolSize(size);
-      }
+      int size = (newVal == null ? DFS_DN_EC_RECONSTRUCTION_THREADS_DEFAULT :
+          Integer.parseInt(newVal));
+      result = Long.toString(size);
+      ecWorker.setStripedReconstructionPoolSize(size);
       return result;
     } catch (IllegalArgumentException e) {
       throw new ReconfigurationException(property, newVal, getConf().get(property), e);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/ErasureCodingWorker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/ErasureCodingWorker.java
@@ -38,7 +38,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_SLOW_IO_WARNING_THRESHOLD_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DN_EC_RECONSTRUCTION_THREADS_KEY;
 
 /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/ErasureCodingWorker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/ErasureCodingWorker.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.datanode.erasurecode;
 
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
@@ -36,6 +37,9 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_SLOW_IO_WARNING_THRESHOLD_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DN_EC_RECONSTRUCTION_THREADS_KEY;
 
 /**
  * ErasureCodingWorker handles the erasure coding reconstruction work commands.
@@ -171,5 +175,20 @@ public final class ErasureCodingWorker {
 
   public float getXmitWeight() {
     return xmitWeight;
+  }
+
+  public void setStripedReconstructionPoolSize(int size) {
+    Preconditions.checkArgument(size > 0,
+        DFS_DN_EC_RECONSTRUCTION_THREADS_KEY + " should be greater than 0");
+    this.stripedReconstructionPool.setCorePoolSize(size);
+    this.stripedReconstructionPool.setMaximumPoolSize(size);
+  }
+
+  @VisibleForTesting
+  public int getStripedReconstructionPoolSize() {
+    int poolSize = this.stripedReconstructionPool.getCorePoolSize();
+    Preconditions.checkArgument(poolSize == this.stripedReconstructionPool.getMaximumPoolSize(),
+        "The maximum pool size should be equal to core pool size");
+    return poolSize;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/ErasureCodingWorker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/ErasureCodingWorker.java
@@ -186,8 +186,6 @@ public final class ErasureCodingWorker {
   @VisibleForTesting
   public int getStripedReconstructionPoolSize() {
     int poolSize = this.stripedReconstructionPool.getCorePoolSize();
-    Preconditions.checkArgument(poolSize == this.stripedReconstructionPool.getMaximumPoolSize(),
-        "The maximum pool size should be equal to core pool size");
     return poolSize;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -349,7 +349,7 @@ public class TestDFSAdmin {
     final List<String> outs = Lists.newArrayList();
     final List<String> errs = Lists.newArrayList();
     getReconfigurableProperties("datanode", address, outs, errs);
-    assertEquals(26, outs.size());
+    assertEquals(27, outs.size());
     assertEquals(DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY, outs.get(1));
   }
 


### PR DESCRIPTION
### Description of PR

dfs.datanode.ec.reconstruction.threads should support dynamic reconfigured, then we can adjust the speed of ec block copy. Especially [HDFS-17550](https://issues.apache.org/jira/browse/HDFS-17550) wanna decommissioning DataNode by EC block reconstruction.

### How was this patch tested?

unit test

### For code changes:

- reconfigure dfs.datanode.ec.reconstruction.threads 