### PR TITLE
MAPREDUCE-7492 MiniHadoopClusterManager does not accept writeDetails …

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/MiniHadoopClusterManager.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/MiniHadoopClusterManager.java
@@ -112,7 +112,7 @@ public class MiniHadoopClusterManager {
                 Option.builder("writeConfig").hasArg().argName("path").desc(
                 "Save configuration to this XML file.").build())
         .addOption(
-                Option.builder("writeDetails").argName("path").desc(
+                Option.builder("writeDetails").hasArg().argName("path").desc(
                 "Write basic information to this JSON file.").build())
         .addOption(
                 Option.builder("help").desc("Prints option help.").build());


### PR DESCRIPTION
…file path

### Description of PR

Fix mapred minicluster -writeDetails option

### How was this patch tested?

Built Hadoop and ran the command manually.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

