### PR TITLE
HADOOP-19305: Fix ProcessEnvironment ClassCastException in Shell.java

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Shell.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Shell.java
@@ -977,7 +977,9 @@ public abstract class Shell {
       builder.environment().clear();
     }
 
-    builder.environment().putAll(this.environment);
+    if (!environment.isEmpty()) {
+      builder.environment().putAll(this.environment);
+    }
 
     if (dir != null) {
       builder.directory(this.dir);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
See HADOOP-19305 and [HIVE-28191](https://issues.apache.org/jira/browse/HIVE-28191)

### How was this patch tested?
Tested with the Apache Hive Tests.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

