### PR TITLE
HADOOP-19292. Don't create new EOFException in BlockDecompressorStream

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/BlockDecompressorStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/BlockDecompressorStream.java
@@ -126,7 +126,7 @@ public class BlockDecompressorStream extends DecompressorStream {
     while (n < len) {
       int count = in.read(buffer, off + n, len - n);
       if (count < 0) {
-        throw new EOFException("Unexpected end of block in input stream");
+        throw EOF_EXCEPTION;
       }
       n += count;
     }
@@ -141,13 +141,15 @@ public class BlockDecompressorStream extends DecompressorStream {
     super.resetState();
   }
 
+  private static final EOFException EOF_EXCEPTION = new EOFException("EOF in BlockDecompressorStream");
+
   private int rawReadInt() throws IOException {
     int b1 = in.read();
     int b2 = in.read();
     int b3 = in.read();
     int b4 = in.read();
     if ((b1 | b2 | b3 | b4) < 0)
-      throw new EOFException();
+      throw EOF_EXCEPTION;
     return ((b1 << 24) + (b2 << 16) + (b3 << 8) + (b4 << 0));
   }
 }


### PR DESCRIPTION
### Description of PR

This saves about 1% of CPU cycles on our HBase clusters.

### How was this patch tested?

Build internally for our clusters.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

