### PR TITLE
HDFS-17591. RBF: Router should follow X-FRAME-OPTIONS protection setting

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterHttpServer.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdfs.server.federation.router;
 import java.net.InetSocketAddress;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.hdfs.server.common.JspHelper;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeHttpServer;
@@ -85,6 +86,16 @@ public class RouterHttpServer extends AbstractService {
         this.conf, this.httpAddress, this.httpsAddress, webApp,
         RBFConfigKeys.DFS_ROUTER_KERBEROS_INTERNAL_SPNEGO_PRINCIPAL_KEY,
         RBFConfigKeys.DFS_ROUTER_KEYTAB_FILE_KEY);
+
+    final boolean xFrameEnabled = conf.getBoolean(
+        DFSConfigKeys.DFS_XFRAME_OPTION_ENABLED,
+        DFSConfigKeys.DFS_XFRAME_OPTION_ENABLED_DEFAULT);
+
+    final String xFrameOptionValue = conf.getTrimmed(
+        DFSConfigKeys.DFS_XFRAME_OPTION_VALUE,
+        DFSConfigKeys.DFS_XFRAME_OPTION_VALUE_DEFAULT);
+
+    builder.configureXFrame(xFrameEnabled).setXFrameOption(xFrameOptionValue);
 
     this.httpServer = builder.build();
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterHttpServerXFrame.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterHttpServerXFrame.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URL;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.http.HttpServer2;
+
+/**
+ * A class to test the XFrame options of Router HTTP Server.
+ */
+public class TestRouterHttpServerXFrame {
+
+  @Test
+  public void testRouterXFrame() throws IOException {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_XFRAME_OPTION_ENABLED, true);
+    conf.set(DFSConfigKeys.DFS_XFRAME_OPTION_VALUE, "SAMEORIGIN");
+
+    Router router = new Router();
+    router.init(conf);
+    router.start();
+
+    InetSocketAddress httpAddress = router.getHttpServerAddress();
+    URL url =
+        URI.create("http://" + httpAddress.getHostName() + ":" + httpAddress.getPort()).toURL();
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.connect();
+
+    String xfoHeader = conn.getHeaderField("X-FRAME-OPTIONS");
+    Assert.assertNotNull("X-FRAME-OPTIONS is absent in the header", xfoHeader);
+    Assert.assertTrue(xfoHeader.endsWith(HttpServer2.XFrameOption.SAMEORIGIN.toString()));
+
+    router.stop();
+    router.close();
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterHttpServerXFrame.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterHttpServerXFrame.java
@@ -29,7 +29,8 @@ import org.junit.Test;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
-import org.apache.hadoop.http.HttpServer2;
+
+import static org.apache.hadoop.http.HttpServer2.XFrameOption.SAMEORIGIN;
 
 /**
  * A class to test the XFrame options of Router HTTP Server.
@@ -40,23 +41,25 @@ public class TestRouterHttpServerXFrame {
   public void testRouterXFrame() throws IOException {
     Configuration conf = new HdfsConfiguration();
     conf.setBoolean(DFSConfigKeys.DFS_XFRAME_OPTION_ENABLED, true);
-    conf.set(DFSConfigKeys.DFS_XFRAME_OPTION_VALUE, "SAMEORIGIN");
+    conf.set(DFSConfigKeys.DFS_XFRAME_OPTION_VALUE, SAMEORIGIN.toString());
 
     Router router = new Router();
-    router.init(conf);
-    router.start();
+    try {
+      router.init(conf);
+      router.start();
 
-    InetSocketAddress httpAddress = router.getHttpServerAddress();
-    URL url =
-        URI.create("http://" + httpAddress.getHostName() + ":" + httpAddress.getPort()).toURL();
-    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    conn.connect();
+      InetSocketAddress httpAddress = router.getHttpServerAddress();
+      URL url =
+          URI.create("http://" + httpAddress.getHostName() + ":" + httpAddress.getPort()).toURL();
+      HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+      conn.connect();
 
-    String xfoHeader = conn.getHeaderField("X-FRAME-OPTIONS");
-    Assert.assertNotNull("X-FRAME-OPTIONS is absent in the header", xfoHeader);
-    Assert.assertTrue(xfoHeader.endsWith(HttpServer2.XFrameOption.SAMEORIGIN.toString()));
-
-    router.stop();
-    router.close();
+      String xfoHeader = conn.getHeaderField("X-FRAME-OPTIONS");
+      Assert.assertNotNull("X-FRAME-OPTIONS is absent in the header", xfoHeader);
+      Assert.assertTrue(xfoHeader.endsWith(SAMEORIGIN.toString()));
+    } finally {
+      router.stop();
+      router.close();
+    }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Router UI doesn't have X-FRAME-OPTIONS in its header. Router should load the value of dfs.xframe.value.

This issue is reported by Daiki Mashima.

### How was this patch tested?

- unit test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
