### PR TITLE
YARN-11730. Mark unreported nodes as LOST on RM Startup/HA failover

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -1278,6 +1278,13 @@ public class YarnConfiguration extends Configuration {
   public static final int DEFAULT_RM_NODE_GRACEFUL_DECOMMISSION_TIMEOUT = 3600;
 
   /**
+   * Enable/disable tracking of unregistered nodes.
+   **/
+  public static final String ENABLE_TRACKING_FOR_UNREGISTERED_NODES =
+      RM_PREFIX + "enable-tracking-for-unregistered-nodes";
+  public static final boolean DEFAULT_ENABLE_TRACKING_FOR_UNREGISTERED_NODES = false;
+
+  /**
    * Period in seconds of the poll timer task inside DecommissioningNodesWatcher
    * to identify and take care of DECOMMISSIONING nodes missing regular heart beat.
    */

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -5810,4 +5810,13 @@
     <value>30s</value>
   </property>
 
+  <property>
+    <description>
+      The setting that controls whether the ResourceManager should track the nodes as
+      lost when they are unregistered and not reported to the RM.
+      It doesn't account for decommissioned nodes. Default is false.
+    </description>
+    <name>yarn.resourcemanager.enable-tracking-for-unregistered-nodes</name>
+    <value>false</value>
+  </property>
 </configuration>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NodesListManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NodesListManager.java
@@ -407,7 +407,8 @@ public class NodesListManager extends CompositeService implements
     // Check if tracking unregistered nodes is enabled in the configuration
     if (!yarnConf.getBoolean(YarnConfiguration.ENABLE_TRACKING_FOR_UNREGISTERED_NODES,
         YarnConfiguration.DEFAULT_ENABLE_TRACKING_FOR_UNREGISTERED_NODES)) {
-      LOG.debug("Unregistered node tracking is disabled. Skipping marking unregistered nodes as LOST.");
+      LOG.debug("Unregistered node tracking is disabled. " +
+          "Skipping marking unregistered nodes as LOST.");
       return;
     }
 
@@ -475,29 +476,24 @@ public class NodesListManager extends CompositeService implements
     RMNodeImpl rmNode = new RMNodeImpl(nodeId, this.rmContext, lostNode, -2, -2,
         new UnknownNode(lostNode), Resource.newInstance(0, 0), "unknown");
 
-    // If the LOST event is valid, dispatch it
-    if (lostEvent != null) {
-      try {
-        // Dispatch the LOST event to signal the node is no longer active
-        eventHandler.handle(lostEvent);
+    try {
+      // Dispatch the LOST event to signal the node is no longer active
+      eventHandler.handle(lostEvent);
 
-        // After successful dispatch, update the node status in RMContext
-        // Set the node's timestamp for when it became untracked
-        rmNode.setUntrackedTimeStamp(Time.monotonicNow());
+      // After successful dispatch, update the node status in RMContext
+      // Set the node's timestamp for when it became untracked
+      rmNode.setUntrackedTimeStamp(Time.monotonicNow());
 
-        // Add the node to the active and inactive node maps in RMContext
-        this.rmContext.getRMNodes().put(nodeId, rmNode);
-        this.rmContext.getInactiveRMNodes().put(nodeId, rmNode);
+      // Add the node to the active and inactive node maps in RMContext
+      this.rmContext.getRMNodes().put(nodeId, rmNode);
+      this.rmContext.getInactiveRMNodes().put(nodeId, rmNode);
 
-        LOG.info("Successfully dispatched LOST event and deactivated node: "
-            + lostNode + ", Node ID: " + nodeId);
-      } catch (Exception e) {
-        // Log any exception encountered during event dispatch
-        LOG.error(
-            "Error dispatching LOST event for node: " + lostNode + ", Node ID: " + nodeId + " - " + e.getMessage());
-      }
-    } else {
-      LOG.error("LOST event creation failed. Event is null for node: " + lostNode + ", Node ID: " + nodeId);
+      LOG.info("Successfully dispatched LOST event and deactivated node: "
+          + lostNode + ", Node ID: " + nodeId);
+    } catch (Exception e) {
+      // Log any exception encountered during event dispatch
+      LOG.error("Error dispatching LOST event for node: " + lostNode +
+          ", Node ID: " + nodeId + " - " + e.getMessage());
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NodesListManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NodesListManager.java
@@ -280,6 +280,7 @@ public class NodesListManager extends CompositeService implements
         StringUtils.join(",", hostsReader.getExcludedHosts()) + "}");
 
     handleExcludeNodeList(graceful, timeout);
+    markUnregisteredNodesAsLost(yarnConf);
   }
 
   private void setDecommissionedNMs() {
@@ -385,6 +386,119 @@ public class NodesListManager extends CompositeService implements
     }
 
     updateInactiveNodes();
+  }
+
+  /**
+   * Marks the unregistered nodes as LOST
+   * if the feature is enabled via a configuration flag.
+   *
+   * This method finds nodes that are present in the include list but are not
+   * registered with the ResourceManager. Such nodes are then marked as LOST.
+   *
+   * The steps are as follows:
+   * 1. Retrieve all hostnames of registered nodes from RM.
+   * 2. Identify the nodes present in the include list but are not registered
+   * 3. Remove nodes from the exclude list
+   * 4. Dispatch LOST events for filtered nodes to mark them as LOST.
+   *
+   * @param yarnConf Configuration object that holds the YARN configurations.
+   */
+  private void markUnregisteredNodesAsLost(Configuration yarnConf) {
+    // Check if tracking unregistered nodes is enabled in the configuration
+    if (!yarnConf.getBoolean(YarnConfiguration.ENABLE_TRACKING_FOR_UNREGISTERED_NODES,
+        YarnConfiguration.DEFAULT_ENABLE_TRACKING_FOR_UNREGISTERED_NODES)) {
+      LOG.debug("Unregistered node tracking is disabled. Skipping marking unregistered nodes as LOST.");
+      return;
+    }
+
+    // Set to store all registered hostnames from both active and inactive lists
+    Set<String> registeredHostNames = gatherRegisteredHostNames();
+    // Event handler to dispatch LOST events
+    EventHandler eventHandler = this.rmContext.getDispatcher().getEventHandler();
+
+    // Identify nodes that are in the include list but are not registered
+    // and are not in the exclude list
+    List<String> nodesToMarkLost = new ArrayList<>();
+    HostDetails hostDetails = hostsReader.getHostDetails();
+    Set<String> includes = hostDetails.getIncludedHosts();
+    Set<String> excludes = hostDetails.getExcludedHosts();
+
+    for (String includedNode : includes) {
+      if (!registeredHostNames.contains(includedNode) && !excludes.contains(includedNode)) {
+        LOG.info("Lost node: " + includedNode);
+        nodesToMarkLost.add(includedNode);
+      }
+    }
+
+    // Dispatch LOST events for the identified lost nodes
+    for (String lostNode : nodesToMarkLost) {
+      dispatchLostEvent(eventHandler, lostNode);
+    }
+
+    // Log successful completion of marking unregistered nodes as LOST
+    LOG.info("Successfully marked unregistered nodes as LOST");
+  }
+
+  /**
+   * Gathers all registered hostnames from both active and inactive RMNodes.
+   *
+   * @return A set of registered hostnames.
+   */
+  private Set<String> gatherRegisteredHostNames() {
+    Set<String> registeredHostNames = new HashSet<>();
+    LOG.info("Getting all the registered hostnames");
+
+    // Gather all registered nodes (active) from RM into the set
+    for (RMNode node : this.rmContext.getRMNodes().values()) {
+      registeredHostNames.add(node.getHostName());
+    }
+
+    // Gather all inactive nodes from RM into the set
+    for (RMNode node : this.rmContext.getInactiveRMNodes().values()) {
+      registeredHostNames.add(node.getHostName());
+    }
+
+    return registeredHostNames;
+  }
+
+  /**
+   * Dispatches a LOST event for a specified lost node.
+   *
+   * @param eventHandler The EventHandler used to dispatch the LOST event.
+   * @param lostNode     The hostname of the lost node for which the event is
+   *                     being dispatched.
+   */
+  private void dispatchLostEvent(EventHandler eventHandler, String lostNode) {
+    // Generate a NodeId for the lost node with a special port -2
+    NodeId nodeId = createLostNodeId(lostNode);
+    RMNodeEvent lostEvent = new RMNodeEvent(nodeId, RMNodeEventType.EXPIRE);
+    RMNodeImpl rmNode = new RMNodeImpl(nodeId, this.rmContext, lostNode, -2, -2,
+        new UnknownNode(lostNode), Resource.newInstance(0, 0), "unknown");
+
+    // If the LOST event is valid, dispatch it
+    if (lostEvent != null) {
+      try {
+        // Dispatch the LOST event to signal the node is no longer active
+        eventHandler.handle(lostEvent);
+
+        // After successful dispatch, update the node status in RMContext
+        // Set the node's timestamp for when it became untracked
+        rmNode.setUntrackedTimeStamp(Time.monotonicNow());
+
+        // Add the node to the active and inactive node maps in RMContext
+        this.rmContext.getRMNodes().put(nodeId, rmNode);
+        this.rmContext.getInactiveRMNodes().put(nodeId, rmNode);
+
+        LOG.info("Successfully dispatched LOST event and deactivated node: "
+            + lostNode + ", Node ID: " + nodeId);
+      } catch (Exception e) {
+        // Log any exception encountered during event dispatch
+        LOG.error(
+            "Error dispatching LOST event for node: " + lostNode + ", Node ID: " + nodeId + " - " + e.getMessage());
+      }
+    } else {
+      LOG.error("LOST event creation failed. Event is null for node: " + lostNode + ", Node ID: " + nodeId);
+    }
   }
 
   @VisibleForTesting
@@ -709,6 +823,20 @@ public class NodesListManager extends CompositeService implements
    */
   public static NodeId createUnknownNodeId(String host) {
     return NodeId.newInstance(host, -1);
+  }
+
+  /**
+   * Creates a NodeId for a node marked as LOST.
+   *
+   * The NodeId combines the hostname with a special port value of -2, indicating
+   * that the node is lost in the cluster.
+   *
+   * @param host The hostname of the lost node.
+   * @return NodeId Unique identifier for the lost node, with the port set to -2.
+   */
+  public static NodeId createLostNodeId(String host) {
+    // Create a NodeId with the given host and port -2 to signify the node is lost.
+    return NodeId.newInstance(host, -2);
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NodesListManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NodesListManager.java
@@ -426,7 +426,7 @@ public class NodesListManager extends CompositeService implements
 
     for (String includedNode : includes) {
       if (!registeredHostNames.contains(includedNode) && !excludes.contains(includedNode)) {
-        LOG.info("Lost node: " + includedNode);
+        LOG.info("Lost node: {}", includedNode);
         nodesToMarkLost.add(includedNode);
       }
     }
@@ -488,12 +488,12 @@ public class NodesListManager extends CompositeService implements
       this.rmContext.getRMNodes().put(nodeId, rmNode);
       this.rmContext.getInactiveRMNodes().put(nodeId, rmNode);
 
-      LOG.info("Successfully dispatched LOST event and deactivated node: "
-          + lostNode + ", Node ID: " + nodeId);
+      LOG.info("Successfully dispatched LOST event and deactivated node: {}, Node ID: {}",
+          lostNode, nodeId);
     } catch (Exception e) {
       // Log any exception encountered during event dispatch
-      LOG.error("Error dispatching LOST event for node: " + lostNode +
-          ", Node ID: " + nodeId + " - " + e.getMessage());
+      LOG.error("Error dispatching LOST event for node: {}, Node ID: {} - {}",
+          lostNode, nodeId, e.getMessage());
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -1608,9 +1608,19 @@ public class ResourceManager extends CompositeService
     // Non HA case, start after RM services are started.
     if (!this.rmContext.isHAEnabled()) {
       transitionToActive();
+
+      // Refresh node state at the service startup to reflect the unregistered
+      // nodemanagers as LOST if the tracking for unregistered nodes flag is enabled.
+      // For HA setup, refreshNodes is already being called during the transition.
+      Configuration yarnConf = getConfig();
+      if (yarnConf.getBoolean(
+          YarnConfiguration.ENABLE_TRACKING_FOR_UNREGISTERED_NODES,
+          YarnConfiguration.DEFAULT_ENABLE_TRACKING_FOR_UNREGISTERED_NODES)) {
+        this.rmContext.getNodesListManager().refreshNodes(yarnConf);
+      }
     }
   }
-  
+
   protected void doSecureLogin() throws IOException {
 	InetSocketAddress socAddr = getBindAddress(conf);
     SecurityUtil.login(this.conf, YarnConfiguration.RM_KEYTAB,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -1609,7 +1609,7 @@ public class ResourceManager extends CompositeService
     // For HA setup, refreshNodes is already being called before the active
     // transition.
     Configuration yarnConf = getConfig();
-    if (yarnConf.getBoolean(
+    if (!this.rmContext.isHAEnabled() && yarnConf.getBoolean(
         YarnConfiguration.ENABLE_TRACKING_FOR_UNREGISTERED_NODES,
         YarnConfiguration.DEFAULT_ENABLE_TRACKING_FOR_UNREGISTERED_NODES)) {
       this.rmContext.getNodesListManager().refreshNodes(yarnConf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestResourceTrackerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestResourceTrackerService.java
@@ -3303,4 +3303,64 @@ public class TestResourceTrackerService extends NodeLabelTestBase {
 
     rm.close();
   }
+
+  /**
+   * Test case to verify the behavior of ResourceManager when unregistered nodes
+   * are marked as 'LOST' and node metrics are correctly updated in the system.
+   *
+   * @throws Exception if any unexpected behavior occurs
+   */
+  @Test
+  public void testMarkUnregisteredNodesAsLost() throws Exception {
+    // Step 1: Create a Configuration object to hold the settings.
+    Configuration conf = new Configuration();
+
+    // Step 2: Setup the host files.
+    // Include the following hosts: test_host1, test_host2, test_host3, test_host4
+    writeToHostsFile(hostFile, "test_host1", "test_host2", "test_host3", "test_host4");
+    conf.set(YarnConfiguration.RM_NODES_INCLUDE_FILE_PATH, hostFile.getAbsolutePath());
+
+    // Exclude the following host: test_host4
+    writeToHostsFile(excludeHostFile, "test_host4");
+    conf.set(YarnConfiguration.RM_NODES_EXCLUDE_FILE_PATH, excludeHostFile.getAbsolutePath());
+
+    // Enable tracking for unregistered nodes in the ResourceManager configuration
+    conf.setBoolean(YarnConfiguration.ENABLE_TRACKING_FOR_UNREGISTERED_NODES, true);
+
+    // Step 3: Create a MockRM (ResourceManager) instance to simulate RM behavior
+    rm = new MockRM(conf);
+    RMContext rmContext = rm.getRMContext(); // Retrieve the ResourceManager context
+    ClusterMetrics clusterMetrics = ClusterMetrics.getMetrics(); // Get cluster metrics for nodes
+    rm.start(); // Start the ResourceManager instance
+
+    // Step 4: Register and simulate node activity for "test_host1"
+    TimeUnit.MILLISECONDS.sleep(50); // Allow some time for event dispatch
+    MockNM nm1 = rm.registerNode("test_host1:1234", 5120); // Register test_host1 with 5120MB
+    nm1.nodeHeartbeat(true); // Send heartbeat to simulate the node being alive
+    TimeUnit.MILLISECONDS.sleep(50); // Allow some time for event processing
+
+    // Step 5: Validate that test_host3 is marked as a LOST node
+    Assert.assertNotNull(clusterMetrics); // Ensure metrics are not null
+    assertEquals("test_host3 should be a lost NM!",
+        NodeState.LOST,
+        rmContext.getInactiveRMNodes().get(
+            rm.getNodesListManager().createLostNodeId("test_host3")).getState());
+
+    // Step 6: Validate node metrics for lost, active, and decommissioned nodes
+    // Two nodes are lost
+    assertEquals("There should be 2 Lost NM!", 2, clusterMetrics.getNumLostNMs());
+    // One node is active
+    assertEquals("There should be 1 Active NM!", 1, clusterMetrics.getNumActiveNMs());
+    // One node is decommissioned
+    assertEquals("There should be 1 Decommissioned NM!", 1, clusterMetrics.getNumDecommisionedNMs());
+
+    // Step 7: Register and simulate node activity for "test_host3"
+    MockNM nm3 = rm.registerNode("test_host3:5678", 10240); // Register test_host3 with 10240MB
+    nm3.nodeHeartbeat(true); // Send heartbeat to simulate the node being alive
+    TimeUnit.MILLISECONDS.sleep(50); // Allow some time for event dispatch and processing
+
+    // Step 8: Validate updated node metrics after registering test_host3
+    assertEquals("There should be 1 Lost NM!", 1, clusterMetrics.getNumLostNMs()); // Only one node is lost now
+    assertEquals("There should be 2 Active NM!", 2, clusterMetrics.getNumActiveNMs()); // Two nodes are now active
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestResourceTrackerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestResourceTrackerService.java
@@ -3352,7 +3352,8 @@ public class TestResourceTrackerService extends NodeLabelTestBase {
     // One node is active
     assertEquals("There should be 1 Active NM!", 1, clusterMetrics.getNumActiveNMs());
     // One node is decommissioned
-    assertEquals("There should be 1 Decommissioned NM!", 1, clusterMetrics.getNumDecommisionedNMs());
+    assertEquals("There should be 1 Decommissioned NM!", 1,
+        clusterMetrics.getNumDecommisionedNMs());
 
     // Step 7: Register and simulate node activity for "test_host3"
     MockNM nm3 = rm.registerNode("test_host3:5678", 10240); // Register test_host3 with 10240MB
@@ -3360,7 +3361,9 @@ public class TestResourceTrackerService extends NodeLabelTestBase {
     TimeUnit.MILLISECONDS.sleep(50); // Allow some time for event dispatch and processing
 
     // Step 8: Validate updated node metrics after registering test_host3
-    assertEquals("There should be 1 Lost NM!", 1, clusterMetrics.getNumLostNMs()); // Only one node is lost now
-    assertEquals("There should be 2 Active NM!", 2, clusterMetrics.getNumActiveNMs()); // Two nodes are now active
+    assertEquals("There should be 1 Lost NM!", 1,
+        clusterMetrics.getNumLostNMs()); // Only one node is lost now
+    assertEquals("There should be 2 Active NM!", 2,
+        clusterMetrics.getNumActiveNMs()); // Two nodes are now active
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA=https://issues.apache.org/jira/browse/YARN-11730
#### 1. Overview
When the ResourceManager starts, nodes listed in the "include" file are not immediately reported until their corresponding NodeManagers send their first heartbeat. However, nodes in the "exclude" file are instantly reflected in the "Decommissioned Hosts" section with a port value of -1.

#### 2. Challenges
1. **Untracked NodeManagers**: During Resourcemanager HA failover or RM standalone restart, some nodes may not report back, even though they are listed in the _"include"_ file. These nodes neither appear in the _LOST_ state nor are they represented in the RM's JMX metrics. This results in an untracked state, making it difficult to monitor their status. While in HDFS similar behaviour exists and datanodes are marked as _"DEAD"_.
2. **Monitoring Gaps**: Nodes in the "include" file are not visible until they send their first heartbeat, impacting real-time cluster monitoring when being dependent on cluster metrics sink.
3. **Operational Impact**: Unreported nodes cause operational difficulties, particularly in automated workflows such as OS Upgrade Automation (OSUA), node recovery automation, etc. requiring workarounds to determine accurate status for nodes that don't report.

#### 3. Proposed Solution
To address these issues, the code automatically assigns the **_LOST_** state to nodes listed in the _"include"_ file that are not registered and not part of the exclude file at RM startup or during HA failover. This is indicated by a special port value of **-2**, marking the node as LOST but not yet reported. Once a heartbeat is received for that node, it will transition from LOST to RUNNING, UNHEALTHY, or any other desired state.

#### 4. Key Implementation Points
1. **Mark Unreported Nodes as LOST**:
   - **Class Modified**: `NodesListManager`
   - **Method**: `refreshHostsReader`
   - **Functionality**:
     - Automatically marks nodes listed in the **"include"** file as **LOST** if they are not part of the RM active node context.
     - For non-HA setups, this process is triggered before **RM service startup**, ensuring unregistered nodes are initially set to **LOST**.
     - Port value **-2** indicates that the node is untracked.

2. **Handle Node Heartbeat and Transition**:
    - **Class Modified**: `RMNodeImpl`
    - **Method**: State transition method
    - **Functionality**:
      - Upon receiving the first heartbeat from a node, the system checks if the node exists in the **LOST** state (If nodeID has -2 port for that host) by verifying against `getInactiveRMNodes()`.
      - If the node is found in the **LOST** state:
        - Remove the node from the inactive node list.
        - Remove the node from the active node list to register it with a new nodeID having its required port.
        - Maintain the hostname in the RM context for proper host tracking.
        - Decrement the count of **LOST** nodes.
        - Re-register the node with the new nodeID and transition it back to the active node set, ensuring it recovers gracefully from the **LOST** state.
      - This logic ensures a smooth transition for nodes from **NEW** to **LOST** and back to active upon heartbeat reception.

#### 5. Flow Diagram
  ```yaml
    +---------------------------+
    |  RM Startup / HA Failover |
    +---------------------------+
             |
             v
    Check Nodes in RM Context
             |
             +-----------------------------+
             |                             |
    Not Registered & Not in         Registered or in
    Exclude File                    Exclude File
             |                             |
             v                             v
     Mark Node as LOST (port -2)   [Node processed normally]
             |
             v
     Wait for Heartbeat
             |
             v
     Receive Heartbeat
             |
             v
    Node State Check
             |
             +------------------------------------+
             |                                    |
    Previous NodeID Removed                Same Hostname 
    With Port -2                           Still remains in the RM Context
             |                                    |
             |                                    |
             v                                    |
       [No Further Transition]                    |
                                                  |
                                                  |
           Handle Node Re-Registration -----------+
                         |
                         v
           New NodeID (Same Hostname + New Registered Port)
                         |
                         v
           +-----------------------+
           |   Transition to       |
           |   ACTIVE/RUNNING      |
           +-----------------------+

  ```

#### 6. Additional Considerations
- **Feature Flag Control**: This feature can be enabled/disabled via a configuration flag (default: False).
  ```bash
  <property>
    <name>yarn.resourcemanager.enable-tracking-for-unregistered-nodes</name>
    <value>false</value>
  </property>
  ```

### How was this patch tested?
- The implementation has been tested on multiple environments both in non-HA and HA setups. A dummy Docker-based [setup](https://github.com/arjunmohnot/hadoop-yarn-docker/tree/main) has been created to replicate the behavior, and bare metal HA setup with Zookeeper was used to validate the failover scenario between HA1 and HA2 RM node.
- Added the required unit test cases that passes with the modified code.
  ```bash
  [INFO] -------------------------------------------------------
  [INFO]  T E S T S
  [INFO] -------------------------------------------------------
  [INFO] Running org.apache.hadoop.yarn.server.resourcemanager.TestResourceTrackerService
  [INFO] Tests run: 47, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 80.975 s - in org.apache.hadoop.yarn.server.resourcemanager.TestResourceTrackerService
  [INFO]
  [INFO] Results:
  [INFO]
  [INFO] Tests run: 47, Failures: 0, Errors: 0, Skipped: 0
  [INFO]
  [INFO] ------------------------------------------------------------------------
  [INFO] BUILD SUCCESS
  [INFO] ------------------------------------------------------------------------
  [INFO] Total time:  02:10 min
  [INFO] Finished at: 2024-09-16T20:31:18+05:30
  [INFO] ------------------------------------------------------------------------
  ```
- Build and code compilation also succeeded.
  ```bash
  [INFO] ------------------------------------------------------------------------
  [INFO] BUILD SUCCESS
  [INFO] ------------------------------------------------------------------------
  [INFO] Total time:  29:27 min
  [INFO] Finished at: 2024-09-16T21:25:07+05:30
  [INFO] ------------------------------------------------------------------------
  ```
- Reference Logs:
  - Event dispatch to mark the qualified unregistered nodes as LOST:
    ```bash
    2024-09-16 17:16:28,550 INFO  resourcemanager.NodesListManager (NodesListManager.java:427) - Lost node: nodemanager2
    2024-09-16 17:16:28,550 INFO  resourcemanager.NodesListManager (NodesListManager.java:427) - Lost node: nodemanager1
    2024-09-16 17:16:28,550 INFO  resourcemanager.NodesListManager (NodesListManager.java:427) - Lost node: nodemanager3
    2024-09-16 17:16:28,550 INFO  resourcemanager.NodesListManager (NodesListManager.java:491) - Successfully dispatched LOST event and deactivated node: nodemanager2, Node ID: nodemanager2:-2
    2024-09-16 17:16:28,550 INFO  resourcemanager.NodesListManager (NodesListManager.java:491) - Successfully dispatched LOST event and deactivated node: nodemanager1, Node ID: nodemanager1:-2
    2024-09-16 17:16:28,550 INFO  resourcemanager.NodesListManager (NodesListManager.java:491) - Successfully dispatched LOST event and deactivated node: nodemanager3, Node ID: nodemanager3:-2
    2024-09-16 17:16:28,550 INFO  resourcemanager.NodesListManager (NodesListManager.java:438) - Successfully marked unregistered nodes as LOST
    2024-09-16 17:16:28,552 INFO  rmnode.RMNodeImpl (RMNodeImpl.java:1232) - Deactivating Node nodemanager2:-2 as it is now LOST
    2024-09-16 17:16:29,278 INFO  rmnode.RMNodeImpl (RMNodeImpl.java:785) - nodemanager2:-2 Node Transitioned from NEW to LOST
    2024-09-16 17:16:29,278 INFO  rmnode.RMNodeImpl (RMNodeImpl.java:1232) - Deactivating Node nodemanager1:-2 as it is now LOST
    2024-09-16 17:16:30,068 INFO  rmnode.RMNodeImpl (RMNodeImpl.java:785) - nodemanager1:-2 Node Transitioned from NEW to LOST
    2024-09-16 17:16:30,069 INFO  rmnode.RMNodeImpl (RMNodeImpl.java:1232) - Deactivating Node nodemanager3:-2 as it is now LOST
    2024-09-16 17:16:30,778 INFO  rmnode.RMNodeImpl (RMNodeImpl.java:785) - nodemanager3:-2 Node Transitioned from NEW to LOST
    ```
  - Once the heartbeat is received it re-registers the hostname and mark them to the running state:
    ```bash
    2024-09-16 17:17:12,672 INFO  rmnode.RMNodeImpl (RMNodeImpl.java:785) - nodemanager1:38065 Node Transitioned from NEW to RUNNING
    2024-09-16 17:17:12,673 INFO  capacity.CapacityScheduler (CapacityScheduler.java:2249) - Added node nodemanager1:38065 clusterResource: <memory:16384, vCores:16>
    2024-09-16 17:17:12,732 INFO  rmnode.RMNodeImpl (RMNodeImpl.java:785) - nodemanager2:40107 Node Transitioned from NEW to RUNNING
    2024-09-16 17:17:12,734 INFO  capacity.CapacityScheduler (CapacityScheduler.java:2249) - Added node nodemanager2:40107 clusterResource: <memory:24576, vCores:24>
    2024-09-16 17:17:12,262 INFO  rmnode.RMNodeImpl (RMNodeImpl.java:785) - nodemanager3:39725 Node Transitioned from NEW to RUNNING
    2024-09-16 17:17:12,265 INFO  capacity.CapacityScheduler (CapacityScheduler.java:2249) - Added node nodemanager3:39725 clusterResource: <memory:8192, vCores:8>
    ```

- Reference screenshots and video to show LOST nodes, and active nodes state transition after the NM re-registration (Note NMs were automatically marked as lost even though its initial heartbeat was not registered at the time of RM startup):
  <img width="1726" alt="Unregistered lost nodes" src="https://github.com/user-attachments/assets/796df3b5-78b1-4ce8-98d4-f65ef23d5e13">
  <img width="1724" alt="Nodes transitioned from lost to active" src="https://github.com/user-attachments/assets/0b995e92-d47b-43f1-8398-69de781bf5b7">


  https://github.com/user-attachments/assets/c8bbe1c7-ddb6-4ba9-bdf3-1d92be908f51

  
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

