### PR TITLE
HDFS-17609. [FGL] Fix lock mode in some RPCs.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManagerSafeMode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManagerSafeMode.java
@@ -374,7 +374,8 @@ class BlockManagerSafeMode {
    * @return true if it leaves safe mode successfully else false
    */
   boolean leaveSafeMode(boolean force) {
-    assert namesystem.hasWriteLock(FSNamesystemLockMode.GLOBAL) : "Leaving safe mode needs write lock!";
+    assert namesystem.hasWriteLock(FSNamesystemLockMode.GLOBAL) :
+        "Leaving safe mode needs write lock!";
 
     final long bytesInFuture = getBytesInFuture();
     if (bytesInFuture > 0) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManagerSafeMode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManagerSafeMode.java
@@ -374,7 +374,7 @@ class BlockManagerSafeMode {
    * @return true if it leaves safe mode successfully else false
    */
   boolean leaveSafeMode(boolean force) {
-    assert namesystem.hasWriteLock(FSNamesystemLockMode.BM) : "Leaving safe mode needs write lock!";
+    assert namesystem.hasWriteLock(FSNamesystemLockMode.GLOBAL) : "Leaving safe mode needs write lock!";
 
     final long bytesInFuture = getBytesInFuture();
     if (bytesInFuture > 0) {


### PR DESCRIPTION
### Description of PR
Fix lock mode in some RPCs and add some assert statement.

- FSNamesystem#getFilesBlockingDecom : use GLOBAL mode rather than FS mode because of below codes:

```java

for (DatanodeDescriptor dataNode :
        blockManager.getDatanodeManager().getDatanodes()) {

}

```

- FSNamesystem#listOpenFiles: use GLOBAL mode because it calls getFilesBlockingDecom method.
- FSNamesystem#getContentSummary： use GLOBAL mode rather than FS mode because it calls computeFileSize method.
- BlockManagerSafeMode#leaveSafeMode： use GLOBAL mode rather than BM mode because it calls startSecretManagerIfNecessary which depended upon FS lock. Change to GLOBAL mode is safe here.


