### PR TITLE
HADOOP-19296. [JDK17] Upgrade maven-war-plugin to 3.4.0.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -178,7 +178,7 @@
     <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
     <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
     <maven-jar-plugin.version>2.5</maven-jar-plugin.version>
-    <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
+    <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
     <maven-source-plugin.version>2.3</maven-source-plugin.version>
     <maven-pdf-plugin.version>1.2</maven-pdf-plugin.version>
     <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-19296. [JDK17] Upgrade maven-war-plugin to 3.4.0.

During the process of compiling JDK17, we needed a higher version `3.4.0`, which has already been successfully applied in our internal builds.

### How was this patch tested?

Local Compilation.

### For code changes:

Upgrade maven-war-plugin to 3.4.0.
