### PR TITLE
HADOOP-19276. Create hadoop-runner based on JDK 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG JAVA_VERSION=11
+ARG JAVA_VERSION=17
 
 # Ubuntu 22.04 LTS
 FROM eclipse-temurin:${JAVA_VERSION}-jammy


### PR DESCRIPTION
## What changes were proposed in this pull request?

Publish another version of `hadoop-runner` image with JDK 17 instead of JDK 11. It can be used for testing JDK 17 runtime compatibility.

(Creating as a draft, because the change shouldn't be merged to the Java 11-specific branch, rather pushed directly as a new branch.)

https://issues.apache.org/jira/browse/HADOOP-19276

## How was this patch tested?

Built locally, verified Java version:

```
$ docker build -t apache/hadoop-runner:dev --no-cache .
...

$ docker run -it --rm apache/hadoop-runner:dev java -version
openjdk version "17.0.11" 2024-04-16
OpenJDK Runtime Environment Temurin-17.0.11+9 (build 17.0.11+9)
OpenJDK 64-Bit Server VM Temurin-17.0.11+9 (build 17.0.11+9, mixed mode, sharing)
```