### PR TITLE
 HDFS-17646. Add Option to limit Balancer overUtilized nodes num in each iteration.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
@@ -208,6 +208,8 @@ public class Balancer {
       + "\n\t[-sortTopNodes]"
       + "\tSort datanodes based on the utilization so "
       + "that highly utilized datanodes get scheduled first."
+      + "\n\t[-limitOverUtilizedNum <specified maximum number of overUtilized datanodes>]"
+      + "\tLimit the maximum number of overUtilized datanodes."
       + "\n\t[-hotBlockTimeInterval]\tprefer to move cold blocks.";
 
   @VisibleForTesting
@@ -227,6 +229,7 @@ public class Balancer {
   private final long maxSizeToMove;
   private final long defaultBlockSize;
   private final boolean sortTopNodes;
+  private final int limitOverUtilizedNum;
   private final BalancerMetrics metrics;
 
   // all data node lists
@@ -352,6 +355,7 @@ public class Balancer {
     this.sourceNodes = p.getSourceNodes();
     this.runDuringUpgrade = p.getRunDuringUpgrade();
     this.sortTopNodes = p.getSortTopNodes();
+    this.limitOverUtilizedNum = p.getlimitOverUtilizedNum();
 
     this.maxSizeToMove = getLongBytes(conf,
         DFSConfigKeys.DFS_BALANCER_MAX_SIZE_TO_MOVE_KEY,
@@ -456,13 +460,20 @@ public class Balancer {
       sortOverUtilized(overUtilizedPercentage);
     }
 
+    // Limit the maximum number of overUtilized datanodes
+    // If excludedOverUtilizedNum is greater than 0, The overUtilized nodes num is limited
+    int excludedOverUtilizedNum = Math.max(overUtilized.size() - limitOverUtilizedNum, 0);
+    if (excludedOverUtilizedNum > 0) {
+      limitOverUtilizedNum();
+    }
+
     logUtilizationCollections();
     metrics.setNumOfOverUtilizedNodes(overUtilized.size());
     metrics.setNumOfUnderUtilizedNodes(underUtilized.size());
-    
-    Preconditions.checkState(dispatcher.getStorageGroupMap().size()
-        == overUtilized.size() + underUtilized.size() + aboveAvgUtilized.size()
-           + belowAvgUtilized.size(),
+
+    Preconditions.checkState(dispatcher.getStorageGroupMap().size() - excludedOverUtilizedNum
+            == overUtilized.size() + underUtilized.size() + aboveAvgUtilized.size()
+            + belowAvgUtilized.size(),
         "Mismatched number of storage groups");
     
     // return number of bytes to be moved in order to make the cluster balanced
@@ -482,6 +493,20 @@ public class Balancer {
             (Double.compare(overUtilizedPercentage.get(source2),
                 overUtilizedPercentage.get(source1)))
     );
+  }
+
+  private void limitOverUtilizedNum() {
+    Preconditions.checkState(overUtilized instanceof LinkedList,
+        "Collection overUtilized is not a LinkedList.");
+    LinkedList<Source> list = (LinkedList<Source>) overUtilized;
+
+    LOG.info("Limiting over-utilized nodes num, if using the '-sortTopNodes' param," +
+        " the overUtilized nodes of top will be retained");
+
+    int size = overUtilized.size();
+    for (int i = 0; i < size - limitOverUtilizedNum; i++) {
+      list.removeLast();
+    }
   }
 
   private static long computeMaxSize2Move(final long capacity, final long remaining,
@@ -1071,6 +1096,12 @@ public class Balancer {
               b.setSortTopNodes(true);
               LOG.info("Balancer will sort nodes by" +
                   " capacity usage percentage to prioritize top used nodes");
+            } else if ("-limitOverUtilizedNum".equalsIgnoreCase(args[i])) {
+              Preconditions.checkArgument(++i < args.length,
+                  "limitOverUtilizedNum value is missing: args = " + Arrays.toString(args));
+              int limitNum = Integer.parseInt(args[i]);
+              LOG.info("Using a limitOverUtilizedNum of {}", limitNum);
+              b.setLimitOverUtilizedNum(limitNum);
             } else {
               throw new IllegalArgumentException("args = "
                   + Arrays.toString(args));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
@@ -355,7 +355,7 @@ public class Balancer {
     this.sourceNodes = p.getSourceNodes();
     this.runDuringUpgrade = p.getRunDuringUpgrade();
     this.sortTopNodes = p.getSortTopNodes();
-    this.limitOverUtilizedNum = p.getlimitOverUtilizedNum();
+    this.limitOverUtilizedNum = p.getLimitOverUtilizedNum();
 
     this.maxSizeToMove = getLongBytes(conf,
         DFSConfigKeys.DFS_BALANCER_MAX_SIZE_TO_MOVE_KEY,
@@ -472,8 +472,8 @@ public class Balancer {
     metrics.setNumOfUnderUtilizedNodes(underUtilized.size());
 
     Preconditions.checkState(dispatcher.getStorageGroupMap().size() - excludedOverUtilizedNum
-            == overUtilized.size() + underUtilized.size() + aboveAvgUtilized.size()
-            + belowAvgUtilized.size(),
+        == overUtilized.size() + underUtilized.size() + aboveAvgUtilized.size()
+           + belowAvgUtilized.size(),
         "Mismatched number of storage groups");
     
     // return number of bytes to be moved in order to make the cluster balanced

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
@@ -470,7 +470,7 @@ public class Balancer {
     logUtilizationCollections();
     metrics.setNumOfOverUtilizedNodes(overUtilized.size());
     metrics.setNumOfUnderUtilizedNodes(underUtilized.size());
-
+    
     Preconditions.checkState(dispatcher.getStorageGroupMap().size() - excludedOverUtilizedNum
         == overUtilized.size() + underUtilized.size() + aboveAvgUtilized.size()
            + belowAvgUtilized.size(),

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
@@ -1100,6 +1100,8 @@ public class Balancer {
               Preconditions.checkArgument(++i < args.length,
                   "limitOverUtilizedNum value is missing: args = " + Arrays.toString(args));
               int limitNum = Integer.parseInt(args[i]);
+              Preconditions.checkArgument(limitNum >= 0,
+                  "limitOverUtilizedNum must be non-negative");
               LOG.info("Using a limitOverUtilizedNum of {}", limitNum);
               b.setLimitOverUtilizedNum(limitNum);
             } else {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/BalancerParameters.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/BalancerParameters.java
@@ -50,6 +50,8 @@ final class BalancerParameters {
 
   private final boolean sortTopNodes;
 
+  private final int limitOverUtilizedNum;
+
   static final BalancerParameters DEFAULT = new BalancerParameters();
 
   private BalancerParameters() {
@@ -67,6 +69,7 @@ final class BalancerParameters {
     this.runDuringUpgrade = builder.runDuringUpgrade;
     this.runAsService = builder.runAsService;
     this.sortTopNodes = builder.sortTopNodes;
+    this.limitOverUtilizedNum = builder.limitOverUtilizedNum;
     this.hotBlockTimeInterval = builder.hotBlockTimeInterval;
   }
 
@@ -110,6 +113,10 @@ final class BalancerParameters {
     return this.sortTopNodes;
   }
 
+  int getlimitOverUtilizedNum() {
+    return this.limitOverUtilizedNum;
+  }
+
   long getHotBlockTimeInterval() {
     return this.hotBlockTimeInterval;
   }
@@ -120,12 +127,12 @@ final class BalancerParameters {
         + " max idle iteration = %s," + " #excluded nodes = %s,"
         + " #included nodes = %s," + " #source nodes = %s,"
         + " #blockpools = %s," + " run during upgrade = %s,"
-        + " sort top nodes = %s,"
+        + " sort top nodes = %s," + " limit overUtilized nodes num = %s"
         + " hot block time interval = %s]",
         Balancer.class.getSimpleName(), getClass().getSimpleName(), policy,
         threshold, maxIdleIteration, excludedNodes.size(),
         includedNodes.size(), sourceNodes.size(), blockpools.size(),
-        runDuringUpgrade, sortTopNodes, hotBlockTimeInterval);
+        runDuringUpgrade, sortTopNodes, limitOverUtilizedNum, hotBlockTimeInterval);
   }
 
   static class Builder {
@@ -141,6 +148,7 @@ final class BalancerParameters {
     private boolean runDuringUpgrade = false;
     private boolean runAsService = false;
     private boolean sortTopNodes = false;
+    private int limitOverUtilizedNum = Integer.MAX_VALUE;
     private long hotBlockTimeInterval = 0;
 
     Builder() {
@@ -198,6 +206,11 @@ final class BalancerParameters {
 
     Builder setSortTopNodes(boolean shouldSortTopNodes) {
       this.sortTopNodes = shouldSortTopNodes;
+      return this;
+    }
+
+    Builder setLimitOverUtilizedNum(int limitOverUtilizedNum) {
+      this.limitOverUtilizedNum = limitOverUtilizedNum;
       return this;
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/BalancerParameters.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/BalancerParameters.java
@@ -113,7 +113,7 @@ final class BalancerParameters {
     return this.sortTopNodes;
   }
 
-  int getlimitOverUtilizedNum() {
+  int getLimitOverUtilizedNum() {
     return this.limitOverUtilizedNum;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/BalancerParameters.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/BalancerParameters.java
@@ -127,7 +127,7 @@ final class BalancerParameters {
         + " max idle iteration = %s," + " #excluded nodes = %s,"
         + " #included nodes = %s," + " #source nodes = %s,"
         + " #blockpools = %s," + " run during upgrade = %s,"
-        + " sort top nodes = %s," + " limit overUtilized nodes num = %s"
+        + " sort top nodes = %s," + " limit overUtilized nodes num = %s,"
         + " hot block time interval = %s]",
         Balancer.class.getSimpleName(), getClass().getSimpleName(), policy,
         threshold, maxIdleIteration, excludedNodes.size(),

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/BalancerParameters.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/BalancerParameters.java
@@ -209,8 +209,8 @@ final class BalancerParameters {
       return this;
     }
 
-    Builder setLimitOverUtilizedNum(int limitOverUtilizedNum) {
-      this.limitOverUtilizedNum = limitOverUtilizedNum;
+    Builder setLimitOverUtilizedNum(int overUtilizedNum) {
+      this.limitOverUtilizedNum = overUtilizedNum;
       return this;
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSCommands.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSCommands.md
@@ -293,6 +293,7 @@ Usage:
               [-runDuringUpgrade]
               [-asService]
               [-sortTopNodes]
+              [-limitOverUtilizedNum <specified maximum number of overUtilized datanodes>]
               [-hotBlockTimeInterval <specified time interval>]
 
 | COMMAND\_OPTION | Description |
@@ -307,6 +308,7 @@ Usage:
 | `-runDuringUpgrade` | Whether to run the balancer during an ongoing HDFS upgrade. This is usually not desired since it will not affect used space on over-utilized machines. |
 | `-asService` | Run Balancer as a long running service. |
 | `-sortTopNodes` | Sort datanodes based on the utilization so that highly utilized datanodes get scheduled first. |
+| `-limitOverUtilizedNum` | Limit the maximum number of overUtilized datanodes. |
 | `-hotBlockTimeInterval` | Prefer moving cold blocks i.e blocks associated with files accessed or modified before the specified time interval. |
 | `-h`\|`--help` | Display the tool usage and help information and exit. |
 


### PR DESCRIPTION
### Description of PR
Limit the maximum number of overutilized datanodes to avoid excessive nodes affecting cluster stability.

https://issues.apache.org/jira/browse/HDFS-17646

### How was this patch tested?
Add UT

