### PR TITLE
HADOOP-19261. Support force close a DomainSocket for server service

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/unix/DomainSocket.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/unix/DomainSocket.java
@@ -339,10 +339,11 @@ public class DomainSocket implements Closeable {
   private static native void shutdown0(int fd) throws IOException;
 
   /**
-   * Close the Socket.
+   * Close the Server Socket without check refCount.
+   * When Server Socket is blocked on accept(), its refCount is 1.
+   * close() call on Server Socket will be stuck in the while loop count check.
    */
-  @Override
-  public void close() throws IOException {
+  public void close(boolean force) throws IOException {
     // Set the closed bit on this DomainSocket
     int count;
     try {
@@ -351,40 +352,60 @@ public class DomainSocket implements Closeable {
       // Someone else already closed the DomainSocket.
       return;
     }
-    // Wait for all references to go away
-    boolean didShutdown = false;
+
     boolean interrupted = false;
-    while (count > 0) {
-      if (!didShutdown) {
-        try {
-          // Calling shutdown on the socket will interrupt blocking system
-          // calls like accept, write, and read that are going on in a
-          // different thread.
-          shutdown0(fd);
-        } catch (IOException e) {
-          LOG.error("shutdown error: ", e);
-        }
-        didShutdown = true;
-      }
+    if (force) {
       try {
-        Thread.sleep(10);
-      } catch (InterruptedException e) {
-        interrupted = true;
+        // Calling shutdown on the socket will interrupt blocking system
+        // calls like accept, write, and read that are going on in a
+        // different thread.
+        shutdown0(fd);
+      } catch (IOException e) {
+        LOG.error("shutdown error: ", e);
       }
-      count = refCount.getReferenceCount();
+    } else {
+      // Wait for all references to go away
+      boolean didShutdown = false;
+      while (count > 0) {
+        if (!didShutdown) {
+          try {
+            // Calling shutdown on the socket will interrupt blocking system
+            // calls like accept, write, and read that are going on in a
+            // different thread.
+            shutdown0(fd);
+          } catch (IOException e) {
+            LOG.error("shutdown error: ", e);
+          }
+          didShutdown = true;
+        }
+        try {
+          Thread.sleep(10);
+        } catch (InterruptedException e) {
+          interrupted = true;
+        }
+        count = refCount.getReferenceCount();
+      }
     }
 
-    // At this point, nobody has a reference to the file descriptor, 
+    // At this point, nobody has a reference to the file descriptor,
     // and nobody will be able to get one in the future either.
     // We now call close(2) on the file descriptor.
-    // After this point, the file descriptor number will be reused by 
-    // something else.  Although this DomainSocket object continues to hold 
-    // the old file descriptor number (it's a final field), we never use it 
+    // After this point, the file descriptor number will be reused by
+    // something else.  Although this DomainSocket object continues to hold
+    // the old file descriptor number (it's a final field), we never use it
     // again because this DomainSocket is closed.
     close0(fd);
     if (interrupted) {
       Thread.currentThread().interrupt();
     }
+  }
+
+  /**
+   * Close the Socket.
+   */
+  @Override
+  public void close() throws IOException {
+   close(false);
   }
   
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/unix/DomainSocket.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/unix/DomainSocket.java
@@ -342,6 +342,8 @@ public class DomainSocket implements Closeable {
    * Close the Server Socket without check refCount.
    * When Server Socket is blocked on accept(), its refCount is 1.
    * close() call on Server Socket will be stuck in the while loop count check.
+   * @param force         if true, will not check refCount before close socket.
+   * @throws IOException  raised on errors performing I/O.
    */
   public void close(boolean force) throws IOException {
     // Set the closed bit on this DomainSocket
@@ -405,7 +407,7 @@ public class DomainSocket implements Closeable {
    */
   @Override
   public void close() throws IOException {
-   close(false);
+    close(false);
   }
   
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/unix/TemporarySocketDirectory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/unix/TemporarySocketDirectory.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.net.unix;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.util.Random;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.FileUtil;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/unix/TemporarySocketDirectory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/unix/TemporarySocketDirectory.java
@@ -35,8 +35,7 @@ public class TemporarySocketDirectory implements Closeable {
 
   public TemporarySocketDirectory() {
     String tmp = System.getProperty("java.io.tmpdir", "/tmp");
-    dir = new File(tmp, "socks." + (System.currentTimeMillis() +
-        "." + (new Random().nextInt())));
+    dir = new File(tmp, "socks." + System.nanoTime());
     dir.mkdirs();
     FileUtil.setWritable(dir, true);
   }


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HADOOP-19261

Currently the DomainSocket#close will check the reference count to be 0 before it goes on to close the socket. In server service case, server calls DomainSocket#listen will add 1 to the reference count. When trying to close the server socket which is blocked by accept, the close call will doing endless count > 0 check, which prevent the server socket to be closed. 

### How was this patch tested?
Improved TestDomainSocket to test the new code.  
Before the patch, most of tests in TestDomainSocket will take 3 minutes and end up like this 

![Screenshot 2024-09-20 at 15 07 50](https://github.com/user-attachments/assets/f94bee40-7e41-4b48-afde-7e0a745257bc)

With the patch applied,  here is the execution result of TestDomainSocket
![Screenshot 2024-09-20 at 15 30 01](https://github.com/user-attachments/assets/2493c383-6fb8-43cf-8cdd-d3aa8d2b0a9f)







