### PR TITLE
HADOOP-19279. ABFS: Disabling Apache Http Client as Default Http Client for ABFS Driver

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -169,7 +169,7 @@ public final class FileSystemConfigurations {
   public static final long THOUSAND = 1000L;
 
   public static final HttpOperationType DEFAULT_NETWORKING_LIBRARY
-      = HttpOperationType.APACHE_HTTP_CLIENT;
+      = HttpOperationType.JDK_HTTP_URL_CONNECTION;
 
   public static final int DEFAULT_APACHE_HTTP_CLIENT_MAX_IO_EXCEPTION_RETRIES = 3;
 

--- a/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
+++ b/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
@@ -878,8 +878,8 @@ ABFS Driver can use the following networking libraries:
 The networking library can be configured using the configuration `fs.azure.networking.library`
 while initializing the filesystem.
 Following are the supported values:
-- `APACHE_HTTP_CLIENT` : Use Apache HttpClient [Default]
-- `JDK_HTTP_URL_CONNECTION` : Use JDK networking library
+- `JDK_HTTP_URL_CONNECTION` : Use JDK networking library [Default]
+- `APACHE_HTTP_CLIENT` : Use Apache HttpClient
 
 #### <a href="ahc_networking_conf"></a>ApacheHttpClient networking layer configuration Options:
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: https://issues.apache.org/jira/browse/HADOOP-19279

As part of work done under [HADOOP-19120](https://issues.apache.org/jira/browse/HADOOP-19120) [ABFS]: ApacheHttpClient adaptation as network library - ASF JIRA
Apache Http Client was introduced as an alternative Network Library that can be used with ABFS Driver. Earlier JDK Http Client was the only supported network library.

Apache Http Client was found to be more helpful in terms of controls and knobs it provides to better manage the Network aspects of driver. Hence it was made the default Network Client to be used with ABFS Driver.

Recently while running scale workloads, we observed a regression where some unexpected wait time was observed while establishing connections. A possible fix has been identified and we are working on getting it fixed.
There was also a possible NPE scenario was identified on the new network client code.

Until we are done with the code fixes and revalidated the whole Apache client flow, we would like to make JDK Client as default client again. The support will still be there, but it will be disabled behind a config.

