### PR TITLE
HDFS-17574. Make NNThroughputBenchmark support human-friendly units about blocksize.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NNThroughputBenchmark.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NNThroughputBenchmark.java
@@ -1260,7 +1260,7 @@ public class NNThroughputBenchmark implements Tool {
           blocksPerFile = Integer.parseInt(args.get(++i));
         } else if (args.get(i).equals("-blockSize")) {
           if(i+1 == args.size())  printUsage();
-          blockSize = Long.parseLong(args.get(++i));
+          blockSize = StringUtils.TraditionalBinaryPrefix.string2long(args.get(++i));
         } else if(args.get(i).equals("-baseDirName")) {
           if (i + 1 == args.size()) {
             printUsage();
@@ -1498,7 +1498,7 @@ public class NNThroughputBenchmark implements Tool {
           replication = Short.parseShort(args.get(++i));
         } else if (args.get(i).equals("-blockSize")) {
           if(i+1 == args.size())  printUsage();
-          blockSize = Long.parseLong(args.get(++i));
+          blockSize = StringUtils.TraditionalBinaryPrefix.string2long(args.get(++i));
         } else if(args.get(i).equals("-baseDirName")) {
           if (i + 1 == args.size()) {
             printUsage();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NNThroughputBenchmark.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NNThroughputBenchmark.java
@@ -587,7 +587,7 @@ public class NNThroughputBenchmark implements Tool {
           numOpsRequired = Integer.parseInt(args.get(++i));
         } else if (args.get(i).equals("-blockSize")) {
           if(i+1 == args.size())  printUsage();
-          blockSize = Long.parseLong(args.get(++i));
+          blockSize = StringUtils.TraditionalBinaryPrefix.string2long(args.get(++i));
         } else if(args.get(i).equals("-threads")) {
           if(i+1 == args.size())  printUsage();
           numThreads = Integer.parseInt(args.get(++i));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNThroughputBenchmark.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNThroughputBenchmark.java
@@ -285,4 +285,23 @@ public class TestNNThroughputBenchmark {
               "-blockSize", "32", "-close"});
     }
   }
+
+  /**
+   * This test runs {@link NNThroughputBenchmark} against a mini DFS cluster
+   * with explicit -blockSize option like 1m.
+   */
+  @Test(timeout = 120000)
+  public void testNNThroughputBlockSizeSuffixedWithLetter() throws Exception {
+    final Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY, 16);
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).build()) {
+      cluster.waitActive();
+      final Configuration benchConf = new HdfsConfiguration();
+      benchConf.setLong(DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY, 16);
+      FileSystem.setDefaultUri(benchConf, cluster.getURI());
+      NNThroughputBenchmark.runBenchmark(benchConf,
+          new String[]{"-op", "create", "-keepResults", "-files", "3",
+              "-blockSize", "1m", "-close"});
+    }
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNThroughputBenchmark.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNThroughputBenchmark.java
@@ -291,7 +291,7 @@ public class TestNNThroughputBenchmark {
    * with explicit -blockSize option like 1m.
    */
   @Test(timeout = 120000)
-  public void testNNThroughputBlockSizeSuffixedWithLetter() throws Exception {
+  public void testNNThroughputBlockSizeArgWithLetterSuffix() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     conf.setInt(DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY, 16);
     try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).build()) {


### PR DESCRIPTION
Description of PR
     As of now,We can not specify data units while specifying the -blockSize as arguments(like 1m), but have to specify numbers.
while which is support with configuration item dfs.blocksize 

How was this patch tested?
     Test with command:hadoop org.apache.hadoop.hdfs.server.namenode.NNThroughputBenchmark -fs [hdfs://](hdfs://ctyunns/)xxxxx -op create -threads 100 -files 250000 -filesPerDir 100  -blockSize 1m -close