### PR TITLE
HDFS-17605. Reduce memory overhead of TestBPOfferService

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBPOfferService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBPOfferService.java
@@ -144,8 +144,9 @@ public class TestBPOfferService {
     mockNN2 = setupNNMock(1);
 
     // Set up a mock DN with the bare-bones configuration
-    // objects, etc.
-    mockDn = Mockito.mock(DataNode.class);
+    // objects, etc. Set as stubOnly to save memory and avoid Mockito holding
+    // references to each invocation. This can cause OOM in some runs.
+    mockDn = Mockito.mock(DataNode.class, Mockito.withSettings().stubOnly());
     Mockito.doReturn(true).when(mockDn).shouldRun();
     Configuration conf = new Configuration();
     File dnDataDir = new File(new File(TEST_BUILD_DATA, "dfs"), "data");


### PR DESCRIPTION
### Description of PR

With default memory settings TestBPOfferService often errors with GC overhead / OOM errors. After analysing the heap dump, this is due to Mockito holding lots of references to invocations on a datanode mock.

This mock is never checked for invocations so we can mark it as stubonly and allow Mockito to drop the invocations. This small change allows the test to consistently pass on my local environment.

### How was this patch tested?

This is a test only change. I ran the test several times in my fork to ensure it passed consistently when it often failed prior to the fix.