### PR TITLE
HDFS-17575. SaslDataTransferClient should use SaslParticipant to create messages.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferClient.java
@@ -519,25 +519,25 @@ public class SaslDataTransferClient {
       // In which case there will be no encrypted secret sent from NN.
       BlockTokenIdentifier blockTokenIdentifier =
           accessToken.decodeIdentifier();
+      final byte[] first = sasl.createFirstMessage();
       if (blockTokenIdentifier != null) {
         byte[] handshakeSecret =
             accessToken.decodeIdentifier().getHandshakeMsg();
         if (handshakeSecret == null || handshakeSecret.length == 0) {
           LOG.debug("Handshake secret is null, "
               + "sending without handshake secret.");
-          sendSaslMessage(out, new byte[0]);
+          sendSaslMessage(out, first);
         } else {
           LOG.debug("Sending handshake secret.");
           BlockTokenIdentifier identifier = new BlockTokenIdentifier();
           identifier.readFields(new DataInputStream(
               new ByteArrayInputStream(accessToken.getIdentifier())));
           String bpid = identifier.getBlockPoolId();
-          sendSaslMessageHandshakeSecret(out, new byte[0],
-              handshakeSecret, bpid);
+          sendSaslMessageHandshakeSecret(out, first, handshakeSecret, bpid);
         }
       } else {
         LOG.debug("Block token id is null, sending without handshake secret.");
-        sendSaslMessage(out, new byte[0]);
+        sendSaslMessage(out, first);
       }
 
       // step 1
@@ -565,6 +565,7 @@ public class SaslDataTransferClient {
           cipherOptions.add(option);
         }
       }
+      LOG.debug("{}: cipherOptions={}", sasl, cipherOptions);
       sendSaslMessageAndNegotiationCipherOptions(out, localResponse,
           cipherOptions);
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslParticipant.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslParticipant.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdfs.protocol.datatransfer.sasl;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.util.Map;
+import java.util.Objects;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslClient;
@@ -52,6 +53,7 @@ class SaslParticipant {
   private static final String SERVER_NAME = "0";
   private static final String PROTOCOL = "hdfs";
   private static final String[] MECHANISM_ARRAY = {SaslConstants.SASL_MECHANISM};
+  private static final byte[] EMPTY_BYTE_ARRAY = {};
 
   // One of these will always be null.
   private final SaslServer saslServer;
@@ -110,7 +112,7 @@ class SaslParticipant {
    * @param saslServer to wrap
    */
   private SaslParticipant(SaslServer saslServer) {
-    this.saslServer = saslServer;
+    this.saslServer = Objects.requireNonNull(saslServer, "saslServer == null");
     this.saslClient = null;
   }
 
@@ -121,7 +123,12 @@ class SaslParticipant {
    */
   private SaslParticipant(SaslClient saslClient) {
     this.saslServer = null;
-    this.saslClient = saslClient;
+    this.saslClient = Objects.requireNonNull(saslClient, "saslClient == null");
+  }
+
+  byte[] createFirstMessage() throws SaslException {
+    return MECHANISM_ARRAY[0].equals(SaslConstants.SASL_MECHANISM_DEFAULT) ? EMPTY_BYTE_ARRAY
+        : evaluateChallengeOrResponse(EMPTY_BYTE_ARRAY);
   }
 
   /**
@@ -227,5 +234,10 @@ class SaslParticipant {
           new SaslInputStream(in, saslServer),
           new SaslOutputStream(out, saslServer));
     }
+  }
+
+  @Override
+  public String toString() {
+    return "Sasl" + (saslServer != null? "Server" : "Client");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestSaslDataTransfer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestSaslDataTransfer.java
@@ -77,7 +77,7 @@ public class TestSaslDataTransfer extends SaslDataTransferTestCase {
   public ExpectedException exception = ExpectedException.none();
 
   @Rule
-  public Timeout timeout = new Timeout(60000);
+  public Timeout timeout = new Timeout(300_000);
 
   @After
   public void shutdown() {


### PR DESCRIPTION
### Description of PR

HDFS-17575

This is a continue work on #6933.

Currently, a SaslDataTransferClient may send a message without using its SaslParticipant as below.
```java
          sendSaslMessage(out, new byte[0]);
```
Instead, it should use its SaslParticipant to create the response.
```java
      byte[] localResponse = sasl.evaluateChallengeOrResponse(remoteResponse);
      sendSaslMessage(out, localResponse);
```

### How was this patch tested?

By existing unit tests.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?