### PR TITLE
HADOOP-19280. [ABFS] Initialize client timer only if metric collection is enabled  

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -131,6 +131,7 @@ import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNEC
 public abstract class AbfsClient implements Closeable {
   public static final Logger LOG = LoggerFactory.getLogger(AbfsClient.class);
   public static final String HUNDRED_CONTINUE_USER_AGENT = SINGLE_WHITE_SPACE + HUNDRED_CONTINUE + SEMICOLON;
+  public static final String ABFS_CLIENT_TIMER_THREAD_NAME = "abfs-timer-client";
 
   private final URL baseUrl;
   private final SharedKeyCredentials sharedKeyCredentials;
@@ -260,7 +261,7 @@ public abstract class AbfsClient implements Closeable {
     }
     if (isMetricCollectionEnabled) {
       this.timer = new Timer(
-              "abfs-timer-client", true);
+              ABFS_CLIENT_TIMER_THREAD_NAME, true);
       timer.schedule(new TimerTaskImpl(),
           metricIdlePeriod,
           metricIdlePeriod);
@@ -1598,7 +1599,7 @@ public abstract class AbfsClient implements Closeable {
   }
 
   @VisibleForTesting
-  Timer getTimer() {
+  protected Timer getTimer() {
     return timer;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1598,7 +1598,9 @@ public abstract class AbfsClient implements Closeable {
   }
 
   @VisibleForTesting
-  Timer getTimer() {return timer;}
+  Timer getTimer() {
+    return timer;
+  }
 
   protected String getUserAgent() {
     return userAgent;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -267,7 +267,7 @@ public class AbfsClient implements Closeable {
   public void close() throws IOException {
     if (runningTimerTask != null && isMetricCollectionEnabled) {
       runningTimerTask.cancel();
-      timer.purge();
+      timer.cancel();
     }
     if (keepAliveCache != null) {
       keepAliveCache.close();

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -293,7 +293,7 @@ public abstract class AbfsClient implements Closeable {
 
   @Override
   public void close() throws IOException {
-    if (runningTimerTask != null && isMetricCollectionEnabled) {
+    if (isMetricCollectionEnabled && runningTimerTask != null) {
       runningTimerTask.cancel();
       timer.cancel();
     }
@@ -1419,7 +1419,7 @@ public abstract class AbfsClient implements Closeable {
   boolean timerOrchestrator(TimerFunctionality timerFunctionality, TimerTask timerTask) {
     switch (timerFunctionality) {
       case RESUME:
-        if (isMetricCollectionEnabled) {
+        if (isMetricCollectionEnabled && isMetricCollectionStopped.get()) {
           synchronized (this) {
             if (isMetricCollectionStopped.get()) {
               resumeTimer();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -31,6 +31,7 @@ import java.util.Random;
 import java.util.regex.Pattern;
 
 import org.apache.hadoop.fs.azurebfs.AbfsCountersImpl;
+import org.apache.hadoop.fs.azurebfs.utils.Base64;
 import org.apache.hadoop.fs.azurebfs.utils.MetricFormat;
 import org.assertj.core.api.Assertions;
 import org.junit.Assume;
@@ -105,6 +106,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.TEST
 public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
 
   private static final String ACCOUNT_NAME = "bogusAccountName.dfs.core.windows.net";
+  private static final String ACCOUNT_KEY = "testAccountKey";
   private static final String FS_AZURE_USER_AGENT_PREFIX = "Partner Service";
   private static final String HUNDRED_CONTINUE_USER_AGENT = SINGLE_WHITE_SPACE + HUNDRED_CONTINUE + SEMICOLON;
   private static final String TEST_PATH = "/testfile";
@@ -716,7 +718,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
     final Configuration configuration = getRawConfiguration();
     configuration.set(FS_AZURE_METRIC_FORMAT, String.valueOf(MetricFormat.INTERNAL_BACKOFF_METRIC_FORMAT));
     configuration.set(FS_AZURE_METRIC_ACCOUNT_NAME, ACCOUNT_NAME);
-    configuration.set(FS_AZURE_METRIC_ACCOUNT_KEY, "vvE5oEbtg19iy5SSPXmuCNeglr3DsvpPe5JIE7eTrDmK6K2vzmoVs5VnY9Q7bI/DiviU+a3YbHx3+AStzRmEJQ==");
+    configuration.set(FS_AZURE_METRIC_ACCOUNT_KEY, Base64.encode(ACCOUNT_KEY.getBytes()));
     AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration, ACCOUNT_NAME);
 
     AbfsCounters abfsCounters = Mockito.spy(new AbfsCountersImpl(new URI("abcd")));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -106,7 +106,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.TEST
 public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
 
   private static final String ACCOUNT_NAME = "bogusAccountName.dfs.core.windows.net";
-  private static final String ACCOUNT_KEY = "testAccountKey";
+  private static final String ACCOUNT_KEY = "testKey";
   private static final String FS_AZURE_USER_AGENT_PREFIX = "Partner Service";
   private static final String HUNDRED_CONTINUE_USER_AGENT = SINGLE_WHITE_SPACE + HUNDRED_CONTINUE + SEMICOLON;
   private static final String TEST_PATH = "/testfile";

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -710,11 +710,14 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
             null,
             abfsClientContext);
 
-    assertNull(client.getTimer());
-    boolean isTimerThreadPresent = isThreadRunning("abfs-timer-client");
+    Assertions.assertThat(client.getTimer())
+        .describedAs("Timer should not be initialized")
+        .isNull();
 
     // Check if a thread with the name "abfs-timer-client" exists
-    assertFalse("Unexpected thread 'abfs-timer-client' found", isTimerThreadPresent);
+    Assertions.assertThat(isThreadRunning("abfs-timer-client"))
+            .describedAs("Expected thread 'abfs-timer-client' not found")
+            .isEqualTo(false);
     client.close();
   }
 
@@ -738,11 +741,20 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
             null,
             abfsClientContext);
 
-    assertNotNull(client.getTimer());
+    Assertions.assertThat(client.getTimer())
+        .describedAs("Timer should be initialized")
+        .isNotNull();
+
     // Check if a thread with the name "abfs-timer-client" exists
-    boolean isTimerThreadPresent = isThreadRunning("abfs-timer-client");
-    assertTrue("Expected thread 'abfs-timer-client' not found", isTimerThreadPresent);
+    Assertions.assertThat(isThreadRunning("abfs-timer-client"))
+            .describedAs("Expected thread 'abfs-timer-client' not found")
+            .isEqualTo(true);
     client.close();
+
+    // Check if the thread is removed after closing the client
+    Assertions.assertThat(isThreadRunning("abfs-timer-client"))
+        .describedAs("Unexpected thread 'abfs-timer-client' found")
+        .isEqualTo(false);
   }
 
   private boolean isThreadRunning(String threadName) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -703,7 +703,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
     AbfsClientContext abfsClientContext = new AbfsClientContextBuilder().withAbfsCounters(abfsCounters).build();
 
     // Get an instance of AbfsClient.
-    AbfsClient client = new AbfsClient(new URL("https://azure.com"),
+    AbfsClient client = new AbfsDfsClient(new URL("https://azure.com"),
             null,
             abfsConfiguration,
             (AccessTokenProvider) null,
@@ -712,7 +712,10 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
 
     assertNull(client.getTimer());
     boolean isTimerThreadPresent = isThreadRunning("abfs-timer-client");
-    assertFalse("Expected thread 'abfs-timer-client' not found", isTimerThreadPresent);
+
+    // Check if a thread with the name "abfs-timer-client" exists
+    assertFalse("Unexpected thread 'abfs-timer-client' found", isTimerThreadPresent);
+    client.close();
   }
 
   @Test
@@ -728,7 +731,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
     AbfsClientContext abfsClientContext = new AbfsClientContextBuilder().withAbfsCounters(abfsCounters).build();
 
     // Get an instance of AbfsClient.
-    AbfsClient client = new AbfsClient(new URL("https://azure.com"),
+    AbfsClient client = new AbfsDfsClient(new URL("https://azure.com"),
             null,
             abfsConfiguration,
             (AccessTokenProvider) null,
@@ -738,7 +741,8 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
     assertNotNull(client.getTimer());
     // Check if a thread with the name "abfs-timer-client" exists
     boolean isTimerThreadPresent = isThreadRunning("abfs-timer-client");
-    assertTrue("Expected thread 'abfs-timer-client' found", isTimerThreadPresent);
+    assertTrue("Expected thread 'abfs-timer-client' not found", isTimerThreadPresent);
+    client.close();
   }
 
   private boolean isThreadRunning(String threadName) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.fs.azurebfs.services;
 
 import org.apache.hadoop.conf.Configuration;
@@ -14,7 +32,9 @@ import java.net.URI;
 import java.net.URL;
 import java.util.Map;
 
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.*;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_METRIC_ACCOUNT_KEY;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_METRIC_ACCOUNT_NAME;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_METRIC_FORMAT;
 
 public class TestAbfsClient {
     private static final String ACCOUNT_NAME = "bogusAccountName.dfs.core.windows.net";

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -40,6 +40,7 @@ import static org.apache.hadoop.fs.azurebfs.services.AbfsClient.ABFS_CLIENT_TIME
 public class TestAbfsClient {
     private static final String ACCOUNT_NAME = "bogusAccountName.dfs.core.windows.net";
     private static final String ACCOUNT_KEY = "testKey";
+    private static final long SLEEP_DURATION_MS = 500;
 
     @Test
     public void testTimerNotInitialize() throws Exception {
@@ -98,7 +99,7 @@ public class TestAbfsClient {
         client.close();
 
         // Check if the thread is removed after closing the client
-        Thread.sleep(500);
+        Thread.sleep(SLEEP_DURATION_MS);
         Assertions.assertThat(isThreadRunning(ABFS_CLIENT_TIMER_THREAD_NAME))
                 .describedAs("Unexpected thread 'abfs-timer-client' found")
                 .isEqualTo(false);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -1,0 +1,97 @@
+package org.apache.hadoop.fs.azurebfs.services;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
+import org.apache.hadoop.fs.azurebfs.AbfsCountersImpl;
+import org.apache.hadoop.fs.azurebfs.oauth2.AccessTokenProvider;
+import org.apache.hadoop.fs.azurebfs.utils.Base64;
+import org.apache.hadoop.fs.azurebfs.utils.MetricFormat;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.Map;
+
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.*;
+
+public class TestAbfsClient {
+    private static final String ACCOUNT_NAME = "bogusAccountName.dfs.core.windows.net";
+    private static final String ACCOUNT_KEY = "testKey";
+
+    @Test
+    public void testTimerNotInitialize() throws Exception {
+        final Configuration configuration = new Configuration();
+        AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration, ACCOUNT_NAME);
+
+        AbfsCounters abfsCounters = Mockito.spy(new AbfsCountersImpl(new URI("abcd")));
+        AbfsClientContext abfsClientContext = new AbfsClientContextBuilder().withAbfsCounters(abfsCounters).build();
+
+        // Get an instance of AbfsClient.
+        AbfsClient client = new AbfsDfsClient(new URL("https://azure.com"),
+                null,
+                abfsConfiguration,
+                (AccessTokenProvider) null,
+                null,
+                abfsClientContext);
+
+        Assertions.assertThat(client.getTimer())
+                .describedAs("Timer should not be initialized")
+                .isNull();
+
+        // Check if a thread with the name "abfs-timer-client" exists
+        Assertions.assertThat(isThreadRunning("abfs-timer-client"))
+                .describedAs("Expected thread 'abfs-timer-client' not found")
+                .isEqualTo(false);
+        client.close();
+    }
+
+    @Test
+    public void testTimerInitialize() throws Exception {
+        final Configuration configuration = new Configuration();
+        configuration.set(FS_AZURE_METRIC_FORMAT, String.valueOf(MetricFormat.INTERNAL_BACKOFF_METRIC_FORMAT));
+        configuration.set(FS_AZURE_METRIC_ACCOUNT_NAME, ACCOUNT_NAME);
+        configuration.set(FS_AZURE_METRIC_ACCOUNT_KEY, Base64.encode(ACCOUNT_KEY.getBytes()));
+        AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration, ACCOUNT_NAME);
+
+        AbfsCounters abfsCounters = Mockito.spy(new AbfsCountersImpl(new URI("abcd")));
+        AbfsClientContext abfsClientContext = new AbfsClientContextBuilder().withAbfsCounters(abfsCounters).build();
+
+        // Get an instance of AbfsClient.
+        AbfsClient client = new AbfsDfsClient(new URL("https://azure.com"),
+                null,
+                abfsConfiguration,
+                (AccessTokenProvider) null,
+                null,
+                abfsClientContext);
+
+        Assertions.assertThat(client.getTimer())
+                .describedAs("Timer should be initialized")
+                .isNotNull();
+
+        // Check if a thread with the name "abfs-timer-client" exists
+        Assertions.assertThat(isThreadRunning("abfs-timer-client"))
+                .describedAs("Expected thread 'abfs-timer-client' not found")
+                .isEqualTo(true);
+        client.close();
+
+        // Check if the thread is removed after closing the client
+        Assertions.assertThat(isThreadRunning("abfs-timer-client"))
+                .describedAs("Unexpected thread 'abfs-timer-client' found")
+                .isEqualTo(false);
+    }
+
+    private boolean isThreadRunning(String threadName) {
+        // Get all threads and their stack traces
+        Map<Thread, StackTraceElement[]> allThreads = Thread.getAllStackTraces();
+
+        // Check if any thread has the specified name
+        for (Thread thread : allThreads.keySet()) {
+            if (thread.getName().equals(threadName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_METRIC_ACCOUNT_KEY;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_METRIC_ACCOUNT_NAME;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_METRIC_FORMAT;
+import static org.apache.hadoop.fs.azurebfs.services.AbfsClient.ABFS_CLIENT_TIMER_THREAD_NAME;
 
 public class TestAbfsClient {
     private static final String ACCOUNT_NAME = "bogusAccountName.dfs.core.windows.net";
@@ -61,7 +62,7 @@ public class TestAbfsClient {
                 .isNull();
 
         // Check if a thread with the name "abfs-timer-client" exists
-        Assertions.assertThat(isThreadRunning("abfs-timer-client"))
+        Assertions.assertThat(isThreadRunning(ABFS_CLIENT_TIMER_THREAD_NAME))
                 .describedAs("Expected thread 'abfs-timer-client' not found")
                 .isEqualTo(false);
         client.close();
@@ -91,7 +92,7 @@ public class TestAbfsClient {
                 .isNotNull();
 
         // Check if a thread with the name "abfs-timer-client" exists
-        Assertions.assertThat(isThreadRunning("abfs-timer-client"))
+        Assertions.assertThat(isThreadRunning(ABFS_CLIENT_TIMER_THREAD_NAME))
                 .describedAs("Expected thread 'abfs-timer-client' not found")
                 .isEqualTo(true);
         client.close();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -98,7 +98,8 @@ public class TestAbfsClient {
         client.close();
 
         // Check if the thread is removed after closing the client
-        Assertions.assertThat(isThreadRunning("abfs-timer-client"))
+        Thread.sleep(500);
+        Assertions.assertThat(isThreadRunning(ABFS_CLIENT_TIMER_THREAD_NAME))
                 .describedAs("Unexpected thread 'abfs-timer-client' found")
                 .isEqualTo(false);
     }


### PR DESCRIPTION
**Description of PR**

**JIRA**: https://issues.apache.org/jira/browse/HADOOP-19280

**Current Flow**: In the current flow, we are initializing the timer of the abfs-timer-client outside the metric collection enable check. As a result, for each file system, when the AbfsClient object is initialized, it spawns a thread to evaluate the time of the ABFS client. Since we are purging/closing the timer inside the metric collection check, these threads are not being closed, causing them to persist in a long-lived state. 

**Changes Made**: This PR contains the changes related to moving the initialization of the timer inside the metric collection check. Also includes check on metric collection if we are accessing the timer variable to avoid the null pointer exception.
Created two test suites to check the behaviour of timer variable and thread spawn in case of metric collection enabled and disabled.