### PR TITLE
HADOOP-19290. Operating on / in ChecksumFileSystem throws NPE.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFileSystem.java
@@ -770,7 +770,7 @@ public abstract class ChecksumFileSystem extends FilterFileSystem {
   abstract class FsOperation {
     boolean run(Path p) throws IOException {
       boolean status = apply(p);
-      if (status) {
+      if (status && !p.isRoot()) {
         Path checkFile = getChecksumFile(p);
         if (fs.exists(checkFile)) {
           apply(checkFile);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestChecksumFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestChecksumFileSystem.java
@@ -300,4 +300,11 @@ public class TestChecksumFileSystem {
       assertEquals(perm, rawFs.getFileStatus(crc).getPermission());
     }
   }
+
+  @Test
+  public void testOperationOnRoot() throws Exception {
+    Path p = new Path("/");
+    localFs.mkdirs(p);
+    localFs.setReplication(p, localFs.getFileStatus(p).getPermission().toShort());
+  }
 }


### PR DESCRIPTION
### Description of PR

Avoid fetching the checksum file for /, / is a directory anyway we don't have checksum files for directories & parent of root is ``null`` which leads to ``NPE`` failing the entire call

### How was this patch tested?

UT

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

