### PR TITLE
HADOOP-19309: S3A CopyFromLocalFile operation fails when the source file does not contain file scheme

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CopyFromLocalOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CopyFromLocalOperation.java
@@ -130,7 +130,7 @@ public class CopyFromLocalOperation extends ExecutingStoreOperation<Void> {
     this.callbacks = callbacks;
     this.deleteSource = deleteSource;
     this.overwrite = overwrite;
-    this.source = source;
+    this.source = source.toUri().getScheme() == null ? new Path("file://", source) : source;
     this.destination = destination;
 
     // Capacity of 1 is a safe default for now since transfer manager can also

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ACopyFromLocalFile.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ACopyFromLocalFile.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.fs.s3a;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -106,5 +107,16 @@ public class ITestS3ACopyFromLocalFile extends
 
     intercept(IllegalArgumentException.class,
         () -> getFileSystem().copyFromLocalFile(true, true, dest, dest));
+  }
+
+  @Test
+  public void testCopyFromLocalWithNoFileScheme() throws IOException {
+    describe("Copying from local file with no file scheme to remote s3 destination");
+    File source = createTempFile("tempData");
+    Path dest = path(getMethodName());
+
+    Path sourcePathWithOutScheme = new Path(source.toURI().getPath());
+    assertNull(sourcePathWithOutScheme.toUri().getScheme());
+    getFileSystem().copyFromLocalFile(true, true, sourcePathWithOutScheme, dest);
   }
 }


### PR DESCRIPTION
### Description of PR

When the sourcePath does not contain any file scheme information, S3A CopyFromLocalFile operation fails. Additionally the failure is seen only when the config `fs.s3a.optimized.copy.from.local.enabled `is enabled (which is by default). This happens only when the local source file is given without any file scheme for example : `/tmp/file.txt` instead of` file:///tmp/file.txt.`

### How was this patch tested?

Added a test case to validate the issue and the fix. Ran the test` ITestS3ACopyFromLocalFile ` in us-east-1

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

