### PR TITLE
HADOOP-19245. S3A: S3ABlockOutputStream no longer sends progress events in close()

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
@@ -1100,7 +1100,8 @@ class S3ABlockOutputStream extends OutputStream implements
       this.progress = progress;
     }
 
-    public void progressChanged(ProgressListenerEvent eventType, int bytesTransferred) {
+    @Override
+    public void progressChanged(ProgressListenerEvent eventType, long bytesTransferred) {
       if (progress != null) {
         progress.progress();
       }


### PR DESCRIPTION

### Description of PR

change signature of bridging class ProgressableListener so progress gets invoked
as events happen during upload

### How was this patch tested?

updated test; verified it failed before the production code change

s3 london

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

