### PR TITLE
HADOOP-19252. Releasing hadoop-thirdparty 1.3.0: switch to 1.4.0-SNAPSHOT

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -97,7 +97,7 @@
     <protoc.path>${env.HADOOP_PROTOC_PATH}</protoc.path>
 
     <hadoop-thirdparty.version>1.2.0</hadoop-thirdparty.version>
-    <hadoop-thirdparty-protobuf.version>1.3.0-SNAPSHOT</hadoop-thirdparty-protobuf.version>
+    <hadoop-thirdparty-protobuf.version>1.4.0-SNAPSHOT</hadoop-thirdparty-protobuf.version>
     <hadoop-thirdparty-guava.version>${hadoop-thirdparty.version}</hadoop-thirdparty-guava.version>
     <hadoop-thirdparty-shaded-prefix>org.apache.hadoop.thirdparty</hadoop-thirdparty-shaded-prefix>
     <hadoop-thirdparty-shaded-protobuf-prefix>${hadoop-thirdparty-shaded-prefix}.protobuf</hadoop-thirdparty-shaded-protobuf-prefix>


### PR DESCRIPTION


Modified build to work with hadoop-thirdparty-1.4.0-SNAPSHOT, which is the nightly build of that sub-project



### How was this patch tested?

did a local build of hadoop-thirdparty 1.4.0-SNAPSHOT -then compiled this.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

The LICENSE-binary is out of date w.r.t protobuf versions in 1.3.0, as are some of the build instructions. That "concerns" me -but is independent of this change
