### PR TITLE
HADOOP-19248. Protobuf code generate and replace should happen together

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -2313,7 +2313,7 @@
           <executions>
             <execution>
               <id>replace-generated-sources</id>
-              <phase>process-sources</phase>
+              <phase>generate-sources</phase>
               <goals>
                 <goal>replace</goal>
               </goals>
@@ -2333,7 +2333,7 @@
             </execution>
             <execution>
               <id>replace-generated-test-sources</id>
-              <phase>process-test-resources</phase>
+              <phase>generate-test-resources</phase>
               <goals>
                 <goal>replace</goal>
               </goals>
@@ -2353,7 +2353,7 @@
             </execution>
             <execution>
               <id>replace-sources</id>
-              <phase>process-sources</phase>
+              <phase>generate-sources</phase>
               <goals>
                 <goal>replace</goal>
               </goals>
@@ -2373,7 +2373,7 @@
             </execution>
             <execution>
               <id>replace-test-sources</id>
-              <phase>process-test-sources</phase>
+              <phase>generate-test-sources</phase>
               <goals>
                 <goal>replace</goal>
               </goals>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

As part of HADOOP-16596, it switched from the vanilla protobuf to the shaded one, thus the generated code by `protobuf` should be modified (replace package name) before compiling and generating Javadoc.

Currently, the protobuf code generate happens in `generate-sources`(and other similar phases), while the replace happens in `process-sources`, this is OK for compiling but has problems for Javadoc.

```
$ mvn clean install -DskipTests
$ mvn javadoc:javadoc
```

The above commands won't trigger replace, thus the final generated Javadoc refers to vanilla protobuf.

<img width="1428" alt="image" src="https://github.com/user-attachments/assets/58dd666e-4c91-497c-ba7e-ffa272393378">

The `javadoc`(Java 8) also complains that

```
[INFO] --- javadoc:3.0.1:javadoc (default-cli) @ hadoop-common ---
[INFO] 
ExcludePrivateAnnotationsStandardDoclet
100 warnings
[WARNING] Javadoc Warnings
[WARNING] /Users/chengpan/Projects/apache-hadoop/hadoop-common-project/hadoop-common/target/generated-sources/java/org/apache/hadoop/ipc/protobuf/RpcHeaderProtos.java:3887: error: cannot find symbol
[WARNING] com.google.protobuf.GeneratedMessageV3 implements
[WARNING] ^
[WARNING] symbol:   class GeneratedMessageV3
[WARNING] location: package com.google.protobuf
```

Seems things become worse in Java 17, such the error will fail the build immediately ...

### How was this patch tested?

Tested with Java 8, macOS aarch64.

```
➜  apache-hadoop git:(trunk) mvn clean install -DskipTests
```

```
➜  apache-hadoop git:(trunk) mvn javadoc:javadoc | grep '@ hadoop-common '                 
[INFO] >>> javadoc:3.0.1:javadoc (default-cli) > generate-sources @ hadoop-common >>>
[INFO] --- antrun:1.7:run (create-testdirs) @ hadoop-common ---
[INFO] --- protobuf:0.5.1:compile (src-compile-protoc) @ hadoop-common ---
[INFO] --- build-helper:1.9:add-source (add-source-legacy-protobuf) @ hadoop-common ---
[INFO] <<< javadoc:3.0.1:javadoc (default-cli) < generate-sources @ hadoop-common <<<
[INFO] --- javadoc:3.0.1:javadoc (default-cli) @ hadoop-common ---
```

```
➜  apache-hadoop git:(HADOOP-19248) mvn javadoc:javadoc | grep '@ hadoop-common '
[INFO] >>> javadoc:3.0.1:javadoc (default-cli) > generate-sources @ hadoop-common >>>
[INFO] --- antrun:1.7:run (create-testdirs) @ hadoop-common ---
[INFO] --- protobuf:0.5.1:compile (src-compile-protoc) @ hadoop-common ---
[INFO] --- replacer:1.5.3:replace (replace-generated-sources) @ hadoop-common ---
[INFO] --- replacer:1.5.3:replace (replace-sources) @ hadoop-common ---
[INFO] --- build-helper:1.9:add-source (add-source-legacy-protobuf) @ hadoop-common ---
[INFO] <<< javadoc:3.0.1:javadoc (default-cli) < generate-sources @ hadoop-common <<<
[INFO] --- javadoc:3.0.1:javadoc (default-cli) @ hadoop-common ---
```

<img width="1384" alt="image" src="https://github.com/user-attachments/assets/30f1bf27-2ebb-4253-a38e-563814645bd0">

Javadoc warnings disappeared and the generated code is correct now.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

