### PR TITLE
HDFS-17586. Fix timestamp in rbfbalance tool.

### DIFF
--- a/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/DistCpProcedure.java
+++ b/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/DistCpProcedure.java
@@ -476,7 +476,7 @@ public class DistCpProcedure extends BalanceProcedure {
       boolean useSnapshotDiff) throws IOException {
     List<String> command = new ArrayList<>();
     command.addAll(Arrays
-        .asList(new String[] {"-async", "-update", "-append", "-pruxgpcab"}));
+        .asList(new String[] {"-async", "-update", "-append", "-pruxgpcabt"}));
     if (useSnapshotDiff) {
       command.add("-diff");
       command.add(LAST_SNAPSHOT_NAME);


### PR DESCRIPTION
### Description of PR
When the 'Federation Balance' Tool calls the 'DistCp' tool, the timestamp is not retained.

### How was this patch tested?
Add UT