### PR TITLE
YARN-10345 HsWebServices containerlogs does not honor ACLs for completed jobs

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/AMWebServices.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/AMWebServices.java
@@ -40,6 +40,7 @@ import javax.ws.rs.core.Response.Status;
 
 import org.apache.hadoop.http.JettyUtils;
 import org.apache.hadoop.mapreduce.JobACL;
+import org.apache.hadoop.mapreduce.JobID;
 import org.apache.hadoop.mapreduce.v2.api.protocolrecords.KillTaskAttemptRequest;
 import org.apache.hadoop.mapreduce.v2.api.protocolrecords.KillTaskAttemptResponse;
 import org.apache.hadoop.mapreduce.v2.api.protocolrecords.impl.pb.KillTaskAttemptRequestPBImpl;
@@ -113,9 +114,17 @@ public class AMWebServices {
     response.setContentType(null);
   }
 
-  /**
-   * convert a job id string to an actual job and handle all the error checking.
-   */
+  public static Job getJobFromContainerIdString(String cid, AppContext appCtx)
+      throws NotFoundException {
+    //example container_e06_1724414851587_0004_01_000001
+    String[] parts = cid.split("_");
+    return getJobFromJobIdString(JobID.JOB + "_" + parts[2] + "_" + parts[3], appCtx);
+  }
+
+
+    /**
+     * convert a job id string to an actual job and handle all the error checking.
+     */
  public static Job getJobFromJobIdString(String jid, AppContext appCtx) throws NotFoundException {
     JobId jobId;
     Job job;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsWebServices.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsWebServices.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.JettyUtils;
 import org.apache.hadoop.mapreduce.JobACL;
+import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.mapreduce.v2.api.records.AMInfo;
 import org.apache.hadoop.mapreduce.v2.api.records.JobState;
 import org.apache.hadoop.mapreduce.v2.api.records.TaskId;
@@ -87,6 +88,7 @@ public class HsWebServices extends WebServices {
   private final HistoryContext ctx;
   private WebApp webapp;
   private LogServlet logServlet;
+  private boolean mrAclsEnabled;
 
   private @Context HttpServletResponse response;
   @Context UriInfo uriInfo;
@@ -100,6 +102,7 @@ public class HsWebServices extends WebServices {
     this.ctx = ctx;
     this.webapp = webapp;
     this.logServlet = new LogServlet(conf, this);
+    this.mrAclsEnabled = conf.getBoolean(MRConfig.MR_ACLS_ENABLED, false);
   }
 
   private boolean hasAccess(Job job, HttpServletRequest request) {
@@ -114,6 +117,11 @@ public class HsWebServices extends WebServices {
   private void checkAccess(Job job, HttpServletRequest request) {
     if (!hasAccess(job, request)) {
       throw new WebApplicationException(Status.UNAUTHORIZED);
+    }
+  }
+  private void checkAccess(String containerIdStr, HttpServletRequest hsr) {
+    if (mrAclsEnabled) {
+      checkAccess(AMWebServices.getJobFromContainerIdString(containerIdStr, ctx), hsr);
     }
   }
 
@@ -500,7 +508,7 @@ public class HsWebServices extends WebServices {
       @QueryParam(YarnWebServiceParams.MANUAL_REDIRECTION)
       @DefaultValue("false") boolean manualRedirection) {
     init();
-
+    checkAccess(containerIdStr, hsr);
     WrappedLogMetaRequest.Builder logMetaRequestBuilder =
         LogServlet.createRequestFromContainerId(containerIdStr);
 
@@ -527,6 +535,7 @@ public class HsWebServices extends WebServices {
       @QueryParam(YarnWebServiceParams.MANUAL_REDIRECTION)
       @DefaultValue("false") boolean manualRedirection) {
     init();
+    checkAccess(containerIdStr, req);
     return logServlet.getLogFile(req, containerIdStr, filename, format, size,
         nmId, redirectedFromNode, null, manualRedirection);
   }


### PR DESCRIPTION
### Description of PR

- following rest apis did not have authorization
- - /ws/v1/history/containerlogs/{containerid}/{filename}
- - /ws/v1/history/containers/{containerid}/logs
- after this fix it has acl authorization

### How was this patch tested?

Setup:
- mapreduce.cluster.acls.enabled = true on history server
- submit example pi job with user1 (called job1)
- - pi -Dmapreduce.job.queuename=root.default -Dmapreduce.job.acl-view-job=*  10 100 
- submit example pi job with user1 (called job2)
- - pi -Dmapreduce.job.queuename=root.default -Dmapreduce.job.acl-view-job=' '  10 100 

Before this commit
- Some other user (aka user2) can see job1 and job2 logs via problematic apis

After this commit
- Some user2 can not see job2 logs

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

