### PR TITLE
HADOOP-19286: S3A: Support cross region access when S3 region/endpoint is set (ADDENDUM)

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -271,8 +271,10 @@ public class DefaultS3ClientFactory extends Configured
    * <li>If endpoint is configured via via fs.s3a.endpoint, set it.
    *     If no region is configured, try to parse region from endpoint. </li>
    * <li> If no region is configured, and it could not be parsed from the endpoint,
-   *     set the default region as US_EAST_2 and enable cross region access. </li>
+   *     set the default region as US_EAST_2</li>
    * <li> If configured region is empty, fallback to SDK resolution chain. </li>
+   * <li> S3 cross region is enabled by default irrespective of region or endpoint
+   *      is set or not.</li>
    * </ol>
    *
    * @param builder S3 client builder.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEndpointRegion.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEndpointRegion.java
@@ -356,6 +356,10 @@ public class ITestS3AEndpointRegion extends AbstractS3ATestBase {
     // skip the test if the region is sa-east-1
     skipCrossRegionTest();
     final Configuration newConf = new Configuration(getConfiguration());
+    removeBaseAndBucketOverrides(newConf,
+        ENDPOINT,
+        AWS_S3_CROSS_REGION_ACCESS_ENABLED,
+        AWS_REGION);
     // disable cross region access
     newConf.setBoolean(AWS_S3_CROSS_REGION_ACCESS_ENABLED, false);
     newConf.set(AWS_REGION, SA_EAST_1);
@@ -374,6 +378,7 @@ public class ITestS3AEndpointRegion extends AbstractS3ATestBase {
     skipCrossRegionTest();
     final Configuration newConf = new Configuration(getConfiguration());
     removeBaseAndBucketOverrides(newConf,
+        ENDPOINT,
         AWS_S3_CROSS_REGION_ACCESS_ENABLED,
         AWS_REGION);
     // enable cross region access


### PR DESCRIPTION
ADDENDUM for https://github.com/apache/hadoop/pull/7067 to fix test failures.