### PR TITLE
YARN-10058. Handle uncaught exception for async-scheduling threads to prevent scheduler hangs

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
@@ -36,6 +36,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.yarn.server.resourcemanager.RMCriticalThreadUncaughtExceptionHandler;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.ApplicationPlacementContext;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.CSMappingPlacementRule;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.PlacementFactory;
@@ -3543,7 +3544,10 @@ public class CapacityScheduler extends
 
         this.asyncSchedulerThreads = new ArrayList<>();
         for (int i = 0; i < maxAsyncSchedulingThreads; i++) {
-          asyncSchedulerThreads.add(new AsyncScheduleThread(cs));
+          AsyncScheduleThread ast = new AsyncScheduleThread(cs);
+          ast.setUncaughtExceptionHandler(
+              new RMCriticalThreadUncaughtExceptionHandler(cs.rmContext));
+          asyncSchedulerThreads.add(ast);
         }
         this.resourceCommitterService = new ResourceCommitterService(cs);
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMHAForAsyncScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMHAForAsyncScheduler.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.server.resourcemanager;
 
 import org.apache.hadoop.ha.HAServiceProtocol;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMApp;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppState;
@@ -144,6 +145,9 @@ public class TestRMHAForAsyncScheduler extends RMHATestBase {
     rm1.registerNode("192.1.1.1:1234", 8192, 8);
     rm1.drainEvents();
 
+    // make sure async-scheduling thread is correct at beginning
+    checkAsyncSchedulerThreads(Thread.currentThread());
+
     // test async-scheduling thread exit
     try{
       // set resource calculator to be null to simulate
@@ -151,28 +155,30 @@ public class TestRMHAForAsyncScheduler extends RMHATestBase {
       CapacityScheduler cs =
           (CapacityScheduler) rm1.getRMContext().getScheduler();
       cs.setResourceCalculator(null);
-      checkAsyncSchedulerThreads(Thread.currentThread());
 
-      // wait for RM to be shutdown until timeout
-      boolean done = TestUtils.waitForUntilTimeout(
-          () -> rm1.getRMContext().getHAServiceState()
-              == HAServiceProtocol.HAServiceState.STANDBY, 100, 5000);
-      Assert.assertTrue(
-          "RM1 should be transitioned to standby, but got state: "
-              + rm1.getRMContext().getHAServiceState(), done);
+      // wait for rm1 to be transitioned to standby
+      GenericTestUtils.waitFor(() -> rm1.getRMContext().getHAServiceState()
+          == HAServiceProtocol.HAServiceState.STANDBY, 100, 5000);
 
-      // failover RM2 to RM1
+      // failover rm2 to rm1
       HAServiceProtocol.StateChangeRequestInfo requestInfo =
           new HAServiceProtocol.StateChangeRequestInfo(
               HAServiceProtocol.RequestSource.REQUEST_BY_USER);
       rm2.adminService.transitionToStandby(requestInfo);
-      rm1.adminService.transitionToActive(requestInfo);
-      done = TestUtils.waitForUntilTimeout(
-          () -> rm1.getRMContext().getHAServiceState()
-              == HAServiceProtocol.HAServiceState.ACTIVE, 100, 5000);
-      Assert.assertTrue(
-          "RM1 should be transitioned to active, but got state: "
-              + rm1.getRMContext().getHAServiceState(), done);
+      GenericTestUtils.waitFor(() -> {
+        try {
+          // this call may fail when rm1 is still initializing
+          // in StandByTransitionRunnable thread
+          rm1.adminService.transitionToActive(requestInfo);
+          return true;
+        } catch (Exception e) {
+          return false;
+        }
+      }, 100, 3000);
+
+      // wait for rm1 to be transitioned to active again
+      GenericTestUtils.waitFor(() -> rm1.getRMContext().getHAServiceState()
+          == HAServiceProtocol.HAServiceState.ACTIVE, 100, 5000);
 
       // make sure async-scheduling thread is correct after failover
       checkAsyncSchedulerThreads(Thread.currentThread());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMHAForAsyncScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMHAForAsyncScheduler.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.TestCapacitySchedulerAsyncScheduling;
-import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.TestUtils;
 import org.apache.hadoop.yarn.util.resource.DominantResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.junit.Assert;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
@@ -67,6 +67,7 @@ import org.apache.hadoop.yarn.util.resource.Resources;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.internal.NoExitSecurityManager;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -1070,6 +1071,38 @@ public class TestCapacitySchedulerAsyncScheduling {
             (Boolean) reservedProposalParts.get(2));
     Assert.assertFalse(isSuccess);
     rm.stop();
+  }
+
+  @Test(timeout = 30000)
+  public void testAsyncScheduleThreadExit() throws Exception {
+    // init RM & NM
+    final MockRM rm = new MockRM(conf);
+    rm.start();
+    rm.registerNode("192.168.0.1:1234", 8 * GB);
+    rm.drainEvents();
+
+    // Set no exit security manager to catch System.exit
+    SecurityManager originalSecurityManager = System.getSecurityManager();
+    NoExitSecurityManager noExitSecurityManager =
+        new NoExitSecurityManager(originalSecurityManager);
+    System.setSecurityManager(noExitSecurityManager);
+
+    // test async-scheduling thread exit
+    try{
+      // set resource calculator to be null to simulate
+      // NPE in async-scheduling thread
+      CapacityScheduler cs =
+          (CapacityScheduler) rm.getRMContext().getScheduler();
+      cs.setResourceCalculator(null);
+
+      // wait for RM to be shutdown until timeout
+      boolean done = TestUtils.waitForUntilTimeout(
+          noExitSecurityManager::isCheckExitCalled, 100, 5000);
+      Assert.assertTrue("RM should be shut down, but nothing happened", done);
+    } finally {
+      System.setSecurityManager(originalSecurityManager);
+      rm.stop();
+    }
   }
 
   private ResourceCommitRequest createAllocateFromReservedProposal(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.Container;
@@ -1096,9 +1097,8 @@ public class TestCapacitySchedulerAsyncScheduling {
       cs.setResourceCalculator(null);
 
       // wait for RM to be shutdown until timeout
-      boolean done = TestUtils.waitForUntilTimeout(
-          noExitSecurityManager::isCheckExitCalled, 100, 5000);
-      Assert.assertTrue("RM should be shut down, but nothing happened", done);
+      GenericTestUtils.waitFor(noExitSecurityManager::isCheckExitCalled,
+          100, 5000);
     } finally {
       System.setSecurityManager(originalSecurityManager);
       rm.stop();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestUtils.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -485,5 +486,27 @@ public class TestUtils {
 
     cs.submitResourceCommitRequest(clusterResource,
         csAssignment);
+  }
+
+  /**
+   * Wait until the condition is met or timeout.
+   * @param condition condition to check
+   * @param intervalMs interval to check the condition
+   * @param timeoutMs timeout
+   * @return true if the condition is met before timeout, false otherwise
+   * @throws InterruptedException
+   */
+  public static boolean waitForUntilTimeout(Supplier<Boolean> condition,
+      long intervalMs, long timeoutMs) throws InterruptedException {
+    long startTime = System.currentTimeMillis();
+    while (!condition.get()) {
+      long elapsedTime = System.currentTimeMillis() - startTime;
+      if (elapsedTime > timeoutMs) {
+        return false;
+      }
+      long remainingTime = timeoutMs - elapsedTime;
+      Thread.sleep(Math.min(intervalMs, remainingTime > 0 ? remainingTime : 0));
+    }
+    return true;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestUtils.java
@@ -54,7 +54,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -486,27 +485,5 @@ public class TestUtils {
 
     cs.submitResourceCommitRequest(clusterResource,
         csAssignment);
-  }
-
-  /**
-   * Wait until the condition is met or timeout.
-   * @param condition condition to check
-   * @param intervalMs interval to check the condition
-   * @param timeoutMs timeout
-   * @return true if the condition is met before timeout, false otherwise
-   * @throws InterruptedException
-   */
-  public static boolean waitForUntilTimeout(Supplier<Boolean> condition,
-      long intervalMs, long timeoutMs) throws InterruptedException {
-    long startTime = System.currentTimeMillis();
-    while (!condition.get()) {
-      long elapsedTime = System.currentTimeMillis() - startTime;
-      if (elapsedTime > timeoutMs) {
-        return false;
-      }
-      long remainingTime = timeoutMs - elapsedTime;
-      Thread.sleep(Math.min(intervalMs, remainingTime > 0 ? remainingTime : 0));
-    }
-    return true;
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Handle uncaught exception for async-scheduling threads to prevent scheduler hangs.

### How was this patch tested?

Includes 2 unit tests:
(1) HA-disabled: RM should be shutdown after async-scheduling thread exit.
(2) HA-enabled: RM1 should be transitioned from active to standby after async-scheduling thread exit, and this RM should work once it is activated again.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

