### PR TITLE
HADOOP-19219. Add JPMS options required by hadoop-common

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -1577,7 +1577,7 @@ function hadoop_finalize_hadoop_opts
 function hadoop_finalize_jpms_opts
 {
     hadoop_add_param HADOOP_OPTS IgnoreUnrecognizedVMOptions "-XX:+IgnoreUnrecognizedVMOptions"
-    hadoop_add_param HADOOP_OPTS open.sun.security.x509 "--add-opens=java.base/java.util.zip=ALL-UNNAMED"
+    hadoop_add_param HADOOP_OPTS open.java.util.zip "--add-opens=java.base/java.util.zip=ALL-UNNAMED"
     hadoop_add_param HADOOP_OPTS open.sun.security.util "--add-opens=java.base/sun.security.util=ALL-UNNAMED"
     hadoop_add_param HADOOP_OPTS open.sun.security.x509 "--add-opens=java.base/sun.security.x509=ALL-UNNAMED"
 }

--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -1569,6 +1569,19 @@ function hadoop_finalize_hadoop_opts
   hadoop_add_param HADOOP_OPTS hadoop.security.logger "-Dhadoop.security.logger=${HADOOP_SECURITY_LOGGER}"
 }
 
+## @description  Finish configuring JPMS that enforced for JDK 17 and higher
+## @description  prior to executing Java
+## @audience     private
+## @stability    evolving
+## @replaceable  yes
+function hadoop_finalize_jpms_opts
+{
+    hadoop_add_param HADOOP_OPTS IgnoreUnrecognizedVMOptions "-XX:+IgnoreUnrecognizedVMOptions"
+    hadoop_add_param HADOOP_OPTS open.sun.security.x509 "--add-opens=java.base/java.util.zip=ALL-UNNAMED"
+    hadoop_add_param HADOOP_OPTS open.sun.security.util "--add-opens=java.base/sun.security.util=ALL-UNNAMED"
+    hadoop_add_param HADOOP_OPTS open.sun.security.x509 "--add-opens=java.base/sun.security.x509=ALL-UNNAMED"
+}
+
 ## @description  Finish Java classpath prior to execution
 ## @audience     private
 ## @stability    evolving
@@ -1597,6 +1610,7 @@ function hadoop_finalize
   hadoop_finalize_libpaths
   hadoop_finalize_hadoop_heap
   hadoop_finalize_hadoop_opts
+  hadoop_finalize_jpms_opts
 
   hadoop_translate_cygwin_path HADOOP_HOME
   hadoop_translate_cygwin_path HADOOP_CONF_DIR

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -167,8 +167,14 @@
     <enforced.java.version>[${javac.version},)</enforced.java.version>
     <enforced.maven.version>[3.3.0,)</enforced.maven.version>
 
+    <extraJavaTestArgs>
+      -XX:+IgnoreUnrecognizedVMOptions
+      --add-opens=java.base/java.util.zip=ALL-UNNAMED
+      --add-opens=java.base/sun.security.util=ALL-UNNAMED
+      --add-opens=java.base/sun.security.x509=ALL-UNNAMED
+    </extraJavaTestArgs>
     <!-- Plugin versions and config -->
-    <maven-surefire-plugin.argLine>-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError</maven-surefire-plugin.argLine>
+    <maven-surefire-plugin.argLine>-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError ${extraJavaTestArgs}</maven-surefire-plugin.argLine>
     <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire-plugin.version}</maven-failsafe-plugin.version>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19219. Add JPMS options required by hadoop-common.

Adding JPMS ([JEP 261: Module System](https://openjdk.org/jeps/261)) options that required by JDK 17+ for testing (maven-surefire-plugin) and runtime (`hadoop-functions.sh`)

This PR is based on https://github.com/apache/hadoop/pull/6939.

### How was this patch tested?

Tested on x86 Linux Java 17, this PR fixes the following cases:

hadoop-auth
```
[ERROR] org.apache.hadoop.security.authentication.server.TestLdapAuthenticationHandler  Time elapsed: 1.14 s  <<< ERROR!
java.lang.IllegalAccessError: class org.apache.directory.server.core.security.CertificateUtil (in unnamed module @0x3196eefd) cannot access class sun.security.x509.X500Name (in module java.base) because module java.base does not export sun.security.x509 to unnamed module @0x3196eefd
[ERROR] org.apache.hadoop.security.authentication.server.TestMultiSchemeAuthenticationHandler  Time elapsed: 1.299 s  <<< ERROR!
java.lang.IllegalAccessError: class org.apache.directory.server.core.security.CertificateUtil (in unnamed module @0x54a097cc) cannot access class sun.security.util.ObjectIdentifier (in module java.base) because module java.base does not export sun.security.util to unnamed module @0x54a097cc
```

hadoop-common
```
[ERROR] Tests run: 9, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.155 s <<< FAILURE! - in org.apache.hadoop.io.compress.TestCodecPool
[ERROR] testCompressorConf(org.apache.hadoop.io.compress.TestCodecPool)  Time elapsed: 0.008 s  <<< ERROR!
java.lang.reflect.InaccessibleObjectException: Unable to make field private int java.util.zip.Deflater.level accessible: module java.base does not "opens java.util.zip" to unnamed module @7ca48474
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

