### PR TITLE
HADOOP-19277. Files and directories mixed up in TreeScanResults#dump

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
@@ -1922,10 +1922,10 @@ public class ContractTestUtils extends Assert {
      */
     private String dump() {
       StringBuilder sb = new StringBuilder(toString());
-      sb.append("\nFiles:");
+      sb.append("\nDirectories:");
       directories.forEach(p ->
           sb.append("\n  \"").append(p.toString()));
-      sb.append("\nDirectories:");
+      sb.append("\nFiles:");
       files.forEach(p ->
           sb.append("\n  \"").append(p.toString()));
       return sb.toString();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix mismatch between header and list items in in `TreeScanResults#dump`.

https://issues.apache.org/jira/browse/HADOOP-19277