### PR TITLE
YARN-11704. No need to apply extra 'AND' placement constraint for non tags in PlacementConstraintManager.getMultilevelConstraint

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/MemoryPlacementConstraintManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/MemoryPlacementConstraintManager.java
@@ -266,6 +266,10 @@ public class MemoryPlacementConstraintManager
             .distinct()
             .collect(Collectors.toList());
 
+    if (allConstraints != null && allConstraints.size() == 1) {
+      return allConstraints.get(0).build();
+    }
+
     // Compose an AND constraint
     // When merge request(RC), app(AC) and global constraint(GC),
     // we do a merge on them with CC=AND(GC, AC, RC) and returns a

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/TestPlacementConstraintManagerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/TestPlacementConstraintManagerService.java
@@ -194,10 +194,8 @@ public class TestPlacementConstraintManagerService {
     // AC = null
     // GC = null
     constraint = pcm.getMultilevelConstraint(appId1, null, c1);
-    Assert.assertTrue(constraint.getConstraintExpr() instanceof And);
-    mergedConstraint = (And) constraint.getConstraintExpr();
-    Assert.assertEquals(1, mergedConstraint.getChildren().size());
-    Assert.assertEquals(c1, mergedConstraint.getChildren().get(0).build());
+    Assert.assertTrue(constraint.getConstraintExpr().getClass() == c1.getConstraintExpr().getClass());
+    Assert.assertEquals(c1, constraint);
 
     // RC = null
     // AC = tag1->c1, tag2->c2
@@ -213,11 +211,7 @@ public class TestPlacementConstraintManagerService {
     Assert.assertEquals(0, mergedConstraint.getChildren().size());
     // if a mapping is found for a given source tag
     constraint = pcm.getMultilevelConstraint(appId1, sourceTag1, null);
-    Assert.assertTrue(constraint.getConstraintExpr() instanceof And);
-    mergedConstraint = (And) constraint.getConstraintExpr();
-    // AND(c1)
-    Assert.assertEquals(1, mergedConstraint.getChildren().size());
-    Assert.assertEquals(c1, mergedConstraint.getChildren().get(0).build());
+    Assert.assertEquals(c1, constraint);
     pcm.unregisterApplication(appId1);
 
     // RC = null
@@ -226,11 +220,7 @@ public class TestPlacementConstraintManagerService {
     pcm.addGlobalConstraint(sourceTag1, c1, true);
     constraint = pcm.getMultilevelConstraint(appId1,
         Sets.newHashSet(sourceTag1), null);
-    Assert.assertTrue(constraint.getConstraintExpr() instanceof And);
-    mergedConstraint = (And) constraint.getConstraintExpr();
-    // AND(c1)
-    Assert.assertEquals(1, mergedConstraint.getChildren().size());
-    Assert.assertEquals(c1, mergedConstraint.getChildren().get(0).build());
+    Assert.assertEquals(c1, constraint);
     pcm.removeGlobalConstraint(sourceTag1);
 
     // RC = c2


### PR DESCRIPTION
### Description of PR

After applying the placement constraint allocator in our internal cluster, I found some hotpoint that will effect the scheduling performance as the allocation time metric value increase a lot. 

After dumping the flamegraph, the hotpoint is that the `SingleConstraintAppPlacementAllocator.checkCardinalityAndPending`, this should be optimized by like cache or other ways. But the unnecessary nested AND placement constraint may be a small improvement for this case.


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

