### PR TITLE
HADOOP-19250. [Addendum] Fix test TestServiceInterruptHandling.testRegisterAndRaise.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/io/erasurecode/erasure_coder.c
+++ b/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/io/erasurecode/erasure_coder.c
@@ -221,5 +221,6 @@ int generateDecodeMatrix(IsalDecoder* pCoder) {
       }
     }
   }
+
   return 0;
 }

--- a/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/io/erasurecode/erasure_coder.c
+++ b/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/io/erasurecode/erasure_coder.c
@@ -221,6 +221,5 @@ int generateDecodeMatrix(IsalDecoder* pCoder) {
       }
     }
   }
-
   return 0;
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/service/launcher/TestServiceInterruptHandling.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/service/launcher/TestServiceInterruptHandling.java
@@ -38,7 +38,7 @@ public class TestServiceInterruptHandling
   @Test
   public void testRegisterAndRaise() throws Throwable {
     InterruptCatcher catcher = new InterruptCatcher();
-    String name = IrqHandler.CONTROL_C;
+    String name = "USR2";
     IrqHandler irqHandler = new IrqHandler(name, catcher);
     irqHandler.bind();
     assertEquals(0, irqHandler.getSignalCount());


### PR DESCRIPTION
### Description of PR

I submitted https://github.com/apache/hadoop/pull/6987 before, but in that PR, because the native code of hadoop common was not changed, "precommit-run Centos 7" was not triggered. Therefore, this unit test may still fail in some PRs. So I debugged in https://github.com/apache/hadoop/pull/6972 and solved this problem.

I found SIGINT was ignored before executing TestServiceInterruptHandling::testRegisterAndRaise. In the java code, for SIGHUP, SIGINT, and SIGTERM, if its SignalHandler have been set to SIG_IGN, any further actions to set SignalHandler will be invalid. For details, see [jdk signal](https://github.com/openjdk/jdk/blob/48ad07fd2cacdfcde606b33a369b1bf8df592088/hotspot/src/os/linux/vm/jvm_linux.cpp#L76)

In fact, it is difficult for me to reproduce this bug on my computer. But if I add `Signal.handle(new Signal(IrqHandler.CONTROL_C), SignalHandler.SIG_IGN);` in front of `irqHandler.bind();`, it can be reproduced stably, which also proves that what I said before is correct.

In order to further prove this problem on docker ci, I submitted [commit](https://github.com/apache/hadoop/pull/6972/commits/57d8f6d20cfaef2a7a6512ff74c7a767297c834d), then will find the following error like this:
```
[ERROR] testRegisterAndRaise(org.apache.hadoop.service.launcher.TestServiceInterruptHandling)  Time elapsed: 0.017 s  <<< FAILURE!
java.lang.AssertionError: SIGINT have been ignored, so can not set signal handler.
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertFalse(Assert.java:65)
```
It also proves that SIGINT was ignored.

Since SIGINT may be ignored, let's use USR2.

### How was this patch tested?

docker ci

### For code changes:

- [x] use signal USR2 instead of signal INT
