### PR TITLE
YARN-11705. Turn off Node Manager working directories validation by default

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2189,7 +2189,7 @@ public class YarnConfiguration extends Configuration {
       NM_DISK_HEALTH_CHECK_PREFIX + "working-dir-content-accessibility-validation.enabled";
 
   public static final boolean DEFAULT_NM_WORKING_DIR_CONTENT_ACCESSIBILITY_VALIDATION_ENABLED =
-      true;
+      false;
 
   /** The health checker scripts. */
   public static final String NM_HEALTH_CHECK_SCRIPTS =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -1998,7 +1998,7 @@
   <property>
     <description>Validate content of the node manager directories can be accessed</description>
     <name>yarn.nodemanager.disk-health-checker.working-dir-content-accessibility-validation.enabled</name>
-    <value>true</value>
+    <value>false</value>
   </property>
 
   <property>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/DirectoryCollection.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/DirectoryCollection.java
@@ -726,4 +726,9 @@ public class DirectoryCollection {
   public int getGoodDirsDiskUtilizationPercentage() {
     return goodDirsDiskUtilizationPercentage;
   }
+
+  @VisibleForTesting
+  public void setSubAccessibilityValidationEnabled(boolean subAccessibilityValidationEnabled) {
+    this.subAccessibilityValidationEnabled = subAccessibilityValidationEnabled;
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestDirectoryCollection.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestDirectoryCollection.java
@@ -528,6 +528,7 @@ public class TestDirectoryCollection {
     Files.setPosixFilePermissions(testFile.toPath(),
         PosixFilePermissions.fromString("-w--w--w-"));
     DirectoryCollection dc = new DirectoryCollection(new String[]{testDir.toString()});
+    dc.setSubAccessibilityValidationEnabled(true);
     Map<String, DirectoryCollection.DiskErrorInformation> diskErrorInformationMap =
         dc.testDirs(Collections.singletonList(testDir.toString()), Collections.emptySet());
     Assert.assertEquals(1, diskErrorInformationMap.size());


### PR DESCRIPTION
Change-Id: I011c13c79719be97c7ebc028804f1fdab5eb34c4

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

[YARN-11703](https://issues.apache.org/jira/browse/YARN-11703) modify the behaviour off Hadoop, by default we should turn off

### How was this patch tested?

Unittest

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

