### PR TITLE
HADOOP-19322. Upgrade hadoop3 docker scripts to 3.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM apache/hadoop-runner
-ARG HADOOP_URL=https://dlcdn.apache.org/hadoop/common/hadoop-3.3.6/hadoop-3.3.6.tar.gz
+ARG HADOOP_URL=https://dlcdn.apache.org/hadoop/common/hadoop-3.4.0/hadoop-3.4.0.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && curl -LSs -o hadoop.tar.gz $HADOOP_URL && tar zxf hadoop.tar.gz && rm hadoop.tar.gz && mv hadoop* hadoop && rm -rf /opt/hadoop/share/doc
 WORKDIR /opt/hadoop

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM apache/hadoop-runner
-ARG HADOOP_URL=https://dlcdn.apache.org/hadoop/common/hadoop-3.4.0/hadoop-3.4.0.tar.gz
+ARG HADOOP_URL=https://dlcdn.apache.org/hadoop/common/hadoop-3.4.1/hadoop-3.4.1.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && curl -LSs -o hadoop.tar.gz $HADOOP_URL && tar zxf hadoop.tar.gz && rm hadoop.tar.gz && mv hadoop* hadoop && rm -rf /opt/hadoop/share/doc
 WORKDIR /opt/hadoop

--- a/build.sh
+++ b/build.sh
@@ -24,4 +24,4 @@ if [ ! -d "$DIR/build/apache-rat-0.15" ]; then
 	cd -
 fi
 java -jar $DIR/build/apache-rat-0.15/apache-rat-0.15.jar $DIR -e public -e apache-rat-0.15 -e .git -e .gitignore
-docker build -t apache/hadoop:3 .
+docker build -t apache/hadoop:3.4 -t apache/hadoop:3.4.0 .


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Update `Dockerfile` to Hadoop 3.4.1.
- Bump Apache Rat to current version, improving download logic to reduce future change when Rat needs to be upgraded next time.
- Change local tag in `build.sh` to `apache/hadoop:dev`.  This allows testing the image locally without overwriting the local copy of the official image.  It does not affect the tag used by automated build in Docker Hub.

https://issues.apache.org/jira/browse/HADOOP-19322

## How was this patch tested?

```
$ ./build.sh
...
 => => writing image sha256:78efe28a57c53aff668629b2af5f87a48121378dd4bbf3752a483cddb458be93
 => => naming to docker.io/apache/hadoop:dev

$ docker run -it --rm apache/hadoop:dev hadoop version
Hadoop 3.4.1
Source code repository https://github.com/apache/hadoop.git -r 4d7825309348956336b8f06a08322b78422849b1
Compiled by mthakur on 2024-10-09T14:57Z
Compiled on platform linux-x86_64
Compiled with protoc 3.23.4
From source with checksum 7292fe9dba5e2e44e3a9f763fce3e680
This command was run using /opt/hadoop/share/hadoop/common/hadoop-common-3.4.1.jar
```