### PR TITLE
HADOOP-19246. Update the yasm rpm download address

### DIFF
--- a/dev-support/docker/pkg-resolver/install-yasm.sh
+++ b/dev-support/docker/pkg-resolver/install-yasm.sh
@@ -40,7 +40,7 @@ fi
 
 if [ "$version_to_install" == "1.2.0-4" ]; then
   mkdir -p /tmp/yasm &&
-    curl -L -s -S https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/y/yasm-1.2.0-4.el7.x86_64.rpm \
+    curl -L -s -S https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/y/yasm-1.2.0-4.el7.x86_64.rpm \
       -o /tmp/yasm-1.2.0-4.el7.x86_64.rpm &&
     rpm -Uvh /tmp/yasm-1.2.0-4.el7.x86_64.rpm
 else


### PR DESCRIPTION
### Description of PR

JIRA: HADOOP-19246. Update the yasm rpm download address.

Some ci run failed, for example:

https://ci-hadoop.apache.org/blue/rest/organizations/jenkins/pipelines/hadoop-multibranch/branches/PR-6972/runs/1/nodes/56/steps/61/log/?start=0

Error message:

```
[2024-08-02T03:51:14.062Z] #17 [13/19] RUN pkg-resolver/install-yasm.sh centos:7
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of <!DOCTYPE failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of HTML failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of PUBLIC failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of -//IETF//DTD HTML 2.0//EN> failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of <html><head> failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of <title>404 failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of Not failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of Found</title> failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of </head><body> failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of <h1>Not failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of Found</h1> failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of <p>The failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of requested failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of URL failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of was failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of not failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of found failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of on failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of this failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of server.</p> failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 0.982 error: open of </body></html> failed: No such file or directory
[2024-08-02T03:51:15.167Z] #17 ERROR: process "/bin/bash --login -c pkg-resolver/install-yasm.sh centos:7" did not complete successfully: exit code: 21
[2024-08-02T03:51:15.167Z] ------
[2024-08-02T03:51:15.167Z]  > [13/19] RUN pkg-resolver/install-yasm.sh centos:7:
[2024-08-02T03:51:15.167Z] 0.982 error: open of <p>The failed: No such file or directory
[2024-08-02T03:51:15.167Z] 0.982 error: open of requested failed: No such file or directory
[2024-08-02T03:51:15.167Z] 0.982 error: open of URL failed: No such file or directory
[2024-08-02T03:51:15.167Z] 0.982 error: open of was failed: No such file or directory
[2024-08-02T03:51:15.167Z] 0.982 error: open of not failed: No such file or directory
[2024-08-02T03:51:15.167Z] 0.982 error: open of found failed: No such file or directory
[2024-08-02T03:51:15.167Z] 0.982 error: open of on failed: No such file or directory
[2024-08-02T03:51:15.167Z] 0.982 error: open of this failed: No such file or directory
[2024-08-02T03:51:15.167Z] 0.982 error: open of server.</p> failed: No such file or directory
[2024-08-02T03:51:15.167Z] 0.982 error: open of </body></html> failed: No such file or directory
[2024-08-02T03:51:15.167Z] ------
[2024-08-02T03:51:15.167Z] Dockerfile:102
[2024-08-02T03:51:15.167Z] --------------------
[2024-08-02T03:51:15.167Z]  100 |     RUN pkg-resolver/install-cmake.sh centos:7
[2024-08-02T03:51:15.167Z]  101 |     RUN pkg-resolver/install-zstandard.sh centos:7
[2024-08-02T03:51:15.167Z]  102 | >>> RUN pkg-resolver/install-yasm.sh centos:7
[2024-08-02T03:51:15.167Z]  103 |     RUN pkg-resolver/install-protobuf.sh centos:7
[2024-08-02T03:51:15.167Z]  104 |     RUN pkg-resolver/install-boost.sh centos:7
[2024-08-02T03:51:15.167Z] --------------------
[2024-08-02T03:51:15.167Z] ERROR: failed to solve: process "/bin/bash --login -c pkg-resolver/install-yasm.sh centos:7" did not complete successfully: exit code: 21
[2024-08-02T03:51:15.167Z] Building run-specific image yetus/hadoop:tp-19006
[2024-08-02T03:51:15.167Z] #0 building with "default" instance using docker driver
[2024-08-02T03:51:15.167Z] 
[2024-08-02T03:51:15.167Z] #1 [internal] load build definition from Dockerfile
[2024-08-02T03:51:15.167Z] #1 transferring dockerfile: 2.01kB done
[2024-08-02T03:51:15.167Z] #1 WARN: InvalidDefaultArgInFrom: Default value for ARG ${baseimagename} results in empty or invalid base image name (line 19)
[2024-08-02T03:51:15.167Z] #1 DONE 0.0s
[2024-08-02T03:51:15.167Z] 
[2024-08-02T03:51:15.167Z] #2 [internal] load metadata for docker.io/yetus/hadoop:4f0ee9d67d9
[2024-08-02T03:51:15.725Z] #2 ERROR: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```

I found the yasm rpm url `https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/y/yasm-1.2.0-4.el7.x86_64.rpm` is outdated.

### How was this patch tested?

curl

### For code changes:

- update rpm download address