### PR TITLE
HADOOP-19237. Upgrade to dnsjava 3.6.1 due to CVEs

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -379,7 +379,7 @@ hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/util/tree
 hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/compat/{fstatat|openat|unlinkat}.h
 
 com.github.luben:zstd-jni:1.5.2-1
-dnsjava:dnsjava:2.1.7
+dnsjava:dnsjava:3.6.0
 org.codehaus.woodstox:stax2-api:4.2.1
 
 

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -379,7 +379,7 @@ hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/util/tree
 hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/compat/{fstatat|openat|unlinkat}.h
 
 com.github.luben:zstd-jni:1.5.2-1
-dnsjava:dnsjava:3.6.0
+dnsjava:dnsjava:3.6.1
 org.codehaus.woodstox:stax2-api:4.2.1
 
 

--- a/hadoop-client-modules/hadoop-client-check-invariants/src/test/resources/ensure-jars-have-correct-contents.sh
+++ b/hadoop-client-modules/hadoop-client-check-invariants/src/test/resources/ensure-jars-have-correct-contents.sh
@@ -51,6 +51,8 @@ allowed_expr+="|^[^-]*-default.xml$"
 allowed_expr+="|^[^-]*-version-info.properties$"
 #   * Hadoop's application classloader properties file.
 allowed_expr+="|^org.apache.hadoop.application-classloader.properties$"
+# Comes from dnsjava, not sure if relocatable.
+allowed_expr+="|^messages.properties$"
 # public suffix list used by httpcomponents
 allowed_expr+="|^mozilla/$"
 allowed_expr+="|^mozilla/public-suffix-list.txt$"

--- a/hadoop-client-modules/hadoop-client-runtime/pom.xml
+++ b/hadoop-client-modules/hadoop-client-runtime/pom.xml
@@ -229,6 +229,7 @@
                         <exclude>jnamed*</exclude>
                         <exclude>lookup*</exclude>
                         <exclude>update*</exclude>
+                        <exclude>META-INF/versions/21/**/*</exclude>
                       </excludes>
                     </filter>
                     <filter>
@@ -243,6 +244,7 @@
                       <excludes>
                         <exclude>META-INF/versions/9/module-info.class</exclude>
                         <exclude>META-INF/versions/11/module-info.class</exclude>
+                        <exclude>META-INF/versions/21/module-info.class</exclude>
                       </excludes>
                     </filter>
 

--- a/hadoop-client-modules/hadoop-client-runtime/pom.xml
+++ b/hadoop-client-modules/hadoop-client-runtime/pom.xml
@@ -229,6 +229,7 @@
                         <exclude>jnamed*</exclude>
                         <exclude>lookup*</exclude>
                         <exclude>update*</exclude>
+                        <exclude>META-INF/versions/21/*</exclude>
                         <exclude>META-INF/versions/21/**/*</exclude>
                       </excludes>
                     </filter>

--- a/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/server/dns/RegistryDNS.java
+++ b/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/server/dns/RegistryDNS.java
@@ -1682,7 +1682,7 @@ public class RegistryDNS extends AbstractService implements DNSOperations,
                   DNSSEC.sign(rRset, dnskeyRecord, privateKey,
                       inception, expiration);
               LOG.info("Adding {}", rrsigRecord);
-              rRset.addRR(rrsigRecord);
+              zone.addRecord(rrsigRecord);
 
               //addDSRecord(zone, record.getName(), record.getDClass(),
               //  record.getTTL(), inception, expiration);

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestRegistryDNS.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestRegistryDNS.java
@@ -350,7 +350,7 @@ public class TestRegistryDNS extends Assert {
     Name name = Name.fromString("19.1.17.172.in-addr.arpa.");
     Record question = Record.newRecord(name, Type.PTR, DClass.IN);
     Message query = Message.newQuery(question);
-    OPTRecord optRecord = new OPTRecord(4096, 0, 0, Flags.DO, null);
+    OPTRecord optRecord = new OPTRecord(4096, 0, 0, Flags.DO);
     query.addRecord(optRecord, Section.ADDITIONAL);
     byte[] responseBytes = getRegistryDNS().generateReply(query, null);
     Message response = new Message(responseBytes);
@@ -392,7 +392,7 @@ public class TestRegistryDNS extends Assert {
     Name name = Name.fromString(lookup);
     Record question = Record.newRecord(name, type, DClass.IN);
     Message query = Message.newQuery(question);
-    OPTRecord optRecord = new OPTRecord(4096, 0, 0, Flags.DO, null);
+    OPTRecord optRecord = new OPTRecord(4096, 0, 0, Flags.DO);
     query.addRecord(optRecord, Section.ADDITIONAL);
     byte[] responseBytes = getRegistryDNS().generateReply(query, null);
     Message response = new Message(responseBytes);
@@ -421,7 +421,7 @@ public class TestRegistryDNS extends Assert {
     Name name = Name.fromString(lookup);
     Record question = Record.newRecord(name, type, DClass.IN);
     Message query = Message.newQuery(question);
-    OPTRecord optRecord = new OPTRecord(4096, 0, 0, Flags.DO, null);
+    OPTRecord optRecord = new OPTRecord(4096, 0, 0, Flags.DO);
     query.addRecord(optRecord, Section.ADDITIONAL);
     byte[] responseBytes = getRegistryDNS().generateReply(query, null);
     Message response = new Message(responseBytes);
@@ -592,7 +592,7 @@ public class TestRegistryDNS extends Assert {
     Name name = Name.fromString("5.0.17.172.in-addr.arpa.");
     Record question = Record.newRecord(name, Type.PTR, DClass.IN);
     Message query = Message.newQuery(question);
-    OPTRecord optRecord = new OPTRecord(4096, 0, 0, Flags.DO, null);
+    OPTRecord optRecord = new OPTRecord(4096, 0, 0, Flags.DO);
     query.addRecord(optRecord, Section.ADDITIONAL);
     byte[] responseBytes = getRegistryDNS().generateReply(query, null);
     Message response = new Message(responseBytes);

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -106,7 +106,7 @@
     <zookeeper.version>3.8.4</zookeeper.version>
     <curator.version>5.2.0</curator.version>
     <findbugs.version>3.0.5</findbugs.version>
-    <dnsjava.version>3.6.0</dnsjava.version>
+    <dnsjava.version>3.6.1</dnsjava.version>
 
     <guava.version>27.0-jre</guava.version>
     <guice.version>5.1.0</guice.version>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -106,7 +106,7 @@
     <zookeeper.version>3.8.4</zookeeper.version>
     <curator.version>5.2.0</curator.version>
     <findbugs.version>3.0.5</findbugs.version>
-    <dnsjava.version>3.4.0</dnsjava.version>
+    <dnsjava.version>3.6.0</dnsjava.version>
 
     <guava.version>27.0-jre</guava.version>
     <guice.version>5.1.0</guice.version>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-19237 - replaces #6955 

https://github.com/dnsjava/dnsjava/blob/master/Changelog

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

