### PR TITLE
HDFS-17579 Better Comments Explaining Why Blocks Need Reconstruction May Not Block Decommission/Maintenance

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
@@ -479,9 +479,11 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
         }
       }
 
-      // Even if the block is without sufficient redundancy,
-      // it might not block decommission/maintenance if it
-      // has sufficient redundancy.
+      // Even if the block requires reconstruction for low sufficient, but it may still not block
+      // decommission/maintenance.  For example:
+      // 1) doesn't meet current block's expected live redundancy but meet
+      //    the system's default redundancy(replication factor)
+      // 2) the redundancy is fine but replicas are but badly located(placement policy unsatisfied)
       if (dnAdmin.isSufficient(block, bc, num, isDecommission, isMaintenance)) {
         if (pruneReliableBlocks) {
           it.remove();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Below comments for explaining why blocks which need reconstruction may not block decommission/maintenance is weird:

```
      // Even if the block is without sufficient redundancy,
      // it might not block decommission/maintenance if it
      // has sufficient redundancy.
      if (dnAdmin.isSufficient(block, bc, num, isDecommission, isMaintenance)) {
        if (pruneReliableBlocks) {
          it.remove(); 
```

I checked the detailed code and get the reason that why blocks which need reconstruction may not block decommission/maintenance, and give it a better comment

### How was this patch tested?
No need to test. Just changed some comments.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

