### PR TITLE
HADOOP-19238. Fix create-release script for arm64 based MacOS

### DIFF
--- a/dev-support/bin/create-release
+++ b/dev-support/bin/create-release
@@ -205,7 +205,7 @@ function set_defaults
   DOCKERRAN=false
 
   CPU_ARCH=$(echo "$MACHTYPE" | cut -d- -f1)
-  if [ "$CPU_ARCH" = "aarch64" ]; then
+  if [[ "$CPU_ARCH" = "aarch64" || "$CPU_ARCH" = "arm64" ]]; then
     DOCKERFILE="${BASEDIR}/dev-support/docker/Dockerfile_aarch64"
   fi
 
@@ -514,7 +514,7 @@ function dockermode
 
     # we always force build with the OpenJDK JDK
     # but with the correct version
-    if [ "$CPU_ARCH" = "aarch64" ]; then
+    if [[ "$CPU_ARCH" = "aarch64" || "$CPU_ARCH" = "arm64" ]]; then
       echo "ENV JAVA_HOME /usr/lib/jvm/java-${JVM_VERSION}-openjdk-arm64"
     else
       echo "ENV JAVA_HOME /usr/lib/jvm/java-${JVM_VERSION}-openjdk-amd64"
@@ -523,7 +523,6 @@ function dockermode
     echo "USER ${user_name}"
     printf "\n\n"
   ) | docker build -t "${imgname}" -f - "${BASEDIR}"/dev-support/docker/
-
   run docker run -i -t \
     --privileged \
     "${extrad[@]}"  \

--- a/dev-support/bin/create-release
+++ b/dev-support/bin/create-release
@@ -523,6 +523,7 @@ function dockermode
     echo "USER ${user_name}"
     printf "\n\n"
   ) | docker build -t "${imgname}" -f - "${BASEDIR}"/dev-support/docker/
+
   run docker run -i -t \
     --privileged \
     "${extrad[@]}"  \


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Add proper checks for arm64 based machine.

### How was this patch tested?
Tested on MacOS


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

