### PR TITLE
HADOOP-19208: [Backport to 3.4][ABFS] Fixing logic to determine HNS nature of account to avoid extra getAcl() calls

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
@@ -28,6 +28,7 @@ import org.mockito.Mockito;
 
 import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.TrileanConversionException;
+import org.apache.hadoop.fs.azurebfs.enums.Trilean;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
@@ -67,6 +68,7 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
     Mockito.doThrow(TrileanConversionException.class)
         .when(store)
         .isNamespaceEnabled();
+    store.setNamespaceEnabled(Trilean.UNKNOWN);
 
     TracingContext tracingContext = getSampleTracingContext(fs, true);
     Mockito.doReturn(Mockito.mock(AbfsRestOperation.class))

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestGetNameSpaceEnabled.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestGetNameSpaceEnabled.java
@@ -24,9 +24,11 @@ import java.util.UUID;
 import org.junit.Assume;
 import org.junit.Test;
 import org.assertj.core.api.Assertions;
+import org.mockito.Mockito;
 
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
 import org.apache.hadoop.conf.Configuration;
@@ -34,9 +36,14 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.enums.Trilean;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -217,4 +224,45 @@ public class ITestGetNameSpaceEnabled extends AbstractAbfsIntegrationTest {
     return mockClient;
   }
 
+  @Test
+  public void ensureGetAclDetermineHnsStatusAccurately() throws Exception {
+    ensureGetAclDetermineHnsStatusAccuratelyInternal(HTTP_BAD_REQUEST,
+        false, false);
+    ensureGetAclDetermineHnsStatusAccuratelyInternal(HTTP_NOT_FOUND,
+        true, true);
+    ensureGetAclDetermineHnsStatusAccuratelyInternal(HTTP_INTERNAL_ERROR,
+        true, true);
+    ensureGetAclDetermineHnsStatusAccuratelyInternal(HTTP_UNAVAILABLE,
+        true, true);
+  }
+
+  private void ensureGetAclDetermineHnsStatusAccuratelyInternal(int statusCode,
+      boolean expectedValue, boolean isExceptionExpected) throws Exception {
+    AzureBlobFileSystemStore store = Mockito.spy(getFileSystem().getAbfsStore());
+    AbfsClient mockClient = mock(AbfsClient.class);
+    store.setNamespaceEnabled(Trilean.UNKNOWN);
+    doReturn(mockClient).when(store).getClient();
+    AbfsRestOperationException ex = new AbfsRestOperationException(
+        statusCode, null, Integer.toString(statusCode), null);
+    doThrow(ex).when(mockClient).getAclStatus(anyString(), any(TracingContext.class));
+
+    if (isExceptionExpected) {
+      try {
+        store.getIsNamespaceEnabled(getTestTracingContext(getFileSystem(), false));
+        Assertions.fail(
+            "Exception Should have been thrown with status code: " + statusCode);
+      } catch (AbfsRestOperationException caughtEx) {
+        Assertions.assertThat(caughtEx.getStatusCode()).isEqualTo(statusCode);
+        Assertions.assertThat(caughtEx.getErrorMessage()).isEqualTo(ex.getErrorMessage());
+      }
+    }
+    // This should not trigger extra getAcl() call in case of exceptions.
+    boolean isHnsEnabled = store.getIsNamespaceEnabled(
+        getTestTracingContext(getFileSystem(), false));
+    Assertions.assertThat(isHnsEnabled).isEqualTo(expectedValue);
+
+    // GetAcl() should be called only once to determine the HNS status.
+    Mockito.verify(mockClient, times(1))
+        .getAclStatus(anyString(), any(TracingContext.class));
+  }
 }


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/HADOOP-19208
PR merged to trunk: https://github.com/apache/hadoop/pull/6893

### Original Description of PR
ABFS driver needs to know the type of account being used. It relies on the user to inform the account type using the config `fs.azure.account.hns.enabled`. If not configured, driver makes a [GetAcl Head Call](https://learn.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/get-properties) call to determine the account type.
Expectation is getAcl() will fail with 400 Bad Request if made on the FNS Account.
If succeeded or fails with any other error code, it means it's an HNS Account.

#### Current Implementation:
Today when someone tries to create a new file system, getAcl is called to determine HNS/FNS account. This call fails with 404 as file system is not yet created. Then another getAcl is needed to determine HNS/FNS post filesystem creation. Leading to redundant getAcl calls.

#### New Implementation
1. If getAcl fails with 400 then only we will determine the account as HNS disabled. For any other error code including 404, we will infer the account as HNS enabled. getAcl call will continue to throw exception in cases where it fails with non 400 error code as earlier.
2. In case of 404, getAcl() will still fail as always but store will capture the HNS enabled/disabled to avoid further calls. File system init will not fail for 404 as per the design.
3. In case of error apart from 400, 404 like 5xx or others, getAcl() will still fail leading to file system initialization failure. Any inference made on account type here won't be used further.

This PR also fixes a test case failing on trunk. `testGetAclCallOnHnsConfigAbsence(org.apache.hadoop.fs.azurebfs.ITestAzureBlobFileSystemInitAndCreate)`

### How was this patch tested?
New test around the production code changes, and existing test suite ran to validate the patch.

### Test Suite Results
Metric related tests are fixed in the the https://github.com/apache/hadoop/pull/6847