### PR TITLE
YARN-11729. Broken 'AM Node Web UI' link on App details page

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/yarn-app-attempt.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/yarn-app-attempt.js
@@ -144,7 +144,7 @@ export default DS.Model.extend({
 
   masterNodeURL: function() {
     var addr = encodeURIComponent(this.get("nodeHttpAddress"));
-    return `#/yarn-node/${this.get("nodeId")}/${addr}/info/`;
+    return `#/yarn-node/${this.get("nodeId")}/${addr}/info`;
   }.property("nodeId", "nodeHttpAddress"),
 
   appAttemptContainerLogsURL: function() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/yarn-container.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/yarn-container.js
@@ -65,7 +65,7 @@ export default DS.Model.extend({
 
   masterNodeURL: function() {
     var addr = encodeURIComponent(this.get("nodeHttpAddress"));
-    return `#/yarn-node/${this.get("nodeId")}/${addr}/info/`;
+    return `#/yarn-node/${this.get("nodeId")}/${addr}/info`;
   }.property("nodeId", "nodeHttpAddress"),
 
   appAttemptContainerLogsURL: function() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/yarn-timeline-appattempt.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/yarn-timeline-appattempt.js
@@ -143,6 +143,6 @@ export default DS.Model.extend({
 
   masterNodeURL: function() {
     var addr = encodeURIComponent(this.get("nodeHttpAddress"));
-    return `#/yarn-node/${this.get("nodeId")}/${addr}/info/`;
+    return `#/yarn-node/${this.get("nodeId")}/${addr}/info`;
   }.property("nodeId", "nodeHttpAddress"),
 });

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/yarn-timeline-container.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/yarn-timeline-container.js
@@ -66,7 +66,7 @@ export default DS.Model.extend({
 
   masterNodeURL: function() {
     var addr = encodeURIComponent(this.get("nodeHttpAddress"));
-    return `#/yarn-node/${this.get("nodeId")}/${addr}/info/`;
+    return `#/yarn-node/${this.get("nodeId")}/${addr}/info`;
   }.property("nodeId", "nodeHttpAddress"),
 
   appAttemptContainerLogsURL: function() {


### PR DESCRIPTION
### Description of PR

- the current link ends with a '/'
- with this ending the RM wont open the link
- to fix the issue we remove the last '/' char from the url

### How was this patch tested?

- manually run example job and click on the generated link

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

