### PR TITLE
HDFS-17584. DistributedFileSystem verifyChecksum should be configurable

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -151,7 +151,7 @@ public class DistributedFileSystem extends FileSystem
   private URI uri;
 
   DFSClient dfs;
-  private boolean verifyChecksum = true;
+  private boolean verifyChecksum;
 
   private DFSOpsCountStatistics storageStatistics;
 
@@ -188,6 +188,8 @@ public class DistributedFileSystem extends FileSystem
     initDFSClient(uri, conf);
     this.uri = URI.create(uri.getScheme()+"://"+uri.getAuthority());
     this.workingDir = getHomeDirectory();
+    this.verifyChecksum = conf.getBoolean(HdfsClientConfigKeys.DFS_CLIENT_VERIFY_CHECKSUM_ENABLED,
+      HdfsClientConfigKeys.DFS_CLIENT_VERIFY_CHECKSUM_ENABLED_DEFAULT);
 
     storageStatistics = (DFSOpsCountStatistics) GlobalStorageStatistics.INSTANCE
         .put(DFSOpsCountStatistics.NAME,

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -296,6 +296,10 @@ public interface HdfsClientConfigKeys {
   int DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME_DEFAULT =
       DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME_DEFAULT * 10;
 
+  String DFS_CLIENT_VERIFY_CHECKSUM_ENABLED =
+    "dfs.client.verify.checksum.enabled";
+  boolean DFS_CLIENT_VERIFY_CHECKSUM_ENABLED_DEFAULT = true;
+
   /**
    * These are deprecated config keys to client code.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6606,4 +6606,11 @@
       Enables observer reads for clients. This should only be enabled when clients are using routers.
     </description>
   </property>
+  <property>
+    <name>dfs.client.verify.checksum.enabled</name>
+    <value>true</value>
+    <description>
+      Whether the HDFS client checksum verify is enabled. The default value is true.
+    </description>
+  </property>
 </configuration>


### PR DESCRIPTION
### Description of PR

JIRA: https://issues.apache.org/jira/browse/HDFS-17584

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

