### PR TITLE
HADOOP-19222. Switch yum repo baseurl due to CentOS 7 sunset

### DIFF
--- a/dev-support/docker/Dockerfile_centos_7
+++ b/dev-support/docker/Dockerfile_centos_7
@@ -31,6 +31,13 @@ RUN chmod a+x pkg-resolver/*.sh pkg-resolver/*.py \
     && chmod a+r pkg-resolver/*.json
 
 ######
+# Centos 7 has reached its EOL and the packages
+# are no longer available on mirror.centos.org site.
+# Please see https://www.centos.org/centos-linux-eol/
+######
+RUN pkg-resolver/set-vault-as-baseurl-centos.sh centos:7
+
+######
 # Install packages from yum
 ######
 # hadolint ignore=DL3008,SC2046
@@ -38,8 +45,12 @@ RUN yum update -y \
     && yum groupinstall -y "Development Tools" \
     && yum install -y \
         centos-release-scl \
-        python3 \
-    && yum install -y $(pkg-resolver/resolve.py centos:7)
+        python3
+
+# Apply the script again because centos-release-scl creates new YUM repo files
+RUN pkg-resolver/set-vault-as-baseurl-centos.sh centos:7
+
+RUN yum install -y $(pkg-resolver/resolve.py centos:7)
 
 # Set GCC 9 as the default C/C++ compiler
 RUN echo "source /opt/rh/devtoolset-9/enable" >> /etc/bashrc

--- a/dev-support/docker/Dockerfile_centos_7
+++ b/dev-support/docker/Dockerfile_centos_7
@@ -50,6 +50,7 @@ RUN yum update -y \
 # Apply the script again because centos-release-scl creates new YUM repo files
 RUN pkg-resolver/set-vault-as-baseurl-centos.sh centos:7
 
+# hadolint ignore=DL3008,SC2046
 RUN yum install -y $(pkg-resolver/resolve.py centos:7)
 
 # Set GCC 9 as the default C/C++ compiler

--- a/dev-support/docker/pkg-resolver/set-vault-as-baseurl-centos.sh
+++ b/dev-support/docker/pkg-resolver/set-vault-as-baseurl-centos.sh
@@ -24,7 +24,7 @@ fi
 if [ "$1" == "centos:7" ] || [ "$1" == "centos:8" ]; then
   cd /etc/yum.repos.d/ || exit &&
     sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* &&
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* &&
+    sed -i 's|# *baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* &&
     yum update -y &&
     cd /root || exit
 else

--- a/dev-support/jenkins.sh
+++ b/dev-support/jenkins.sh
@@ -197,7 +197,7 @@ function run_ci() {
 
   # don't let these tests cause -1s because we aren't really paying that
   # much attention to them
-  YETUS_ARGS+=("--tests-filter=checkstyle")
+  YETUS_ARGS+=("--tests-filter=checkstyle,test4tests")
 
   # effectively treat dev-suport as a custom maven module
   YETUS_ARGS+=("--skip-dirs=dev-support")

--- a/dev-support/jenkins.sh
+++ b/dev-support/jenkins.sh
@@ -197,7 +197,7 @@ function run_ci() {
 
   # don't let these tests cause -1s because we aren't really paying that
   # much attention to them
-  YETUS_ARGS+=("--tests-filter=checkstyle,test4tests")
+  YETUS_ARGS+=("--tests-filter=checkstyle")
 
   # effectively treat dev-suport as a custom maven module
   YETUS_ARGS+=("--skip-dirs=dev-support")


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19222. Switch yum repo baseurl due to CentOS 7 sunset.

Similar to [HADOOP-18151](https://issues.apache.org/jira/browse/HADOOP-18151) (which handled sunset for CentOS 8), CentOS 7 reached EOL on July 1, 2024

### How was this patch tested?

This change will trigger Yetus to run the native library building.

Without this change, the CentOS 7 CI fails with:
```
[2024-07-01T13:07:41.573Z] #9 [ 5/16] RUN yum update -y     && yum groupinstall -y "Development Tools"     && yum install -y         centos-release-scl         python3     && yum install -y $(pkg-resolver/resolve.py centos:7)
[2024-07-01T13:07:42.135Z] #9 0.452 Loaded plugins: fastestmirror, ovl
[2024-07-01T13:07:42.135Z] #9 0.570 Determining fastest mirrors
[2024-07-01T13:07:42.696Z] #9 0.824 Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
[2024-07-01T13:07:42.696Z] #9 0.824 14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error"
[2024-07-01T13:07:42.696Z] #9 0.826 
[2024-07-01T13:07:42.696Z] #9 0.826 
[2024-07-01T13:07:42.696Z] #9 0.826  One of the configured repositories failed (Unknown),
[2024-07-01T13:07:42.696Z] #9 0.826  and yum doesn't have enough cached data to continue. At this point the only
[2024-07-01T13:07:42.696Z] #9 0.826  safe thing yum can do is fail. There are a few ways to work "fix" this:
[2024-07-01T13:07:42.696Z] #9 0.826 
[2024-07-01T13:07:42.696Z] #9 0.826      1. Contact the upstream for the repository and get them to fix the problem.
[2024-07-01T13:07:42.696Z] #9 0.826 
[2024-07-01T13:07:42.696Z] #9 0.826      2. Reconfigure the baseurl/etc. for the repository, to point to a working
[2024-07-01T13:07:42.696Z] #9 0.826         upstream. This is most often useful if you are using a newer
[2024-07-01T13:07:42.696Z] #9 0.826         distribution release than is supported by the repository (and the
[2024-07-01T13:07:42.696Z] #9 0.826         packages for the previous distribution release still work).
[2024-07-01T13:07:42.696Z] #9 0.826 
[2024-07-01T13:07:42.696Z] #9 0.826      3. Run the command with the repository temporarily disabled
[2024-07-01T13:07:42.696Z] #9 0.826             yum --disablerepo=<repoid> ...
[2024-07-01T13:07:42.696Z] #9 0.826 
[2024-07-01T13:07:42.696Z] #9 0.826      4. Disable the repository permanently, so yum won't use it by default. Yum
[2024-07-01T13:07:42.696Z] #9 0.826         will then just ignore the repository until you permanently enable it
[2024-07-01T13:07:42.696Z] #9 0.826         again or use --enablerepo for temporary usage:
[2024-07-01T13:07:42.696Z] #9 0.826 
[2024-07-01T13:07:42.696Z] #9 0.826             yum-config-manager --disable <repoid>
[2024-07-01T13:07:42.696Z] #9 0.826         or
[2024-07-01T13:07:42.696Z] #9 0.826             subscription-manager repos --disable=<repoid>
[2024-07-01T13:07:42.696Z] #9 0.826 
[2024-07-01T13:07:42.696Z] #9 0.826      5. Configure the failing repository to be skipped, if it is unavailable.
[2024-07-01T13:07:42.696Z] #9 0.826         Note that yum will try to contact the repo. when it runs most commands,
[2024-07-01T13:07:42.696Z] #9 0.826         so will have to try and fail each time (and thus. yum will be be much
[2024-07-01T13:07:42.696Z] #9 0.826         slower). If it is a very temporary problem though, this is often a nice
[2024-07-01T13:07:42.696Z] #9 0.826         compromise:
[2024-07-01T13:07:42.696Z] #9 0.826 
[2024-07-01T13:07:42.696Z] #9 0.826             yum-config-manager --save --setopt=<repoid>.skip_if_unavailable=true
[2024-07-01T13:07:42.696Z] #9 0.826 
[2024-07-01T13:07:42.696Z] #9 0.826 Cannot find a valid baseurl for repo: base/7/x86_64
[2024-07-01T13:07:43.258Z] #9 ERROR: process "/bin/bash -o pipefail -c yum update -y     && yum groupinstall -y \"Development Tools\"     && yum install -y         centos-release-scl         python3     && yum install -y $(pkg-resolver/resolve.py centos:7)" did not complete successfully: exit code: 1
[2024-07-01T13:07:43.258Z] ------
[2024-07-01T13:07:43.258Z]  > [ 5/16] RUN yum update -y     && yum groupinstall -y "Development Tools"     && yum install -y         centos-release-scl         python3     && yum install -y $(pkg-resolver/resolve.py centos:7):
[2024-07-01T13:07:43.258Z] 0.826 
[2024-07-01T13:07:43.258Z] 0.826      5. Configure the failing repository to be skipped, if it is unavailable.
[2024-07-01T13:07:43.258Z] 0.826         Note that yum will try to contact the repo. when it runs most commands,
[2024-07-01T13:07:43.259Z] 0.826         so will have to try and fail each time (and thus. yum will be be much
[2024-07-01T13:07:43.259Z] 0.826         slower). If it is a very temporary problem though, this is often a nice
[2024-07-01T13:07:43.259Z] 0.826         compromise:
[2024-07-01T13:07:43.259Z] 0.826 
[2024-07-01T13:07:43.259Z] 0.826             yum-config-manager --save --setopt=<repoid>.skip_if_unavailable=true
[2024-07-01T13:07:43.259Z] 0.826 
[2024-07-01T13:07:43.259Z] 0.826 Cannot find a valid baseurl for repo: base/7/x86_64
[2024-07-01T13:07:43.259Z] ------
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

