### PR TITLE
HADOOP-19291. `CombinedFileRange.merge` should not convert disjoint ranges into overlapped ones

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/CombinedFileRange.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/CombinedFileRange.java
@@ -81,7 +81,11 @@ public class CombinedFileRange extends FileRangeImpl {
     long end = this.getOffset() + this.getLength();
     long newEnd = Math.max(end, otherEnd);
     if (otherOffset - end >= minSeek || newEnd - this.getOffset() > maxSize) {
-      return false;
+      // Guarantee that the ranges are not overlapped in order to avoid HADOOP-19098 violation later.
+      // The case `maxSize==0` is excluded due to the explicit test case, testMaxSizeZeroDisablesMerging.
+      if (otherOffset >= end || maxSize == 0) {
+        return false;
+      }
     }
     this.setLength((int) (newEnd - this.getOffset()));
     append(other);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/impl/TestVectoredReadUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/impl/TestVectoredReadUtils.java
@@ -254,6 +254,20 @@ public class TestVectoredReadUtils extends HadoopTestBase {
     assertOrderedDisjoint(list4, 16, 700);
   }
 
+  @Test
+  public void testMergeSortedRanges() {
+    List<FileRange> input = asList(
+        createFileRange(13816220, 24, null),
+        createFileRange(13816244, 7423960, null)
+    );
+    assertIsNotOrderedDisjoint(input, 100, 800);
+    final List<CombinedFileRange> outputList = mergeSortedRanges(
+        sortRangeList(input), 100, 1001, 2500);
+
+    assertRangeListSize(outputList, 1);
+    assertFileRange(outputList.get(0), 13816200, 7424100);
+  }
+
   /**
    * Assert that a file range has the specified start position and length.
    * @param range range to validate


### PR DESCRIPTION
### Description of PR

Currently, Hadoop has a bug to convert disjoint ranges into overlapped ones and eventually fails by itself.

**INPUT**
Range(offset: 13816220, length: 24)
Range(offset: 13816244, length: 7423960)

**OUTPUT (from the test case error)**
Range(offset: 13816200, length: 100)
Range(offset: 13816200, length: 7424100)

```
[ERROR] Failures:
[ERROR]   TestVectoredReadUtils.testMergeSortedRanges:267->assertRangeListSize:358 [coalesced ranges]
Expected size:<1> but was:<2> in:
<[range [13816200-13816300], length=100, reference=null; range count=1, data size=24,
  range [13816200-21240300], length=7,424,100, reference=null; range count=1, data size=7,423,960]>
```

**FAILURE**
```
Caused by: java.lang.IllegalArgumentException: Overlapping ranges range [...] and range [...]
	at org.apache.hadoop.util.Preconditions.checkArgument(Preconditions.java:213)
	at org.apache.hadoop.fs.VectoredReadUtils.validateAndSortRanges(VectoredReadUtils.java:316)
```


### How was this patch tested?

Pass the newly added test case.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

