### PR TITLE
Revert "HADOOP-19298. [JDK17] Add a JDK17 profile."

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -2754,16 +2754,6 @@
         </dependencies>
       </dependencyManagement>
     </profile>
-    <!-- We added this profile to support compilation for JDK 9 and above. -->
-    <profile>
-      <id>java9</id>
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <properties>
-        <maven.compiler.release>${javac.version}</maven.compiler.release>
-      </properties>
-    </profile>
   </profiles>
 
   <repositories>


### PR DESCRIPTION
Reverts apache/hadoop#7085

During the upgrade process, we found that the use of `sun.misc` has not been replaced, which has led to compilation errors. We need to wait until `sun.misc` is replaced before proceeding with the upgrade.

```
hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/FastByteComparisons.java
hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/nativeio/NativeIO.java
hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/service/launcher/IrqHandler.java
hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalLogger.java
hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/ShortCircuitShm.java
```