### PR TITLE
HADOOP-19250. Fix test TestServiceInterruptHandling.testRegisterAndRaise

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/service/launcher/TestServiceInterruptHandling.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/service/launcher/TestServiceInterruptHandling.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.service.launcher;
 
 import org.apache.hadoop.service.BreakableService;
 import org.apache.hadoop.service.launcher.testservices.FailureTestService;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ExitUtil;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -43,10 +44,8 @@ public class TestServiceInterruptHandling
     assertEquals(0, irqHandler.getSignalCount());
     irqHandler.raise();
     // allow for an async event
-    Thread.sleep(500);
-    IrqHandler.InterruptData data = catcher.interruptData;
-    assertNotNull("interrupt data", data);
-    assertEquals(name, data.getName());
+    GenericTestUtils.waitFor(() -> catcher.interruptData != null, 100, 10000);
+    assertEquals(name, catcher.interruptData.getName());
     assertEquals(1, irqHandler.getSignalCount());
   }
 


### PR DESCRIPTION
### Description of PR

If test on some slow server, testRegisterAndRaise may fail. The error link is https://ci-hadoop.apache.org/job/hadoop-multibranch/job/PR-6813/7/artifact/out/patch-unit-hadoop-common-project_hadoop-common.txt

### How was this patch tested?

unit test

### For code changes:

- Check the results periodically instead of after sleep

