### PR TITLE
YARN-11733. Fix the order of updating CPU controls with cgroup v1

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsCpuResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsCpuResourceHandlerImpl.java
@@ -59,13 +59,13 @@ public class CGroupsCpuResourceHandlerImpl extends AbstractCGroupsCpuResourceHan
 
   @Override
   protected void updateCgroupMaxCpuLimit(String cgroupId, String quota, String period) throws ResourceHandlerException {
-    if (quota != null) {
-      cGroupsHandler
-          .updateCGroupParam(CPU, cgroupId, CGroupsHandler.CGROUP_CPU_QUOTA_US, quota);
-    }
     if (period != null) {
       cGroupsHandler
           .updateCGroupParam(CPU, cgroupId, CGroupsHandler.CGROUP_CPU_PERIOD_US, period);
+    }
+    if (quota != null) {
+      cGroupsHandler
+          .updateCGroupParam(CPU, cgroupId, CGroupsHandler.CGROUP_CPU_QUOTA_US, quota);
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsCpuResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsCpuResourceHandlerImpl.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.yarn.util.ResourceCalculatorPlugin;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -190,11 +191,12 @@ public class TestCGroupsCpuResourceHandlerImpl {
             CGroupsHandler.CGROUP_CPU_SHARES,
             String.valueOf(CGroupsCpuResourceHandlerImpl.CPU_DEFAULT_WEIGHT));
     // set quota and period
-    verify(mockCGroupsHandler, times(1))
+    InOrder cpuLimitOrder = inOrder(mockCGroupsHandler);
+    cpuLimitOrder.verify(mockCGroupsHandler, times(1))
         .updateCGroupParam(CGroupsHandler.CGroupController.CPU, id,
             CGroupsHandler.CGROUP_CPU_PERIOD_US,
             String.valueOf(CGroupsCpuResourceHandlerImpl.MAX_QUOTA_US));
-    verify(mockCGroupsHandler, times(1))
+    cpuLimitOrder.verify(mockCGroupsHandler, times(1))
         .updateCGroupParam(CGroupsHandler.CGroupController.CPU, id,
             CGroupsHandler.CGROUP_CPU_QUOTA_US, String.valueOf(
                 (int) (CGroupsCpuResourceHandlerImpl.MAX_QUOTA_US * share)));
@@ -222,10 +224,11 @@ public class TestCGroupsCpuResourceHandlerImpl {
     conf.setInt(YarnConfiguration.NM_RESOURCE_PERCENTAGE_PHYSICAL_CPU_LIMIT,
         cpuPerc);
     cGroupsCpuResourceHandler.bootstrap(plugin, conf);
-    verify(mockCGroupsHandler, times(1))
+    InOrder rootCpuLimitOrder = inOrder(mockCGroupsHandler);
+    rootCpuLimitOrder.verify(mockCGroupsHandler, times(1))
         .updateCGroupParam(CGroupsHandler.CGroupController.CPU, "",
             CGroupsHandler.CGROUP_CPU_PERIOD_US, String.valueOf("333333"));
-    verify(mockCGroupsHandler, times(1))
+    rootCpuLimitOrder.verify(mockCGroupsHandler, times(1))
         .updateCGroupParam(CGroupsHandler.CGroupController.CPU, "",
             CGroupsHandler.CGROUP_CPU_QUOTA_US,
             String.valueOf(CGroupsCpuResourceHandlerImpl.MAX_QUOTA_US));
@@ -262,10 +265,11 @@ public class TestCGroupsCpuResourceHandlerImpl {
               CGroupsHandler.CGROUP_CPU_SHARES, String.valueOf(
               CGroupsCpuResourceHandlerImpl.CPU_DEFAULT_WEIGHT * cVcores));
       // set quota and period
-      verify(mockCGroupsHandler, times(1))
+      InOrder cpuLimitOrder = inOrder(mockCGroupsHandler);
+      cpuLimitOrder.verify(mockCGroupsHandler, times(1))
           .updateCGroupParam(CGroupsHandler.CGroupController.CPU, id,
               CGroupsHandler.CGROUP_CPU_PERIOD_US, String.valueOf(periodUS));
-      verify(mockCGroupsHandler, times(1))
+      cpuLimitOrder.verify(mockCGroupsHandler, times(1))
           .updateCGroupParam(CGroupsHandler.CGroupController.CPU, id,
               CGroupsHandler.CGROUP_CPU_QUOTA_US, String.valueOf(quotaUS));
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsCpuResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsCpuResourceHandlerImpl.java
@@ -224,11 +224,11 @@ public class TestCGroupsCpuResourceHandlerImpl {
     conf.setInt(YarnConfiguration.NM_RESOURCE_PERCENTAGE_PHYSICAL_CPU_LIMIT,
         cpuPerc);
     cGroupsCpuResourceHandler.bootstrap(plugin, conf);
-    InOrder rootCpuLimitOrder = inOrder(mockCGroupsHandler);
-    rootCpuLimitOrder.verify(mockCGroupsHandler, times(1))
+    InOrder cpuLimitOrder = inOrder(mockCGroupsHandler);
+    cpuLimitOrder.verify(mockCGroupsHandler, times(1))
         .updateCGroupParam(CGroupsHandler.CGroupController.CPU, "",
             CGroupsHandler.CGROUP_CPU_PERIOD_US, String.valueOf("333333"));
-    rootCpuLimitOrder.verify(mockCGroupsHandler, times(1))
+    cpuLimitOrder.verify(mockCGroupsHandler, times(1))
         .updateCGroupParam(CGroupsHandler.CGroupController.CPU, "",
             CGroupsHandler.CGROUP_CPU_QUOTA_US,
             String.valueOf(CGroupsCpuResourceHandlerImpl.MAX_QUOTA_US));
@@ -265,7 +265,6 @@ public class TestCGroupsCpuResourceHandlerImpl {
               CGroupsHandler.CGROUP_CPU_SHARES, String.valueOf(
               CGroupsCpuResourceHandlerImpl.CPU_DEFAULT_WEIGHT * cVcores));
       // set quota and period
-      InOrder cpuLimitOrder = inOrder(mockCGroupsHandler);
       cpuLimitOrder.verify(mockCGroupsHandler, times(1))
           .updateCGroupParam(CGroupsHandler.CGroupController.CPU, id,
               CGroupsHandler.CGROUP_CPU_PERIOD_US, String.valueOf(periodUS));


### PR DESCRIPTION
Change-Id: I09429c878c124be9d6a09e8f027ab89d34606f2f

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
With using cgroup v1, cpu.cfs_period_us control gets the default value of 100 000 when a new cgroup is created, but when YARN calculates the limit, it uses 1 000 000 for that. Because of this we need to update cpu.cfs_period_us before cpu.cfs_quota_us, to keep the ratio between the two values and not to exceed the limit defined at parent level.

### How was this patch tested?
Unit tests, tested the change on a cluster

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

