### PR TITLE
YARN-11711. Clean Up ServiceScheduler Code.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/dev-support/findbugs-exclude.xml
+++ b/hadoop-yarn-project/hadoop-yarn/dev-support/findbugs-exclude.xml
@@ -725,4 +725,13 @@
   <Match>
     <Package name="org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.placement.schema" />
   </Match>
+
+  <!-- The ServiceScheduler#createConfigFileCache method uses the `load` method,
+       which is not allowed to return null; we can ignore it here. -->
+  <Match>
+    <Class name="org.apache.hadoop.yarn.service.ServiceScheduler"/>
+    <Method name="$1.load(ConfigFile)" />
+    <Bug pattern="NP_NONNULL_RETURN_VIOLATION"/>
+  </Match>
+
 </FindBugsFilter>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11711. Improve ServiceScheduler Code.

[HADOOP-16928](https://issues.apache.org/jira/browse/HADOOP-16928)(#6976) encountered a sputbug issue during compilation. The portion of code flagged by sputbug seems to be fine; we just need to bypass this validation. In addition, I made some minor improvements to other parts of the code.

### How was this patch tested?

We don't need to perform unit tests.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

