### PR TITLE
HDFS-17606. Do not require implementing CustomizedCallbackHandler.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/CustomizedCallbackHandler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/CustomizedCallbackHandler.java
@@ -28,7 +28,7 @@ import java.util.List;
 public interface CustomizedCallbackHandler {
   class DefaultHandler implements CustomizedCallbackHandler{
     @Override
-    public void handleCallback(List<Callback> callbacks, String username, char[] password)
+    public void handleCallbacks(List<Callback> callbacks, String username, char[] password)
         throws UnsupportedCallbackException {
       if (!callbacks.isEmpty()) {
         throw new UnsupportedCallbackException(callbacks.get(0));
@@ -37,15 +37,16 @@ public interface CustomizedCallbackHandler {
   }
 
   static CustomizedCallbackHandler delegate(Object delegated) {
+    final String methodName = "handleCallbacks";
+    final Class<?> clazz = delegated.getClass();
+    final Method method;
+    try {
+      method = clazz.getMethod(methodName, List.class, String.class, char[].class);
+    } catch (NoSuchMethodException e) {
+      throw new IllegalStateException("Failed to get method " + methodName + " from " + clazz, e);
+    }
+
     return (callbacks, name, password) -> {
-      final String methodName = "handleCallback";
-      final Class<?> clazz = delegated.getClass();
-      final Method method;
-      try {
-        method = clazz.getMethod("handleCallback", List.class, String.class, char[].class);
-      } catch (NoSuchMethodException e) {
-        throw new IllegalStateException("Failed to get method " + methodName + " from " + clazz, e);
-      }
       try {
         method.invoke(delegated, callbacks, name, password);
       } catch (IllegalAccessException | InvocationTargetException e) {
@@ -54,6 +55,6 @@ public interface CustomizedCallbackHandler {
     };
   }
 
-  void handleCallback(List<Callback> callbacks, String name, char[] password)
+  void handleCallbacks(List<Callback> callbacks, String name, char[] password)
       throws UnsupportedCallbackException, IOException;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
@@ -225,13 +225,19 @@ public class SaslDataTransferServer {
     SaslServerCallbackHandler(Configuration conf, PasswordFunction passwordFunction) {
       this.passwordFunction = passwordFunction;
 
-      final Class<? extends CustomizedCallbackHandler> clazz = conf.getClass(
+      final Class<?> clazz = conf.getClass(
           HdfsClientConfigKeys.DFS_DATA_TRANSFER_SASL_CUSTOMIZEDCALLBACKHANDLER_CLASS_KEY,
-          CustomizedCallbackHandler.DefaultHandler.class, CustomizedCallbackHandler.class);
+          CustomizedCallbackHandler.DefaultHandler.class);
+      final Object callbackHandler;
       try {
-        this.customizedCallbackHandler = clazz.newInstance();
+        callbackHandler = clazz.newInstance();
       } catch (Exception e) {
         throw new IllegalStateException("Failed to create a new instance of " + clazz, e);
+      }
+      if (callbackHandler instanceof CustomizedCallbackHandler) {
+        customizedCallbackHandler = (CustomizedCallbackHandler) callbackHandler;
+      } else {
+        customizedCallbackHandler = CustomizedCallbackHandler.delegate(callbackHandler);
       }
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
@@ -277,7 +277,7 @@ public class SaslDataTransferServer {
       if (unknownCallbacks != null) {
         final String name = nc != null ? nc.getDefaultName() : null;
         final char[] password = name != null ? passwordFunction.apply(name) : null;
-        customizedCallbackHandler.handleCallback(unknownCallbacks, name, password);
+        customizedCallbackHandler.handleCallbacks(unknownCallbacks, name, password);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestCustomizedCallbackHandler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestCustomizedCallbackHandler.java
@@ -110,7 +110,8 @@ public class TestCustomizedCallbackHandler {
     LambdaTestUtils.intercept(IOException.class, () -> runTest(conf, callbacks));
   }
 
-  static void runTest(Configuration conf, Callback... callbacks) throws IOException, UnsupportedCallbackException {
+  static void runTest(Configuration conf, Callback... callbacks)
+      throws IOException, UnsupportedCallbackException {
     new SaslServerCallbackHandler(conf, String::toCharArray).handle(callbacks);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestCustomizedCallbackHandler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestCustomizedCallbackHandler.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdfs.protocol.datatransfer.sasl;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.protocol.datatransfer.sasl.SaslDataTransferServer.SaslServerCallbackHandler;
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -27,18 +28,35 @@ import org.slf4j.LoggerFactory;
 
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.UnsupportedCallbackException;
-import java.util.Arrays;
+import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class TestCustomizedCallbackHandler {
   public static final Logger LOG = LoggerFactory.getLogger(TestCustomizedCallbackHandler.class);
+
+  static final AtomicReference<List<Callback>> LAST_CALLBACKS = new AtomicReference<>();
+
+  static void runHandleCallbacks(Object caller, List<Callback> callbacks, String name) {
+    LOG.info("{}: handling {} for {}", caller.getClass().getSimpleName(), callbacks, name);
+    LAST_CALLBACKS.set(callbacks);
+  }
+
+  static void assertCallbacks(Callback[] expected) {
+    final List<Callback> computed = LAST_CALLBACKS.getAndSet(null);
+    Assert.assertNotNull(computed);
+    Assert.assertEquals(expected.length, computed.size());
+    for (int i = 0; i < expected.length; i++) {
+      Assert.assertSame(expected[i], computed.get(i));
+    }
+  }
 
   static class MyCallback implements Callback { }
 
   static class MyCallbackHandler implements CustomizedCallbackHandler {
     @Override
-    public void handleCallback(List<Callback> callbacks, String name, char[] password) {
-      LOG.info("{}: handling {} for {}", getClass().getSimpleName(), callbacks, name);
+    public void handleCallbacks(List<Callback> callbacks, String name, char[] password) {
+      runHandleCallbacks(this, callbacks, name);
     }
   }
 
@@ -48,23 +66,27 @@ public class TestCustomizedCallbackHandler {
     final Callback[] callbacks = {new MyCallback()};
 
     // without setting conf, expect UnsupportedCallbackException
-    try {
-      new SaslServerCallbackHandler(conf, String::toCharArray).handle(callbacks);
-      Assert.fail("Expected UnsupportedCallbackException for " + Arrays.asList(callbacks));
-    } catch (UnsupportedCallbackException e) {
-      LOG.info("The failure is expected", e);
-    }
+    LambdaTestUtils.intercept(UnsupportedCallbackException.class, () -> runTest(conf, callbacks));
 
     // set conf and expect success
     conf.setClass(HdfsClientConfigKeys.DFS_DATA_TRANSFER_SASL_CUSTOMIZEDCALLBACKHANDLER_CLASS_KEY,
         MyCallbackHandler.class, CustomizedCallbackHandler.class);
     new SaslServerCallbackHandler(conf, String::toCharArray).handle(callbacks);
+    assertCallbacks(callbacks);
   }
 
   static class MyCallbackMethod {
-    public void handleCallback(List<Callback> callbacks, String name, char[] password)
+    public void handleCallbacks(List<Callback> callbacks, String name, char[] password)
         throws UnsupportedCallbackException {
-      LOG.info("{}: handling {} for {}", getClass().getSimpleName(), callbacks, name);
+      runHandleCallbacks(this, callbacks, name);
+    }
+  }
+
+  static class MyExceptionMethod {
+    public void handleCallbacks(List<Callback> callbacks, String name, char[] password)
+        throws UnsupportedCallbackException {
+      runHandleCallbacks(this, callbacks, name);
+      throw new UnsupportedCallbackException(callbacks.get(0));
     }
   }
 
@@ -74,16 +96,21 @@ public class TestCustomizedCallbackHandler {
     final Callback[] callbacks = {new MyCallback()};
 
     // without setting conf, expect UnsupportedCallbackException
-    try {
-      new SaslServerCallbackHandler(conf, String::toCharArray).handle(callbacks);
-      Assert.fail("Expected UnsupportedCallbackException for " + Arrays.asList(callbacks));
-    } catch (UnsupportedCallbackException e) {
-      LOG.info("The failure is expected", e);
-    }
+    LambdaTestUtils.intercept(UnsupportedCallbackException.class, () -> runTest(conf, callbacks));
 
     // set conf and expect success
     conf.setClass(HdfsClientConfigKeys.DFS_DATA_TRANSFER_SASL_CUSTOMIZEDCALLBACKHANDLER_CLASS_KEY,
         MyCallbackMethod.class, Object.class);
+    new SaslServerCallbackHandler(conf, String::toCharArray).handle(callbacks);
+    assertCallbacks(callbacks);
+
+    // set conf and expect exception
+    conf.setClass(HdfsClientConfigKeys.DFS_DATA_TRANSFER_SASL_CUSTOMIZEDCALLBACKHANDLER_CLASS_KEY,
+        MyExceptionMethod.class, Object.class);
+    LambdaTestUtils.intercept(IOException.class, () -> runTest(conf, callbacks));
+  }
+
+  static void runTest(Configuration conf, Callback... callbacks) throws IOException, UnsupportedCallbackException {
     new SaslServerCallbackHandler(conf, String::toCharArray).handle(callbacks);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestCustomizedCallbackHandler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestCustomizedCallbackHandler.java
@@ -32,8 +32,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+/** For testing {@link CustomizedCallbackHandler}. */
 public class TestCustomizedCallbackHandler {
-  public static final Logger LOG = LoggerFactory.getLogger(TestCustomizedCallbackHandler.class);
+  static final Logger LOG = LoggerFactory.getLogger(TestCustomizedCallbackHandler.class);
 
   static final AtomicReference<List<Callback>> LAST_CALLBACKS = new AtomicReference<>();
 
@@ -42,6 +43,7 @@ public class TestCustomizedCallbackHandler {
     LAST_CALLBACKS.set(callbacks);
   }
 
+  /** Assert if the callbacks in {@link #LAST_CALLBACKS} are the same as the expected callbacks. */
   static void assertCallbacks(Callback[] expected) {
     final List<Callback> computed = LAST_CALLBACKS.getAndSet(null);
     Assert.assertNotNull(computed);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestCustomizedCallbackHandler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestCustomizedCallbackHandler.java
@@ -60,4 +60,30 @@ public class TestCustomizedCallbackHandler {
         MyCallbackHandler.class, CustomizedCallbackHandler.class);
     new SaslServerCallbackHandler(conf, String::toCharArray).handle(callbacks);
   }
+
+  static class MyCallbackMethod {
+    public void handleCallback(List<Callback> callbacks, String name, char[] password)
+        throws UnsupportedCallbackException {
+      LOG.info("{}: handling {} for {}", getClass().getSimpleName(), callbacks, name);
+    }
+  }
+
+  @Test
+  public void testCustomizedCallbackMethod() throws Exception {
+    final Configuration conf = new Configuration();
+    final Callback[] callbacks = {new MyCallback()};
+
+    // without setting conf, expect UnsupportedCallbackException
+    try {
+      new SaslServerCallbackHandler(conf, String::toCharArray).handle(callbacks);
+      Assert.fail("Expected UnsupportedCallbackException for " + Arrays.asList(callbacks));
+    } catch (UnsupportedCallbackException e) {
+      LOG.info("The failure is expected", e);
+    }
+
+    // set conf and expect success
+    conf.setClass(HdfsClientConfigKeys.DFS_DATA_TRANSFER_SASL_CUSTOMIZEDCALLBACKHANDLER_CLASS_KEY,
+        MyCallbackMethod.class, Object.class);
+    new SaslServerCallbackHandler(conf, String::toCharArray).handle(callbacks);
+  }
 }


### PR DESCRIPTION
### Description of PR

HDFS-17576 added a `CustomizedCallbackHandler` interface which declares the following method:
```java
  void handleCallback(List<Callback> callbacks, String name, char[] password)
      throws UnsupportedCallbackException, IOException;
```

This Jira HDFS-17606 is to allow an implementation to define the handleCallback method without implementing the `CustomizedCallbackHandler` interface.  It is to avoid a security provider  depending on the HDFS project.

### How was this patch tested?

A new test.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

