### PR TITLE
HADOOP-19257. S3A: ITestAssumeRole.testAssumeRoleBadInnerAuth failure

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
@@ -283,8 +283,7 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
     conf.set(SECRET_KEY, "not secret");
     expectFileSystemCreateFailure(conf,
         AWSBadRequestException.class,
-        "not a valid " +
-        "key=value pair (missing equal-sign) in Authorization header");
+        "");
   }
 
   @Test


### PR DESCRIPTION

Remove the error string matched on so that no future message change from AWS will trigger a regression

### How was this patch tested?

ran failing test against us-west-1 and verified it worked now


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

