### PR TITLE
HADOOP-19287. Fix KMSTokenRenewer#handleKind dependency on BouncyCastleProvider class

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/kms/KMSClientProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/kms/KMSClientProvider.java
@@ -178,7 +178,7 @@ public class KMSClientProvider extends KeyProvider implements CryptoExtension,
 
     @Override
     public boolean handleKind(Text kind) {
-      return kind.equals(TOKEN_KIND);
+      return kind.equals(KMSDelegationToken.TOKEN_KIND);
     }
 
     @Override


### PR DESCRIPTION
### Description of PR

`KMSTokenRenewer` uses `KMSClientProvider#TOKEN_KIND` as a judgment. `KMSClientProvider` requires class `BouncyCastleProvider` to load, which leads to `ClassNotFoundException: org.bouncycastle.jce.provider.BouncyCastleProvider`.

```java
Exception in thread "main" java.lang.NoClassDefFoundError: org/bouncycastle/jce/provider/BouncyCastleProvider
    at org.apache.hadoop.crypto.key.kms.KMSClientProvider$KMSTokenRenewer.handleKind(KMSClientProvider.java:180)
    at org.apache.hadoop.security.token.Token.getRenewer(Token.java:467)
    at org.apache.hadoop.security.token.Token.renew(Token.java:500)
    at org.apache.spark.deploy.security.HadoopFSDelegationTokenProvider.$anonfun$getTokenRenewalInterval$3(HadoopFSDelegationTokenProvider.scala:147)
    at scala.runtime.java8.JFunction0$mcJ$sp.apply(JFunction0$mcJ$sp.scala:17)
    at scala.util.Try$.apply(Try.scala:217)
    at org.apache.spark.deploy.security.HadoopFSDelegationTokenProvider.$anonfun$getTokenRenewalInterval$2(HadoopFSDelegationTokenProvider.scala:146) 
```

### How was this patch tested?
Production environment verification

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

