### PR TITLE
HDFS-17611. Move all DistCp execution logic to execute()

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -139,9 +139,9 @@ public class DistCp extends Configured implements Tool {
     }
     
     try {
-      DistCpContext context = new DistCpContext(OptionsParser.parse(argv));
-      LOG.info("Input Options: " + context);
-      setContext(context);
+      DistCpContext ctx = new DistCpContext(OptionsParser.parse(argv));
+      LOG.info("Input Options: " + ctx);
+      setContext(ctx);
     } catch (Throwable e) {
       LOG.error("Invalid arguments: ", e);
       System.err.println("Invalid arguments: " + e.getMessage());
@@ -151,7 +151,7 @@ public class DistCp extends Configured implements Tool {
 
     Job job = null;
     try {
-      job = execute();
+      job = execute(true);
     } catch (InvalidInputException e) {
       LOG.error("Invalid input: ", e);
       return DistCpConstants.INVALID_ARGUMENT;
@@ -180,17 +180,23 @@ public class DistCp extends Configured implements Tool {
     return DistCpConstants.SUCCESS;
   }
 
+  public Job execute() throws Exception {
+    return execute(false);
+  }
+
   /**
    * Implements the core-execution. Creates the file-list for copy,
    * and launches the Hadoop-job, to do the copy.
    * @return Job handle
    * @throws Exception
    */
-  public Job execute() throws Exception {
+  public Job execute(boolean extraContextChecks) throws Exception {
     Preconditions.checkState(context != null,
         "The DistCpContext should have been created before running DistCp!");
-    checkSplitLargeFile();
-    setTargetPathExists();
+    if (extraContextChecks) {
+      checkSplitLargeFile();
+      setTargetPathExists();
+    }
 
     Job job = createAndSubmitJob();
 

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -182,6 +182,8 @@ public class DistCp extends Configured implements Tool {
   /**
    * Original entrypoint of a distcp job. Calls {@link DistCp#execute(boolean)}
    * without doing extra context checks and setting some configs.
+   * @return Job handle
+   * @throws Exception
    */
   public Job execute() throws Exception {
     return execute(false);

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -180,7 +180,7 @@ public class DistCp extends Configured implements Tool {
   }
 
   /**
-   * Original entrypoint of a distcp job. Calls {@link DistCp#execute(boolean))
+   * Original entrypoint of a distcp job. Calls {@link DistCp#execute(boolean)}
    * without doing extra context checks and setting some configs.
    */
   public Job execute() throws Exception {

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -139,9 +139,8 @@ public class DistCp extends Configured implements Tool {
     }
     
     try {
-      DistCpContext ctx = new DistCpContext(OptionsParser.parse(argv));
-      LOG.info("Input Options: " + ctx);
-      setContext(ctx);
+      context = new DistCpContext(OptionsParser.parse(argv));
+      LOG.info("Input Options: {}", context);
     } catch (Throwable e) {
       LOG.error("Invalid arguments: ", e);
       System.err.println("Invalid arguments: " + e.getMessage());
@@ -180,6 +179,10 @@ public class DistCp extends Configured implements Tool {
     return DistCpConstants.SUCCESS;
   }
 
+  /**
+   * Original entrypoint of a distcp job. Calls {@link DistCp#execute(boolean))
+   * without doing extra context checks and setting some configs.
+   */
   public Job execute() throws Exception {
     return execute(false);
   }
@@ -187,6 +190,7 @@ public class DistCp extends Configured implements Tool {
   /**
    * Implements the core-execution. Creates the file-list for copy,
    * and launches the Hadoop-job, to do the copy.
+   * @param extraContextChecks if true, does extra context checks and sets some configs.
    * @return Job handle
    * @throws Exception
    */
@@ -444,15 +448,6 @@ public class DistCp extends Configured implements Tool {
    */
   protected DistCpContext getContext() {
     return context;
-  }
-
-  /**
-   * Sets the current context.
-   *
-   * @param context context to be set to.
-   */
-  public void setContext(DistCpContext context) {
-    this.context = context;
   }
 
   /**

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -139,10 +139,9 @@ public class DistCp extends Configured implements Tool {
     }
     
     try {
-      context = new DistCpContext(OptionsParser.parse(argv));
-      checkSplitLargeFile();
-      setTargetPathExists();
+      DistCpContext context = new DistCpContext(OptionsParser.parse(argv));
       LOG.info("Input Options: " + context);
+      setContext(context);
     } catch (Throwable e) {
       LOG.error("Invalid arguments: ", e);
       System.err.println("Invalid arguments: " + e.getMessage());
@@ -169,7 +168,7 @@ public class DistCp extends Configured implements Tool {
       LOG.error("Exception encountered ", e);
       return DistCpConstants.UNKNOWN_ERROR;
     } finally {
-      //Blocking distcp so close the job after its done
+      // Blocking distcp so close the job after it's done
       if (job != null && context.shouldBlock()) {
         try {
           job.close();
@@ -190,6 +189,9 @@ public class DistCp extends Configured implements Tool {
   public Job execute() throws Exception {
     Preconditions.checkState(context != null,
         "The DistCpContext should have been created before running DistCp!");
+    checkSplitLargeFile();
+    setTargetPathExists();
+
     Job job = createAndSubmitJob();
 
     if (context.shouldBlock()) {
@@ -436,6 +438,15 @@ public class DistCp extends Configured implements Tool {
    */
   protected DistCpContext getContext() {
     return context;
+  }
+
+  /**
+   * Sets the current context.
+   *
+   * @param context context to be set to.
+   */
+  public void setContext(DistCpContext context) {
+    this.context = context;
   }
 
   /**

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -183,7 +183,7 @@ public class DistCp extends Configured implements Tool {
    * Original entrypoint of a distcp job. Calls {@link DistCp#execute(boolean)}
    * without doing extra context checks and setting some configs.
    * @return Job handle
-   * @throws Exception
+   * @throws Exception when fails to submit distcp job or distcp job fails
    */
   public Job execute() throws Exception {
     return execute(false);
@@ -194,7 +194,7 @@ public class DistCp extends Configured implements Tool {
    * and launches the Hadoop-job, to do the copy.
    * @param extraContextChecks if true, does extra context checks and sets some configs.
    * @return Job handle
-   * @throws Exception
+   * @throws Exception when fails to submit distcp job or distcp job fails, or context checks fail
    */
   public Job execute(boolean extraContextChecks) throws Exception {
     Preconditions.checkState(context != null,

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
@@ -155,7 +155,6 @@ public class TestExternalCall {
 
     DistCp distcp = mock(DistCp.class);
     Job job = spy(Job.class);
-    Mockito.doCallRealMethod().when(distcp).setContext(Mockito.any());
     Mockito.when(distcp.getConf()).thenReturn(conf);
     Mockito.when(distcp.createAndSubmitJob()).thenReturn(job);
     Mockito.when(distcp.execute()).thenCallRealMethod();

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
@@ -155,8 +155,12 @@ public class TestExternalCall {
 
     DistCp distcp = mock(DistCp.class);
     Job job = spy(Job.class);
+    Mockito.doCallRealMethod().when(distcp).setContext(Mockito.any());
     Mockito.when(distcp.getConf()).thenReturn(conf);
-    Mockito.when(distcp.execute()).thenReturn(job);
+    Mockito.when(distcp.createAndSubmitJob()).thenReturn(job);
+    Mockito.when(distcp.execute()).thenCallRealMethod();
+    Mockito.when(distcp.execute(Mockito.anyBoolean())).thenCallRealMethod();
+    Mockito.doReturn(true).when(job).waitForCompletion(Mockito.anyBoolean());
     Mockito.when(distcp.run(Mockito.any())).thenCallRealMethod();
     String[] arg = { soure.toString(), target.toString() };
 


### PR DESCRIPTION
### Description of PR

Many code flows create a DistCp instance and call the public method execute() to get the Job object for better control over the distcp job but some logics are only called by the run() method. Should move these lines over to execute().

### How was this patch tested?
Trivial code change