### PR TITLE
HADOOP-19216. (3.4) Upgrade Guice from 4.0 to 5.1.0 to support Java 17

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -228,8 +228,8 @@ com.fasterxml.uuid:java-uuid-generator:3.1.4
 com.fasterxml.woodstox:woodstox-core:5.4.0
 com.github.davidmoten:rxjava-extras:0.8.0.17
 com.github.stephenc.jcip:jcip-annotations:1.0-1
-com.google:guice:4.0
-com.google:guice-servlet:4.0
+com.google:guice:5.1.0
+com.google:guice-servlet:5.1.0
 com.google.api.grpc:proto-google-common-protos:1.0.0
 com.google.code.gson:2.9.0
 com.google.errorprone:error_prone_annotations:2.5.1

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -109,7 +109,7 @@
     <dnsjava.version>3.6.1</dnsjava.version>
 
     <guava.version>27.0-jre</guava.version>
-    <guice.version>4.2.3</guice.version>
+    <guice.version>5.1.0</guice.version>
 
     <bouncycastle.version>1.78.1</bouncycastle.version>
 
@@ -2502,7 +2502,7 @@
                   <includes>
                     <!-- for JDK 8 support -->
                     <include>cglib:cglib:3.2.0</include>
-                    <include>com.google.inject:guice:4.0</include>
+                    <include>com.google.inject:guice:5.1.0</include>
                     <include>com.sun.jersey:jersey-core:1.19.4</include>
                     <include>com.sun.jersey:jersey-servlet:1.19.4</include>
                     <include>com.github.pjfanning:jersey-json:1.22.0</include>


### PR DESCRIPTION
Backport https://github.com/apache/hadoop/commit/25e28b41cc3d4cf15dc5b793fe2b6ed7820e6c86 (#6913) from trunk to branch-3.4
