### PR TITLE
HDFS-17575. SaslDataTransferClient should use SaslParticipant to create messages.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferClient.java
@@ -63,6 +63,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Lists;
+import org.apache.hadoop.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -522,6 +523,10 @@ public class SaslDataTransferClient {
       BlockTokenIdentifier blockTokenIdentifier =
           accessToken.decodeIdentifier();
       final byte[] first = sasl.evaluateChallengeOrResponse(EMPTY_BYTE_ARRAY);
+      if (LOG.isDebugEnabled()) {
+        LOG.info("first: {}", first == null ? null : first.length == 0 ? "<empty>"
+            : StringUtils.byteToHexString(first));
+      }
       if (blockTokenIdentifier != null) {
         byte[] handshakeSecret =
             accessToken.decodeIdentifier().getHandshakeMsg();

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslParticipant.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslParticipant.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdfs.protocol.datatransfer.sasl;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.util.Map;
+import java.util.Objects;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslClient;
@@ -110,7 +111,7 @@ class SaslParticipant {
    * @param saslServer to wrap
    */
   private SaslParticipant(SaslServer saslServer) {
-    this.saslServer = saslServer;
+    this.saslServer = Objects.requireNonNull(saslServer, "saslServer == null");
     this.saslClient = null;
   }
 
@@ -121,7 +122,7 @@ class SaslParticipant {
    */
   private SaslParticipant(SaslClient saslClient) {
     this.saslServer = null;
-    this.saslClient = saslClient;
+    this.saslClient = Objects.requireNonNull(saslClient, "saslClient == null");
   }
 
   /**
@@ -227,5 +228,10 @@ class SaslParticipant {
           new SaslInputStream(in, saslServer),
           new SaslOutputStream(out, saslServer));
     }
+  }
+
+  @Override
+  public String toString() {
+    return "Sasl" + (saslServer != null? "Server" : "Client");
   }
 }


### PR DESCRIPTION
### Description of PR

HDFS-17575

Currently, a SaslDataTransferClient may send a message without using its SaslParticipant as below.
```java
          sendSaslMessage(out, new byte[0]);
```
Instead, it should use its SaslParticipant to create the response.
```java
      byte[] localResponse = sasl.evaluateChallengeOrResponse(remoteResponse);
      sendSaslMessage(out, localResponse);
```

### How was this patch tested?

By existing unit tests.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

