### PR TITLE
HADOOP-19271. NPE in AbfsManagedApacheHttpConnection.toString() when not connected

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsManagedApacheHttpConnection.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsManagedApacheHttpConnection.java
@@ -52,7 +52,7 @@ class AbfsManagedApacheHttpConnection
    */
   private AbfsManagedHttpClientContext managedHttpContext;
 
-  final HttpHost targetHost;
+  private final HttpHost targetHost;
 
   private final int hashCode;
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsManagedApacheHttpConnection.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsManagedApacheHttpConnection.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import org.apache.http.HttpConnectionMetrics;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.conn.ManagedHttpClientConnection;
@@ -51,10 +52,17 @@ class AbfsManagedApacheHttpConnection
    */
   private AbfsManagedHttpClientContext managedHttpContext;
 
+  final HttpHost targetHost;
+
   private final int hashCode;
 
   AbfsManagedApacheHttpConnection(ManagedHttpClientConnection conn,
       final HttpRoute route) {
+    if (route != null) {
+      targetHost = route.getTargetHost();
+    } else {
+      targetHost = null;
+    }
     this.httpClientConnection = conn;
     this.hashCode = (UUID.randomUUID().toString()
         + httpClientConnection.getId()).hashCode();
@@ -228,11 +236,9 @@ class AbfsManagedApacheHttpConnection
 
   @Override
   public String toString() {
-    StringBuilder stringBuilder = new StringBuilder();
-    stringBuilder.append(
-            httpClientConnection.getRemoteAddress().getHostName())
-        .append(COLON)
-        .append(httpClientConnection.getRemotePort())
+    StringBuilder stringBuilder = targetHost != null ? new StringBuilder(
+        targetHost.toString()) : new StringBuilder();
+    stringBuilder
         .append(COLON)
         .append(hashCode());
     return stringBuilder.toString();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestApacheClientConnectionPool.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestApacheClientConnectionPool.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import org.apache.hadoop.conf.Configuration;
@@ -27,12 +28,25 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.AbstractAbfsIntegrationTest;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsDriverException;
+import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
+import org.apache.http.HttpHost;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.config.SocketConfig;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.conn.DefaultHttpClientConnectionOperator;
 
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.COLON;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.KEEP_ALIVE_CACHE_CLOSED;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_NETWORKING_LIBRARY;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.HTTPS_SCHEME;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpOperationType.APACHE_HTTP_CLIENT;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.apache.hadoop.test.LambdaTestUtils.verifyCause;
+import static org.apache.http.conn.ssl.SSLConnectionSocketFactory.getDefaultHostnameVerifier;
 
 /**
  * This test class tests the exception handling in ABFS thrown by the
@@ -59,5 +73,37 @@ public class ITestApacheClientConnectionPool extends
           });
       verifyCause(ClosedIOException.class, ex);
     }
+  }
+
+  @Test
+  public void testConnectionLogging() throws Exception {
+    HttpHost host = new HttpHost(getFileSystem().getUri().getHost(),
+        getFileSystem().getUri().getPort(),
+        HTTPS_SCHEME);
+    HttpRoute httpRoute = new HttpRoute(host);
+
+    AbfsManagedApacheHttpConnection conn
+        = (AbfsManagedApacheHttpConnection) new AbfsHttpClientConnectionFactory().create(
+        httpRoute, null);
+    String log = conn.toString();
+    Assertions.assertThat(log.split(COLON).length)
+        .describedAs("Log to have three field: https://host:port:hashCode")
+        .isEqualTo(4);
+
+    Registry<ConnectionSocketFactory> socketFactoryRegistry
+        = RegistryBuilder.<ConnectionSocketFactory>create()
+        .register(HTTPS_SCHEME, new SSLConnectionSocketFactory(
+            DelegatingSSLSocketFactory.getDefaultFactory(),
+            getDefaultHostnameVerifier()))
+        .build();
+    new DefaultHttpClientConnectionOperator(
+        socketFactoryRegistry, null, null).connect(conn,
+        httpRoute.getTargetHost(), httpRoute.getLocalSocketAddress(),
+        getConfiguration().getHttpConnectionTimeout(), SocketConfig.DEFAULT,
+        new HttpClientContext());
+    log = conn.toString();
+    Assertions.assertThat(log.split(COLON).length)
+        .describedAs("Log to have three field: https://host:port:hashCode")
+        .isEqualTo(4);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestApacheClientConnectionPool.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestApacheClientConnectionPool.java
@@ -19,8 +19,8 @@
 package org.apache.hadoop.fs.azurebfs.services;
 
 import java.io.IOException;
+import java.util.Map;
 
-import com.sun.tools.javac.util.Pair;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
@@ -32,6 +32,7 @@ import org.apache.hadoop.fs.azurebfs.AbstractAbfsIntegrationTest;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsDriverException;
 import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
+import org.apache.hadoop.util.functional.Tuples;
 import org.apache.http.HttpHost;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.config.Registry;
@@ -80,9 +81,9 @@ public class ITestApacheClientConnectionPool extends
 
   @Test
   public void testNonConnectedConnectionLogging() throws Exception {
-    Pair<HttpRoute, AbfsManagedApacheHttpConnection> testConnPair
+    Map.Entry<HttpRoute, AbfsManagedApacheHttpConnection> testConnPair
         = getTestConnection();
-    AbfsManagedApacheHttpConnection conn = testConnPair.snd;
+    AbfsManagedApacheHttpConnection conn = testConnPair.getValue();
     String log = conn.toString();
     Assertions.assertThat(log.split(COLON).length)
         .describedAs("Log to have three fields: https://host:port:hashCode")
@@ -91,10 +92,10 @@ public class ITestApacheClientConnectionPool extends
 
   @Test
   public void testConnectedConnectionLogging() throws Exception {
-    Pair<HttpRoute, AbfsManagedApacheHttpConnection> testConnPair
+    Map.Entry<HttpRoute, AbfsManagedApacheHttpConnection> testConnPair
         = getTestConnection();
-    AbfsManagedApacheHttpConnection conn = testConnPair.snd;
-    HttpRoute httpRoute = testConnPair.fst;
+    AbfsManagedApacheHttpConnection conn = testConnPair.getValue();
+    HttpRoute httpRoute = testConnPair.getKey();
 
     Registry<ConnectionSocketFactory> socketFactoryRegistry
         = RegistryBuilder.<ConnectionSocketFactory>create()
@@ -114,7 +115,7 @@ public class ITestApacheClientConnectionPool extends
         .isEqualTo(4);
   }
 
-  private Pair<HttpRoute, AbfsManagedApacheHttpConnection> getTestConnection()
+  private Map.Entry<HttpRoute, AbfsManagedApacheHttpConnection> getTestConnection()
       throws IOException {
     HttpHost host = new HttpHost(getFileSystem().getUri().getHost(),
         getFileSystem().getUri().getPort(),
@@ -125,6 +126,6 @@ public class ITestApacheClientConnectionPool extends
         = (AbfsManagedApacheHttpConnection) new AbfsHttpClientConnectionFactory().create(
         httpRoute, null);
 
-    return Pair.of(httpRoute, conn);
+    return Tuples.pair(httpRoute, conn);
   }
 }


### PR DESCRIPTION
When AbfsManagedApacheHttpConnection is not connected, the toString() fails with NPE, as it doesn't have `httpClientConnection.getRemoteAddress()` set.

This PR fixes this and removes dependency on connection being made. When the connection instance is constructed the required target host is shared. This field would be used in the logs.