### PR TITLE
HDFS-17580. Change the default value of dfs.datanode.lock.fair to false due to potential hang

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -669,7 +669,7 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       10000; //ms
   public static final String DFS_DATANODE_LOCK_FAIR_KEY =
       "dfs.datanode.lock.fair";
-  public static final boolean DFS_DATANODE_LOCK_FAIR_DEFAULT = true;
+  public static final boolean DFS_DATANODE_LOCK_FAIR_DEFAULT = false;
 
   public static final String  DFS_UPGRADE_DOMAIN_FACTOR = "dfs.namenode.upgrade.domain.factor";
   public static final int DFS_UPGRADE_DOMAIN_FACTOR_DEFAULT = DFS_REPLICATION_DEFAULT;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -3540,7 +3540,7 @@
 
 <property>
   <name>dfs.datanode.lock.fair</name>
-  <value>true</value>
+  <value>false</value>
   <description>If this is true, the Datanode FsDataset lock will be used in Fair
     mode, which will help to prevent writer threads from being starved, but can
     lower lock throughput. See java.util.concurrent.locks.ReentrantReadWriteLock


### PR DESCRIPTION
…se due to potential hang

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

