### PR TITLE
HDFS-17566. Got wrong sorted block order when StorageType is considered.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -684,7 +684,7 @@ public class DatanodeManager {
             } else if (s2 == null) {
               return 1;
             } else {
-              return s2.compareTo(s1);
+              return s1.compareTo(s2);
             }
           });
       secondarySort = list -> Collections.sort(list, comp);


### PR DESCRIPTION
### Description of PR

https://issues.apache.org/jira/browse/HDFS-17566

### How was this patch tested?

Existing unit test: org.apache.hadoop.hdfs.server.blockmanagement.testGetBlockLocationConsiderStorageType

### For code changes:

- fix comparator order
