### PR TITLE
HDFS-17626. Reduce lock contention at datanode startup

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -258,7 +258,7 @@ class BPServiceActor implements Runnable {
     while (shouldRun()) {
       try {
         nsInfo = bpNamenode.versionRequest();
-        LOG.debug(this + " received versionRequest response: " + nsInfo);
+        LOG.debug("{} received versionRequest response: {}", this, nsInfo);
         break;
       } catch(SocketTimeoutException e) {  // namenode is busy
         LOG.warn("Problem connecting to server: " + nnAddr);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->
JIRA: HDFS-17626

### Description of PR
During the datanode startup process, there is a debug log, because there is no LOG.isDebugEnabled() guard, so even if debug is not enabled, the read lock will be obtained. The guard should be added here to reduce lock contention.
![image](https://github.com/user-attachments/assets/8f3714c7-6a79-403e-8e9c-070d03ee1fe5)

### How was this patch tested?
Not required

