### PR TITLE
HDFS-17629.The IP address is incorrectly displayed in the IPv6 enviro…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/static/histogram-hostip.js
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/static/histogram-hostip.js
@@ -27,6 +27,9 @@ function open_hostip_list(x0, x1) {
     //More than 100% do not care,so not record in 95%-100% bar
     if (index > x0 && index <= x1) {
       ips.push(dn.infoAddr.split(":")[0]);
+      var idx = dn.infoAddr.lastIndexOf(":");
+      var dnIp = dn.infoAddr.substring(0, idx);
+      ips.push(dnIp);
     }
   }
   var ipsText = '';


### PR DESCRIPTION
…nment.

### Description of PR

for https://issues.apache.org/jira/browse/HDFS-17629

unction open_hostip_list in histogram-hostip.js , here is root  reason

```js
if (index > x0 && index <= x1) {
      ips.push(dn.infoAddr.split(":")[0]);
} 
```
need change to:

```js
if (index > x0 && index <= x1) {
       ips.push(dn.infoAddr.split(":")[0]);
       var idx = dn.infoAddr.lastIndexOf(":"); 
       var dnIp = dn.infoAddr.substring(0, idx);
       ips.push(dnIp);   
}
```

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

