### PR TITLE
HADOOP-19262: Upgrade wildfly-openssl:1.1.3.Final to 2.1.4.Final

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -362,7 +362,7 @@ org.lz4:lz4-java:1.7.1
 org.objenesis:objenesis:2.6
 org.xerial.snappy:snappy-java:1.1.10.4
 org.yaml:snakeyaml:2.0
-org.wildfly.openssl:wildfly-openssl:1.1.3.Final
+org.wildfly.openssl:wildfly-openssl:2.1.4.Final
 software.amazon.awssdk:bundle:2.25.53
 
 

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -212,7 +212,7 @@
     <jline.version>3.9.0</jline.version>
     <powermock.version>1.5.6</powermock.version>
     <solr.version>8.11.2</solr.version>
-    <openssl-wildfly.version>1.1.3.Final</openssl-wildfly.version>
+    <openssl-wildfly.version>2.1.4.Final</openssl-wildfly.version>
     <jsonschema2pojo.version>1.0.2</jsonschema2pojo.version>
     <woodstox.version>5.4.0</woodstox.version>
     <nimbus-jose-jwt.version>9.37.2</nimbus-jose-jwt.version>


### PR DESCRIPTION


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Upgrade wildfly-openssl:1.1.3.Final to 2.1.4.Final to support Java17+

### How was this patch tested?
Ran "mvn verify" in hadoop-azure, and hadoop-aws (against ap-south-1) on both Java8 and Java11 

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

