### PR TITLE
HADOOP-19221. S3A: Unable to recover from failure of multipart block upload attempt (#6938)

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StoreStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StoreStatisticNames.java
@@ -385,6 +385,47 @@ public final class StoreStatisticNames {
       = "action_http_patch_request";
 
   /**
+   * HTTP error response: {@value}.
+   */
+  public static final String HTTP_RESPONSE_400
+      = "http_response_400";
+
+  /**
+   * HTTP error response: {@value}.
+   * Returned by some stores for throttling events.
+   */
+  public static final String HTTP_RESPONSE_429
+      = "http_response_429";
+
+  /**
+   * Other 4XX HTTP response: {@value}.
+   * (404 responses are excluded as they are rarely 'errors'
+   * and will be reported differently if they are.
+   */
+  public static final String HTTP_RESPONSE_4XX
+      = "http_response_4XX";
+
+  /**
+   * HTTP error response: {@value}.
+   * Sign of server-side problems, possibly transient
+   */
+  public static final String HTTP_RESPONSE_500
+      = "http_response_500";
+
+  /**
+   * HTTP error response: {@value}.
+   * AWS Throttle.
+   */
+  public static final String HTTP_RESPONSE_503
+      = "http_response_503";
+
+  /**
+   * Other 5XX HTTP response: {@value}.
+   */
+  public static final String HTTP_RESPONSE_5XX
+      = "http_response_5XX";
+
+  /**
    * An HTTP POST request was made: {@value}.
    */
   public static final String ACTION_HTTP_POST_REQUEST

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/store/ByteBufferInputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/store/ByteBufferInputStream.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.store;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.fs.FSExceptionMessages;
+import org.apache.hadoop.util.Preconditions;
+
+/**
+ * Provide an input stream from a byte buffer; supporting
+ * {@link #mark(int)}.
+ */
+public final class ByteBufferInputStream extends InputStream {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ByteBufferInputStream.class);
+
+  /** Size of the buffer. */
+  private final int size;
+
+  /**
+   * Not final so that in close() it will be set to null, which
+   * may result in faster cleanup of the buffer.
+   */
+  private ByteBuffer byteBuffer;
+
+  public ByteBufferInputStream(int size,
+      ByteBuffer byteBuffer) {
+    LOG.debug("Creating ByteBufferInputStream of size {}", size);
+    this.size = size;
+    this.byteBuffer = byteBuffer;
+  }
+
+  /**
+   * After the stream is closed, set the local reference to the byte
+   * buffer to null; this guarantees that future attempts to use
+   * stream methods will fail.
+   */
+  @Override
+  public synchronized void close() {
+    LOG.debug("ByteBufferInputStream.close()");
+    byteBuffer = null;
+  }
+
+  /**
+   * Is the stream open?
+   * @return true if the stream has not been closed.
+   */
+  public synchronized boolean isOpen() {
+    return byteBuffer != null;
+  }
+
+  /**
+   * Verify that the stream is open.
+   * @throws IOException if the stream is closed
+   */
+  private void verifyOpen() throws IOException {
+    if (byteBuffer == null) {
+      throw new IOException(FSExceptionMessages.STREAM_IS_CLOSED);
+    }
+  }
+
+  /**
+   * Check the open state.
+   * @throws IllegalStateException if the stream is closed.
+   */
+  private void checkOpenState() {
+    Preconditions.checkState(isOpen(),
+        FSExceptionMessages.STREAM_IS_CLOSED);
+  }
+
+  public synchronized int read() throws IOException {
+    if (available() > 0) {
+      return byteBuffer.get() & 0xFF;
+    } else {
+      return -1;
+    }
+  }
+
+  @Override
+  public synchronized long skip(long offset) throws IOException {
+    verifyOpen();
+    long newPos = position() + offset;
+    if (newPos < 0) {
+      throw new EOFException(FSExceptionMessages.NEGATIVE_SEEK);
+    }
+    if (newPos > size) {
+      throw new EOFException(FSExceptionMessages.CANNOT_SEEK_PAST_EOF);
+    }
+    byteBuffer.position((int) newPos);
+    return newPos;
+  }
+
+  @Override
+  public synchronized int available() {
+    checkOpenState();
+    return byteBuffer.remaining();
+  }
+
+  /**
+   * Get the current buffer position.
+   * @return the buffer position
+   */
+  public synchronized int position() {
+    checkOpenState();
+    return byteBuffer.position();
+  }
+
+  /**
+   * Check if there is data left.
+   * @return true if there is data remaining in the buffer.
+   */
+  public synchronized boolean hasRemaining() {
+    checkOpenState();
+    return byteBuffer.hasRemaining();
+  }
+
+  @Override
+  public synchronized void mark(int readlimit) {
+    LOG.debug("mark at {}", position());
+    checkOpenState();
+    byteBuffer.mark();
+  }
+
+  @Override
+  public synchronized void reset() throws IOException {
+    LOG.debug("reset");
+    checkOpenState();
+    byteBuffer.reset();
+  }
+
+  @Override
+  public boolean markSupported() {
+    return true;
+  }
+
+  /**
+   * Read in data.
+   * @param b destination buffer.
+   * @param offset offset within the buffer.
+   * @param length length of bytes to read.
+   * @throws EOFException if the position is negative
+   * @throws IndexOutOfBoundsException if there isn't space for the
+   * amount of data requested.
+   * @throws IllegalArgumentException other arguments are invalid.
+   */
+  @SuppressWarnings("NullableProblems")
+  public synchronized int read(byte[] b, int offset, int length)
+      throws IOException {
+    Preconditions.checkArgument(length >= 0, "length is negative");
+    Preconditions.checkArgument(b != null, "Null buffer");
+    if (b.length - offset < length) {
+      throw new IndexOutOfBoundsException(
+          FSExceptionMessages.TOO_MANY_BYTES_FOR_DEST_BUFFER
+              + ": request length =" + length
+              + ", with offset =" + offset
+              + "; buffer capacity =" + (b.length - offset));
+    }
+    verifyOpen();
+    if (!hasRemaining()) {
+      return -1;
+    }
+
+    int toRead = Math.min(length, available());
+    byteBuffer.get(b, offset, toRead);
+    return toRead;
+  }
+
+  @Override
+  public String toString() {
+    return "ByteBufferInputStream{" +
+        "size=" + size +
+        ", byteBuffer=" + byteBuffer +
+        ((byteBuffer != null) ? ", available=" + byteBuffer.remaining() : "") +
+        "} " + super.toString();
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/AWSStatus500Exception.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/AWSStatus500Exception.java
@@ -22,12 +22,19 @@ import software.amazon.awssdk.awscore.exception.AwsServiceException;
 
 /**
  * A 5xx response came back from a service.
- * The 500 error considered retriable by the AWS SDK, which will have already
- * tried it {@code fs.s3a.attempts.maximum} times before reaching s3a
+ * <p>
+ * The 500 error is considered retryable by the AWS SDK, which will have already
+ * retried it {@code fs.s3a.attempts.maximum} times before reaching s3a
  * code.
- * How it handles other 5xx errors is unknown: S3A FS code will treat them
- * as unrecoverable on the basis that they indicate some third-party store
- * or gateway problem.
+ * <p>
+ * These are rare, but can occur; they are considered retryable.
+ * Note that HADOOP-19221 shows a failure condition where the
+ * SDK itself did not recover on retry from the error.
+ * In S3A code, retries happen if the retry policy configuration
+ * {@code fs.s3a.retry.http.5xx.errors} is {@code true}.
+ * <p>
+ * In third party stores it may have a similar meaning -though it
+ * can often just mean "misconfigured server".
  */
 public class AWSStatus500Exception extends AWSServiceIOException {
   public AWSStatus500Exception(String operation,
@@ -35,8 +42,4 @@ public class AWSStatus500Exception extends AWSServiceIOException {
     super(operation, cause);
   }
 
-  @Override
-  public boolean retryable() {
-    return false;
-  }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1119,6 +1119,22 @@ public final class Constants {
    */
   public static final String RETRY_THROTTLE_INTERVAL_DEFAULT = "500ms";
 
+
+  /**
+   * Should S3A connector retry on all 5xx errors which don't have
+   * explicit support: {@value}?
+   * <p>
+   * This is in addition to any retries the AWS SDK itself does, which
+   * is known to retry on many of these (e.g. 500).
+   */
+  public static final String RETRY_HTTP_5XX_ERRORS =
+      "fs.s3a.retry.http.5xx.errors";
+
+  /**
+   * Default value for {@link #RETRY_HTTP_5XX_ERRORS}: {@value}.
+   */
+  public static final boolean DEFAULT_RETRY_HTTP_5XX_ERRORS = true;
+
   /**
    * Should etags be exposed as checksums?
    */

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/ProgressableProgressListener.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/ProgressableProgressListener.java
@@ -29,21 +29,21 @@ import org.slf4j.Logger;
  */
 public class ProgressableProgressListener implements TransferListener {
   private static final Logger LOG = S3AFileSystem.LOG;
-  private final S3AFileSystem fs;
+  private final S3AStore store;
   private final String key;
   private final Progressable progress;
   private long lastBytesTransferred;
 
   /**
    * Instantiate.
-   * @param fs filesystem: will be invoked with statistics updates
+   * @param store store: will be invoked with statistics updates
    * @param key key for the upload
    * @param progress optional callback for progress.
    */
-  public ProgressableProgressListener(S3AFileSystem fs,
+  public ProgressableProgressListener(S3AStore store,
       String key,
       Progressable progress) {
-    this.fs = fs;
+    this.store = store;
     this.key = key;
     this.progress = progress;
     this.lastBytesTransferred = 0;
@@ -51,12 +51,12 @@ public class ProgressableProgressListener implements TransferListener {
 
   @Override
   public void transferInitiated(TransferListener.Context.TransferInitiated context) {
-    fs.incrementWriteOperations();
+    store.incrementWriteOperations();
   }
 
   @Override
   public void transferComplete(TransferListener.Context.TransferComplete context) {
-    fs.incrementWriteOperations();
+    store.incrementWriteOperations();
   }
 
   @Override
@@ -68,7 +68,7 @@ public class ProgressableProgressListener implements TransferListener {
 
     long transferred = context.progressSnapshot().transferredBytes();
     long delta = transferred - lastBytesTransferred;
-    fs.incrementPutProgressStatistics(key, delta);
+    store.incrementPutProgressStatistics(key, delta);
     lastBytesTransferred = transferred;
   }
 
@@ -84,7 +84,7 @@ public class ProgressableProgressListener implements TransferListener {
         upload.progress().snapshot().transferredBytes() - lastBytesTransferred;
     if (delta > 0) {
       LOG.debug("S3A write delta changed after finished: {} bytes", delta);
-      fs.incrementPutProgressStatistics(key, delta);
+      store.incrementPutProgressStatistics(key, delta);
     }
     return delta;
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.fs.s3a;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
@@ -43,6 +42,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Objects;
 import java.util.TreeSet;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
@@ -85,11 +85,8 @@ import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import software.amazon.awssdk.transfer.s3.model.CompletedCopy;
-import software.amazon.awssdk.transfer.s3.model.CompletedFileUpload;
 import software.amazon.awssdk.transfer.s3.model.Copy;
 import software.amazon.awssdk.transfer.s3.model.CopyRequest;
-import software.amazon.awssdk.transfer.s3.model.FileUpload;
-import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 
 import org.apache.hadoop.fs.impl.prefetch.ExecutorServiceFuturePool;
 import org.slf4j.Logger;
@@ -149,6 +146,7 @@ import org.apache.hadoop.fs.s3a.impl.StatusProbeEnum;
 import org.apache.hadoop.fs.s3a.impl.StoreContext;
 import org.apache.hadoop.fs.s3a.impl.StoreContextBuilder;
 import org.apache.hadoop.fs.s3a.impl.StoreContextFactory;
+import org.apache.hadoop.fs.s3a.impl.UploadContentProviders;
 import org.apache.hadoop.fs.s3a.prefetch.S3APrefetchingInputStream;
 import org.apache.hadoop.fs.s3a.tools.MarkerToolOperations;
 import org.apache.hadoop.fs.s3a.tools.MarkerToolOperationsImpl;
@@ -248,6 +246,7 @@ import static org.apache.hadoop.fs.s3a.impl.CreateFileBuilder.OPTIONS_CREATE_FIL
 import static org.apache.hadoop.fs.s3a.impl.CreateFileBuilder.OPTIONS_CREATE_FILE_PERFORMANCE;
 import static org.apache.hadoop.fs.s3a.impl.ErrorTranslation.isObjectNotFound;
 import static org.apache.hadoop.fs.s3a.impl.ErrorTranslation.isUnknownBucket;
+import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.CONTENT_TYPE_OCTET_STREAM;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.AP_REQUIRED_EXCEPTION;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.ARN_BUCKET_OPTION;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.CSE_PADDING_LENGTH;
@@ -356,8 +355,6 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   /** Log to warn of storage class configuration problems. */
   private static final LogExactlyOnce STORAGE_CLASS_WARNING = new LogExactlyOnce(LOG);
 
-  private static final Logger PROGRESS =
-      LoggerFactory.getLogger("org.apache.hadoop.fs.s3a.S3AFileSystem.Progress");
   private LocalDirAllocator directoryAllocator;
   private String cannedACL;
 
@@ -729,7 +726,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       }
       blockOutputBuffer = conf.getTrimmed(FAST_UPLOAD_BUFFER,
           DEFAULT_FAST_UPLOAD_BUFFER);
-      blockFactory = S3ADataBlocks.createFactory(this, blockOutputBuffer);
+      blockFactory = S3ADataBlocks.createFactory(createStoreContext(), blockOutputBuffer);
       blockOutputActiveBlocks = intOption(conf,
           FAST_UPLOAD_ACTIVE_BLOCKS, DEFAULT_FAST_UPLOAD_ACTIVE_BLOCKS, 1);
       // If CSE is enabled, do multipart uploads serially.
@@ -829,12 +826,13 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   protected S3AStore createS3AStore(final ClientManager clientManager,
       final int rateLimitCapacity) {
     return new S3AStoreBuilder()
+        .withAuditSpanSource(getAuditManager())
         .withClientManager(clientManager)
         .withDurationTrackerFactory(getDurationTrackerFactory())
-        .withStoreContextFactory(this)
-        .withAuditSpanSource(getAuditManager())
+        .withFsStatistics(getFsStatistics())
         .withInstrumentation(getInstrumentation())
         .withStatisticsContext(statisticsContext)
+        .withStoreContextFactory(this)
         .withStorageStatistics(getStorageStatistics())
         .withReadRateLimiter(unlimitedRate())
         .withWriteRateLimiter(RateLimitingFactory.create(rateLimitCapacity))
@@ -1960,9 +1958,48 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       implements WriteOperationHelper.WriteOperationHelperCallbacks {
 
     @Override
+    @Retries.OnceRaw
     public CompleteMultipartUploadResponse completeMultipartUpload(
         CompleteMultipartUploadRequest request) {
-      return getS3Client().completeMultipartUpload(request);
+      return store.completeMultipartUpload(request);
+    }
+
+    @Override
+    @Retries.OnceRaw
+    public UploadPartResponse uploadPart(
+        final UploadPartRequest request,
+        final RequestBody body,
+        final DurationTrackerFactory durationTrackerFactory)
+        throws AwsServiceException, UncheckedIOException {
+      return store.uploadPart(request, body, durationTrackerFactory);
+    }
+
+    /**
+     * Perform post-write actions.
+     * <p>
+     * This operation MUST be called after any PUT/multipart PUT completes
+     * successfully.
+     * <p>
+     * The actions include calling
+     * {@link #deleteUnnecessaryFakeDirectories(Path)}
+     * if directory markers are not being retained.
+     * @param eTag eTag of the written object
+     * @param versionId S3 object versionId of the written object
+     * @param key key written to
+     * @param length total length of file written
+     * @param putOptions put object options
+     */
+    @Override
+    @Retries.RetryExceptionsSwallowed
+    public void finishedWrite(
+        String key,
+        long length,
+        PutObjectOptions putOptions) {
+      S3AFileSystem.this.finishedWrite(
+          key,
+          length,
+          putOptions);
+
     }
   }
 
@@ -2921,7 +2958,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
 
   /**
    * Get the instrumentation's IOStatistics.
-   * @return statistics
+   * @return statistics or null if instrumentation has not yet been instantiated.
    */
   @Override
   public IOStatistics getIOStatistics() {
@@ -2950,9 +2987,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    */
   protected DurationTrackerFactory nonNullDurationTrackerFactory(
       DurationTrackerFactory factory) {
-    return factory != null
-        ? factory
-        : getDurationTrackerFactory();
+    return store.nonNullDurationTrackerFactory(factory);
   }
 
   /**
@@ -3267,18 +3302,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   @Retries.OnceRaw
   public UploadInfo putObject(PutObjectRequest putObjectRequest, File file,
       ProgressableProgressListener listener) throws IOException {
-    long len = getPutRequestLength(putObjectRequest);
-    LOG.debug("PUT {} bytes to {} via transfer manager ", len, putObjectRequest.key());
-    incrementPutStartStatistics(len);
-
-    FileUpload upload = store.getOrCreateTransferManager().uploadFile(
-            UploadFileRequest.builder()
-                .putObjectRequest(putObjectRequest)
-                .source(file)
-                .addTransferListener(listener)
-                .build());
-
-    return new UploadInfo(upload, len);
+    return store.putObject(putObjectRequest, file, listener);
   }
 
   /**
@@ -3291,9 +3315,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * <i>Important: this call will close any input stream in the request.</i>
    * @param putObjectRequest the request
    * @param putOptions put object options
-   * @param durationTrackerFactory factory for duration tracking
    * @param uploadData data to be uploaded
-   * @param isFile represents if data to be uploaded is a file
+   * @param durationTrackerFactory factory for duration tracking
    * @return the upload initiated
    * @throws SdkException on problems
    */
@@ -3301,27 +3324,27 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   @Retries.OnceRaw("For PUT; post-PUT actions are RetryExceptionsSwallowed")
   PutObjectResponse putObjectDirect(PutObjectRequest putObjectRequest,
       PutObjectOptions putOptions,
-      S3ADataBlocks.BlockUploadData uploadData, boolean isFile,
+      S3ADataBlocks.BlockUploadData uploadData,
       DurationTrackerFactory durationTrackerFactory)
       throws SdkException {
+
     long len = getPutRequestLength(putObjectRequest);
     LOG.debug("PUT {} bytes to {}", len, putObjectRequest.key());
     incrementPutStartStatistics(len);
+    final UploadContentProviders.BaseContentProvider provider =
+        uploadData.getContentProvider();
     try {
       PutObjectResponse response =
           trackDurationOfSupplier(nonNullDurationTrackerFactory(durationTrackerFactory),
               OBJECT_PUT_REQUESTS.getSymbol(),
-              () -> isFile
-                  ? getS3Client().putObject(putObjectRequest,
-                      RequestBody.fromFile(uploadData.getFile()))
-                  : getS3Client().putObject(putObjectRequest,
-                      RequestBody.fromInputStream(uploadData.getUploadStream(),
-                          putObjectRequest.contentLength())));
+              () -> getS3Client().putObject(putObjectRequest,
+                  RequestBody.fromContentProvider(
+                      provider,
+                      provider.getSize(),
+                      CONTENT_TYPE_OCTET_STREAM)));
       incrementPutCompletedStatistics(true, len);
       // apply any post-write actions.
-      finishedWrite(putObjectRequest.key(), len,
-          response.eTag(), response.versionId(),
-          putOptions);
+      finishedWrite(putObjectRequest.key(), len, putOptions);
       return response;
     } catch (SdkException e) {
       incrementPutCompletedStatistics(false, len);
@@ -3379,13 +3402,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    *
    * @param bytes bytes in the request.
    */
-  public void incrementPutStartStatistics(long bytes) {
-    LOG.debug("PUT start {} bytes", bytes);
-    incrementWriteOperations();
-    incrementGauge(OBJECT_PUT_REQUESTS_ACTIVE, 1);
-    if (bytes > 0) {
-      incrementGauge(OBJECT_PUT_BYTES_PENDING, bytes);
-    }
+  protected void incrementPutStartStatistics(long bytes) {
+    store.incrementPutStartStatistics(bytes);
   }
 
   /**
@@ -3395,14 +3413,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * @param success did the operation succeed?
    * @param bytes bytes in the request.
    */
-  public void incrementPutCompletedStatistics(boolean success, long bytes) {
-    LOG.debug("PUT completed success={}; {} bytes", success, bytes);
-    if (bytes > 0) {
-      incrementStatistic(OBJECT_PUT_BYTES, bytes);
-      decrementGauge(OBJECT_PUT_BYTES_PENDING, bytes);
-    }
-    incrementStatistic(OBJECT_PUT_REQUESTS_COMPLETED);
-    decrementGauge(OBJECT_PUT_REQUESTS_ACTIVE, 1);
+  protected void incrementPutCompletedStatistics(boolean success, long bytes) {
+    store.incrementPutCompletedStatistics(success, bytes);
   }
 
   /**
@@ -3412,12 +3424,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * @param key key to file that is being written (for logging)
    * @param bytes bytes successfully uploaded.
    */
-  public void incrementPutProgressStatistics(String key, long bytes) {
-    PROGRESS.debug("PUT {}: {} bytes", key, bytes);
-    incrementWriteOperations();
-    if (bytes > 0) {
-      statistics.incrementBytesWritten(bytes);
-    }
+  protected void incrementPutProgressStatistics(String key, long bytes) {
+    store.incrementPutProgressStatistics(key, bytes);
   }
 
   /**
@@ -4248,6 +4256,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     }
 
     @Override
+    @Retries.RetryTranslated
     public void copyLocalFileFromTo(File file, Path from, Path to) throws IOException {
       // the duration of the put is measured, but the active span is the
       // constructor-supplied one -this ensures all audit log events are grouped correctly
@@ -4264,11 +4273,13 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     }
 
     @Override
+    @Retries.RetryTranslated
     public FileStatus getFileStatus(Path f) throws IOException {
       return S3AFileSystem.this.getFileStatus(f);
     }
 
     @Override
+    @Retries.RetryTranslated
     public boolean createEmptyDir(Path path, StoreContext storeContext)
         throws IOException {
       return trackDuration(getDurationTrackerFactory(),
@@ -4289,8 +4300,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * @param putOptions put object options
    * @return the upload result
    * @throws IOException IO failure
+   * @throws CancellationException if the wait() was cancelled
    */
-  @Retries.OnceRaw("For PUT; post-PUT actions are RetrySwallowed")
+  @Retries.OnceTranslated("For PUT; post-PUT actions are RetrySwallowed")
   PutObjectResponse executePut(
       final PutObjectRequest putObjectRequest,
       final Progressable progress,
@@ -4300,49 +4312,21 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     String key = putObjectRequest.key();
     long len = getPutRequestLength(putObjectRequest);
     ProgressableProgressListener listener =
-        new ProgressableProgressListener(this, putObjectRequest.key(), progress);
+        new ProgressableProgressListener(store, putObjectRequest.key(), progress);
     UploadInfo info = putObject(putObjectRequest, file, listener);
-    PutObjectResponse result = waitForUploadCompletion(key, info).response();
+    PutObjectResponse result = store.waitForUploadCompletion(key, info).response();
     listener.uploadCompleted(info.getFileUpload());
 
     // post-write actions
-    finishedWrite(key, len,
-        result.eTag(), result.versionId(), putOptions);
+    finishedWrite(key, len, putOptions);
     return result;
-  }
-
-  /**
-   * Wait for an upload to complete.
-   * If the upload (or its result collection) failed, this is where
-   * the failure is raised as an AWS exception.
-   * Calls {@link #incrementPutCompletedStatistics(boolean, long)}
-   * to update the statistics.
-   * @param key destination key
-   * @param uploadInfo upload to wait for
-   * @return the upload result
-   * @throws IOException IO failure
-   */
-  @Retries.OnceRaw
-  CompletedFileUpload waitForUploadCompletion(String key, UploadInfo uploadInfo)
-      throws IOException {
-    FileUpload upload = uploadInfo.getFileUpload();
-    try {
-      CompletedFileUpload result = upload.completionFuture().join();
-      incrementPutCompletedStatistics(true, uploadInfo.getLength());
-      return result;
-    } catch (CompletionException e) {
-      LOG.info("Interrupted: aborting upload");
-      incrementPutCompletedStatistics(false, uploadInfo.getLength());
-      throw extractException("upload", key, e);
-    }
   }
 
   /**
    * This override bypasses checking for existence.
    *
    * @param f the path to delete; this may be unqualified.
-   * @return true, always.   * @param f the path to delete.
-   * @return  true if deleteOnExit is successful, otherwise false.
+   * @return true, always.
    * @throws IOException IO failure
    */
   @Override
@@ -4723,9 +4707,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * {@link #deleteUnnecessaryFakeDirectories(Path)}
    * if directory markers are not being retained.
    * @param key key written to
-   * @param length  total length of file written
-   * @param eTag eTag of the written object
-   * @param versionId S3 object versionId of the written object
+   * @param length total length of file written
    * @param putOptions put object options
    */
   @InterfaceAudience.Private
@@ -4733,11 +4715,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   void finishedWrite(
       String key,
       long length,
-      String eTag,
-      String versionId,
       PutObjectOptions putOptions) {
-    LOG.debug("Finished write to {}, len {}. etag {}, version {}",
-        key, length, eTag, versionId);
+    LOG.debug("Finished write to {}, len {}.",
+        key, length);
     Preconditions.checkArgument(length >= 0, "content length is negative");
     if (!putOptions.isKeepMarkers()) {
       Path p = keyToQualifiedPath(key);
@@ -4831,18 +4811,16 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   @Retries.RetryTranslated
   private void createEmptyObject(final String objectName, PutObjectOptions putOptions)
       throws IOException {
-    final InputStream im = new InputStream() {
-      @Override
-      public int read() throws IOException {
-        return -1;
-      }
-    };
 
-    S3ADataBlocks.BlockUploadData uploadData = new S3ADataBlocks.BlockUploadData(im);
+    S3ADataBlocks.BlockUploadData uploadData = new S3ADataBlocks.BlockUploadData(
+        new byte[0], 0, 0, null);
 
     invoker.retry("PUT 0-byte object ", objectName, true,
-        () -> putObjectDirect(getRequestFactory().newDirectoryMarkerRequest(objectName).build(),
-            putOptions, uploadData, false, getDurationTrackerFactory()));
+        () -> putObjectDirect(
+            getRequestFactory().newDirectoryMarkerRequest(objectName).build(),
+            putOptions,
+            uploadData,
+            getDurationTrackerFactory()));
     incrementPutProgressStatistics(objectName, 0);
     instrumentation.directoryCreated();
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -1505,6 +1505,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
               INVOCATION_HFLUSH.getSymbol(),
               INVOCATION_HSYNC.getSymbol())
           .withGauges(
+              STREAM_WRITE_BLOCK_UPLOADS_ACTIVE.getSymbol(),
               STREAM_WRITE_BLOCK_UPLOADS_PENDING.getSymbol(),
               STREAM_WRITE_BLOCK_UPLOADS_BYTES_PENDING.getSymbol())
           .withDurationTracking(

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
 import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.retry.RetryUtils;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
@@ -297,7 +298,7 @@ public final class S3AUtils {
       case SC_405_METHOD_NOT_ALLOWED:
       case SC_415_UNSUPPORTED_MEDIA_TYPE:
       case SC_501_NOT_IMPLEMENTED:
-        ioe = new AWSUnsupportedFeatureException(message, s3Exception);
+        ioe = new AWSUnsupportedFeatureException(message, ase);
         break;
 
       // precondition failure: the object is there, but the precondition
@@ -1174,6 +1175,19 @@ public final class S3AUtils {
     S3AFileStatus[] statuses = RemoteIterators
         .toArray(iterator, new S3AFileStatus[0]);
     return statuses;
+  }
+
+  /**
+   * Get the length of the PUT, verifying that the length is known.
+   * @param putObjectRequest a request bound to a file or a stream.
+   * @return the request length
+   * @throws IllegalArgumentException if the length is negative
+   */
+  public static long getPutRequestLength(PutObjectRequest putObjectRequest) {
+    long len = putObjectRequest.contentLength();
+
+    Preconditions.checkState(len >= 0, "Cannot PUT object of unknown length");
+    return len;
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
@@ -65,6 +65,38 @@ public enum Statistic {
       "GET request.",
       TYPE_DURATION),
 
+  /* Http error responses */
+  HTTP_RESPONSE_400(
+      StoreStatisticNames.HTTP_RESPONSE_400,
+      "400 response.",
+      TYPE_COUNTER),
+
+  HTTP_RESPONSE_429(
+      StoreStatisticNames.HTTP_RESPONSE_429,
+      "429 response.",
+      TYPE_COUNTER),
+
+  HTTP_RESPONSE_4XX(
+      StoreStatisticNames.HTTP_RESPONSE_4XX,
+      "4XX response.",
+      TYPE_COUNTER),
+
+  HTTP_RESPONSE_500(
+      StoreStatisticNames.HTTP_RESPONSE_500,
+      "500 response.",
+      TYPE_COUNTER),
+
+  HTTP_RESPONSE_503(
+      StoreStatisticNames.HTTP_RESPONSE_503,
+      "503 response.",
+      TYPE_COUNTER),
+
+  HTTP_RESPONSE_5XX(
+      StoreStatisticNames.HTTP_RESPONSE_5XX,
+      "5XX response.",
+      TYPE_COUNTER),
+
+
   /* FileSystem Level statistics */
 
   FILESYSTEM_INITIALIZATION(

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperationHelper.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperationHelper.java
@@ -21,9 +21,11 @@ package org.apache.hadoop.fs.s3a;
 import javax.annotation.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
@@ -233,14 +235,12 @@ public class WriteOperationHelper implements WriteOperations {
    * @param destKey destination key
    * @param length size, if known. Use -1 for not known
    * @param options options for the request
-   * @param isFile is data to be uploaded a file
    * @return the request
    */
   @Retries.OnceRaw
   public PutObjectRequest createPutObjectRequest(String destKey,
       long length,
-      final PutObjectOptions options,
-      boolean isFile) {
+      final PutObjectOptions options) {
 
     activateAuditSpan();
 
@@ -289,7 +289,7 @@ public class WriteOperationHelper implements WriteOperations {
   /**
    * Finalize a multipart PUT operation.
    * This completes the upload, and, if that works, calls
-   * {@link S3AFileSystem#finishedWrite(String, long, String, String, org.apache.hadoop.fs.s3a.impl.PutObjectOptions)}
+   * {@link WriteOperationHelperCallbacks#finishedWrite(String, long, PutObjectOptions)}
    * to update the filesystem.
    * Retry policy: retrying, translated.
    * @param destKey destination of the commit
@@ -324,8 +324,7 @@ public class WriteOperationHelper implements WriteOperations {
                     destKey, uploadId, partETags);
             return writeOperationHelperCallbacks.completeMultipartUpload(requestBuilder.build());
           });
-      owner.finishedWrite(destKey, length, uploadResult.eTag(),
-          uploadResult.versionId(),
+      writeOperationHelperCallbacks.finishedWrite(destKey, length,
           putOptions);
       return uploadResult;
     }
@@ -404,11 +403,12 @@ public class WriteOperationHelper implements WriteOperations {
   /**
    * Abort a multipart commit operation.
    * @param upload upload to abort.
+   * @throws FileNotFoundException if the upload is unknown
    * @throws IOException on problems.
    */
   @Retries.RetryTranslated
   public void abortMultipartUpload(MultipartUpload upload)
-      throws IOException {
+      throws FileNotFoundException, IOException {
     invoker.retry("Aborting multipart commit", upload.key(), true,
         withinAuditSpan(getAuditSpan(),
             () -> owner.abortMultipartUpload(upload)));
@@ -508,20 +508,19 @@ public class WriteOperationHelper implements WriteOperations {
    * file, from the content length of the header.
    * @param putObjectRequest the request
    * @param putOptions put object options
-   * @param durationTrackerFactory factory for duration tracking
    * @param uploadData data to be uploaded
-   * @param isFile is data to be uploaded a file
-   *
+   * @param durationTrackerFactory factory for duration tracking
    * @return the upload initiated
    * @throws IOException on problems
    */
   @Retries.RetryTranslated
   public PutObjectResponse putObject(PutObjectRequest putObjectRequest,
-      PutObjectOptions putOptions, S3ADataBlocks.BlockUploadData uploadData, boolean isFile,
+      PutObjectOptions putOptions,
+      S3ADataBlocks.BlockUploadData uploadData,
       DurationTrackerFactory durationTrackerFactory)
       throws IOException {
     return retry("Writing Object", putObjectRequest.key(), true, withinAuditSpan(getAuditSpan(),
-        () -> owner.putObjectDirect(putObjectRequest, putOptions, uploadData, isFile,
+        () -> owner.putObjectDirect(putObjectRequest, putOptions, uploadData,
             durationTrackerFactory)));
   }
 
@@ -578,7 +577,6 @@ public class WriteOperationHelper implements WriteOperations {
 
   /**
    * Upload part of a multi-partition file.
-   * @param request request
    * @param durationTrackerFactory duration tracker factory for operation
    * @param request the upload part request.
    * @param body the request body.
@@ -594,7 +592,9 @@ public class WriteOperationHelper implements WriteOperations {
         request.key(),
         true,
         withinAuditSpan(getAuditSpan(),
-            () -> owner.uploadPart(request, body, durationTrackerFactory)));
+            () -> writeOperationHelperCallbacks.uploadPart(request,
+                body,
+                durationTrackerFactory)));
   }
 
   /**
@@ -644,8 +644,44 @@ public class WriteOperationHelper implements WriteOperations {
      * @param request Complete multi-part upload request
      * @return completeMultipartUploadResult
      */
-    CompleteMultipartUploadResponse completeMultipartUpload(CompleteMultipartUploadRequest request);
+    @Retries.OnceRaw
+    CompleteMultipartUploadResponse completeMultipartUpload(
+        CompleteMultipartUploadRequest request);
 
+    /**
+     * Upload part of a multi-partition file.
+     * Increments the write and put counters.
+     * <i>Important: this call does not close any input stream in the body.</i>
+     * <p>
+     * Retry Policy: none.
+     * @param durationTrackerFactory duration tracker factory for operation
+     * @param request the upload part request.
+     * @param body the request body.
+     * @return the result of the operation.
+     * @throws AwsServiceException on problems
+     * @throws UncheckedIOException failure to instantiate the s3 client
+     */
+    @Retries.OnceRaw
+    UploadPartResponse uploadPart(
+        UploadPartRequest request,
+        RequestBody body,
+        DurationTrackerFactory durationTrackerFactory)
+        throws AwsServiceException, UncheckedIOException;
+
+    /**
+     * Perform post-write actions.
+     * <p>
+     * This operation MUST be called after any PUT/multipart PUT completes
+     * successfully.
+     * @param key key written to
+     * @param length total length of file written
+     * @param putOptions put object options
+     */
+    @Retries.RetryExceptionsSwallowed
+    void finishedWrite(
+        String key,
+        long length,
+        PutObjectOptions putOptions);
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperations.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperations.java
@@ -74,13 +74,11 @@ public interface WriteOperations extends AuditSpanSource, Closeable {
    * @param destKey destination key
    * @param length size, if known. Use -1 for not known
    * @param options options for the request
-   * @param isFile is data to be uploaded a file
    * @return the request
    */
   PutObjectRequest createPutObjectRequest(String destKey,
       long length,
-      @Nullable PutObjectOptions options,
-      boolean isFile);
+      @Nullable PutObjectOptions options);
 
   /**
    * Callback on a successful write.
@@ -148,6 +146,7 @@ public interface WriteOperations extends AuditSpanSource, Closeable {
   /**
    * Abort a multipart commit operation.
    * @param upload upload to abort.
+   * @throws FileNotFoundException if the upload is unknown
    * @throws IOException on problems.
    */
   @Retries.RetryTranslated
@@ -208,15 +207,15 @@ public interface WriteOperations extends AuditSpanSource, Closeable {
    * file, from the content length of the header.
    * @param putObjectRequest the request
    * @param putOptions put object options
-   * @param durationTrackerFactory factory for duration tracking
    * @param uploadData data to be uploaded
-   * @param isFile is data to be uploaded a file
+   * @param durationTrackerFactory factory for duration tracking
    * @return the upload initiated
    * @throws IOException on problems
    */
   @Retries.RetryTranslated
   PutObjectResponse putObject(PutObjectRequest putObjectRequest,
-      PutObjectOptions putOptions, S3ADataBlocks.BlockUploadData uploadData, boolean isFile,
+      PutObjectOptions putOptions,
+      S3ADataBlocks.BlockUploadData uploadData,
       DurationTrackerFactory durationTrackerFactory)
       throws IOException;
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/AbstractOperationAuditor.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/AbstractOperationAuditor.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.fs.s3a.audit.OperationAuditorOptions;
 import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 import org.apache.hadoop.service.AbstractService;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * This is a long-lived service which is created in S3A FS initialize
  * (make it fast!) which provides context for tracking operations made to S3.
@@ -85,7 +87,7 @@ public abstract class AbstractOperationAuditor extends AbstractService
   @Override
   public void init(final OperationAuditorOptions opts) {
     this.options = opts;
-    this.iostatistics = opts.getIoStatisticsStore();
+    this.iostatistics = requireNonNull(opts.getIoStatisticsStore());
     init(opts.getConfiguration());
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/S3MagicCommitTracker.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/S3MagicCommitTracker.java
@@ -18,9 +18,7 @@
 
 package org.apache.hadoop.fs.s3a.commit.magic;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,8 +79,8 @@ public class S3MagicCommitTracker extends MagicCommitTracker {
     PutObjectRequest originalDestPut = getWriter().createPutObjectRequest(
         getOriginalDestKey(),
         0,
-        new PutObjectOptions(true, null, headers), false);
-    upload(originalDestPut, new ByteArrayInputStream(EMPTY));
+        new PutObjectOptions(true, null, headers));
+    upload(originalDestPut, EMPTY);
 
     // build the commit summary
     SinglePendingCommit commitData = new SinglePendingCommit();
@@ -105,8 +103,8 @@ public class S3MagicCommitTracker extends MagicCommitTracker {
         getPath(), getPendingPartKey(), commitData);
     PutObjectRequest put = getWriter().createPutObjectRequest(
         getPendingPartKey(),
-        bytes.length, null, false);
-    upload(put, new ByteArrayInputStream(bytes));
+        bytes.length, null);
+    upload(put, bytes);
     return false;
   }
 
@@ -117,9 +115,9 @@ public class S3MagicCommitTracker extends MagicCommitTracker {
    * @throws IOException on problems
    */
   @Retries.RetryTranslated
-  private void upload(PutObjectRequest request, InputStream inputStream) throws IOException {
+  private void upload(PutObjectRequest request, byte[] bytes) throws IOException {
     trackDurationOfInvocation(getTrackerStatistics(), COMMITTER_MAGIC_MARKER_PUT.getSymbol(),
         () -> getWriter().putObject(request, PutObjectOptions.keepingDirs(),
-            new S3ADataBlocks.BlockUploadData(inputStream), false, null));
+            new S3ADataBlocks.BlockUploadData(bytes, null), null));
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ClientManager.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ClientManager.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.s3a.impl;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -39,9 +40,33 @@ public interface ClientManager extends Closeable {
   S3TransferManager getOrCreateTransferManager()
       throws IOException;
 
+  /**
+   * Get the S3Client, raising a failure to create as an IOException.
+   * @return the S3 client
+   * @throws IOException failure to create the client.
+   */
   S3Client getOrCreateS3Client() throws IOException;
 
+  /**
+   * Get the S3Client, raising a failure to create as an UncheckedIOException.
+   * @return the S3 client
+   * @throws UncheckedIOException failure to create the client.
+   */
+  S3Client getOrCreateS3ClientUnchecked() throws UncheckedIOException;
+
+  /**
+   * Get the Async S3Client,raising a failure to create as an IOException.
+   * @return the Async S3 client
+   * @throws IOException failure to create the client.
+   */
   S3AsyncClient getOrCreateAsyncClient() throws IOException;
+
+  /**
+   * Get the AsyncS3Client, raising a failure to create as an UncheckedIOException.
+   * @return the S3 client
+   * @throws UncheckedIOException failure to create the client.
+   */
+  S3Client getOrCreateAsyncS3ClientUnchecked() throws UncheckedIOException;
 
   /**
    * Close operation is required to not raise exceptions.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ClientManagerImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ClientManagerImpl.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.fs.s3a.impl;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -147,10 +148,32 @@ public class ClientManagerImpl implements ClientManager {
     return s3Client.eval();
   }
 
+  /**
+   * Get the S3Client, raising a failure to create as an UncheckedIOException.
+   * @return the S3 client
+   * @throws UncheckedIOException failure to create the client.
+   */
+  @Override
+  public synchronized S3Client getOrCreateS3ClientUnchecked() throws UncheckedIOException {
+    checkNotClosed();
+    return s3Client.get();
+  }
+
   @Override
   public synchronized S3AsyncClient getOrCreateAsyncClient() throws IOException {
     checkNotClosed();
     return s3AsyncClient.eval();
+  }
+
+  /**
+   * Get the AsyncS3Client, raising a failure to create as an UncheckedIOException.
+   * @return the S3 client
+   * @throws UncheckedIOException failure to create the client.
+   */
+  @Override
+  public synchronized S3Client getOrCreateAsyncS3ClientUnchecked() throws UncheckedIOException {
+    checkNotClosed();
+    return s3Client.get();
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
@@ -292,4 +292,11 @@ public final class InternalConstants {
    */
   public static final String AUTH_SCHEME_AWS_SIGV_4 = "aws.auth#sigv4";
 
+
+  /**
+   * Progress logge name; fairly noisy.
+   */
+  public static final String UPLOAD_PROGRESS_LOG_NAME =
+      "org.apache.hadoop.fs.s3a.S3AFileSystem.Progress";
+
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ProgressListenerEvent.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ProgressListenerEvent.java
@@ -20,10 +20,72 @@ package org.apache.hadoop.fs.s3a.impl;
 
 /**
  * Enum for progress listener events.
+ * Some are used in the {@code S3ABlockOutputStream}
+ * class to manage progress; others are to assist
+ * testing.
  */
 public enum ProgressListenerEvent {
+
+  /**
+   * Stream has been closed.
+   */
+  CLOSE_EVENT,
+
+  /** PUT operation completed successfully. */
+  PUT_COMPLETED_EVENT,
+
+  /** PUT operation was interrupted. */
+  PUT_INTERRUPTED_EVENT,
+
+  /** PUT operation was interrupted. */
+  PUT_FAILED_EVENT,
+
+  /** A PUT operation was started. */
+  PUT_STARTED_EVENT,
+
+  /** Bytes were transferred. */
   REQUEST_BYTE_TRANSFER_EVENT,
+
+  /**
+   * A multipart upload was initiated.
+   */
+  TRANSFER_MULTIPART_INITIATED_EVENT,
+
+  /**
+   * A multipart upload was aborted.
+   */
+  TRANSFER_MULTIPART_ABORTED_EVENT,
+
+  /**
+   * A multipart upload was successfully.
+   */
+  TRANSFER_MULTIPART_COMPLETED_EVENT,
+
+  /**
+   * An upload of a part of a multipart upload was started.
+   */
   TRANSFER_PART_STARTED_EVENT,
+
+  /**
+   * An upload of a part of a multipart upload was completed.
+   * This does not indicate the upload was successful.
+   */
   TRANSFER_PART_COMPLETED_EVENT,
-  TRANSFER_PART_FAILED_EVENT;
+
+  /**
+   * An upload of a part of a multipart upload was completed
+   * successfully.
+   */
+  TRANSFER_PART_SUCCESS_EVENT,
+
+  /**
+   * An upload of a part of a multipart upload was abported.
+   */
+  TRANSFER_PART_ABORTED_EVENT,
+
+  /**
+   * An upload of a part of a multipart upload failed.
+   */
+  TRANSFER_PART_FAILED_EVENT,
+
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreBuilder.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreBuilder.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.s3a.impl;
 
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3AStorageStatistics;
 import org.apache.hadoop.fs.s3a.S3AStore;
@@ -49,6 +50,13 @@ public class S3AStoreBuilder {
   private RateLimiting writeRateLimiter;
 
   private AuditSpanSource<AuditSpanS3A> auditSpanSource;
+
+  /**
+   * The original file system statistics: fairly minimal but broadly
+   * collected so it is important to pick up.
+   * This may be null.
+   */
+  private FileSystem.Statistics fsStatistics;
 
   public S3AStoreBuilder withStoreContextFactory(
           final StoreContextFactory storeContextFactoryValue) {
@@ -104,6 +112,11 @@ public class S3AStoreBuilder {
     return this;
   }
 
+  public S3AStoreBuilder withFsStatistics(final FileSystem.Statistics value) {
+    this.fsStatistics = value;
+    return this;
+  }
+
   public S3AStore build() {
     return new S3AStoreImpl(storeContextFactory,
         clientManager,
@@ -113,6 +126,7 @@ public class S3AStoreBuilder {
         storageStatistics,
         readRateLimiter,
         writeRateLimiter,
-        auditSpanSource);
+        auditSpanSource,
+        fsStatistics);
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreImpl.java
@@ -18,34 +18,49 @@
 
 package org.apache.hadoop.fs.s3a.impl;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
 import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Error;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.CompletedFileUpload;
+import software.amazon.awssdk.transfer.s3.model.FileUpload;
+import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.s3a.Invoker;
+import org.apache.hadoop.fs.s3a.ProgressableProgressListener;
 import org.apache.hadoop.fs.s3a.Retries;
 import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3AStorageStatistics;
 import org.apache.hadoop.fs.s3a.S3AStore;
 import org.apache.hadoop.fs.s3a.Statistic;
+import org.apache.hadoop.fs.s3a.UploadInfo;
 import org.apache.hadoop.fs.s3a.api.RequestFactory;
 import org.apache.hadoop.fs.s3a.audit.AuditSpanS3A;
 import org.apache.hadoop.fs.s3a.statistics.S3AStatisticsContext;
@@ -57,11 +72,18 @@ import org.apache.hadoop.util.RateLimiting;
 import org.apache.hadoop.util.functional.Tuples;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.fs.s3a.S3AUtils.extractException;
+import static org.apache.hadoop.fs.s3a.S3AUtils.getPutRequestLength;
 import static org.apache.hadoop.fs.s3a.S3AUtils.isThrottleException;
 import static org.apache.hadoop.fs.s3a.Statistic.IGNORED_ERRORS;
+import static org.apache.hadoop.fs.s3a.Statistic.MULTIPART_UPLOAD_PART_PUT;
 import static org.apache.hadoop.fs.s3a.Statistic.OBJECT_BULK_DELETE_REQUEST;
 import static org.apache.hadoop.fs.s3a.Statistic.OBJECT_DELETE_OBJECTS;
 import static org.apache.hadoop.fs.s3a.Statistic.OBJECT_DELETE_REQUEST;
+import static org.apache.hadoop.fs.s3a.Statistic.OBJECT_PUT_BYTES;
+import static org.apache.hadoop.fs.s3a.Statistic.OBJECT_PUT_BYTES_PENDING;
+import static org.apache.hadoop.fs.s3a.Statistic.OBJECT_PUT_REQUESTS_ACTIVE;
+import static org.apache.hadoop.fs.s3a.Statistic.OBJECT_PUT_REQUESTS_COMPLETED;
 import static org.apache.hadoop.fs.s3a.Statistic.STORE_IO_RATE_LIMITED;
 import static org.apache.hadoop.fs.s3a.Statistic.STORE_IO_RETRY;
 import static org.apache.hadoop.fs.s3a.Statistic.STORE_IO_THROTTLED;
@@ -69,6 +91,7 @@ import static org.apache.hadoop.fs.s3a.Statistic.STORE_IO_THROTTLE_RATE;
 import static org.apache.hadoop.fs.s3a.impl.ErrorTranslation.isObjectNotFound;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.DELETE_CONSIDERED_IDEMPOTENT;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.trackDurationOfOperation;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.trackDurationOfSupplier;
 import static org.apache.hadoop.util.Preconditions.checkArgument;
 
 /**
@@ -79,6 +102,12 @@ import static org.apache.hadoop.util.Preconditions.checkArgument;
 public class S3AStoreImpl implements S3AStore {
 
   private static final Logger LOG = LoggerFactory.getLogger(S3AStoreImpl.class);
+
+  /**
+   * Progress logger; fairly noisy.
+   */
+  private static final Logger PROGRESS =
+      LoggerFactory.getLogger(InternalConstants.UPLOAD_PROGRESS_LOG_NAME);
 
   /** Factory to create store contexts. */
   private final StoreContextFactory storeContextFactory;
@@ -119,6 +148,13 @@ public class S3AStoreImpl implements S3AStore {
   /** Audit span source. */
   private final AuditSpanSource<AuditSpanS3A> auditSpanSource;
 
+  /**
+   * The original file system statistics: fairly minimal but broadly
+   * collected so it is important to pick up.
+   * This may be null.
+   */
+  private final FileSystem.Statistics fsStatistics;
+
   /** Constructor to create S3A store. */
   S3AStoreImpl(StoreContextFactory storeContextFactory,
       ClientManager clientManager,
@@ -128,7 +164,8 @@ public class S3AStoreImpl implements S3AStore {
       S3AStorageStatistics storageStatistics,
       RateLimiting readRateLimiter,
       RateLimiting writeRateLimiter,
-      AuditSpanSource<AuditSpanS3A> auditSpanSource) {
+      AuditSpanSource<AuditSpanS3A> auditSpanSource,
+      @Nullable FileSystem.Statistics fsStatistics) {
     this.storeContextFactory = requireNonNull(storeContextFactory);
     this.clientManager = requireNonNull(clientManager);
     this.durationTrackerFactory = requireNonNull(durationTrackerFactory);
@@ -139,6 +176,7 @@ public class S3AStoreImpl implements S3AStore {
     this.writeRateLimiter = requireNonNull(writeRateLimiter);
     this.auditSpanSource = requireNonNull(auditSpanSource);
     this.storeContext = requireNonNull(storeContextFactory.createStoreContext());
+    this.fsStatistics = fsStatistics;
     this.invoker = storeContext.getInvoker();
     this.bucket = storeContext.getBucket();
     this.requestFactory = storeContext.getRequestFactory();
@@ -178,10 +216,10 @@ public class S3AStoreImpl implements S3AStore {
   /**
    * Get the S3 client.
    * @return the S3 client.
-   * @throws IOException on any failure to create the client.
+   * @throws UncheckedIOException on any failure to create the client.
    */
-  private S3Client getS3Client() throws IOException {
-    return clientManager.getOrCreateS3Client();
+  private S3Client getS3Client() throws UncheckedIOException {
+    return clientManager.getOrCreateS3ClientUnchecked();
   }
 
   @Override
@@ -197,6 +235,16 @@ public class S3AStoreImpl implements S3AStore {
   @Override
   public S3AsyncClient getOrCreateAsyncClient() throws IOException {
     return clientManager.getOrCreateAsyncClient();
+  }
+
+  @Override
+  public S3Client getOrCreateS3ClientUnchecked() throws UncheckedIOException {
+    return clientManager.getOrCreateS3ClientUnchecked();
+  }
+
+  @Override
+  public S3Client getOrCreateAsyncS3ClientUnchecked() throws UncheckedIOException {
+    return clientManager.getOrCreateAsyncS3ClientUnchecked();
   }
 
   @Override
@@ -306,6 +354,105 @@ public class S3AStoreImpl implements S3AStore {
   }
 
   /**
+   * Increment read operations.
+   */
+  @Override
+  public void incrementReadOperations() {
+    if (fsStatistics != null) {
+      fsStatistics.incrementReadOps(1);
+    }
+  }
+
+  /**
+   * Increment the write operation counter.
+   * This is somewhat inaccurate, as it appears to be invoked more
+   * often than needed in progress callbacks.
+   */
+  @Override
+  public void incrementWriteOperations() {
+    if (fsStatistics != null) {
+      fsStatistics.incrementWriteOps(1);
+    }
+  }
+
+
+  /**
+   * Increment the bytes written statistic.
+   * @param bytes number of bytes written.
+   */
+  private void incrementBytesWritten(final long bytes) {
+    if (fsStatistics != null) {
+      fsStatistics.incrementBytesWritten(bytes);
+    }
+  }
+
+  /**
+   * At the start of a put/multipart upload operation, update the
+   * relevant counters.
+   *
+   * @param bytes bytes in the request.
+   */
+  @Override
+  public void incrementPutStartStatistics(long bytes) {
+    LOG.debug("PUT start {} bytes", bytes);
+    incrementWriteOperations();
+    incrementGauge(OBJECT_PUT_REQUESTS_ACTIVE, 1);
+    if (bytes > 0) {
+      incrementGauge(OBJECT_PUT_BYTES_PENDING, bytes);
+    }
+  }
+
+  /**
+   * At the end of a put/multipart upload operation, update the
+   * relevant counters and gauges.
+   *
+   * @param success did the operation succeed?
+   * @param bytes bytes in the request.
+   */
+  @Override
+  public void incrementPutCompletedStatistics(boolean success, long bytes) {
+    LOG.debug("PUT completed success={}; {} bytes", success, bytes);
+    if (bytes > 0) {
+      incrementStatistic(OBJECT_PUT_BYTES, bytes);
+      decrementGauge(OBJECT_PUT_BYTES_PENDING, bytes);
+    }
+    incrementStatistic(OBJECT_PUT_REQUESTS_COMPLETED);
+    decrementGauge(OBJECT_PUT_REQUESTS_ACTIVE, 1);
+  }
+
+  /**
+   * Callback for use in progress callbacks from put/multipart upload events.
+   * Increments those statistics which are expected to be updated during
+   * the ongoing upload operation.
+   * @param key key to file that is being written (for logging)
+   * @param bytes bytes successfully uploaded.
+   */
+  @Override
+  public void incrementPutProgressStatistics(String key, long bytes) {
+    PROGRESS.debug("PUT {}: {} bytes", key, bytes);
+    incrementWriteOperations();
+    if (bytes > 0) {
+      incrementBytesWritten(bytes);
+    }
+  }
+
+  /**
+   * Given a possibly null duration tracker factory, return a non-null
+   * one for use in tracking durations -either that or the FS tracker
+   * itself.
+   *
+   * @param factory factory.
+   * @return a non-null factory.
+   */
+  @Override
+  public DurationTrackerFactory nonNullDurationTrackerFactory(
+      DurationTrackerFactory factory) {
+    return factory != null
+        ? factory
+        : getDurationTrackerFactory();
+  }
+
+  /**
    * Start an operation; this informs the audit service of the event
    * and then sets it as the active span.
    * @param operation operation name.
@@ -388,7 +535,6 @@ public class S3AStoreImpl implements S3AStore {
       return Tuples.pair(d.asDuration(), response);
 
     } catch (IOException e) {
-      // this is part of the retry signature, nothing else.
       // convert to unchecked.
       throw new UncheckedIOException(e);
     }
@@ -430,10 +576,125 @@ public class S3AStoreImpl implements S3AStore {
       d.close();
       return Tuples.pair(d.asDuration(), Optional.empty());
     } catch (IOException e) {
-      // this is part of the retry signature, nothing else.
       // convert to unchecked.
       throw new UncheckedIOException(e);
     }
+  }
+
+  /**
+   * Upload part of a multi-partition file.
+   * Increments the write and put counters.
+   * <i>Important: this call does not close any input stream in the body.</i>
+   * <p>
+   * Retry Policy: none.
+   * @param trackerFactory duration tracker factory for operation
+   * @param request the upload part request.
+   * @param body the request body.
+   * @return the result of the operation.
+   * @throws AwsServiceException on problems
+   * @throws UncheckedIOException failure to instantiate the s3 client
+   */
+  @Override
+  @Retries.OnceRaw
+  public UploadPartResponse uploadPart(
+      final UploadPartRequest request,
+      final RequestBody body,
+      @Nullable final DurationTrackerFactory trackerFactory)
+      throws AwsServiceException, UncheckedIOException {
+    long len = request.contentLength();
+    incrementPutStartStatistics(len);
+    try {
+      UploadPartResponse uploadPartResponse = trackDurationOfSupplier(
+          nonNullDurationTrackerFactory(trackerFactory),
+          MULTIPART_UPLOAD_PART_PUT.getSymbol(), () ->
+              getS3Client().uploadPart(request, body));
+      incrementPutCompletedStatistics(true, len);
+      return uploadPartResponse;
+    } catch (AwsServiceException e) {
+      incrementPutCompletedStatistics(false, len);
+      throw e;
+    }
+  }
+
+  /**
+   * Start a transfer-manager managed async PUT of an object,
+   * incrementing the put requests and put bytes
+   * counters.
+   * <p>
+   * It does not update the other counters,
+   * as existing code does that as progress callbacks come in.
+   * Byte length is calculated from the file length, or, if there is no
+   * file, from the content length of the header.
+   * <p>
+   * Because the operation is async, any stream supplied in the request
+   * must reference data (files, buffers) which stay valid until the upload
+   * completes.
+   * Retry policy: N/A: the transfer manager is performing the upload.
+   * Auditing: must be inside an audit span.
+   * @param putObjectRequest the request
+   * @param file the file to be uploaded
+   * @param listener the progress listener for the request
+   * @return the upload initiated
+   * @throws IOException if transfer manager creation failed.
+   */
+  @Override
+  @Retries.OnceRaw
+  public UploadInfo putObject(
+      PutObjectRequest putObjectRequest,
+      File file,
+      ProgressableProgressListener listener) throws IOException {
+    long len = getPutRequestLength(putObjectRequest);
+    LOG.debug("PUT {} bytes to {} via transfer manager ", len, putObjectRequest.key());
+    incrementPutStartStatistics(len);
+
+    FileUpload upload = getOrCreateTransferManager().uploadFile(
+            UploadFileRequest.builder()
+                .putObjectRequest(putObjectRequest)
+                .source(file)
+                .addTransferListener(listener)
+                .build());
+
+    return new UploadInfo(upload, len);
+  }
+
+  /**
+   * Wait for an upload to complete.
+   * If the upload (or its result collection) failed, this is where
+   * the failure is raised as an AWS exception.
+   * Calls {@link S3AStore#incrementPutCompletedStatistics(boolean, long)}
+   * to update the statistics.
+   * @param key destination key
+   * @param uploadInfo upload to wait for
+   * @return the upload result
+   * @throws IOException IO failure
+   * @throws CancellationException if the wait() was cancelled
+   */
+  @Override
+  @Retries.OnceTranslated
+  public CompletedFileUpload waitForUploadCompletion(String key, UploadInfo uploadInfo)
+      throws IOException {
+    FileUpload upload = uploadInfo.getFileUpload();
+    try {
+      CompletedFileUpload result = upload.completionFuture().join();
+      incrementPutCompletedStatistics(true, uploadInfo.getLength());
+      return result;
+    } catch (CompletionException e) {
+      LOG.info("Interrupted: aborting upload");
+      incrementPutCompletedStatistics(false, uploadInfo.getLength());
+      throw extractException("upload", key, e);
+    }
+  }
+
+  /**
+   * Complete a multipart upload.
+   * @param request request
+   * @return the response
+   */
+  @Override
+  @Retries.OnceRaw
+  public CompleteMultipartUploadResponse completeMultipartUpload(
+      CompleteMultipartUploadRequest request) {
+    return getS3Client().completeMultipartUpload(request);
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/UploadContentProviders.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/UploadContentProviders.java
@@ -1,0 +1,549 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.http.ContentStreamProvider;
+
+import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.fs.store.ByteBufferInputStream;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.io.IOUtils.cleanupWithLogger;
+import static org.apache.hadoop.util.Preconditions.checkArgument;
+import static org.apache.hadoop.util.Preconditions.checkState;
+import static org.apache.hadoop.util.functional.FunctionalIO.uncheckIOExceptions;
+
+/**
+ * Implementations of {@code software.amazon.awssdk.http.ContentStreamProvider}.
+ * <p>
+ * These are required to ensure that retry of multipart uploads are reliable,
+ * while also avoiding memory copy/consumption overhead.
+ * <p>
+ * For these reasons the providers built in to the AWS SDK are not used.
+ * <p>
+ * See HADOOP-19221 for details.
+ */
+public final class UploadContentProviders {
+
+  public static final Logger LOG = LoggerFactory.getLogger(UploadContentProviders.class);
+
+  private UploadContentProviders() {
+  }
+
+  /**
+   * Create a content provider from a file.
+   * @param file file to read.
+   * @param offset offset in file.
+   * @param size of data.
+   * @return the provider
+   * @throws IllegalArgumentException if the offset is negative.
+   */
+  public static BaseContentProvider<BufferedInputStream> fileContentProvider(
+      File file,
+      long offset,
+      final int size) {
+
+    return new FileWithOffsetContentProvider(file, offset, size);
+  }
+
+  /**
+   * Create a content provider from a file.
+   * @param file file to read.
+   * @param offset offset in file.
+   * @param size of data.
+   * @param isOpen optional predicate to check if the stream is open.
+   * @return the provider
+   * @throws IllegalArgumentException if the offset is negative.
+   */
+  public static BaseContentProvider<BufferedInputStream> fileContentProvider(
+      File file,
+      long offset,
+      final int size,
+      final Supplier<Boolean> isOpen) {
+
+    return new FileWithOffsetContentProvider(file, offset, size, isOpen);
+  }
+
+  /**
+   * Create a content provider from a byte buffer.
+   * The buffer is not copied and MUST NOT be modified while
+   * the upload is taking place.
+   * @param byteBuffer buffer to read.
+   * @param size size of the data.
+   * @return the provider
+   * @throws IllegalArgumentException if the arguments are invalid.
+   * @throws NullPointerException if the buffer is null
+   */
+  public static BaseContentProvider<ByteBufferInputStream> byteBufferContentProvider(
+      final ByteBuffer byteBuffer,
+      final int size) {
+    return new ByteBufferContentProvider(byteBuffer, size);
+  }
+
+  /**
+   * Create a content provider from a byte buffer.
+   * The buffer is not copied and MUST NOT be modified while
+   * the upload is taking place.
+   * @param byteBuffer buffer to read.
+   * @param size size of the data.
+   * @param isOpen optional predicate to check if the stream is open.
+   * @return the provider
+   * @throws IllegalArgumentException if the arguments are invalid.
+   * @throws NullPointerException if the buffer is null
+   */
+  public static BaseContentProvider<ByteBufferInputStream> byteBufferContentProvider(
+      final ByteBuffer byteBuffer,
+      final int size,
+      final @Nullable Supplier<Boolean> isOpen) {
+
+    return new ByteBufferContentProvider(byteBuffer, size, isOpen);
+  }
+
+  /**
+   * Create a content provider for all or part of a byte array.
+   * The buffer is not copied and MUST NOT be modified while
+   * the upload is taking place.
+   * @param bytes buffer to read.
+   * @param offset offset in buffer.
+   * @param size size of the data.
+   * @return the provider
+   * @throws IllegalArgumentException if the arguments are invalid.
+   * @throws NullPointerException if the buffer is null.
+   */
+  public static BaseContentProvider<ByteArrayInputStream> byteArrayContentProvider(
+      final byte[] bytes, final int offset, final int size) {
+    return new ByteArrayContentProvider(bytes, offset, size);
+  }
+
+  /**
+   * Create a content provider for all or part of a byte array.
+   * The buffer is not copied and MUST NOT be modified while
+   * the upload is taking place.
+   * @param bytes buffer to read.
+   * @param offset offset in buffer.
+   * @param size size of the data.
+   * @param isOpen optional predicate to check if the stream is open.
+   * @return the provider
+   * @throws IllegalArgumentException if the arguments are invalid.
+   * @throws NullPointerException if the buffer is null.
+   */
+  public static BaseContentProvider<ByteArrayInputStream> byteArrayContentProvider(
+      final byte[] bytes,
+      final int offset,
+      final int size,
+      final @Nullable Supplier<Boolean> isOpen) {
+    return new ByteArrayContentProvider(bytes, offset, size, isOpen);
+  }
+
+  /**
+   * Create a content provider for all of a byte array.
+   * @param bytes buffer to read.
+   * @return the provider
+   * @throws IllegalArgumentException if the arguments are invalid.
+   * @throws NullPointerException if the buffer is null.
+   */
+  public static BaseContentProvider<ByteArrayInputStream> byteArrayContentProvider(
+      final byte[] bytes) {
+    return byteArrayContentProvider(bytes, 0, bytes.length);
+  }
+
+  /**
+   * Create a content provider for all of a byte array.
+   * @param bytes buffer to read.
+   * @param isOpen optional predicate to check if the stream is open.
+   * @return the provider
+   * @throws IllegalArgumentException if the arguments are invalid.
+   * @throws NullPointerException if the buffer is null.
+   */
+  public static BaseContentProvider<ByteArrayInputStream> byteArrayContentProvider(
+      final byte[] bytes,
+      final @Nullable Supplier<Boolean> isOpen) {
+    return byteArrayContentProvider(bytes, 0, bytes.length, isOpen);
+  }
+
+  /**
+   * Base class for content providers; tracks the number of times a stream
+   * has been opened.
+   * @param <T> type of stream created.
+   */
+  @VisibleForTesting
+  public static abstract class BaseContentProvider<T extends InputStream>
+      implements ContentStreamProvider, Closeable {
+
+    /**
+     * Size of the data.
+     */
+    private final int size;
+
+    /**
+     * Probe to check if the stream is open.
+     * Invoked in {@link #checkOpen()}, which is itself
+     * invoked in {@link #newStream()}.
+     */
+    private final Supplier<Boolean> isOpen;
+
+    /**
+     * How many times has a stream been created?
+     */
+    private int streamCreationCount;
+
+    /**
+     * Current stream. Null if not opened yet.
+     * When {@link #newStream()} is called, this is set to the new value,
+     * Note: when the input stream itself is closed, this reference is not updated.
+     * Therefore this field not being null does not imply that the stream is open.
+     */
+    private T currentStream;
+
+    /**
+     * Constructor.
+     * @param size size of the data. Must be non-negative.
+     */
+    protected BaseContentProvider(int size) {
+      this(size, null);
+    }
+
+    /**
+     * Constructor.
+     * @param size size of the data. Must be non-negative.
+     * @param isOpen optional predicate to check if the stream is open.
+     */
+    protected BaseContentProvider(int size, @Nullable Supplier<Boolean> isOpen) {
+      checkArgument(size >= 0, "size is negative: %s", size);
+      this.size = size;
+      this.isOpen = isOpen;
+    }
+
+    /**
+     * Check if the stream is open.
+     * If the stream is not open, raise an exception
+     * @throws IllegalStateException if the stream is not open.
+     */
+    private void checkOpen() {
+      checkState(isOpen == null || isOpen.get(), "Stream is closed: %s", this);
+    }
+
+    /**
+     * Close the current stream.
+     */
+    @Override
+    public void close() {
+      cleanupWithLogger(LOG, getCurrentStream());
+      setCurrentStream(null);
+    }
+
+    /**
+     * Create a new stream.
+     * <p>
+     * Calls {@link #close()} to ensure that any existing stream is closed,
+     * then {@link #checkOpen()} to verify that the data source is still open.
+     * Logs if this is a subsequent event as it implies a failure of the first attempt.
+     * @return the new stream
+     */
+    @Override
+    public final InputStream newStream() {
+      close();
+      checkOpen();
+      streamCreationCount++;
+      if (streamCreationCount > 1) {
+        LOG.info("Stream created more than once: {}", this);
+      }
+      return setCurrentStream(createNewStream());
+    }
+
+    /**
+     * Override point for subclasses to create their new streams.
+     * @return a stream
+     */
+    protected abstract T createNewStream();
+
+    /**
+     * How many times has a stream been created?
+     * @return stream creation count
+     */
+    public int getStreamCreationCount() {
+      return streamCreationCount;
+    }
+
+    /**
+     * Size as set by constructor parameter.
+     * @return size of the data
+     */
+    public int getSize() {
+      return size;
+    }
+
+    /**
+     * Current stream.
+     * When {@link #newStream()} is called, this is set to the new value,
+     * after closing the previous one.
+     * <p>
+     * Why? The AWS SDK implementations do this, so there
+     * is an implication that it is needed to avoid keeping streams
+     * open on retries.
+     * @return the current stream, or null if none is open.
+     */
+    protected T getCurrentStream() {
+      return currentStream;
+    }
+
+    /**
+     * Set the current stream.
+     * @param stream the new stream
+     * @return the current stream.
+     */
+    protected T setCurrentStream(T stream) {
+      this.currentStream = stream;
+      return stream;
+    }
+
+    @Override
+    public String toString() {
+      return "BaseContentProvider{" +
+          "size=" + size +
+          ", streamCreationCount=" + streamCreationCount +
+          ", currentStream=" + currentStream +
+          '}';
+    }
+  }
+
+  /**
+   * Content provider for a file with an offset.
+   */
+  private static final class FileWithOffsetContentProvider
+      extends BaseContentProvider<BufferedInputStream> {
+
+    /**
+     * File to read.
+     */
+    private final File file;
+
+    /**
+     * Offset in file.
+     */
+    private final long offset;
+
+    /**
+     * Constructor.
+     * @param file file to read.
+     * @param offset offset in file.
+     * @param size of data.
+     * @param isOpen optional predicate to check if the stream is open.
+     * @throws IllegalArgumentException if the offset is negative.
+     */
+    private FileWithOffsetContentProvider(
+        final File file,
+        final long offset,
+        final int size,
+        @Nullable final Supplier<Boolean> isOpen) {
+      super(size, isOpen);
+      this.file = requireNonNull(file);
+      checkArgument(offset >= 0, "Offset is negative: %s", offset);
+      this.offset = offset;
+    }
+
+    /**
+     * Constructor.
+     * @param file file to read.
+     * @param offset offset in file.
+     * @param size of data.
+     * @throws IllegalArgumentException if the offset is negative.
+     */
+    private FileWithOffsetContentProvider(final File file,
+        final long offset,
+        final int size) {
+      this(file, offset, size, null);
+    }
+
+    /**
+     * Create a new stream.
+     * @return a stream at the start of the offset in the file
+     * @throws UncheckedIOException on IO failure.
+     */
+    @Override
+    protected BufferedInputStream createNewStream() throws UncheckedIOException {
+      // create the stream, seek to the offset.
+      final FileInputStream fis = uncheckIOExceptions(() -> {
+        final FileInputStream f = new FileInputStream(file);
+        f.getChannel().position(offset);
+        return f;
+      });
+      return setCurrentStream(new BufferedInputStream(fis));
+    }
+
+    @Override
+    public String toString() {
+      return "FileWithOffsetContentProvider{" +
+          "file=" + file +
+          ", offset=" + offset +
+          "} " + super.toString();
+    }
+
+  }
+
+  /**
+   * Create a content provider for a byte buffer.
+   * Uses {@link ByteBufferInputStream} to read the data.
+   */
+  private static final class ByteBufferContentProvider
+      extends BaseContentProvider<ByteBufferInputStream> {
+
+    /**
+     * The buffer which will be read; on or off heap.
+     */
+    private final ByteBuffer blockBuffer;
+
+    /**
+     * The position in the buffer at the time the provider was created.
+     */
+    private final int initialPosition;
+
+    /**
+     * Constructor.
+     * @param blockBuffer buffer to read.
+     * @param size size of the data.
+     * @throws IllegalArgumentException if the arguments are invalid.
+     * @throws NullPointerException if the buffer is null
+     */
+    private ByteBufferContentProvider(final ByteBuffer blockBuffer, int size) {
+      this(blockBuffer, size, null);
+    }
+
+    /**
+     * Constructor.
+     * @param blockBuffer buffer to read.
+     * @param size size of the data.
+     * @param isOpen optional predicate to check if the stream is open.
+     * @throws IllegalArgumentException if the arguments are invalid.
+     * @throws NullPointerException if the buffer is null
+     */
+    private ByteBufferContentProvider(
+        final ByteBuffer blockBuffer,
+        int size,
+        @Nullable final Supplier<Boolean> isOpen) {
+      super(size, isOpen);
+      this.blockBuffer = blockBuffer;
+      this.initialPosition = blockBuffer.position();
+    }
+
+    @Override
+    protected ByteBufferInputStream createNewStream() {
+      // set the buffer up from reading from the beginning
+      blockBuffer.limit(initialPosition);
+      blockBuffer.position(0);
+      return new ByteBufferInputStream(getSize(), blockBuffer);
+    }
+
+    @Override
+    public String toString() {
+      return "ByteBufferContentProvider{" +
+          "blockBuffer=" + blockBuffer +
+          ", initialPosition=" + initialPosition +
+          "} " + super.toString();
+    }
+  }
+
+  /**
+   * Simple byte array content provider.
+   * <p>
+   * The array is not copied; if it is changed during the write the outcome
+   * of the upload is undefined.
+   */
+  private static final class ByteArrayContentProvider
+      extends BaseContentProvider<ByteArrayInputStream> {
+
+    /**
+     * The buffer where data is stored.
+     */
+    private final byte[] bytes;
+
+    /**
+     * Offset in the buffer.
+     */
+    private final int offset;
+
+    /**
+     * Constructor.
+     * @param bytes buffer to read.
+     * @param offset offset in buffer.
+     * @param size length of the data.
+     * @throws IllegalArgumentException if the arguments are invalid.
+     * @throws NullPointerException if the buffer is null
+     */
+    private ByteArrayContentProvider(
+        final byte[] bytes,
+        final int offset,
+        final int size) {
+      this(bytes, offset, size, null);
+    }
+
+    /**
+     * Constructor.
+     * @param bytes buffer to read.
+     * @param offset offset in buffer.
+     * @param size length of the data.
+     * @param isOpen optional predicate to check if the stream is open.
+     * @throws IllegalArgumentException if the arguments are invalid.
+     * @throws NullPointerException if the buffer is null
+     */
+    private ByteArrayContentProvider(
+        final byte[] bytes,
+        final int offset,
+        final int size,
+        final Supplier<Boolean> isOpen) {
+
+      super(size, isOpen);
+      this.bytes = bytes;
+      this.offset = offset;
+      checkArgument(offset >= 0, "Offset is negative: %s", offset);
+      final int length = bytes.length;
+      checkArgument((offset + size) <= length,
+          "Data to read [%d-%d] is past end of array %s",
+          offset,
+          offset + size, length);
+    }
+
+    @Override
+    protected ByteArrayInputStream createNewStream() {
+      return new ByteArrayInputStream(bytes, offset, getSize());
+    }
+
+    @Override
+    public String toString() {
+      return "ByteArrayContentProvider{" +
+          "buffer with length=" + bytes.length +
+          ", offset=" + offset +
+          "} " + super.toString();
+    }
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/BlockOutputStreamStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/BlockOutputStreamStatistics.java
@@ -42,7 +42,8 @@ public interface BlockOutputStreamStatistics extends Closeable,
   void blockUploadStarted(Duration timeInQueue, long blockSize);
 
   /**
-   * A block upload has completed. Duration excludes time in the queue.
+   * A block upload has completed, successfully or not.
+   * Duration excludes time in the queue.
    * @param timeSinceUploadStarted time in since the transfer began.
    * @param blockSize block size
    */

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/impl/StatisticsFromAwsSdkImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/impl/StatisticsFromAwsSdkImpl.java
@@ -27,6 +27,16 @@ import static org.apache.hadoop.fs.s3a.Statistic.STORE_IO_REQUEST;
 import static org.apache.hadoop.fs.s3a.Statistic.STORE_IO_RETRY;
 import static org.apache.hadoop.fs.s3a.Statistic.STORE_IO_THROTTLED;
 import static org.apache.hadoop.fs.s3a.Statistic.STORE_IO_THROTTLE_RATE;
+import static org.apache.hadoop.fs.s3a.impl.InternalConstants.SC_400_BAD_REQUEST;
+import static org.apache.hadoop.fs.s3a.impl.InternalConstants.SC_404_NOT_FOUND;
+import static org.apache.hadoop.fs.s3a.impl.InternalConstants.SC_429_TOO_MANY_REQUESTS_GCS;
+import static org.apache.hadoop.fs.s3a.impl.InternalConstants.SC_500_INTERNAL_SERVER_ERROR;
+import static org.apache.hadoop.fs.s3a.impl.InternalConstants.SC_503_SERVICE_UNAVAILABLE;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.HTTP_RESPONSE_400;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.HTTP_RESPONSE_4XX;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.HTTP_RESPONSE_500;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.HTTP_RESPONSE_503;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.HTTP_RESPONSE_5XX;
 
 /**
  * Hook up AWS SDK Statistics to the S3 counters.
@@ -84,5 +94,38 @@ public final class StatisticsFromAwsSdkImpl implements
   @Override
   public void noteResponseProcessingTime(final Duration duration) {
 
+  }
+
+  /**
+   * Map error status codes to statistic names, excluding 404.
+   * 429 (google throttle events) are mapped to the 503 statistic.
+   * @param sc status code.
+   * @return a statistic name or null.
+   */
+  public static String mapErrorStatusCodeToStatisticName(int sc) {
+    String stat = null;
+    switch (sc) {
+    case SC_400_BAD_REQUEST:
+      stat = HTTP_RESPONSE_400;
+      break;
+    case SC_404_NOT_FOUND:
+      /* do not map; not measured */
+      break;
+    case SC_500_INTERNAL_SERVER_ERROR:
+      stat = HTTP_RESPONSE_500;
+      break;
+    case SC_503_SERVICE_UNAVAILABLE:
+    case SC_429_TOO_MANY_REQUESTS_GCS:
+      stat = HTTP_RESPONSE_503;
+      break;
+
+    default:
+      if (sc > 500) {
+        stat = HTTP_RESPONSE_5XX;
+      } else if (sc > 400) {
+        stat = HTTP_RESPONSE_4XX;
+      }
+    }
+    return stat;
   }
 }

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/third_party_stores.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/third_party_stores.md
@@ -213,7 +213,26 @@ as they keep trying to reconnect to ports which are never going to be available.
     <name>fs.s3a.bucket.nonexistent-bucket-example.connection.establish.timeout</name>
     <value>500</value>
   </property>
+
+  <property>
+    <name>fs.s3a.bucket.nonexistent-bucket-example.retry.http.5xx.errors</name>
+    <value>false</value>
+  </property>
 ```
+
+Setting the option `fs.s3a.retry.http.5xx.errors` to `false` stops the S3A client from treating
+500 and other HTTP 5xx status codes other than 501 and 503 as errors to retry on.
+With AWS S3 they are eventually recovered from.
+On a third-party store they may be cause by other problems, such as:
+
+* General service misconfiguration
+* Running out of disk storage
+* Storage Permissions
+
+Disabling the S3A client's retrying of these errors ensures that failures happen faster;
+the AWS SDK itself still makes a limited attempt to retry.
+
+
 ## Cloudstore's Storediag
 
 There's an external utility, [cloudstore](https://github.com/steveloughran/cloudstore) whose [storediag](https://github.com/steveloughran/cloudstore#command-storediag) exists to debug the connection settings to hadoop cloud storage.

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
@@ -29,7 +29,7 @@ Common problems working with S3 are:
 7. [Other Errors](#other)
 8. [SDK Upgrade Warnings](#upgrade_warnings)
 
-This document also includes some [best pactises](#best) to aid troubleshooting.
+This document also includes some [best practises](#best) to aid troubleshooting.
 
 
 Troubleshooting IAM Assumed Roles is covered in its
@@ -236,8 +236,61 @@ read requests are allowed, but operations which write to the bucket are denied.
 
 Check the system clock.
 
-### <a name="bad_request"></a> "Bad Request" exception when working with data stores in an AWS region other than us-eaast
 
+### `Class does not implement software.amazon.awssdk.auth.credentials.AwsCredentialsProvider`
+
+A credential provider listed in `fs.s3a.aws.credentials.provider` does not implement
+the interface `software.amazon.awssdk.auth.credentials.AwsCredentialsProvider`.
+
+```
+InstantiationIOException: `s3a://stevel-gcs/': Class org.apache.hadoop.fs.s3a.S3ARetryPolicy does not implement
+ software.amazon.awssdk.auth.credentials.AwsCredentialsProvider (configuration key fs.s3a.aws.credentials.provider)
+        at org.apache.hadoop.fs.s3a.impl.InstantiationIOException.isNotInstanceOf(InstantiationIOException.java:128)
+        at org.apache.hadoop.fs.s3a.S3AUtils.getInstanceFromReflection(S3AUtils.java:604)
+        at org.apache.hadoop.fs.s3a.auth.CredentialProviderListFactory.createAWSV2CredentialProvider(CredentialProviderListFactory.java:299)
+        at org.apache.hadoop.fs.s3a.auth.CredentialProviderListFactory.buildAWSProviderList(CredentialProviderListFactory.java:245)
+        at org.apache.hadoop.fs.s3a.auth.CredentialProviderListFactory.createAWSCredentialProviderList(CredentialProviderListFactory.java:144)
+        at org.apache.hadoop.fs.s3a.S3AFileSystem.bindAWSClient(S3AFileSystem.java:971)
+        at org.apache.hadoop.fs.s3a.S3AFileSystem.initialize(S3AFileSystem.java:624)
+        at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:3601)
+        at org.apache.hadoop.fs.FileSystem.access$300(FileSystem.java:171)
+        at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:3702)
+        at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3653)
+        at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:555)
+        at org.apache.hadoop.fs.Path.getFileSystem(Path.java:366)
+
+```
+
+There's two main causes
+
+1. A class listed there is not an implementation of the interface.
+   Fix: review the settings and correct as appropriate.
+1. A class listed there does implement the interface, but it has been loaded in a different
+   classloader, so the JVM does not consider it to be an implementation.
+   Fix: learn the entire JVM classloader model and see if you can then debug it.
+   Tip: having both the AWS Shaded SDK and individual AWS SDK modules on your classpath
+   may be a cause of this.
+
+If you see this and you are trying to use the S3A connector with Spark, then the cause can
+be that the isolated classloader used to load Hive classes is interfering with the S3A
+connector's dynamic loading of `software.amazon.awssdk` classes. To fix this, declare that
+the classes in the aws SDK are loaded from the same classloader which instantiated
+the S3A FileSystem instance:
+
+```
+spark.sql.hive.metastore.sharedPrefixes software.amazon.awssdk.
+```
+
+
+## <a name="400_bad_request"></a> 400 Bad Request errors
+
+S3 stores return HTTP status code 400 "Bad Request" when the client make a request which
+the store considers invalid.
+
+This is most commonly caused by signing errors: secrets, region, even confusion between public and private
+S3 stores.
+
+### <a name="bad_request"></a> "Bad Request" exception when working with data stores in an AWS region other than us-east
 
 
 ```
@@ -286,50 +339,59 @@ S3 region as `ca-central-1`.
 </property>
 ```
 
-### `Classdoes not implement software.amazon.awssdk.auth.credentials.AwsCredentialsProvider`
-
-A credential provider listed in `fs.s3a.aws.credentials.provider` does not implement
-the interface `software.amazon.awssdk.auth.credentials.AwsCredentialsProvider`.
+### <a name="request_timeout"></a> 400 + RequestTimeout "Your socket connection to the server was not read from or written to within the timeout period"
 
 ```
-InstantiationIOException: `s3a://stevel-gcs/': Class org.apache.hadoop.fs.s3a.S3ARetryPolicy does not implement software.amazon.awssdk.auth.credentials.AwsCredentialsProvider (configuration key fs.s3a.aws.credentials.provider)
-        at org.apache.hadoop.fs.s3a.impl.InstantiationIOException.isNotInstanceOf(InstantiationIOException.java:128)
-        at org.apache.hadoop.fs.s3a.S3AUtils.getInstanceFromReflection(S3AUtils.java:604)
-        at org.apache.hadoop.fs.s3a.auth.CredentialProviderListFactory.createAWSV2CredentialProvider(CredentialProviderListFactory.java:299)
-        at org.apache.hadoop.fs.s3a.auth.CredentialProviderListFactory.buildAWSProviderList(CredentialProviderListFactory.java:245)
-        at org.apache.hadoop.fs.s3a.auth.CredentialProviderListFactory.createAWSCredentialProviderList(CredentialProviderListFactory.java:144)
-        at org.apache.hadoop.fs.s3a.S3AFileSystem.bindAWSClient(S3AFileSystem.java:971)
-        at org.apache.hadoop.fs.s3a.S3AFileSystem.initialize(S3AFileSystem.java:624)
-        at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:3601)
-        at org.apache.hadoop.fs.FileSystem.access$300(FileSystem.java:171)
-        at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:3702)
-        at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3653)
-        at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:555)
-        at org.apache.hadoop.fs.Path.getFileSystem(Path.java:366)
-
+org.apache.hadoop.fs.s3a.AWSBadRequestException: upload part #1 upload ID 1122334455:
+  software.amazon.awssdk.services.s3.model.S3Exception:
+  Your socket connection to the server was not read from or written to within the timeout period.
+  Idle connections will be closed.
+  (Service: S3, Status Code: 400, Request ID: 1122334455, Extended Request ID: ...):
+  RequestTimeout:
+   Your socket connection to the server was not read from or written to within the timeout period.
+   Idle connections will be closed. (Service: S3, Status Code: 400, Request ID: 1122334455, Extended Request ID: ...
 ```
 
-There's two main causes
+This is an obscure failure which was encountered as part of
+[HADOOP-19221](https://issues.apache.org/jira/browse/HADOOP-19221) : an upload of part of a file could not
+be succesfully retried after a failure was reported on the first attempt.
 
-1. A class listed there is not an implementation of the interface.
-   Fix: review the settings and correct as appropriate.
-1. A class listed there does implement the interface, but it has been loaded in a different
-   classloader, so the JVM does not consider it to be an implementation.
-   Fix: learn the entire JVM classloader model and see if you can then debug it.
-   Tip: having both the AWS Shaded SDK and individual AWS SDK modules on your classpath
-   may be a cause of this.
+1. It was only encountered during uploading files via the Staging Committers
+2. And is a regression in the V2 SDK.
+3. This should have been addressed in the S3A connector.
 
-If you see this and you are trying to use the S3A connector with Spark, then the cause can
-be that the isolated classloader used to load Hive classes is interfering with the S3A
-connector's dynamic loading of `software.amazon.awssdk` classes. To fix this, declare that
-the classes in the aws SDK are loaded from the same classloader which instantiated
-the S3A FileSystem instance:
+* If it is encountered on a hadoop release with HADOOP-19221, then this is a regression -please report it.
+* If it is encountered on a release without the fix, please upgrade.
+
+It may be that the problem arises in the AWS SDK's "TransferManager", which is used for a
+higher performance upload of data from the local fileystem. If this is the case. disable this feature:
+```
+<property>
+  <name>fs.s3a.optimized.copy.from.local.enabled</name>
+  <value>false</value>
+</property>
+```
+
+### Status Code 400 "One or more of the specified parts could not be found"
 
 ```
-spark.sql.hive.metastore.sharedPrefixes software.amazon.awssdk.
+org.apache.hadoop.fs.s3a.AWSBadRequestException: Completing multipart upload on job-00-fork-0003/test/testTwoPartUpload:
+software.amazon.awssdk.services.s3.model.S3Exception: One or more of the specified parts could not be found.
+The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.
+(Service: S3, Status Code: 400, Request ID: EKNW2V7P34T7YK9E,
+ Extended Request ID: j64Dfdmfd2ZnjErbX1c05YmidLGx/5pJF9Io4B0w8Cx3aDTSFn1pW007BuzyxPeAbph/ZqXHjbU=):InvalidPart:
 ```
 
-## <a name="access_denied"></a> "The security token included in the request is invalid"
+Happens if a multipart upload is being completed, but one of the parts is missing.
+* An upload took so long that the part was deleted by the store
+* A magic committer job's list of in-progress uploads somehow got corrupted
+* Bug in the S3A codebase (rare, but not impossible...)
+
+## <a name="access_denied"></a> Access Denied
+
+HTTP error codes 401 and 403 are mapped to `AccessDeniedException` in the S3A connector.
+
+### "The security token included in the request is invalid"
 
 You are trying to use session/temporary credentials and the session token
 supplied is considered invalid.
@@ -501,7 +563,53 @@ endpoint and region like the following:
   <value>${sts.region}</value>
 </property>
 ```
+## <a name="500_internal_error"></a> HTTP 500 status code "We encountered an internal error"
 
+```
+We encountered an internal error. Please try again.
+(Service: S3, Status Code: 500, Request ID: <id>, Extended Request ID: <extended-id>)
+```
+
+The [status code 500](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) indicates
+the S3 store has reported an internal problem.
+When raised by Amazon S3, this is a rare sign of a problem within the S3 system
+or another part of the cloud infrastructure on which it depends.
+Retrying _should_ make it go away.
+
+The 500 error is considered retryable by the AWS SDK, which will have already
+tried it `fs.s3a.attempts.maximum` times before reaching the S3A client -which
+will also retry.
+
+The S3A client will attempt to retry on a 500 (or other 5xx error other than 501/503)
+if the option `fs.s3a.retry.http.5xx.errors` is set to `true`.
+This is the default.
+```xml
+<property>
+  <name>fs.s3a.retry.http.5xx.errors</name>
+  <value>true</value>
+</property>
+```
+
+If encountered against a third party store (the lack of an extended request ID always implies this),
+then it may be a permanent server-side failure.
+
+* All HTTP status codes other than 503 (service unavailable) and 501 (unsupported) are
+treated as 500 exceptions.
+* The S3A Filesystem IOStatistics counts the number of 500 errors received.
+
+## <a name="503 Throttling"></a> HTTP 503 status code "slow down" or 429 "Too Many Requests"
+
+The [status code 503](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503)
+is returned by AWS S3 when the IO rate limit of the bucket is reached.
+
+Google's cloud storage returns the response [429 Too Many Requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429)
+for the same situation.
+
+The AWS S3 documentation [covers this and suggests mitigation strategies](https://repost.aws/knowledge-center/http-5xx-errors-s3).
+Note that it can also be caused by throttling in the KMS bencryption subsystem if
+SSE-KMS or DSSE-KMS is used to encrypt data.
+
+Consult [performance - throttling](./performance.html#throttling) for details on throttling.
 
 ## <a name="connectivity"></a> Connectivity Problems
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputByteBuffer.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputByteBuffer.java
@@ -27,7 +27,7 @@ public class ITestS3ABlockOutputByteBuffer extends ITestS3ABlockOutputArray {
   }
 
   protected S3ADataBlocks.BlockFactory createFactory(S3AFileSystem fileSystem) {
-    return new S3ADataBlocks.ByteBufferBlockFactory(fileSystem);
+    return new S3ADataBlocks.ByteBufferBlockFactory(fileSystem.createStoreContext());
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputDisk.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputDisk.java
@@ -36,7 +36,7 @@ public class ITestS3ABlockOutputDisk extends ITestS3ABlockOutputArray {
    * @return null
    */
   protected S3ADataBlocks.BlockFactory createFactory(S3AFileSystem fileSystem) {
-    Assume.assumeTrue("mark/reset nopt supoprted", false);
+    Assume.assumeTrue("mark/reset not supported", false);
     return null;
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMiscOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMiscOperations.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.fs.s3a;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -107,9 +106,11 @@ public class ITestS3AMiscOperations extends AbstractS3ATestBase {
           factory.newPutObjectRequestBuilder(path.toUri().getPath(), null, -1, false);
       putObjectRequestBuilder.contentLength(-1L);
       LambdaTestUtils.intercept(IllegalStateException.class,
-          () -> fs.putObjectDirect(putObjectRequestBuilder.build(), PutObjectOptions.keepingDirs(),
-              new S3ADataBlocks.BlockUploadData(new ByteArrayInputStream("PUT".getBytes())),
-              false, null));
+          () -> fs.putObjectDirect(
+              putObjectRequestBuilder.build(),
+              PutObjectOptions.keepingDirs(),
+              new S3ADataBlocks.BlockUploadData("PUT".getBytes(), null),
+              null));
       assertPathDoesNotExist("put object was created", path);
     }
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.fs.s3a.statistics.CommitterStatistics;
 import org.apache.hadoop.fs.s3a.statistics.impl.EmptyS3AStatisticsContext;
 import org.apache.hadoop.fs.s3a.test.MinimalWriteOperationHelperCallbacks;
 import org.apache.hadoop.fs.statistics.DurationTrackerFactory;
+import org.apache.hadoop.fs.store.audit.AuditSpan;
 import org.apache.hadoop.util.Progressable;
 
 
@@ -184,7 +185,7 @@ public class MockS3AFileSystem extends S3AFileSystem {
         new EmptyS3AStatisticsContext(),
         noopAuditor(conf),
         AuditTestSupport.NOOP_SPAN,
-        new MinimalWriteOperationHelperCallbacks());
+        new MinimalWriteOperationHelperCallbacks(this::getS3Client));
   }
 
   @Override
@@ -193,6 +194,11 @@ public class MockS3AFileSystem extends S3AFileSystem {
 
   @Override
   public WriteOperationHelper getWriteOperationHelper() {
+    return writeHelper;
+  }
+
+  @Override
+  public WriteOperationHelper createWriteOperationHelper(final AuditSpan auditSpan) {
     return writeHelper;
   }
 
@@ -230,8 +236,6 @@ public class MockS3AFileSystem extends S3AFileSystem {
   @Override
   void finishedWrite(String key,
       long length,
-      String eTag,
-      String versionId,
       final PutObjectOptions putOptions) {
 
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestDataBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestDataBlocks.java
@@ -18,41 +18,90 @@
 
 package org.apache.hadoop.fs.s3a;
 
-import org.apache.hadoop.fs.contract.ContractTestUtils;
-import org.junit.Assert;
-import org.junit.Before;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.data.Index;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.s3a.impl.UploadContentProviders;
+import org.apache.hadoop.fs.store.ByteBufferInputStream;
+import org.apache.hadoop.test.HadoopTestBase;
+
+import static java.util.Optional.empty;
+import static org.apache.hadoop.fs.s3a.Constants.FAST_UPLOAD_BUFFER_ARRAY;
+import static org.apache.hadoop.fs.s3a.Constants.FAST_UPLOAD_BUFFER_DISK;
+import static org.apache.hadoop.fs.s3a.Constants.FAST_UPLOAD_BYTEBUFFER;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
  * Unit tests for {@link S3ADataBlocks}.
+ * Parameterized on the buffer type.
  */
-public class TestDataBlocks extends Assert {
+@RunWith(Parameterized.class)
+public class TestDataBlocks extends HadoopTestBase {
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> params() {
+    return Arrays.asList(new Object[][]{
+        {FAST_UPLOAD_BUFFER_DISK},
+        {FAST_UPLOAD_BUFFER_ARRAY},
+        {FAST_UPLOAD_BYTEBUFFER}
+    });
+  }
 
   @Rule
-  public Timeout testTimeout = new Timeout(30 * 1000);
+  public final TemporaryFolder tempDir = new TemporaryFolder();
 
-  @Before
-  public void nameThread() {
-    Thread.currentThread().setName("JUnit");
+  /**
+   * Buffer type.
+   */
+  private final String bufferType;
+
+  public TestDataBlocks(final String bufferType) {
+    this.bufferType = bufferType;
   }
 
   /**
-   * Test the {@link S3ADataBlocks.ByteBufferBlockFactory}.
-   * That code implements an input stream over a ByteBuffer, and has to
-   * return the buffer to the pool after the read complete.
-   *
-   * This test verifies the basic contract of the process.
+   * Create a block factory.
+   * @return the factory
+   */
+  private S3ADataBlocks.BlockFactory createFactory() {
+    switch (bufferType) {
+    // this one passed in a file allocation function
+    case FAST_UPLOAD_BUFFER_DISK:
+      return new S3ADataBlocks.DiskBlockFactory((i, l) ->
+          tempDir.newFile("file" + i));
+    case FAST_UPLOAD_BUFFER_ARRAY:
+      return new S3ADataBlocks.ArrayBlockFactory(null);
+    case FAST_UPLOAD_BYTEBUFFER:
+      return new S3ADataBlocks.ByteBufferBlockFactory(null);
+    default:
+      throw new IllegalArgumentException("Unknown buffer type: " + bufferType);
+    }
+  }
+
+  /**
+   * Test the content providers from the block factory and the streams
+   * they produce.
+   * There are extra assertions on the {@link ByteBufferInputStream}.
    */
   @Test
-  public void testByteBufferIO() throws Throwable {
-    try (S3ADataBlocks.ByteBufferBlockFactory factory =
-             new S3ADataBlocks.ByteBufferBlockFactory(null)) {
+  public void testBlockFactoryIO() throws Throwable {
+    try (S3ADataBlocks.BlockFactory factory = createFactory()) {
       int limit = 128;
-      S3ADataBlocks.ByteBufferBlockFactory.ByteBufferBlock block
+      S3ADataBlocks.DataBlock block
           = factory.create(1, limit, null);
-      assertOutstandingBuffers(factory, 1);
+      maybeAssertOutstandingBuffers(factory, 1);
 
       byte[] buffer = ContractTestUtils.toAsciiByteArray("test data");
       int bufferLen = buffer.length;
@@ -66,32 +115,46 @@ public class TestDataBlocks extends Assert {
 
       // now start the write
       S3ADataBlocks.BlockUploadData blockUploadData = block.startUpload();
-      S3ADataBlocks.ByteBufferBlockFactory.ByteBufferBlock.ByteBufferInputStream
-          stream =
-          (S3ADataBlocks.ByteBufferBlockFactory.ByteBufferBlock.ByteBufferInputStream)
-              blockUploadData.getUploadStream();
-      assertTrue("Mark not supported in " + stream, stream.markSupported());
-      assertTrue("!hasRemaining() in " + stream, stream.hasRemaining());
-      int expected = bufferLen;
-      assertEquals("wrong available() in " + stream,
-          expected, stream.available());
+      final UploadContentProviders.BaseContentProvider<?> cp =
+          blockUploadData.getContentProvider();
 
-      assertEquals('t', stream.read());
-      stream.mark(limit);
+      assertStreamCreationCount(cp, 0);
+      InputStream stream = cp.newStream();
+
+      assertStreamCreationCount(cp, 1);
+      Assertions.assertThat(stream.markSupported())
+          .describedAs("markSupported() of %s", stream)
+          .isTrue();
+
+      Optional<ByteBufferInputStream> bbStream =
+          stream instanceof ByteBufferInputStream
+              ? Optional.of((ByteBufferInputStream) stream)
+              : empty();
+
+      bbStream.ifPresent(bb -> {
+        Assertions.assertThat(bb.hasRemaining())
+            .describedAs("hasRemaining() in %s", bb)
+            .isTrue();
+      });
+      int expected = bufferLen;
+      assertAvailableValue(stream, expected);
+
+      assertReadEquals(stream, 't');
+
+      stream.mark(Integer.MAX_VALUE);
       expected--;
-      assertEquals("wrong available() in " + stream,
-          expected, stream.available());
+
+      assertAvailableValue(stream, expected);
 
 
       // read into a byte array with an offset
       int offset = 5;
       byte[] in = new byte[limit];
       assertEquals(2, stream.read(in, offset, 2));
-      assertEquals('e', in[offset]);
-      assertEquals('s', in[offset + 1]);
+      assertByteAtIndex(in, offset++, 'e');
+      assertByteAtIndex(in, offset++, 's');
       expected -= 2;
-      assertEquals("wrong available() in " + stream,
-          expected, stream.available());
+      assertAvailableValue(stream, expected);
 
       // read to end
       byte[] remainder = new byte[limit];
@@ -101,37 +164,107 @@ public class TestDataBlocks extends Assert {
         remainder[index++] = (byte) c;
       }
       assertEquals(expected, index);
-      assertEquals('a', remainder[--index]);
+      assertByteAtIndex(remainder, --index, 'a');
 
-      assertEquals("wrong available() in " + stream,
-          0, stream.available());
-      assertTrue("hasRemaining() in " + stream, !stream.hasRemaining());
+      // no more data left
+      assertAvailableValue(stream, 0);
+
+      bbStream.ifPresent(bb -> {
+        Assertions.assertThat(bb.hasRemaining())
+            .describedAs("hasRemaining() in %s", bb)
+            .isFalse();
+      });
+
+      // at the end of the stream, a read fails
+      assertReadEquals(stream, -1);
 
       // go the mark point
       stream.reset();
-      assertEquals('e', stream.read());
+      assertAvailableValue(stream, bufferLen - 1);
+      assertReadEquals(stream, 'e');
 
-      // when the stream is closed, the data should be returned
-      stream.close();
-      assertOutstandingBuffers(factory, 1);
+      // now ask the content provider for another content stream.
+      final InputStream stream2 = cp.newStream();
+      assertStreamCreationCount(cp, 2);
+
+      // this must close the old stream
+      bbStream.ifPresent(bb -> {
+        Assertions.assertThat(bb.isOpen())
+            .describedAs("stream %s is open", bb)
+            .isFalse();
+      });
+
+      // do a read(byte[]) of everything
+      byte[] readBuffer = new byte[bufferLen];
+      Assertions.assertThat(stream2.read(readBuffer))
+          .describedAs("number of bytes read from stream %s", stream2)
+          .isEqualTo(bufferLen);
+      Assertions.assertThat(readBuffer)
+          .describedAs("data read into buffer")
+          .isEqualTo(buffer);
+
+      // when the block is closed, the buffer must be returned
+      // to the pool.
       block.close();
-      assertOutstandingBuffers(factory, 0);
+      maybeAssertOutstandingBuffers(factory, 0);
       stream.close();
-      assertOutstandingBuffers(factory, 0);
+      maybeAssertOutstandingBuffers(factory, 0);
+
+      // now the block is closed, the content provider must fail to
+      // create a new stream
+      intercept(IllegalStateException.class, cp::newStream);
+
     }
 
   }
 
+  private static void assertByteAtIndex(final byte[] bytes,
+      final int index, final char expected) {
+    Assertions.assertThat(bytes)
+        .contains(expected, Index.atIndex(index));
+  }
+
+  private static void assertReadEquals(final InputStream stream,
+      final int ch)
+      throws IOException {
+    Assertions.assertThat(stream.read())
+        .describedAs("read() in %s", stream)
+        .isEqualTo(ch);
+  }
+
+  private static void assertAvailableValue(final InputStream stream,
+      final int expected) throws IOException {
+    Assertions.assertThat(stream.available())
+        .describedAs("wrong available() in %s", stream)
+        .isEqualTo(expected);
+  }
+
+  private static void assertStreamCreationCount(
+      final UploadContentProviders.BaseContentProvider<?> cp,
+      final int count) {
+    Assertions.assertThat(cp.getStreamCreationCount())
+        .describedAs("stream creation count of %s", cp)
+        .isEqualTo(count);
+  }
+
   /**
-   * Assert the number of buffers active for a block factory.
+   * Assert the number of buffers active for a block factory,
+   * if the factory is a ByteBufferBlockFactory.
+   * <p>
+   * If it is of any other type, no checks are made.
    * @param factory factory
    * @param expectedCount expected count.
    */
-  private static void assertOutstandingBuffers(
-      S3ADataBlocks.ByteBufferBlockFactory factory,
+  private static void maybeAssertOutstandingBuffers(
+      S3ADataBlocks.BlockFactory factory,
       int expectedCount) {
-    assertEquals("outstanding buffers in " + factory,
-        expectedCount, factory.getOutstandingBufferCount());
+    if (factory instanceof S3ADataBlocks.ByteBufferBlockFactory) {
+      S3ADataBlocks.ByteBufferBlockFactory bufferFactory =
+          (S3ADataBlocks.ByteBufferBlockFactory) factory;
+      Assertions.assertThat(bufferFactory.getOutstandingBufferCount())
+          .describedAs("outstanding buffers in %s", factory)
+          .isEqualTo(expectedCount);
+    }
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/AuditTestSupport.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/AuditTestSupport.java
@@ -36,6 +36,11 @@ import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.LOGGING_AUDIT_SER
 import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.NOOP_AUDIT_SERVICE;
 import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.REFERRER_HEADER_ENABLED;
 import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.REJECT_OUT_OF_SPAN_OPERATIONS;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.HTTP_RESPONSE_400;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.HTTP_RESPONSE_4XX;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.HTTP_RESPONSE_500;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.HTTP_RESPONSE_503;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.HTTP_RESPONSE_5XX;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.iostatisticsStore;
 
 /**
@@ -105,7 +110,12 @@ public final class AuditTestSupport {
             AUDIT_ACCESS_CHECK_FAILURE.getSymbol(),
             AUDIT_FAILURE.getSymbol(),
             AUDIT_REQUEST_EXECUTION.getSymbol(),
-            AUDIT_SPAN_CREATION.getSymbol())
+            AUDIT_SPAN_CREATION.getSymbol(),
+            HTTP_RESPONSE_400,
+            HTTP_RESPONSE_4XX,
+            HTTP_RESPONSE_500,
+            HTTP_RESPONSE_503,
+            HTTP_RESPONSE_5XX)
         .build();
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestUploadRecovery.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestUploadRecovery.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.commit;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Assumptions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.interceptor.Context;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.fs.s3a.commit.files.SinglePendingCommit;
+import org.apache.hadoop.fs.s3a.commit.impl.CommitContext;
+import org.apache.hadoop.fs.s3a.commit.impl.CommitOperations;
+import org.apache.hadoop.fs.s3a.performance.AbstractS3ACostTest;
+import org.apache.hadoop.fs.s3a.test.SdkFaultInjector;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.verifyFileContents;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_MULTIPART_SIZE;
+import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_OPERATIONS_PURGE_UPLOADS;
+import static org.apache.hadoop.fs.s3a.Constants.FAST_UPLOAD_BUFFER;
+import static org.apache.hadoop.fs.s3a.Constants.FAST_UPLOAD_BUFFER_ARRAY;
+import static org.apache.hadoop.fs.s3a.Constants.FAST_UPLOAD_BUFFER_DISK;
+import static org.apache.hadoop.fs.s3a.Constants.FAST_UPLOAD_BYTEBUFFER;
+import static org.apache.hadoop.fs.s3a.Constants.FS_S3A_CREATE_PERFORMANCE;
+import static org.apache.hadoop.fs.s3a.Constants.MAX_ERROR_RETRIES;
+import static org.apache.hadoop.fs.s3a.Constants.RETRY_HTTP_5XX_ERRORS;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
+import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.AUDIT_EXECUTION_INTERCEPTORS;
+import static org.apache.hadoop.fs.s3a.commit.CommitConstants.BASE;
+import static org.apache.hadoop.fs.s3a.commit.CommitConstants.MAGIC_PATH_PREFIX;
+import static org.apache.hadoop.fs.s3a.test.SdkFaultInjector.setRequestFailureConditions;
+
+/**
+ * Test upload recovery by injecting failures into the response chain.
+ * The tests are parameterized on upload buffering.
+ * <p>
+ * The test case {@link #testCommitOperations()} is independent of this option;
+ * the test parameterization only runs this once.
+ * A bit inelegant but as the fault injection code is shared and the problem "adjacent"
+ * this isolates all forms of upload recovery into the same test class without
+ * wasting time with duplicate uploads.
+ * <p>
+ * Fault injection is implemented in {@link SdkFaultInjector}.
+ */
+@RunWith(Parameterized.class)
+public class ITestUploadRecovery extends AbstractS3ACostTest {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ITestUploadRecovery.class);
+
+  /**
+   * Parameterization.
+   */
+  @Parameterized.Parameters(name = "{0}-commit-{1}")
+  public static Collection<Object[]> params() {
+    return Arrays.asList(new Object[][]{
+        {FAST_UPLOAD_BUFFER_ARRAY, true},
+        {FAST_UPLOAD_BUFFER_DISK, false},
+        {FAST_UPLOAD_BYTEBUFFER, false},
+    });
+  }
+
+  private static final String JOB_ID = UUID.randomUUID().toString();
+
+  /**
+   * Upload size for the committer test.
+   */
+  public static final int COMMIT_FILE_UPLOAD_SIZE = 1024 * 2;
+
+  /**
+   * should the commit test be included?
+   */
+  private final boolean includeCommitTest;
+
+  /**
+   * Buffer type for this test run.
+   */
+  private final String buffer;
+
+  /**
+   * Parameterized test suite.
+   * @param buffer buffer type
+   * @param includeCommitTest should the commit upload test be included?
+   */
+  public ITestUploadRecovery(final String buffer, final boolean includeCommitTest) {
+    this.includeCommitTest = includeCommitTest;
+    this.buffer = buffer;
+  }
+
+  @Override
+  public Configuration createConfiguration() {
+    Configuration conf = super.createConfiguration();
+
+    removeBaseAndBucketOverrides(conf,
+        AUDIT_EXECUTION_INTERCEPTORS,
+        DIRECTORY_OPERATIONS_PURGE_UPLOADS,
+        FAST_UPLOAD_BUFFER,
+        FS_S3A_CREATE_PERFORMANCE,
+        MAX_ERROR_RETRIES,
+        RETRY_HTTP_5XX_ERRORS);
+
+    // select buffer location
+    conf.set(FAST_UPLOAD_BUFFER, buffer);
+
+    // save overhead on file creation
+    conf.setBoolean(FS_S3A_CREATE_PERFORMANCE, true);
+
+    // guarantees teardown will abort pending uploads.
+    conf.setBoolean(DIRECTORY_OPERATIONS_PURGE_UPLOADS, true);
+
+    // fail fast on 500 errors
+    conf.setBoolean(DIRECTORY_OPERATIONS_PURGE_UPLOADS, false);
+
+    // use the fault injector
+    SdkFaultInjector.addFaultInjection(conf);
+    return conf;
+  }
+
+  /**
+   * Setup MUST set up the evaluator before the FS is created.
+   */
+  @Override
+  public void setup() throws Exception {
+    SdkFaultInjector.resetEvaluator();
+    super.setup();
+  }
+
+  @Override
+  public void teardown() throws Exception {
+    // safety check in case the evaluation is failing any
+    // request needed in cleanup.
+    SdkFaultInjector.resetEvaluator();
+
+    super.teardown();
+  }
+
+  /**
+   * Verify that failures of simple PUT requests can be recovered from.
+   */
+  @Test
+  public void testPutRecovery() throws Throwable {
+    describe("test put recovery");
+    final S3AFileSystem fs = getFileSystem();
+    final Path path = methodPath();
+    final int attempts = 2;
+    final Function<Context.ModifyHttpResponse, Boolean> evaluator =
+        SdkFaultInjector::isPutRequest;
+    setRequestFailureConditions(attempts, evaluator);
+    final FSDataOutputStream out = fs.create(path);
+    out.writeUTF("utfstring");
+    out.close();
+  }
+
+  /**
+   * Validate recovery of multipart uploads within a magic write sequence.
+   */
+  @Test
+  public void testMagicWriteRecovery() throws Throwable {
+    describe("test magic write recovery with multipart uploads");
+    final S3AFileSystem fs = getFileSystem();
+
+    Assumptions.assumeThat(fs.isMultipartUploadEnabled())
+        .describedAs("Multipart upload is disabled")
+        .isTrue();
+
+    final Path path = new Path(methodPath(),
+        MAGIC_PATH_PREFIX + buffer + "/" + BASE + "/file.txt");
+
+    SdkFaultInjector.setEvaluator(SdkFaultInjector::isPartUpload);
+    final FSDataOutputStream out = fs.create(path);
+
+    // set the failure count again
+    SdkFaultInjector.setRequestFailureCount(2);
+
+    out.writeUTF("utfstring");
+    out.close();
+  }
+
+  /**
+   * Test the commit operations iff {@link #includeCommitTest} is true.
+   */
+  @Test
+  public void testCommitOperations() throws Throwable {
+    Assumptions.assumeThat(includeCommitTest)
+        .describedAs("commit test excluded")
+        .isTrue();
+    describe("test staging upload");
+    final S3AFileSystem fs = getFileSystem();
+
+    // write a file to the local fS, to simulate a staged upload
+    final byte[] dataset = ContractTestUtils.dataset(COMMIT_FILE_UPLOAD_SIZE, '0', 36);
+    File tempFile = File.createTempFile("commit", ".txt");
+    FileUtils.writeByteArrayToFile(tempFile, dataset);
+    CommitOperations actions = new CommitOperations(fs);
+    Path dest = methodPath();
+    setRequestFailureConditions(2, SdkFaultInjector::isPartUpload);
+
+    // upload from the local FS to the S3 store.
+    // making sure that progress callbacks occur
+    AtomicLong progress = new AtomicLong(0);
+    SinglePendingCommit commit =
+        actions.uploadFileToPendingCommit(tempFile,
+            dest,
+            null,
+            DEFAULT_MULTIPART_SIZE,
+            progress::incrementAndGet);
+
+    // at this point the upload must have succeeded, despite the failures.
+
+    // commit will fail twice on the complete call.
+    setRequestFailureConditions(2,
+        SdkFaultInjector::isCompleteMultipartUploadRequest);
+
+    try (CommitContext commitContext
+             = actions.createCommitContextForTesting(dest, JOB_ID, 0)) {
+      commitContext.commitOrFail(commit);
+    }
+    // make sure the saved data is as expected
+    verifyFileContents(fs, dest, dataset);
+
+    // and that we got some progress callbacks during upload
+    Assertions.assertThat(progress.get())
+        .describedAs("progress count")
+        .isGreaterThan(0);
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/TestStagingCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/TestStagingCommitter.java
@@ -203,6 +203,15 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
   }
 
   @Test
+  public void testMockFSclientWiredUp() throws Throwable {
+    final S3Client client = mockFS.getS3AInternals().getAmazonS3Client("test");
+    Assertions.assertThat(client)
+        .describedAs("S3Client from FS")
+        .isNotNull()
+        .isSameAs(mockClient);
+  }
+
+  @Test
   public void testUUIDPropagation() throws Exception {
     Configuration config = newConfig();
     String uuid = uuid();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/AbstractS3ACostTest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/AbstractS3ACostTest.java
@@ -301,7 +301,7 @@ public class AbstractS3ACostTest extends AbstractS3ATestBase {
   /**
    * Reset all the metrics being tracked.
    */
-  private void resetStatistics() {
+  protected void resetStatistics() {
     costValidator.resetMetricDiffs();
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/CountingProgressListener.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/CountingProgressListener.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.scale;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.assertj.core.api.AbstractLongAssert;
+import org.assertj.core.api.Assertions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.s3a.impl.ProgressListener;
+import org.apache.hadoop.fs.s3a.impl.ProgressListenerEvent;
+import org.apache.hadoop.util.Progressable;
+
+import static org.apache.hadoop.fs.s3a.impl.ProgressListenerEvent.PUT_FAILED_EVENT;
+import static org.apache.hadoop.fs.s3a.impl.ProgressListenerEvent.PUT_STARTED_EVENT;
+import static org.apache.hadoop.fs.s3a.impl.ProgressListenerEvent.REQUEST_BYTE_TRANSFER_EVENT;
+import static org.apache.hadoop.fs.s3a.impl.ProgressListenerEvent.TRANSFER_PART_FAILED_EVENT;
+import static org.apache.hadoop.fs.s3a.impl.ProgressListenerEvent.TRANSFER_PART_STARTED_EVENT;
+
+/**
+ * Progress listener for AWS upload tracking.
+ * Declared as {@link Progressable} to be passed down through the hadoop FS create()
+ * operations, it also implements {@link ProgressListener} to get direct
+ * information from the AWS SDK
+ */
+public class CountingProgressListener implements Progressable, ProgressListener {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractSTestS3AHugeFiles.class);
+
+  private final ContractTestUtils.NanoTimer timer;
+
+  private final Map<ProgressListenerEvent, AtomicLong> eventCounts;
+
+  private final AtomicLong bytesTransferred = new AtomicLong(0);
+
+  /**
+   * Create a progress listener.
+   * @param timer timer to use
+   */
+  public CountingProgressListener(final ContractTestUtils.NanoTimer timer) {
+    this.timer = timer;
+    this.eventCounts = new EnumMap<>(ProgressListenerEvent.class);
+    for (ProgressListenerEvent e : ProgressListenerEvent.values()) {
+      this.eventCounts.put(e, new AtomicLong(0));
+    }
+  }
+
+  /**
+   * Create a progress listener with a nano timer.
+   */
+  public CountingProgressListener() {
+    this(new ContractTestUtils.NanoTimer());
+  }
+
+  @Override
+  public void progress() {
+  }
+
+  @Override
+  public void progressChanged(ProgressListenerEvent eventType, long transferredBytes) {
+
+    eventCounts.get(eventType).incrementAndGet();
+
+    switch (eventType) {
+
+    // part Upload has started
+    case TRANSFER_PART_STARTED_EVENT:
+    case PUT_STARTED_EVENT:
+      LOG.info("Transfer started");
+      break;
+
+    // an upload part completed
+    case TRANSFER_PART_COMPLETED_EVENT:
+    case PUT_COMPLETED_EVENT:
+      // completion
+      bytesTransferred.addAndGet(transferredBytes);
+      long elapsedTime = timer.elapsedTime();
+      double elapsedTimeS = elapsedTime / 1.0e9;
+      long written = bytesTransferred.get();
+      long writtenMB = written / S3AScaleTestBase._1MB;
+      LOG.info(String.format(
+          "Event %s; total uploaded=%d MB in %.1fs;" + " effective upload bandwidth = %.2f MB/s",
+          eventType, writtenMB, elapsedTimeS, writtenMB / elapsedTimeS));
+      break;
+
+    // and a transfer failed
+    case PUT_FAILED_EVENT:
+    case TRANSFER_PART_FAILED_EVENT:
+      LOG.warn("Transfer failure");
+      break;
+    default:
+      // nothing
+      break;
+    }
+  }
+
+  public String toString() {
+    String sb =
+        "ProgressCallback{" + "bytesTransferred=" + bytesTransferred.get() + '}';
+    return sb;
+  }
+
+  /**
+   * Get the count of a specific event.
+   * @param key event
+   * @return count
+   */
+  public long get(ProgressListenerEvent key) {
+    return eventCounts.get(key).get();
+  }
+
+  /**
+   * Get the number of bytes transferred.
+   * @return byte count
+   */
+  public long getBytesTransferred() {
+    return bytesTransferred.get();
+  }
+
+  /**
+   * Get the number of event callbacks.
+   * @return count of byte transferred events.
+   */
+  public long getUploadEvents() {
+    return get(REQUEST_BYTE_TRANSFER_EVENT);
+  }
+
+  /**
+   * Get count of started events.
+   * @return count of started events.
+   */
+  public long getStartedEvents() {
+    return get(PUT_STARTED_EVENT) + get(TRANSFER_PART_STARTED_EVENT);
+  }
+
+  /**
+   * Get count of started events.
+   * @return count of started events.
+   */
+  public long getFailures() {
+    return get(PUT_FAILED_EVENT) + get(TRANSFER_PART_FAILED_EVENT);
+  }
+
+  /**
+   * Verify that no failures took place.
+   * @param operation operation being verified
+   */
+  public void verifyNoFailures(String operation) {
+    Assertions.assertThat(getFailures())
+        .describedAs("Failures in %s: %s", operation, this)
+        .isEqualTo(0);
+  }
+
+  /**
+   * Assert that the event count is as expected.
+   * @param event event to look up
+   * @return ongoing assertion
+   */
+  public AbstractLongAssert<?> assertEventCount(ProgressListenerEvent event) {
+    return Assertions.assertThat(get(event)).describedAs("Event %s count", event);
+  }
+
+  /**
+   * Assert that the event count is as expected.
+   * @param event event to look up
+   * @param count expected value.
+   */
+  public void assertEventCount(ProgressListenerEvent event, long count) {
+    assertEventCount(event).isEqualTo(count);
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ABlockOutputStreamInterruption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ABlockOutputStreamInterruption.java
@@ -1,0 +1,493 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.scale;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Abortable;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FSDataOutputStreamBuilder;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.impl.ProgressListenerEvent;
+import org.apache.hadoop.fs.s3a.test.SdkFaultInjector;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.StoreStatisticNames;
+import org.apache.hadoop.util.functional.InvocationRaisingIOE;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_OPERATIONS_PURGE_UPLOADS;
+import static org.apache.hadoop.fs.s3a.Constants.FAST_UPLOAD_ACTIVE_BLOCKS;
+import static org.apache.hadoop.fs.s3a.Constants.FAST_UPLOAD_BUFFER;
+import static org.apache.hadoop.fs.s3a.Constants.FAST_UPLOAD_BUFFER_ARRAY;
+import static org.apache.hadoop.fs.s3a.Constants.FAST_UPLOAD_BUFFER_DISK;
+import static org.apache.hadoop.fs.s3a.Constants.FAST_UPLOAD_BYTEBUFFER;
+import static org.apache.hadoop.fs.s3a.Constants.FS_S3A_CREATE_PERFORMANCE;
+import static org.apache.hadoop.fs.s3a.Constants.MAX_ERROR_RETRIES;
+import static org.apache.hadoop.fs.s3a.Constants.MULTIPART_SIZE;
+import static org.apache.hadoop.fs.s3a.Constants.RETRY_HTTP_5XX_ERRORS;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestPropertyInt;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
+import static org.apache.hadoop.fs.s3a.Statistic.OBJECT_MULTIPART_UPLOAD_ABORTED;
+import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.AUDIT_EXECUTION_INTERCEPTORS;
+import static org.apache.hadoop.fs.s3a.commit.CommitConstants.MAGIC_PATH_PREFIX;
+import static org.apache.hadoop.fs.s3a.impl.ProgressListenerEvent.PUT_INTERRUPTED_EVENT;
+import static org.apache.hadoop.fs.s3a.impl.ProgressListenerEvent.PUT_STARTED_EVENT;
+import static org.apache.hadoop.fs.s3a.impl.ProgressListenerEvent.TRANSFER_MULTIPART_ABORTED_EVENT;
+import static org.apache.hadoop.fs.s3a.impl.ProgressListenerEvent.TRANSFER_MULTIPART_INITIATED_EVENT;
+import static org.apache.hadoop.fs.s3a.impl.ProgressListenerEvent.TRANSFER_PART_FAILED_EVENT;
+import static org.apache.hadoop.fs.s3a.impl.ProgressListenerEvent.TRANSFER_PART_STARTED_EVENT;
+import static org.apache.hadoop.fs.s3a.test.SdkFaultInjector.setRequestFailureConditions;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatisticCounterValue;
+import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsToPrettyString;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.SUFFIX_FAILURES;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+
+/**
+ * Testing interrupting file writes to s3 in
+ * {@link FSDataOutputStream#close()}.
+ * <p>
+ * This is a bit tricky as we want to verify for all the block types that we
+ * can interrupt active and pending uploads and not end up with failures
+ * in the close() method.
+ * Ideally cleanup should take place, especially of files.
+ * <p>
+ * Marked as a scale test even though it tries to aggressively abort streams being written
+ * and should, if working, complete fast.
+ */
+@RunWith(Parameterized.class)
+public class ITestS3ABlockOutputStreamInterruption extends S3AScaleTestBase {
+
+  public static final int MAX_RETRIES_IN_SDK = 2;
+
+  /**
+   * Parameterized on (buffer type, active blocks).
+   * @return parameters
+   */
+  @Parameterized.Parameters(name = "{0}-{1}")
+  public static Collection<Object[]> params() {
+    return Arrays.asList(new Object[][]{
+        {FAST_UPLOAD_BUFFER_DISK, 2},
+        {FAST_UPLOAD_BUFFER_ARRAY, 1},
+        {FAST_UPLOAD_BYTEBUFFER, 2}
+    });
+  }
+
+  public static final int MPU_SIZE = 5 * _1MB;
+
+  /**
+   * Buffer type.
+   */
+  private final String bufferType;
+
+  /**
+   * How many blocks can a stream have uploading?
+   */
+  private final int activeBlocks;
+
+  /**
+   * Constructor.
+   * @param bufferType buffer type
+   * @param activeBlocks number of active blocks which can be uploaded
+   */
+  public ITestS3ABlockOutputStreamInterruption(final String bufferType,
+      int activeBlocks) {
+    this.bufferType = requireNonNull(bufferType);
+    this.activeBlocks = activeBlocks;
+  }
+
+  /**
+   * Get the test timeout in seconds.
+   * @return the test timeout as set in system properties or the default.
+   */
+  protected int getTestTimeoutSeconds() {
+    return getTestPropertyInt(new Configuration(),
+        KEY_TEST_TIMEOUT,
+        SCALE_TEST_TIMEOUT_SECONDS);
+  }
+
+  @Override
+  protected Configuration createScaleConfiguration() {
+    Configuration conf = super.createScaleConfiguration();
+
+    removeBaseAndBucketOverrides(conf,
+        AUDIT_EXECUTION_INTERCEPTORS,
+        DIRECTORY_OPERATIONS_PURGE_UPLOADS,
+        FAST_UPLOAD_BUFFER,
+        MAX_ERROR_RETRIES,
+        MULTIPART_SIZE,
+        RETRY_HTTP_5XX_ERRORS);
+    conf.set(FAST_UPLOAD_BUFFER, bufferType);
+    conf.setLong(MULTIPART_SIZE, MPU_SIZE);
+    // limiting block size allows for stricter ordering of block uploads:
+    // only 1 should be active at a time, so when a write is cancelled
+    // it should be the only one to be aborted.
+    conf.setLong(FAST_UPLOAD_ACTIVE_BLOCKS, activeBlocks);
+
+    // guarantees teardown will abort pending uploads.
+    conf.setBoolean(DIRECTORY_OPERATIONS_PURGE_UPLOADS, true);
+    // don't retry much
+    conf.setInt(MAX_ERROR_RETRIES, MAX_RETRIES_IN_SDK);
+    // use the fault injector
+    SdkFaultInjector.addFaultInjection(conf);
+    return conf;
+  }
+
+  /**
+   * Setup MUST set up the evaluator before the FS is created.
+   */
+  @Override
+  public void setup() throws Exception {
+    SdkFaultInjector.resetEvaluator();
+    super.setup();
+  }
+
+  @Override
+  public void teardown() throws Exception {
+    // safety check in case the evaluation is failing any
+    // request needed in cleanup.
+    SdkFaultInjector.resetEvaluator();
+
+    super.teardown();
+  }
+
+  @Test
+  public void testInterruptMultipart() throws Throwable {
+    describe("Interrupt a thread performing close() on a multipart upload");
+
+    interruptMultipartUpload(methodPath(), 6 * _1MB);
+  }
+
+  /**
+   * Initiate the upload of a file of a given length, then interrupt the
+   * operation in close(); assert the expected outcome including verifying
+   * that it was a multipart upload which was interrupted.
+   * @param path path to write
+   * @param len file length
+   */
+  private void interruptMultipartUpload(final Path path, int len) throws Exception {
+    // dataset is bigger than one block
+    final byte[] dataset = dataset(len, 'a', 'z' - 'a');
+
+    InterruptingProgressListener listener = new InterruptingProgressListener(
+        Thread.currentThread(),
+        TRANSFER_PART_STARTED_EVENT);
+    final FSDataOutputStream out = createFile(path, listener);
+    // write it twice to force a multipart upload
+    out.write(dataset);
+    out.write(dataset);
+    expectCloseInterrupted(out);
+
+    LOG.info("Write aborted; total bytes written = {}", listener.getBytesTransferred());
+    final IOStatistics streamStats = out.getIOStatistics();
+    LOG.info("stream statistics {}", ioStatisticsToPrettyString(streamStats));
+    listener.assertTriggered();
+    listener.assertEventCount(TRANSFER_MULTIPART_INITIATED_EVENT, 1);
+    listener.assertEventCount(TRANSFER_MULTIPART_ABORTED_EVENT, 1);
+
+    // examine the statistics
+    verifyStatisticCounterValue(streamStats,
+        StoreStatisticNames.OBJECT_MULTIPART_UPLOAD_ABORTED, 1);
+    // expect at least one byte to be transferred
+    assertBytesTransferred(listener, 1, len * 2);
+  }
+
+  /**
+   * Invoke Abortable.abort() during the upload,
+   * then go on to simulate an NPE in the part upload and verify
+   * that this does not get escalated.
+   */
+  @Test
+  public void testAbortDuringUpload() throws Throwable {
+    describe("Abort during multipart upload");
+    int len = 6 * _1MB;
+    final byte[] dataset = dataset(len, 'a', 'z' - 'a');
+    // the listener aborts a target
+    AtomicReference<Abortable> target = new AtomicReference<>();
+    Semaphore semaphore = new Semaphore(1);
+    semaphore.acquire();
+    InterruptingProgressListener listener = new InterruptingProgressListener(
+        TRANSFER_PART_STARTED_EVENT,
+        () -> {
+          final NullPointerException ex =
+              new NullPointerException("simulated failure after abort");
+          LOG.info("aborting target", ex);
+
+          // abort the stream
+          target.get().abort();
+
+          // wake up any thread
+          semaphore.release();
+
+          throw ex;
+        });
+
+    final FSDataOutputStream out = createFile(methodPath(), listener);
+    // the target can only be set once we have the stream reference
+    target.set(out);
+    // queue the write which, once the block upload begins, will trigger the abort
+    out.write(dataset);
+    // block until the abort is triggered
+    semaphore.acquire();
+
+    // rely on the stream having closed at this point so that the
+    // failed multipart event doesn't cause any problem
+    out.close();
+
+    // abort the stream again, expect it to be already closed
+
+    final Abortable.AbortableResult result = target.get().abort();
+    Assertions.assertThat(result.alreadyClosed())
+        .describedAs("already closed flag in %s", result)
+        .isTrue();
+    listener.assertEventCount(TRANSFER_MULTIPART_ABORTED_EVENT, 1);
+    // the raised NPE should have been noted but does not escalate to any form of failure.
+    // note that race conditions in the code means that it is too brittle for a strict
+    // assert here
+    listener.assertEventCount(TRANSFER_PART_FAILED_EVENT)
+        .isBetween(0L, 1L);
+  }
+
+  /**
+   * Test that a part upload failure is propagated to
+   * the close() call.
+   */
+  @Test
+  public void testPartUploadFailure() throws Throwable {
+    describe("Trigger a failure during a multipart upload");
+    int len = 6 * _1MB;
+    final byte[] dataset = dataset(len, 'a', 'z' - 'a');
+    final String text = "Simulated failure";
+
+    // uses a semaphore to control the timing of the NPE and close() call.
+    Semaphore semaphore = new Semaphore(1);
+    semaphore.acquire();
+    InterruptingProgressListener listener = new InterruptingProgressListener(
+        TRANSFER_PART_STARTED_EVENT,
+        () -> {
+          // wake up any thread
+          semaphore.release();
+          throw new NullPointerException(text);
+        });
+
+    final FSDataOutputStream out = createFile(methodPath(), listener);
+    out.write(dataset);
+    semaphore.acquire();
+    // quick extra sleep to ensure the NPE is raised
+    Thread.sleep(1000);
+
+    // this will pass up the exception from the part upload
+    intercept(IOException.class, text, out::close);
+
+    listener.assertEventCount(TRANSFER_MULTIPART_ABORTED_EVENT, 1);
+    listener.assertEventCount(TRANSFER_PART_FAILED_EVENT, 1);
+  }
+
+  /**
+   * Assert that bytes were transferred between (inclusively) the min and max values.
+   * @param listener listener
+   * @param min minimum
+   * @param max maximum
+   */
+  private static void assertBytesTransferred(
+      final InterruptingProgressListener listener,
+      final long min,
+      final long max) {
+
+    Assertions.assertThat(listener.getBytesTransferred())
+        .describedAs("bytes transferred")
+        .isBetween(min, max);
+  }
+
+  /**
+   * Write a small dataset and interrupt the close() operation.
+   */
+  @Test
+  public void testInterruptMagicWrite() throws Throwable {
+    describe("Interrupt a thread performing close() on a magic upload");
+
+    // write a smaller file to a magic path and assert multipart outcome
+    Path path = new Path(methodPath(), MAGIC_PATH_PREFIX + "1/__base/file");
+    interruptMultipartUpload(path, _1MB);
+  }
+
+  /**
+   * Write a small dataset and interrupt the close() operation.
+   */
+  @Test
+  public void testInterruptWhenAbortingAnUpload() throws Throwable {
+    describe("Interrupt a thread performing close() on a magic upload");
+
+    // fail more than the SDK will retry
+    setRequestFailureConditions(MAX_RETRIES_IN_SDK * 2, SdkFaultInjector::isMultipartAbort);
+
+    // write a smaller file to a magic path and assert multipart outcome
+    Path path = new Path(methodPath(), MAGIC_PATH_PREFIX + "1/__base/file");
+    interruptMultipartUpload(path, _1MB);
+
+    // an abort is double counted; the outer one also includes time to cancel
+    // all pending aborts so is important to measure.
+    verifyStatisticCounterValue(getFileSystem().getIOStatistics(),
+        OBJECT_MULTIPART_UPLOAD_ABORTED.getSymbol() + SUFFIX_FAILURES,
+        2);
+  }
+
+  /**
+   * Interrupt a thread performing close() on a simple PUT.
+   * This is less complex than the multipart upload case
+   * because the progress callback should be on the current thread.
+   * <p>
+   * We do expect exception translation to map the interruption to
+   * a {@code InterruptedIOException} and the count of interrupted events
+   * to increase.
+   */
+  @Test
+  public void testInterruptSimplePut() throws Throwable {
+    describe("Interrupt simple object PUT");
+
+    // dataset is less than one block
+    final int len = _1MB;
+    final byte[] dataset = dataset(len, 'a', 'z' - 'a');
+    Path path = methodPath();
+
+    InterruptingProgressListener listener = new InterruptingProgressListener(
+        Thread.currentThread(),
+        PUT_STARTED_EVENT);
+    final FSDataOutputStream out = createFile(path, listener);
+    out.write(dataset);
+    expectCloseInterrupted(out);
+
+    LOG.info("Write aborted; total bytes written = {}", listener.getBytesTransferred());
+    final IOStatistics streamStats = out.getIOStatistics();
+    LOG.info("stream statistics {}", ioStatisticsToPrettyString(streamStats));
+    listener.assertTriggered();
+    listener.assertEventCount(PUT_INTERRUPTED_EVENT, 1);
+    assertBytesTransferred(listener, 0, len);
+  }
+
+  /**
+   * Expect that a close operation is interrupted the first time it
+   * is invoked.
+   * the second time it is invoked, it should succeed.
+   * @param out output stream
+   */
+  private static void expectCloseInterrupted(final FSDataOutputStream out)
+      throws Exception {
+
+    // first call will be interrupted
+    intercept(InterruptedIOException.class, out::close);
+    // second call must be safe
+    out.close();
+  }
+
+  /**
+   * Create a file with a progress listener.
+   * @param path path to file
+   * @param listener listener
+   * @return the output stream
+   * @throws IOException IO failure
+   */
+  private FSDataOutputStream createFile(final Path path,
+      final InterruptingProgressListener listener) throws IOException {
+    final FSDataOutputStreamBuilder builder = getFileSystem().createFile(path);
+    builder
+        .overwrite(true)
+        .progress(listener)
+        .must(FS_S3A_CREATE_PERFORMANCE, true);
+    return builder.build();
+  }
+
+  /**
+   * Progress listener which interrupts the thread at any chosen callback.
+   * or any other action
+   */
+  private static final class InterruptingProgressListener
+      extends CountingProgressListener {
+
+    /** Event to trigger action. */
+    private final ProgressListenerEvent trigger;
+
+    /** Flag set when triggered. */
+    private final AtomicBoolean triggered = new AtomicBoolean(false);
+
+    /**
+     * Action to take on trigger.
+     */
+    private final InvocationRaisingIOE action;
+
+    /**
+     * Create.
+     * @param thread thread to interrupt
+     * @param trigger event to trigger on
+     */
+    private InterruptingProgressListener(
+        final Thread thread,
+        final ProgressListenerEvent trigger) {
+      this(trigger, thread::interrupt);
+    }
+
+    /**
+     * Create for any arbitrary action.
+     * @param trigger event to trigger on
+     * @param action action to take
+     */
+    private InterruptingProgressListener(
+        final ProgressListenerEvent trigger,
+        final InvocationRaisingIOE action) {
+      this.trigger = trigger;
+      this.action = action;
+    }
+
+    @Override
+    public void progressChanged(final ProgressListenerEvent eventType,
+        final long transferredBytes) {
+      super.progressChanged(eventType, transferredBytes);
+      if (trigger == eventType && !triggered.getAndSet(true)) {
+        LOG.info("triggering action");
+        try {
+          action.apply();
+        } catch (IOException e) {
+          LOG.warn("action failed", e);
+        }
+      }
+    }
+
+    /**
+     * Assert that the trigger took place.
+     */
+    private void assertTriggered() {
+      assertTrue("Not triggered", triggered.get());
+    }
+  }
+
+
+
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ADirectoryPerformance.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ADirectoryPerformance.java
@@ -44,7 +44,6 @@ import org.slf4j.LoggerFactory;
 
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -262,7 +261,7 @@ public class ITestS3ADirectoryPerformance extends S3AScaleTestBase {
         futures.add(submit(executorService,
             () -> writeOperationHelper.putObject(putObjectRequestBuilder.build(),
                 PutObjectOptions.keepingDirs(),
-                new S3ADataBlocks.BlockUploadData(new FailingInputStream()), false, null)));
+                new S3ADataBlocks.BlockUploadData(new byte[0], null), null)));
       }
       LOG.info("Waiting for PUTs to complete");
       waitForCompletion(futures);
@@ -360,16 +359,6 @@ public class ITestS3ADirectoryPerformance extends S3AScaleTestBase {
       LOG.info("FS statistics {}",
           ioStatisticsToPrettyString(fs.getIOStatistics()));
       fs.close();
-    }
-  }
-
-  /**
-   * Input stream which always returns -1.
-   */
-  private static final class FailingInputStream  extends InputStream {
-    @Override
-    public int read() throws IOException {
-      return -1;
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/TestErrorCodeMapping.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/TestErrorCodeMapping.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.statistics;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.hadoop.fs.s3a.statistics.impl.StatisticsFromAwsSdkImpl;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static org.apache.hadoop.fs.s3a.impl.InternalConstants.SC_400_BAD_REQUEST;
+import static org.apache.hadoop.fs.s3a.impl.InternalConstants.SC_404_NOT_FOUND;
+import static org.apache.hadoop.fs.s3a.impl.InternalConstants.SC_429_TOO_MANY_REQUESTS_GCS;
+import static org.apache.hadoop.fs.s3a.impl.InternalConstants.SC_500_INTERNAL_SERVER_ERROR;
+import static org.apache.hadoop.fs.s3a.impl.InternalConstants.SC_503_SERVICE_UNAVAILABLE;
+import static org.apache.hadoop.fs.s3a.statistics.impl.StatisticsFromAwsSdkImpl.mapErrorStatusCodeToStatisticName;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.HTTP_RESPONSE_400;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.HTTP_RESPONSE_4XX;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.HTTP_RESPONSE_500;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.HTTP_RESPONSE_503;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.HTTP_RESPONSE_5XX;
+
+/**
+ * Test mapping logic of {@link StatisticsFromAwsSdkImpl}.
+ */
+@RunWith(Parameterized.class)
+public class TestErrorCodeMapping extends AbstractHadoopTestBase {
+
+  /**
+   * Parameterization.
+   */
+  @Parameterized.Parameters(name = "http {0} to {1}")
+  public static Collection<Object[]> params() {
+    return Arrays.asList(new Object[][]{
+        {200, null},
+        {302, null},
+        {SC_400_BAD_REQUEST, HTTP_RESPONSE_400},
+        {SC_404_NOT_FOUND, null},
+        {416, HTTP_RESPONSE_4XX},
+        {SC_429_TOO_MANY_REQUESTS_GCS, HTTP_RESPONSE_503},
+        {SC_500_INTERNAL_SERVER_ERROR, HTTP_RESPONSE_500},
+        {SC_503_SERVICE_UNAVAILABLE, HTTP_RESPONSE_503},
+        {510, HTTP_RESPONSE_5XX},
+    });
+  }
+
+  private final int code;
+
+  private final String name;
+
+  public TestErrorCodeMapping(final int code, final String name) {
+    this.code = code;
+    this.name = name;
+  }
+
+  @Test
+  public void testMapping() throws Throwable {
+    Assertions.assertThat(mapErrorStatusCodeToStatisticName(code))
+        .describedAs("Mapping of status code %d", code)
+        .isEqualTo(name);
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/SdkFaultInjector.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/SdkFaultInjector.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+
+import org.apache.hadoop.conf.Configuration;
+
+import static org.apache.hadoop.fs.s3a.audit.AuditTestSupport.enableLoggingAuditor;
+import static org.apache.hadoop.fs.s3a.audit.AuditTestSupport.resetAuditOptions;
+import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.AUDIT_EXECUTION_INTERCEPTORS;
+import static org.apache.hadoop.fs.s3a.impl.InternalConstants.SC_500_INTERNAL_SERVER_ERROR;
+
+/**
+ * This runs inside the AWS execution pipeline so can insert faults and so
+ * trigger recovery in the SDK.
+ * It is wired up through the auditor mechanism.
+ * <p>
+ * This uses the evaluator function {@link #evaluator} to determine if
+ * the request type is that for which failures are targeted;
+ * When there is a match then the failure count
+ * is decremented and, if the count is still positive, an error is raised with the
+ * error code defined in {@link #FAILURE_STATUS_CODE}.
+ * This happens <i>after</i> the request has already succeeded against the S3 store:
+ * whatever was requested has actually already happened.
+ */
+public final class SdkFaultInjector implements ExecutionInterceptor {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SdkFaultInjector.class);
+
+  private static final AtomicInteger FAILURE_STATUS_CODE =
+      new AtomicInteger(SC_500_INTERNAL_SERVER_ERROR);
+
+  /**
+   * Always allow requests.
+   */
+  public static final Function<Context.ModifyHttpResponse, Boolean>
+      ALWAYS_ALLOW = (c) -> false;
+
+  /**
+   * How many requests with the matching evaluator to fail on.
+   */
+  public static final AtomicInteger REQUEST_FAILURE_COUNT = new AtomicInteger(1);
+
+  /**
+   * Evaluator for responses.
+   */
+  private static Function<Context.ModifyHttpResponse, Boolean> evaluator = ALWAYS_ALLOW;
+
+  /**
+   * Update the value of {@link #FAILURE_STATUS_CODE}.
+   * @param value new value
+   */
+  public static void setFailureStatusCode(int value) {
+    FAILURE_STATUS_CODE.set(value);
+  }
+
+
+  /**
+   * Set the evaluator function used to determine whether or not to raise
+   * an exception.
+   * @param value new evaluator.
+   */
+  public static void setEvaluator(Function<Context.ModifyHttpResponse, Boolean> value) {
+    evaluator = value;
+  }
+
+
+  /**
+   * Reset the evaluator to enable everything.
+   */
+  public static void resetEvaluator() {
+    setEvaluator(ALWAYS_ALLOW);
+  }
+
+  /**
+   * Set the failure count.
+   * @param count failure count
+   */
+  public static void setRequestFailureCount(int count) {
+    LOG.debug("Failure count set to {}", count);
+    REQUEST_FAILURE_COUNT.set(count);
+  }
+
+  /**
+   * Set up the request failure conditions.
+   * @param attempts how many times to fail before succeeding
+   * @param condition condition to trigger the failure
+   */
+  public static void setRequestFailureConditions(final int attempts,
+      final Function<Context.ModifyHttpResponse, Boolean> condition) {
+    setRequestFailureCount(attempts);
+    setEvaluator(condition);
+  }
+
+  /**
+   * Is the response being processed from a PUT request?
+   * @param context request context.
+   * @return true if the request is of the right type.
+   */
+  public static boolean isPutRequest(final Context.ModifyHttpResponse context) {
+    return context.httpRequest().method().equals(SdkHttpMethod.PUT);
+  }
+
+  /**
+   * Is the response being processed from any POST request?
+   * @param context request context.
+   * @return true if the request is of the right type.
+   */
+  public static boolean isPostRequest(final Context.ModifyHttpResponse context) {
+    return context.httpRequest().method().equals(SdkHttpMethod.POST);
+  }
+
+  /**
+   * Is the request a commit completion request?
+   * @param context response
+   * @return true if the predicate matches
+   */
+  public static boolean isCompleteMultipartUploadRequest(
+      final Context.ModifyHttpResponse context) {
+    return context.request() instanceof CompleteMultipartUploadRequest;
+  }
+
+  /**
+   * Is the request a part upload?
+   * @param context response
+   * @return true if the predicate matches
+   */
+  public static boolean isPartUpload(final Context.ModifyHttpResponse context) {
+    return context.request() instanceof UploadPartRequest;
+  }
+  /**
+   * Is the request a multipart upload abort?
+   * @param context response
+   * @return true if the predicate matches
+   */
+  public static boolean isMultipartAbort(final Context.ModifyHttpResponse context) {
+    return context.request() instanceof AbortMultipartUploadRequest;
+  }
+
+  /**
+   * Review response from S3 and optionall modify its status code.
+   * @return the original response or a copy with a different status code.
+   */
+  @Override
+  public SdkHttpResponse modifyHttpResponse(final Context.ModifyHttpResponse context,
+      final ExecutionAttributes executionAttributes) {
+    SdkRequest request = context.request();
+    SdkHttpResponse httpResponse = context.httpResponse();
+    if (evaluator.apply(context) && shouldFail()) {
+
+      // fail the request
+      final int code = FAILURE_STATUS_CODE.get();
+      LOG.info("Fault Injector returning {} error code for request {}",
+          code, request);
+
+      return httpResponse.copy(b -> {
+        b.statusCode(code);
+      });
+
+    } else {
+      // pass unchanged
+      return httpResponse;
+    }
+  }
+
+  /**
+   * Should the request fail based on the failure count?
+   * @return true if the request count means a request must fail
+   */
+  private static boolean shouldFail() {
+    return REQUEST_FAILURE_COUNT.decrementAndGet() > 0;
+  }
+
+  /**
+   * Add fault injection.
+   * This wires up auditing as needed.
+   * @param conf configuration to patch
+   * @return patched configuration
+   */
+  public static Configuration addFaultInjection(Configuration conf) {
+    resetAuditOptions(conf);
+    enableLoggingAuditor(conf);
+    // use the fault injector
+    conf.set(AUDIT_EXECUTION_INTERCEPTORS, SdkFaultInjector.class.getName());
+    return conf;
+  }
+}


### PR DESCRIPTION

This is a major change which handles 400 error responses when uploading large files from memory heap/buffer (or staging committer) and the remote S3 store returns a 500 response from a upload of a block in a multipart upload.

The SDK's own streaming code seems unable to fully replay the upload; at attempts to but then blocks and the S3 store returns a 400 response

    "Your socket connection to the server was not read from or written to
     within the timeout period. Idle connections will be closed.
     (Service: S3, Status Code: 400...)"

There is an option to control whether or not the S3A client itself attempts to retry on a 50x error other than 503 throttling events (which are independently processed as before)

Option:  fs.s3a.retry.http.5xx.errors
Default: true

500 errors are very rare from standard AWS S3, which has a five nines SLA. It may be more common against S3 Express which has lower guarantees.

Third party stores have unknown guarantees, and the exception may indicate a bad server configuration. Consider setting fs.s3a.retry.http.5xx.errors to false when working with such stores.

Signification Code changes:

There is now a custom set of implementations of
software.amazon.awssdk.http.ContentStreamProvidercontent in the class org.apache.hadoop.fs.s3a.impl.UploadContentProviders.

These:

* Restart on failures
* Do not copy buffers/byte buffers into new private byte arrays, so avoid exacerbating memory problems..

There new IOStatistics for specific http error codes -these are collected even when all recovery is performed within the SDK.
  
S3ABlockOutputStream has major changes, including handling of Thread.interrupt() on the main thread, which now triggers and briefly awaits cancellation of any ongoing uploads.

If the writing thread is interrupted in close(), it is mapped to an InterruptedIOException. Applications like Hive and Spark must catch these after cancelling a worker thread.

Contributed by Steve Loughran


### How was this patch tested?

in progress

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

