### PR TITLE
HADOOP-19275. Initialize default auth_to_local rules before getting user shortname

### DIFF
--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/KerberosName.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/KerberosName.java
@@ -54,6 +54,8 @@ public class KerberosName {
    */
   public static final String MECHANISM_MIT = "mit";
 
+  public static final String DEFAULT_RULES = "DEFAULT";
+
   /** Constant that defines the default behavior of the rule mechanism */
   public static final String DEFAULT_MECHANISM = MECHANISM_HADOOP;
 
@@ -414,11 +416,19 @@ public class KerberosName {
       params = new String[]{realm, serviceName, hostName};
     }
     String ruleMechanism = this.ruleMechanism;
+    List<Rule> rules = this.rules;
+
+    if (rules == null) {
+      LOG.warn("auth_to_local rules not set."
+        + "Using default of " + DEFAULT_RULES);
+      rules = parseRules(DEFAULT_RULES);
+    }
     if (ruleMechanism == null && rules != null) {
       LOG.warn("auth_to_local rule mechanism not set."
       + "Using default of " + DEFAULT_MECHANISM);
       ruleMechanism = DEFAULT_MECHANISM;
     }
+
     for(Rule r: rules) {
       String result = r.apply(params, ruleMechanism);
       if (result != null) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/User.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/User.java
@@ -24,6 +24,7 @@ import javax.security.auth.login.LoginContext;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
 
 /**
@@ -45,6 +46,7 @@ class User implements Principal {
   
   public User(String name, AuthenticationMethod authMethod, LoginContext login) {
     try {
+      HadoopKerberosName.setConfiguration(new Configuration());
       shortName = new HadoopKerberosName(name).getShortName();
     } catch (IOException ioe) {
       throw new IllegalArgumentException("Illegal principal name " + name

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/User.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/User.java
@@ -46,7 +46,6 @@ class User implements Principal {
   
   public User(String name, AuthenticationMethod authMethod, LoginContext login) {
     try {
-      HadoopKerberosName.setConfiguration(new Configuration());
       shortName = new HadoopKerberosName(name).getShortName();
     } catch (IOException ioe) {
       throw new IllegalArgumentException("Illegal principal name " + name


### PR DESCRIPTION


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The hadoop dtutil cancel command gives NullPointerException.

```java.lang.NullPointerException
	at org.apache.hadoop.security.authentication.util.KerberosName.getShortName(KerberosName.java:422)
	at org.apache.hadoop.security.User.<init>(User.java:48)
	at org.apache.hadoop.security.User.<init>(User.java:43)
	at org.apache.hadoop.security.UserGroupInformation.createRemoteUser(UserGroupInformation.java:1418)
	at org.apache.hadoop.security.UserGroupInformation.createRemoteUser(UserGroupInformation.java:1402)
	at org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier.getUser(AbstractDelegationTokenIdentifier.java:80)
	at org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier.getUser(DelegationTokenIdentifier.java:81)
	at org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier.toString(DelegationTokenIdentifier.java:91)
	at java.base/java.lang.String.valueOf(String.java:2951)
	at java.base/java.lang.StringBuilder.append(StringBuilder.java:168)
	at org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier.stringifyToken(DelegationTokenIdentifier.java:123)
	at org.apache.hadoop.hdfs.DFSClient$Renewer.cancel(DFSClient.java:804)
	at org.apache.hadoop.security.token.Token.cancel(Token.java:527)
	at org.apache.hadoop.security.token.DtFileOperations.removeTokenFromFile(DtFileOperations.java:283)
	at org.apache.hadoop.security.token.DtUtilShell$Remove.execute(DtUtilShell.java:320)
	at org.apache.hadoop.tools.CommandShell.run(CommandShell.java:72)
	at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:81)
	at org.apache.hadoop.security.token.DtUtilShell.main(DtUtilShell.java:361)
```
This is because it is trying to create a User and in User.java we are calling [this](https://github.com/apache/hadoop/blob/ea6e0f7cd58d0129897dfc7870aee188be80a904/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/User.java#L48) line.

But due to this direct call it doesn't initialize the auth_to_local rules and causes NPE in [here](https://github.com/apache/hadoop/blob/ea6e0f7cd58d0129897dfc7870aee188be80a904/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/KerberosName.java#L422) in KerberosName.java

This patch addresses this issue.

### How was this patch tested?

This patch was tested manually by creating a cluster and running the commands to verify the Delegation Token is cancelled

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

