### PR TITLE
HADOOP-19223. Continue running the pipeline even if stages fail

### DIFF
--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -121,12 +121,14 @@ pipeline {
             }
 
             steps {
-                withCredentials(getGithubCreds()) {
-                        sh '''#!/usr/bin/env bash
+                catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
+                    withCredentials(getGithubCreds()) {
+                            sh '''#!/usr/bin/env bash
 
-                        chmod u+x "${SOURCEDIR}/dev-support/jenkins.sh"
-                        "${SOURCEDIR}/dev-support/jenkins.sh" run_ci
-                        '''
+                            chmod u+x "${SOURCEDIR}/dev-support/jenkins.sh"
+                            "${SOURCEDIR}/dev-support/jenkins.sh" run_ci
+                            '''
+                    }
                 }
             }
 
@@ -167,12 +169,14 @@ pipeline {
             }
 
             steps {
-                withCredentials(getGithubCreds()) {
-                    sh '''#!/usr/bin/env bash
+                catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
+                    withCredentials(getGithubCreds()) {
+                        sh '''#!/usr/bin/env bash
 
-                    chmod u+x "${SOURCEDIR}/dev-support/jenkins.sh"
-                    "${SOURCEDIR}/dev-support/jenkins.sh" run_ci
-                    '''
+                        chmod u+x "${SOURCEDIR}/dev-support/jenkins.sh"
+                        "${SOURCEDIR}/dev-support/jenkins.sh" run_ci
+                        '''
+                    }
                 }
             }
 

--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -266,21 +266,21 @@
       "openjdk-17-jdk"
     ],
     "ubuntu:focal": [
-      "temurin-24-jdk",
       "openjdk-8-jdk",
       "openjdk-11-jdk",
-      "openjdk-17-jdk"
+      "openjdk-17-jdk",
+      "temurin-24-jdk"
     ],
     "ubuntu:noble": [
-      "temurin-24-jdk",
       "openjdk-11-jdk",
-      "openjdk-17-jdk"
+      "openjdk-17-jdk",
+      "temurin-24-jdk"
     ],
     "ubuntu:focal::arch64": [
-      "temurin-24-jdk",
       "openjdk-8-jdk",
       "openjdk-11-jdk",
-      "openjdk-17-jdk"
+      "openjdk-17-jdk",
+      "temurin-24-jdk"
     ]
   },
   "pinentry-curses": {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Yetus votes -1 if the PR does not touch tests, which causes the pipeline fail fast and have no chance to run the rest stages. This PR changes the strategy to always run the whole pipeline and report failure at the end.

### How was this patch tested?

Before 

<img width="884" alt="image" src="https://github.com/apache/hadoop/assets/26535726/9e456695-8922-4ee4-9ff4-c2b853701e29">


After

![QQ_1720948692554](https://github.com/user-attachments/assets/a9441a34-f995-4126-8fe9-e32097cb36eb)


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

