### PR TITLE
HDFS-17624. Fix DFSNetworkTopology#chooseRandomWithStorageType() availableCount when excluded node is not in selected scope.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/net/DFSNetworkTopology.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/net/DFSNetworkTopology.java
@@ -219,7 +219,7 @@ public class DFSNetworkTopology extends NetworkTopology {
     }
     if (excludedNodes != null) {
       for (Node excludedNode : excludedNodes) {
-        if (excludeRoot != null && isNodeInScope(excludedNode, excludedScope) &&
+        if ((excludeRoot != null && isNodeInScope(excludedNode, excludedScope)) ||
             !isNodeInScope(excludedNode, scope)) {
           continue;
         }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/net/DFSNetworkTopology.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/net/DFSNetworkTopology.java
@@ -219,7 +219,8 @@ public class DFSNetworkTopology extends NetworkTopology {
     }
     if (excludedNodes != null) {
       for (Node excludedNode : excludedNodes) {
-        if (excludeRoot != null && isNodeInScope(excludedNode, excludedScope)) {
+        if (excludeRoot != null && isNodeInScope(excludedNode, excludedScope) &&
+            !isNodeInScope(excludedNode, scope)) {
           continue;
         }
         if (excludedNode instanceof DatanodeDescriptor) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/net/TestDFSNetworkTopology.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/net/TestDFSNetworkTopology.java
@@ -667,4 +667,23 @@ public class TestDFSNetworkTopology {
         null, excluded, StorageType.DISK);
     assertNull("No node should have been selected.", n);
   }
+
+  @Test
+  public void testChooseRandomWithStorageTypeWithExcludeNodes() {
+    DFSNetworkTopology dfsCluster =
+        DFSNetworkTopology.getInstance(new Configuration());
+    final String[] racks = {"/default/rack1", "/default/rack2"};
+    final String[] hosts = {"host1", "host2"};
+    final StorageType[] types = {StorageType.DISK, StorageType.DISK};
+    final DatanodeStorageInfo[] storages =
+        DFSTestUtil.createDatanodeStorageInfos(2, racks, hosts, types);
+    DatanodeDescriptor[] dns = DFSTestUtil.toDatanodeDescriptor(storages);
+    dfsCluster.add(dns[0]);
+    dfsCluster.add(dns[1]);
+    HashSet<Node> excluded = new HashSet<>();
+    excluded.add(dns[1]);
+    Node n = dfsCluster.chooseRandomWithStorageType("/default/rack1",
+        null, excluded, StorageType.DISK);
+    assertNotNull("/default/rack1/host1 should be selected.", n);
+  }
 }


### PR DESCRIPTION
Presently if chosen scope is /default/rack1 and excluded node is /default/rack2/host2. Then the available count will be deducted.