### PR TITLE
HADOOP-19295. S3A: fs.s3a.connection.request.timeout too low: quick fix

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -26,11 +26,6 @@
 
 <!--- global properties -->
 
-<property>
-  <name>hadoop.common.configuration.version</name>
-  <value>3.0.0</value>
-  <description>version of this configuration file</description>
-</property>
 
 <property>
   <name>hadoop.tmp.dir</name>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -357,6 +357,12 @@ public final class Constants {
    * This makes it different from {@link #REQUEST_TIMEOUT}, which is for total
    * HTTP request.
    * <p>
+   * In V1 SDK, this value was not used in POST/PUT operations; a low value
+   * (default 15s) allowed for a fast failure of all other operations.
+   * In V2 SDK this now applies to all operations, including uploads.
+   * A large timeout is now needed, even though it means that some service/network
+   * failures may now take a long time to surface.
+   * <p>
    * Default unit is milliseconds.
    * <p>
    * There is a minimum duration set in {@link #MINIMUM_NETWORK_OPERATION_DURATION};
@@ -373,9 +379,9 @@ public final class Constants {
       "fs.s3a.connection.request.timeout";
 
   /**
-   * Default duration of a request before it is timed out: 60s.
+   * Default duration of a request before it is timed out: 16m.
    */
-  public static final Duration DEFAULT_REQUEST_TIMEOUT_DURATION = Duration.ofSeconds(60);
+  public static final Duration DEFAULT_REQUEST_TIMEOUT_DURATION = Duration.ofMinutes(15);
 
   /**
    * Default duration of a request before it is timed out: Zero.

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
@@ -375,7 +375,7 @@ The choice is yours. Generally recovery is better, but sometimes fail-fast is mo
 | `fs.s3a.connection.acquisition.timeout` | `60s`   | `*` | Timeout for waiting for a connection from the pool.   |
 | `fs.s3a.connection.establish.timeout`   | `30s`   |     | Time to establish the TCP/TLS connection              |
 | `fs.s3a.connection.idle.time`           | `60s`   | `*` | Maximum time for idle HTTP connections in the pool    |
-| `fs.s3a.connection.request.timeout`     | `60s`   |     | If greater than zero, maximum time for a response     |
+| `fs.s3a.connection.request.timeout`     | `15m`   |     | If greater than zero, maximum time for any response.  |
 | `fs.s3a.connection.timeout`             | `200s`  |     | Timeout for socket problems on a TCP channel          |
 | `fs.s3a.connection.ttl`                 | `5m`    |     | Lifetime of HTTP connections from the pool            |
 


### PR DESCRIPTION

...for large uploads over slow links

* New default value of 15 minutes in source
* Updated docs
* Troubleshooting: new stack trace and details of the problem

I don't think this should be the final patch.

Because I've just discovered how we can set different timeouts on each request, so
a long timeout for data put/post seems straightforward, as well as testing.

### How was this patch tested?

big bulk uploads

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

