### PR TITLE
YARN-11702: Fix Yarn over allocating containers

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -1531,14 +1531,13 @@ public class YarnConfiguration extends Configuration {
       10;
 
   /**
-   * The configuration key for enabling or disabling the auto-correction of
-   * container allocations by the ResourceManager scheduler.
+   * The configuration key for enabling or disabling the auto-correction of container allocation.
    */
   public static final String RM_SCHEDULER_AUTOCORRECT_CONTAINER_ALLOCATION = RM_PREFIX
       + "scheduler.autocorrect.container.allocation";
 
   /**
-   * Default value: {@value}
+   * Default value: {@value}.
    */
   public static final boolean DEFAULT_RM_SCHEDULER_AUTOCORRECT_CONTAINER_ALLOCATION = false;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -1530,6 +1530,18 @@ public class YarnConfiguration extends Configuration {
   public static final int DEFAULT_RM_MAX_LOG_AGGREGATION_DIAGNOSTICS_IN_MEMORY =
       10;
 
+  /**
+   * The configuration key for enabling or disabling the auto-correction of
+   * container allocations by the ResourceManager scheduler.
+   */
+  public static final String RM_SCHEDULER_AUTOCORRECT_CONTAINER_ALLOCATION = RM_PREFIX
+      + "scheduler.autocorrect.container.allocation";
+
+  /**
+   * Default value: {@value}
+   */
+  public static final boolean DEFAULT_RM_SCHEDULER_AUTOCORRECT_CONTAINER_ALLOCATION = false;
+
   /** Whether to enable log aggregation */
   public static final String LOG_AGGREGATION_ENABLED = YARN_PREFIX
       + "log-aggregation-enable";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -184,7 +184,14 @@
 
   <property>
     <description>
-      The configuration key for enabling or disabling the auto-correction of container allocation.
+      This configuration key enables or disables the auto-correction of container allocation in
+      YARN. Due to the asynchronous nature of container request and allocation, YARN may sometimes
+      over-allocate more containers than requested. The auto-correction feature addresses this by
+      automatically adjusting the number of requested containers based on those already allocated,
+      preventing extra containers from being allocated.
+      While the extra allocated containers will be released by the client within a few seconds,
+      this may not be a concern in normal circumstances. However, if the user is worried about
+      resource contention due to over-allocation, enabling this feature can help avoid such cases.
     </description>
     <name>yarn.resourcemanager.scheduler.autocorrect.container.allocation</name>
     <value>false</value>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -191,11 +191,6 @@
   </property>
 
   <property>
-    <description>The Kerberos principal for the resource manager.</description>
-    <name>yarn.resourcemanager.principal</name>
-  </property>
-
-  <property>
     <description>The address of the scheduler interface.</description>
     <name>yarn.resourcemanager.scheduler.address</name>
     <value>${yarn.resourcemanager.hostname}:8030</value>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -183,6 +183,19 @@
   </property>
 
   <property>
+    <description>
+      The configuration key for enabling or disabling the auto-correction of container allocation.
+    </description>
+    <name>yarn.resourcemanager.scheduler.autocorrect.container.allocation</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <description>The Kerberos principal for the resource manager.</description>
+    <name>yarn.resourcemanager.principal</name>
+  </property>
+
+  <property>
     <description>The address of the scheduler interface.</description>
     <name>yarn.resourcemanager.scheduler.address</name>
     <value>${yarn.resourcemanager.hostname}:8030</value>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
@@ -1796,7 +1796,8 @@ public abstract class AbstractYarnScheduler
   }
 
   /**
-   * ContainerObjectType is a container object with allocationId, priority, executionType and resource.
+   * ContainerObjectType is a container object with the following properties.
+   * Namely allocationId, priority, executionType and resourceType.
    */
   protected class ContainerObjectType extends Object {
     private final long allocationId;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
@@ -22,8 +22,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,6 +36,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+
+import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerState;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CSQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -151,6 +155,7 @@ public abstract class AbstractYarnScheduler
   Thread updateThread;
   private final Object updateThreadMonitor = new Object();
   private Timer releaseCache;
+  private boolean autoCorrectContainerAllocation;
 
   /*
    * All schedulers which are inheriting AbstractYarnScheduler should use
@@ -212,6 +217,9 @@ public abstract class AbstractYarnScheduler
         conf.getLong(YarnConfiguration.RM_NM_HEARTBEAT_INTERVAL_MS,
             YarnConfiguration.DEFAULT_RM_NM_HEARTBEAT_INTERVAL_MS);
     skipNodeInterval = YarnConfiguration.getSkipNodeInterval(conf);
+    autoCorrectContainerAllocation =
+        conf.getBoolean(YarnConfiguration.RM_SCHEDULER_AUTOCORRECT_CONTAINER_ALLOCATION,
+            YarnConfiguration.DEFAULT_RM_SCHEDULER_AUTOCORRECT_CONTAINER_ALLOCATION);
     long configuredMaximumAllocationWaitTime =
         conf.getLong(YarnConfiguration.RM_WORK_PRESERVING_RECOVERY_SCHEDULING_WAIT_MS,
           YarnConfiguration.DEFAULT_RM_WORK_PRESERVING_RECOVERY_SCHEDULING_WAIT_MS);
@@ -624,6 +632,103 @@ public abstract class AbstractYarnScheduler
     }
   }
 
+  /**
+   * Autocorrect container resourceRequests by decrementing the number of newly allocated containers
+   * from the current container request. This also updates the newlyAllocatedContainers to be within
+   * the limits of the current container resourceRequests.
+   * ResourceRequests locality/resourceName is not considered while autocorrecting the container request, hence
+   * when there are two types of resourceRequest which is same except for the locality/resourceName, it is counted as
+   * same {@link ContainerObjectType} and the container ask and number of newly allocated container is decremented
+   * accordingly. For example when a client requests for 4 containers with locality/resourceName as "node1", AMRMClient
+   * augments the resourceRequest into two where R1(numContainer=4,locality=*) and R2(numContainer=4,locality=node1),
+   * if Yarn allocated 6 containers previously, it will release 2 containers as well as update the container ask to 0.
+   *
+   * If there is a client which directly calls Yarn (without AMRMClient) with  two where R1(numContainer=4,locality=*)
+   * and R2(numContainer=4,locality=node1) the autocorrection may not work as expected. The use case of such client is
+   * very rare.
+   *
+   * <p>
+   * This method is called from {@link AbstractYarnScheduler#allocate} method. It is package private
+   * to be used within the scheduler package only.
+   * @param resourceRequests List of resources to be allocated
+   * @param application ApplicationAttempt
+   */
+  @VisibleForTesting
+  protected void autoCorrectContainerAllocation(List<ResourceRequest> resourceRequests,
+      SchedulerApplicationAttempt application) {
+
+    // if there is no resourceRequests for containers or no newly allocated container from
+    // the previous request there is nothing to do.
+    if (!autoCorrectContainerAllocation || resourceRequests.isEmpty() ||
+        application.newlyAllocatedContainers.isEmpty()) {
+      return;
+    }
+
+    // iterate newlyAllocatedContainers and form a mapping of container type
+    // and number of its occurrence.
+    Map<ContainerObjectType, List<RMContainer>> allocatedContainerMap = new HashMap<>();
+    for (RMContainer rmContainer : application.newlyAllocatedContainers) {
+      Container container = rmContainer.getContainer();
+      ContainerObjectType containerObjectType = new ContainerObjectType(
+          container.getAllocationRequestId(), container.getPriority(),
+          container.getExecutionType(), container.getResource());
+      allocatedContainerMap.computeIfAbsent(containerObjectType,
+          k -> new ArrayList<>()).add(rmContainer);
+    }
+
+    Map<ContainerObjectType, Integer> extraContainerAllocatedMap = new HashMap<>();
+    // iterate through resourceRequests and update the request by
+    // decrementing the already allocated containers.
+    for (ResourceRequest request : resourceRequests) {
+      ContainerObjectType containerObjectType =
+          new ContainerObjectType(request.getAllocationRequestId(),
+              request.getPriority(), request.getExecutionTypeRequest().getExecutionType(),
+              request.getCapability());
+      int numContainerAllocated = allocatedContainerMap.getOrDefault(containerObjectType,
+          Collections.emptyList()).size();
+      if (numContainerAllocated > 0) {
+        int numContainerAsk = request.getNumContainers();
+        int updatedContainerRequest = numContainerAsk - numContainerAllocated;
+        if (updatedContainerRequest < 0) {
+          // add an entry to extra allocated map
+          extraContainerAllocatedMap.put(containerObjectType, Math.abs(updatedContainerRequest));
+          LOG.debug("{} container of the resource type: {} will be released",
+              Math.abs(updatedContainerRequest), request);
+          // if newlyAllocatedContainer count is more than the current container
+          // resourceRequests, reset it to 0.
+          updatedContainerRequest = 0;
+        }
+
+        // update the request
+        LOG.debug("Updating container resourceRequests from {} to {} for the resource type: {}",
+            numContainerAsk, updatedContainerRequest, request);
+        request.setNumContainers(updatedContainerRequest);
+      }
+    }
+
+    // Iterate over the entries in extraContainerAllocatedMap
+    for (Map.Entry<ContainerObjectType, Integer> entry : extraContainerAllocatedMap.entrySet()) {
+      ContainerObjectType containerObjectType = entry.getKey();
+      int extraContainers = entry.getValue();
+
+      // Get the list of allocated containers for the current ContainerObjectType
+      List<RMContainer> allocatedContainers = allocatedContainerMap.get(containerObjectType);
+      if (allocatedContainers != null) {
+        for (RMContainer rmContainer : allocatedContainers) {
+          if (extraContainers > 0) {
+            // Change the state of the container from ALLOCATED to EXPIRED since it is not required.
+            LOG.debug("Removing extra container:{}", rmContainer.getContainer());
+            completedContainer(rmContainer, SchedulerUtils.createAbnormalContainerStatus(
+                rmContainer.getContainerId(), SchedulerUtils.EXPIRED_CONTAINER),
+                RMContainerEventType.EXPIRE);
+            application.newlyAllocatedContainers.remove(rmContainer);
+            extraContainers--;
+          }
+        }
+      }
+    }
+  }
+
   private RMContainer recoverAndCreateContainer(NMContainerStatus status,
       RMNode node, String queueName) {
     Container container =
@@ -655,6 +760,14 @@ public abstract class AbstractYarnScheduler
 
     // If container state is moved to ACQUIRED, request will be empty.
     if (containerRequest == null) {
+      return;
+    }
+
+    // when auto correct container allocation is enabled, there can be a case when extra containers
+    // go to expired state from allocated state. When such scenario happens do not re-attempt the
+    // container request since this is expected.
+    if (autoCorrectContainerAllocation &&
+        RMContainerState.EXPIRED.equals(rmContainer.getState())) {
       return;
     }
 
@@ -1677,5 +1790,77 @@ public abstract class AbstractYarnScheduler
           + " doesn't exist");
     }
     return apps;
+  }
+
+  /**
+   * ContainerObjectType is a container object with allocationId, priority, executionType and resource.
+   */
+  protected class ContainerObjectType extends Object {
+    private final long allocationId;
+    private final Priority priority;
+    private final ExecutionType executionType;
+    private final Resource resource;
+
+    public ContainerObjectType(long allocationId, Priority priority, ExecutionType executionType, Resource resource) {
+      this.allocationId = allocationId;
+      this.priority = priority;
+      this.executionType = executionType;
+      this.resource = resource;
+    }
+
+    public long getAllocationId() {
+      return allocationId;
+    }
+
+    public Priority getPriority() {
+      return priority;
+    }
+
+    public ExecutionType getExecutionType() {
+      return executionType;
+    }
+
+    public Resource getResource() {
+      return resource;
+    }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = (int) (prime * result +  allocationId);
+      result = prime * result + (priority == null ? 0 : priority.hashCode());
+      result = prime * result + (executionType == null ? 0 : executionType.hashCode());
+      result = prime * result + (resource == null ? 0 : resource.hashCode());
+      return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == null) {
+        return false;
+      }
+      if (obj.getClass() != this.getClass()) {
+        return false;
+      }
+      ContainerObjectType containerObjectType = (ContainerObjectType) obj;
+      if (allocationId == containerObjectType.getAllocationId() &&
+          priority.equals(containerObjectType.getPriority()) &&
+          executionType.equals(containerObjectType.getExecutionType()) &&
+          resource.equals(containerObjectType.getResource())) {
+        return true;
+      }
+      return false;
+    }
+
+    @Override
+    public String toString() {
+      return "{ContainerObjectType: "
+          + ", Priority: " + getPriority()
+          + ", Allocation Id: " + getAllocationId()
+          + ", Execution Type: " + getExecutionType()
+          + ", Resource: " + getResource()
+          + "}";
+    }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
@@ -37,6 +37,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerState;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CSQueue;
 import org.slf4j.Logger;
@@ -1831,13 +1833,12 @@ public abstract class AbstractYarnScheduler
 
     @Override
     public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = (int) (prime * result +  allocationId);
-      result = prime * result + (priority == null ? 0 : priority.hashCode());
-      result = prime * result + (executionType == null ? 0 : executionType.hashCode());
-      result = prime * result + (resource == null ? 0 : resource.hashCode());
-      return result;
+      return new HashCodeBuilder(17, 37)
+          .append(allocationId)
+          .append(priority)
+          .append(executionType)
+          .append(resource)
+          .toHashCode();
     }
 
     @Override
@@ -1848,14 +1849,14 @@ public abstract class AbstractYarnScheduler
       if (obj.getClass() != this.getClass()) {
         return false;
       }
-      ContainerObjectType containerObjectType = (ContainerObjectType) obj;
-      if (allocationId == containerObjectType.getAllocationId() &&
-          priority.equals(containerObjectType.getPriority()) &&
-          executionType.equals(containerObjectType.getExecutionType()) &&
-          resource.equals(containerObjectType.getResource())) {
-        return true;
-      }
-      return false;
+
+      ContainerObjectType other = (ContainerObjectType) obj;
+      return new EqualsBuilder()
+          .append(allocationId, other.getAllocationId())
+          .append(priority, other.getPriority())
+          .append(executionType, other.getExecutionType())
+          .append(resource, other.getResource())
+          .isEquals();
     }
 
     @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
@@ -636,16 +636,19 @@ public abstract class AbstractYarnScheduler
    * Autocorrect container resourceRequests by decrementing the number of newly allocated containers
    * from the current container request. This also updates the newlyAllocatedContainers to be within
    * the limits of the current container resourceRequests.
-   * ResourceRequests locality/resourceName is not considered while autocorrecting the container request, hence
-   * when there are two types of resourceRequest which is same except for the locality/resourceName, it is counted as
-   * same {@link ContainerObjectType} and the container ask and number of newly allocated container is decremented
-   * accordingly. For example when a client requests for 4 containers with locality/resourceName as "node1", AMRMClient
-   * augments the resourceRequest into two where R1(numContainer=4,locality=*) and R2(numContainer=4,locality=node1),
-   * if Yarn allocated 6 containers previously, it will release 2 containers as well as update the container ask to 0.
+   * ResourceRequests locality/resourceName is not considered while autocorrecting the container
+   * request, hence when there are two types of resourceRequest which is same except for the
+   * locality/resourceName, it is counted as same {@link ContainerObjectType} and the container
+   * ask and number of newly allocated container is decremented accordingly.
+   * For example when a client requests for 4 containers with locality/resourceName
+   * as "node1", AMRMClientaugments the resourceRequest into two
+   * where R1(numContainer=4,locality=*) and R2(numContainer=4,locality=node1),
+   * if Yarn allocated 6 containers previously, it will release 2 containers as well as
+   * update the container ask to 0.
    *
-   * If there is a client which directly calls Yarn (without AMRMClient) with  two where R1(numContainer=4,locality=*)
-   * and R2(numContainer=4,locality=node1) the autocorrection may not work as expected. The use case of such client is
-   * very rare.
+   * If there is a client which directly calls Yarn (without AMRMClient) with
+   * two where R1(numContainer=4,locality=*) and R2(numContainer=4,locality=node1)
+   * the autocorrection may not work as expected. The use case of such client is very rare.
    *
    * <p>
    * This method is called from {@link AbstractYarnScheduler#allocate} method. It is package private
@@ -1801,7 +1804,8 @@ public abstract class AbstractYarnScheduler
     private final ExecutionType executionType;
     private final Resource resource;
 
-    public ContainerObjectType(long allocationId, Priority priority, ExecutionType executionType, Resource resource) {
+    public ContainerObjectType(long allocationId, Priority priority,
+        ExecutionType executionType, Resource resource) {
       this.allocationId = allocationId;
       this.priority = priority;
       this.executionType = executionType;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerApplicationAttempt.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerApplicationAttempt.java
@@ -862,7 +862,8 @@ public class SchedulerApplicationAttempt implements SchedulableEntity {
     updateContainerErrors.add(error);
   }
 
-  protected synchronized void addToNewlyAllocatedContainers(
+  @VisibleForTesting
+  public synchronized void addToNewlyAllocatedContainers(
       SchedulerNode node, RMContainer rmContainer) {
     ContainerId matchedContainerId =
         getUpdateContext().matchContainerToOutstandingIncreaseReq(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
@@ -1363,6 +1363,10 @@ public class CapacityScheduler extends
           application.showRequests();
         }
 
+        // update the current container ask by considering the already allocated
+        // containers from previous allocation request and return updatedNewlyAllocatedContainers.
+        autoCorrectContainerAllocation(ask, application);
+
         // Update application requests
         if (application.updateResourceRequests(ask) || application
             .updateSchedulingRequests(schedulingRequests)) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairScheduler.java
@@ -943,6 +943,11 @@ public class FairScheduler extends
         }
         application.showRequests();
 
+        // update the current container ask by considering the already allocated containers
+        // from previous allocation request as well as populate the updatedNewlyAllocatedContainers
+        // list according the to the current ask.
+        autoCorrectContainerAllocation(ask, application);
+
         // Update application requests
         application.updateResourceRequests(ask);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestAbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestAbstractYarnScheduler.java
@@ -277,25 +277,6 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
     Assert.assertEquals(0, scheduler.getNumClusterNodes());
   }
 
-  private void mockContainers(Container container,
-      int containerId,
-      NodeId nodeId,
-      ApplicationAttemptId appAttemptId,
-      long allocationId,
-      int memory,
-      int vcore,
-      Priority priority,
-      ExecutionType executionType) {
-    when(container.getResource()).thenReturn(Resource.newInstance(memory, vcore));
-    when(container.getPriority()).thenReturn(priority);
-    when(container.getId()).thenReturn(ContainerId.newContainerId(appAttemptId, containerId));
-    when(container.getNodeId()).thenReturn(nodeId);
-    when(container.getAllocationRequestId()).thenReturn(allocationId);
-    when(container.getExecutionType()).thenReturn(executionType);
-    when(container.getContainerToken()).thenReturn(Token.newInstance(new byte[0], "kind",
-        new byte[0], "service"));
-  }
-
   /**
    * Test for testing autocorrect container allocation feature.
    */
@@ -369,20 +350,25 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
    * @param appAttemptId    The ApplicationAttemptId of the application attempt
    * @param allocationId    The allocation ID of the container
    * @param memory          The amount of memory (in MB) requested for the container
-   * @param vCores          The number of virtual cores requested for the container
    * @param priority        The priority of the container request
    * @param executionType   The execution type of the container request
    * @return A mock instance of RMContainer with the specified parameters
    */
   private RMContainer createMockRMContainer(int containerId, NodeId nodeId,
-      ApplicationAttemptId appAttemptId, long allocationId, int memory, int vCores,
+      ApplicationAttemptId appAttemptId, long allocationId, int memory,
       Priority priority, ExecutionType executionType) {
     // Create a mock instance of Container
     Container container = mock(Container.class);
 
     // Mock the Container instance with the specified parameters
-    mockContainers(container, containerId, nodeId, appAttemptId, allocationId, memory, vCores,
-        priority, executionType);
+    when(container.getResource()).thenReturn(Resource.newInstance(memory, 1));
+    when(container.getPriority()).thenReturn(priority);
+    when(container.getId()).thenReturn(ContainerId.newContainerId(appAttemptId, containerId));
+    when(container.getNodeId()).thenReturn(nodeId);
+    when(container.getAllocationRequestId()).thenReturn(allocationId);
+    when(container.getExecutionType()).thenReturn(executionType);
+    when(container.getContainerToken()).thenReturn(Token.newInstance(new byte[0], "kind",
+        new byte[0], "service"));
 
     // Create a mock instance of RMContainerImpl
     RMContainer rmContainer = mock(RMContainerImpl.class);
@@ -446,7 +432,7 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
 
     // Create an RMContainer with the specified parameters
     RMContainer rmContainer = createMockRMContainer(1, nodeId, appAttemptId,
-        0L, 1024, 1, priority, ExecutionType.GUARANTEED);
+        0L, 1024, priority, ExecutionType.GUARANTEED);
 
     // Add the RMContainer to the newly allocated containers of the application
     application.addToNewlyAllocatedContainers(schedulerNode, rmContainer);
@@ -483,7 +469,7 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
 
     // Create an RMContainer with the specified parameters
     RMContainer rmContainer1 = createMockRMContainer(1, nodeId, appAttemptId,
-        0L, 1024, 1, priority, ExecutionType.GUARANTEED);
+        0L, 1024, priority, ExecutionType.GUARANTEED);
 
     // Add the RMContainer to the newly allocated containers of the application
     application.addToNewlyAllocatedContainers(schedulerNode, rmContainer1);
@@ -535,21 +521,21 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
 
     // Create eight RMContainers (two for each resource request type)
     RMContainer rmContainer1 = createMockRMContainer(1, nodeId, appAttemptId,
-        0L, 1024, 1, priority, ExecutionType.GUARANTEED);
+        0L, 1024, priority, ExecutionType.GUARANTEED);
     RMContainer rmContainer2 = createMockRMContainer(2, nodeId, appAttemptId,
-        0L, 1024, 1, priority, ExecutionType.GUARANTEED);
+        0L, 1024, priority, ExecutionType.GUARANTEED);
     RMContainer rmContainer3 = createMockRMContainer(3, nodeId, appAttemptId,
-        0L, 2048, 1, priority, ExecutionType.GUARANTEED);
+        0L, 2048, priority, ExecutionType.GUARANTEED);
     RMContainer rmContainer4 = createMockRMContainer(4, nodeId, appAttemptId,
-        0L, 2048, 1, priority, ExecutionType.GUARANTEED);
+        0L, 2048, priority, ExecutionType.GUARANTEED);
     RMContainer rmContainer5 = createMockRMContainer(5, nodeId, appAttemptId,
-        1L, 1024, 1, priority, ExecutionType.GUARANTEED);
+        1L, 1024, priority, ExecutionType.GUARANTEED);
     RMContainer rmContainer6 = createMockRMContainer(6, nodeId, appAttemptId,
-        1L, 1024, 1, priority, ExecutionType.GUARANTEED);
+        1L, 1024, priority, ExecutionType.GUARANTEED);
     RMContainer rmContainer7 = createMockRMContainer(7, nodeId, appAttemptId,
-        0L, 1024, 1, priority, ExecutionType.OPPORTUNISTIC);
+        0L, 1024, priority, ExecutionType.OPPORTUNISTIC);
     RMContainer rmContainer8 = createMockRMContainer(8, nodeId, appAttemptId,
-        0L, 1024, 1, priority, ExecutionType.OPPORTUNISTIC);
+        0L, 1024, priority, ExecutionType.OPPORTUNISTIC);
 
     // Add the RMContainers to the newly allocated containers of the application
     application.addToNewlyAllocatedContainers(schedulerNode, rmContainer1);
@@ -605,17 +591,17 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
 
     // Create six RMContainers with the specified parameters
     RMContainer rmContainer1 = createMockRMContainer(1, nodeId, appAttemptId,
-        0L, 1024, 1, priority, ExecutionType.GUARANTEED);
+        0L, 1024, priority, ExecutionType.GUARANTEED);
     RMContainer rmContainer2 = createMockRMContainer(2, nodeId, appAttemptId,
-        0L, 1024, 1, priority, ExecutionType.GUARANTEED);
+        0L, 1024, priority, ExecutionType.GUARANTEED);
     RMContainer rmContainer3 = createMockRMContainer(3, nodeId, appAttemptId,
-        0L, 1024, 1, priority, ExecutionType.GUARANTEED);
-    RMContainer rmContainer4 = createMockRMContainer(4, nodeId, appAttemptId, 
-        0L, 1024, 1, priority, ExecutionType.GUARANTEED);
+        0L, 1024, priority, ExecutionType.GUARANTEED);
+    RMContainer rmContainer4 = createMockRMContainer(4, nodeId, appAttemptId,
+        0L, 1024, priority, ExecutionType.GUARANTEED);
     RMContainer rmContainer5 = createMockRMContainer(5, nodeId, appAttemptId,
-        0L, 1024, 1, priority, ExecutionType.GUARANTEED);
+        0L, 1024, priority, ExecutionType.GUARANTEED);
     RMContainer rmContainer6 = createMockRMContainer(6, nodeId, appAttemptId,
-        0L, 1024, 1, priority, ExecutionType.GUARANTEED);
+        0L, 1024, priority, ExecutionType.GUARANTEED);
 
     // Add the RMContainers to the newly allocated containers of the application
     application.addToNewlyAllocatedContainers(schedulerNode, rmContainer1);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestUtils.java
@@ -195,6 +195,20 @@ public class TestUtils {
     request.setNodeLabelExpression(labelExpression);
     return request;
   }
+
+  public static ResourceRequest createResourceRequest(int memory, int vcores, int numContainers,
+      Priority priority, long allocationId, ExecutionTypeRequest type, String resourceName) {
+    ResourceRequest request =
+        recordFactory.newRecordInstance(ResourceRequest.class);
+    Resource capability = Resources.createResource(memory, vcores);
+    request.setNumContainers(numContainers);
+    request.setCapability(capability);
+    request.setPriority(priority);
+    request.setAllocationRequestId(allocationId);
+    request.setExecutionTypeRequest(type);
+    request.setResourceName(resourceName);
+    return request;
+  }
   
   public static ResourceRequest createResourceRequest(
       String resourceName, int memory, int numContainers, boolean relaxLocality,


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Refer https://issues.apache.org/jira/browse/YARN-11702 for more information

### How was this patch tested?
1. Added Unit Test
2. Manual Testing 

### For code changes:

- [ X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [NA ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

