### PR TITLE
HADOOP-19281. MetricsSystemImpl should not print INFO message in CLI

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MetricsConfig.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MetricsConfig.java
@@ -26,12 +26,12 @@ import static java.security.AccessController.*;
 
 import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedAction;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 import org.apache.hadoop.thirdparty.com.google.common.base.Splitter;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Iterables;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
@@ -106,8 +106,8 @@ class MetricsConfig extends SubsetConfiguration {
 
   /**
    * Load configuration from a list of files until the first successful load
-   * @param conf  the configuration object
-   * @param files the list of filenames to try
+   * @param prefix The prefix of the configuration.
+   * @param fileNames the list of filenames to try.
    * @return  the configuration object
    */
   static MetricsConfig loadFirst(String prefix, String... fileNames) {
@@ -119,10 +119,7 @@ class MetricsConfig extends SubsetConfiguration {
         fh.setFileName(fname);
         fh.load();
         Configuration cf = pcf.interpolatedConfiguration();
-        LOG.info("Loaded properties from {}", fname);
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Properties: {}", toString(cf));
-        }
+        LOG.debug("Loaded properties from {}: {}", fname, cf);
         MetricsConfig mc = new MetricsConfig(cf, prefix);
         LOG.debug("Metrics Config: {}", mc);
         return mc;
@@ -135,8 +132,7 @@ class MetricsConfig extends SubsetConfiguration {
         throw new MetricsConfigException(e);
       }
     }
-    LOG.debug("Cannot locate configuration: tried " +
-             Joiner.on(",").join(fileNames));
+    LOG.debug("Cannot locate configuration: tried {}", Arrays.asList(fileNames));
     // default to an empty configuration
     return new MetricsConfig(new PropertiesConfiguration(), prefix);
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MetricsConfig.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MetricsConfig.java
@@ -135,7 +135,7 @@ class MetricsConfig extends SubsetConfiguration {
         throw new MetricsConfigException(e);
       }
     }
-    LOG.warn("Cannot locate configuration: tried " +
+    LOG.debug("Cannot locate configuration: tried " +
              Joiner.on(",").join(fileNames));
     // default to an empty configuration
     return new MetricsConfig(new PropertiesConfiguration(), prefix);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MetricsSystemImpl.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MetricsSystemImpl.java
@@ -188,7 +188,7 @@ public class MetricsSystemImpl extends MetricsSystem implements MetricsSource {
     configure(prefix);
     startTimer();
     monitoring = true;
-    LOG.info(prefix +" metrics system started");
+    LOG.debug(prefix +" metrics system started");
     for (Callback cb : callbacks) cb.postStart();
     for (Callback cb : namedCallbacks.values()) cb.postStart();
   }
@@ -207,13 +207,13 @@ public class MetricsSystemImpl extends MetricsSystem implements MetricsSource {
     }
     for (Callback cb : callbacks) cb.preStop();
     for (Callback cb : namedCallbacks.values()) cb.preStop();
-    LOG.info("Stopping "+ prefix +" metrics system...");
+    LOG.debug("Stopping "+ prefix +" metrics system...");
     stopTimer();
     stopSources();
     stopSinks();
     clearConfigs();
     monitoring = false;
-    LOG.info(prefix +" metrics system stopped.");
+    LOG.debug(prefix +" metrics system stopped.");
     for (Callback cb : callbacks) cb.postStop();
     for (Callback cb : namedCallbacks.values()) cb.postStop();
   }
@@ -375,7 +375,7 @@ public class MetricsSystemImpl extends MetricsSystem implements MetricsSource {
             }
           }
         }, millis, millis);
-    LOG.info("Scheduled Metric snapshot period at " + (period / 1000)
+    LOG.debug("Scheduled Metric snapshot period at " + (period / 1000)
         + " second(s).");
   }
 
@@ -609,7 +609,7 @@ public class MetricsSystemImpl extends MetricsSystem implements MetricsSource {
       MBeans.unregister(mbeanName);
       mbeanName = null;
     }
-    LOG.info(prefix +" metrics system shutdown complete.");
+    LOG.debug(prefix +" metrics system shutdown complete.");
     return true;
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MetricsSystemImpl.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MetricsSystemImpl.java
@@ -155,7 +155,7 @@ public class MetricsSystemImpl extends MetricsSystem implements MetricsSource {
     ++refCount;
     if (monitoring) {
       // in mini cluster mode
-      LOG.info(this.prefix +" metrics system started (again)");
+      LOG.debug("{} metrics system started (again)", prefix);
       return this;
     }
     switch (initMode()) {
@@ -169,7 +169,7 @@ public class MetricsSystemImpl extends MetricsSystem implements MetricsSource {
         }
         break;
       case STANDBY:
-        LOG.info(prefix +" metrics system started in standby mode");
+        LOG.debug("{} metrics system started in standby mode", prefix);
     }
     initSystemMBean();
     return this;
@@ -188,7 +188,7 @@ public class MetricsSystemImpl extends MetricsSystem implements MetricsSource {
     configure(prefix);
     startTimer();
     monitoring = true;
-    LOG.debug(prefix +" metrics system started");
+    LOG.debug("{} metrics system started", prefix);
     for (Callback cb : callbacks) cb.postStart();
     for (Callback cb : namedCallbacks.values()) cb.postStart();
   }
@@ -202,18 +202,18 @@ public class MetricsSystemImpl extends MetricsSystem implements MetricsSource {
     }
     if (!monitoring) {
       // in mini cluster mode
-      LOG.info(prefix +" metrics system stopped (again)");
+      LOG.debug("{} metrics system stopped (again)", prefix);
       return;
     }
     for (Callback cb : callbacks) cb.preStop();
     for (Callback cb : namedCallbacks.values()) cb.preStop();
-    LOG.debug("Stopping "+ prefix +" metrics system...");
+    LOG.debug("Stopping {} metrics system...", prefix);
     stopTimer();
     stopSources();
     stopSinks();
     clearConfigs();
     monitoring = false;
-    LOG.debug(prefix +" metrics system stopped.");
+    LOG.debug("{} metrics system stopped.", prefix);
     for (Callback cb : callbacks) cb.postStop();
     for (Callback cb : namedCallbacks.values()) cb.postStop();
   }
@@ -302,7 +302,7 @@ public class MetricsSystemImpl extends MetricsSystem implements MetricsSource {
     sinks.put(name, sa);
     allSinks.put(name, sink);
     sa.start();
-    LOG.info("Registered sink "+ name);
+    LOG.debug("Registered sink {}", name);
   }
 
   @Override
@@ -375,8 +375,7 @@ public class MetricsSystemImpl extends MetricsSystem implements MetricsSource {
             }
           }
         }, millis, millis);
-    LOG.debug("Scheduled Metric snapshot period at " + (period / 1000)
-        + " second(s).");
+    LOG.debug("Scheduled Metric snapshot period at {} second(s).", period / 1000);
   }
 
   synchronized void onTimerEvent() {
@@ -609,7 +608,7 @@ public class MetricsSystemImpl extends MetricsSystem implements MetricsSource {
       MBeans.unregister(mbeanName);
       mbeanName = null;
     }
-    LOG.debug(prefix +" metrics system shutdown complete.");
+    LOG.debug("{} metrics system shutdown complete.", prefix);
     return true;
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-19281

Adjusted the log level of specific messages from `MetricsSystemImpl` and `MetricsConfig` to prevent unrelated logs from cluttering the output.

### How was this patch tested?
This patch was tested by running the test classes associated with the above classes.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?