### PR TITLE
HADOOP-19228. ShellCommandFencer#setConfAsEnvVars should also replace '-' with '_'.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/HAServiceTarget.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/HAServiceTarget.java
@@ -183,7 +183,7 @@ public abstract class HAServiceTarget {
    * expose to fencing implementations/scripts. Fencing methods are free
    * to use this map as they see fit -- notably, the shell script
    * implementation takes each entry, prepends 'target_', substitutes
-   * '_' for '.', and adds it to the environment of the script.
+   * '_' for '.' and '-', and adds it to the environment of the script.
    *
    * Subclass implementations should be sure to delegate to the superclass
    * implementation as well as adding their own keys.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/ShellCommandFencer.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/ShellCommandFencer.java
@@ -39,8 +39,8 @@ import org.slf4j.LoggerFactory;
  * (cmd.exe on Windows) and may not include any closing parentheses.<p>
  * 
  * The shell command will be run with an environment set up to contain
- * all of the current Hadoop configuration variables, with the '_' character 
- * replacing any '.' characters in the configuration keys.<p>
+ * all of the current Hadoop configuration variables, with the '_' character
+ * replacing any '.' or '-' characters in the configuration keys.<p>
  * 
  * If the shell command returns an exit code of 0, the fencing is
  * determined to be successful. If it returns any other exit code, the
@@ -202,7 +202,7 @@ public class ShellCommandFencer
 
   /**
    * Set the environment of the subprocess to be the Configuration,
-   * with '.'s replaced by '_'s.
+   * with '.'s and '-'s replaced by '_'s.
    */
   private void setConfAsEnvVars(Map<String, String> env) {
     for (Map.Entry<String, String> pair : getConf()) {
@@ -237,7 +237,7 @@ public class ShellCommandFencer
     for (Map.Entry<String, String> e :
          target.getFencingParameters().entrySet()) {
       String key = prefix + e.getKey();
-      key = key.replace('.', '_');
+      key = key.replaceAll("[.-]", "_");
       environment.put(key, e.getValue());
     }
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/ShellCommandFencer.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/ShellCommandFencer.java
@@ -206,7 +206,7 @@ public class ShellCommandFencer
    */
   private void setConfAsEnvVars(Map<String, String> env) {
     for (Map.Entry<String, String> pair : getConf()) {
-      env.put(pair.getKey().replace('.', '_'), pair.getValue());
+      env.put(pair.getKey().replaceAll("[.-]", "_"), pair.getValue());
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestShellCommandFencer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestShellCommandFencer.java
@@ -63,7 +63,7 @@ public class TestShellCommandFencer {
   
   private static ShellCommandFencer createFencer() {
     Configuration conf = new Configuration();
-    conf.set("in.fencing.tests", "yessir");
+    conf.set("in.fencing-tests", "yessir");
     ShellCommandFencer fencer = new ShellCommandFencer();
     fencer.setConf(conf);
     return fencer;


### PR DESCRIPTION
JIRA: HADOOP-19228.
When setting configuration into environment variables, '-' should also be replaced with '_'.