### PR TITLE
HDFS-17636. Don't add declspec for Windows

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/CMakeLists.txt
@@ -57,7 +57,7 @@ set(LIBHDFS_VERSION "0.0.0")
 set_target_properties(hdfs PROPERTIES
     SOVERSION ${LIBHDFS_VERSION})
 
-build_libhdfs_test(test_libhdfs_ops hdfs_static test_libhdfs_ops.c)
+build_libhdfs_test(test_libhdfs_ops hdfs_static test_libhdfs_ops.c ../libhdfs/hdfs.c)
 link_libhdfs_test(test_libhdfs_ops hdfs_static native_mini_dfs ${JAVA_JVM_LIBRARY})
 add_libhdfs_test(test_libhdfs_ops hdfs_static)
 

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/CMakeLists.txt
@@ -67,7 +67,7 @@ set(LIBHDFS_VERSION "0.0.0")
 set_target_properties(hdfs PROPERTIES
     SOVERSION ${LIBHDFS_VERSION})
 
-build_libhdfs_test(test_libhdfs_ops hdfs_static test_libhdfs_ops.c ../libhdfs/hdfs.c)
+build_libhdfs_test(test_libhdfs_ops hdfs_static test_libhdfs_ops.c)
 link_libhdfs_test(test_libhdfs_ops hdfs_static native_mini_dfs ${JAVA_JVM_LIBRARY})
 add_libhdfs_test(test_libhdfs_ops hdfs_static)
 

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/CMakeLists.txt
@@ -46,6 +46,7 @@ set(HDFS_SOURCES
 # link to hdfs's publicly linked libraries
 # (like jvm)
 add_library(hdfs_obj OBJECT ${HDFS_SOURCES})
+set_target_properties(hdfs_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
 hadoop_add_dual_library(hdfs
     $<TARGET_OBJECTS:hdfs_obj>
     $<TARGET_OBJECTS:x_platform_obj>

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/CMakeLists.txt
@@ -40,6 +40,11 @@ set(HDFS_SOURCES
     ${OS_DIR}/mutexes.c
     ${OS_DIR}/thread_local_storage.c
 )
+# We want to create an object library for hdfs
+# so that we can reuse it for the targets
+# (like get_jni_test), where we don't wish to
+# link to hdfs's publicly linked libraries
+# (like jvm)
 add_library(hdfs_obj OBJECT ${HDFS_SOURCES})
 hadoop_add_dual_library(hdfs
     $<TARGET_OBJECTS:hdfs_obj>

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/CMakeLists.txt
@@ -32,13 +32,17 @@ include_directories(
     ../libhdfspp/lib
 )
 
-hadoop_add_dual_library(hdfs
+set(HDFS_SOURCES
     exception.c
     jni_helper.c
     hdfs.c
     jclasses.c
     ${OS_DIR}/mutexes.c
     ${OS_DIR}/thread_local_storage.c
+)
+add_library(hdfs_obj OBJECT ${HDFS_SOURCES})
+hadoop_add_dual_library(hdfs
+    $<TARGET_OBJECTS:hdfs_obj>
     $<TARGET_OBJECTS:x_platform_obj>
     $<TARGET_OBJECTS:x_platform_obj_c_api>
 )

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/CMakeLists.txt
@@ -74,8 +74,17 @@ add_executable(uri_test uri_test.cc)
 target_link_libraries(uri_test common gmock_main ${CMAKE_THREAD_LIBS_INIT})
 add_memcheck_test(uri uri_test)
 
+get_target_property(HDFS_STATIC_LIBS_NO_JVM hdfs_static LINK_LIBRARIES)
+list(REMOVE_ITEM HDFS_STATIC_LIBS_NO_JVM ${JAVA_JVM_LIBRARY})
+
 add_executable(get_jni_test libhdfs_getjni_test.cc)
-target_link_libraries(get_jni_test gmock_main hdfs_static ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(get_jni_test
+    gmock_main
+    $<TARGET_OBJECTS:hdfs_obj>
+    $<TARGET_OBJECTS:x_platform_obj>
+    $<TARGET_OBJECTS:x_platform_obj_c_api>
+    ${HDFS_STATIC_LIBS_NO_JVM}
+    ${CMAKE_THREAD_LIBS_INIT})
 add_memcheck_test(get_jni get_jni_test)
 
 add_executable(remote_block_reader_test remote_block_reader_test.cc)

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/CMakeLists.txt
@@ -74,9 +74,11 @@ add_executable(uri_test uri_test.cc)
 target_link_libraries(uri_test common gmock_main ${CMAKE_THREAD_LIBS_INIT})
 add_memcheck_test(uri uri_test)
 
+# We want to link to all the libraries of hdfs_static library,
+# except jvm.lib since we want to override some of the functions
+# provided by jvm.lib.
 get_target_property(HDFS_STATIC_LIBS_NO_JVM hdfs_static LINK_LIBRARIES)
 list(REMOVE_ITEM HDFS_STATIC_LIBS_NO_JVM ${JAVA_JVM_LIBRARY})
-
 add_executable(get_jni_test libhdfs_getjni_test.cc)
 target_link_libraries(get_jni_test
     gmock_main

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/libhdfs_getjni_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/libhdfs_getjni_test.cc
@@ -38,6 +38,11 @@ DECLSPEC jint JNICALL JNI_CreateJavaVM(JavaVM**, void**, void*) {
     return 1;
 }
 
+// hook the jvm runtime function. expect always failure
+DECLSPEC jint JNICALL JNI_GetCreatedJavaVMs(JavaVM**, jsize, jsize*) {
+    return 1;
+}
+
 TEST(GetJNITest, TestRepeatedGetJNIFailsButNoCrash) {
     // connect to nothing, should fail but not crash
     EXPECT_EQ(NULL, hdfsConnectNewInstance(NULL, 0));

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/libhdfs_getjni_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/libhdfs_getjni_test.cc
@@ -20,13 +20,21 @@
 #include <hdfs/hdfs.h>
 #include <jni.h>
 
+#ifdef WIN32
+#define DECLSPEC
+#else
+// Windows cribs when this is declared in the function definition,
+// However, Linux needs it.
+#define DECLSPEC _JNI_IMPORT_OR_EXPORT_
+#endif
+
 // hook the jvm runtime function. expect always failure
-_JNI_IMPORT_OR_EXPORT_ jint JNICALL JNI_GetDefaultJavaVMInitArgs(void*) {
+DECLSPEC jint JNICALL JNI_GetDefaultJavaVMInitArgs(void*) {
     return 1;
 }
 
 // hook the jvm runtime function. expect always failure
-_JNI_IMPORT_OR_EXPORT_ jint JNICALL JNI_CreateJavaVM(JavaVM**, void**, void*) {
+DECLSPEC jint JNICALL JNI_CreateJavaVM(JavaVM**, void**, void*) {
     return 1;
 }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

* Windows doesn't want the macro _JNI_IMPORT_OR_EXPORT_ to be defined in the function definition. It fails to compile with the following error - "definition of dllimport function not allowed".
* However, Linux needs it. Hence, we're going to add this macro based on the OS.

### How was this patch tested?
Jenkins CI validation.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

