### PR TITLE
HDFS-17550. EC: Support decommissioning DataNode by EC block reconstruction.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1023,6 +1023,9 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       "dfs.namenode.decommission.backoff.monitor.pending.blocks.per.lock";
   public static final int DFS_NAMENODE_DECOMMISSION_BACKOFF_MONITOR_PENDING_BLOCKS_PER_LOCK_DEFAULT
       = 1000;
+  public static final String DFS_NAMENODE_DECOMMISSION_EC_RECONSTRUCTION_ENABLE =
+      "dfs.namenode.decommission.ec.reconstruction.enable";
+  public static final boolean DFS_NAMENODE_DECOMMISSION_EC_RECONSTRUCTION_ENABLE_DEFAULT = false;
   public static final String  DFS_NAMENODE_HANDLER_COUNT_KEY = "dfs.namenode.handler.count";
   public static final int     DFS_NAMENODE_HANDLER_COUNT_DEFAULT = 10;
   public static final String  DFS_NAMENODE_LIFELINE_HANDLER_RATIO_KEY =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -2310,7 +2310,8 @@ public class BlockManager implements BlockStatsMXBean {
       byte[] newIndices = new byte[liveBlockIndices.size()];
       adjustSrcNodesAndIndices((BlockInfoStriped)block,
           srcNodes, liveBlockIndices, newSrcNodes, newIndices);
-      byte[] liveAndDecommissioningBusyIndices = new byte[liveAndDecommissioningBusyBlockIndices.size()];
+      byte[] liveAndDecommissioningBusyIndices =
+          new byte[liveAndDecommissioningBusyBlockIndices.size()];
       for (int i = 0; i < liveAndDecommissioningBusyBlockIndices.size(); i++) {
         liveAndDecommissioningBusyIndices[i] = liveAndDecommissioningBusyBlockIndices.get(i);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
@@ -351,6 +351,10 @@ public class DataNodeMetrics {
     blocksReplicated.incr();
   }
 
+  public long getBlocksReplicated() {
+    return blocksReplicated.value();
+  }
+
   public void incrBlocksWritten() {
     blocksWritten.incr();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
@@ -584,6 +584,10 @@ public class DataNodeMetrics {
     ecReconstructionTasks.incr();
   }
 
+  public long getECReconstructionTasks() {
+    return ecReconstructionTasks.value();
+  }
+
   public void incrECFailedReconstructionTasks() {
     ecFailedReconstructionTasks.incr();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -1233,6 +1233,14 @@
   </description>
 </property>
 
+  <property>
+    <name>dfs.namenode.decommission.ec.reconstruction.enable</name>
+    <value>false</value>
+    <description>
+      Whether to use reconstruction to copy ec block when the related node is busy.
+    </description>
+  </property>
+
 <property>
   <name>dfs.namenode.redundancy.interval.seconds</name>
   <value>3</value>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithStriped.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithStriped.java
@@ -63,7 +63,6 @@ import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.hadoop.util.Lists;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -1215,7 +1214,7 @@ public class TestDecommissionWithStriped {
     assertTrue(newStorageInfos.size() >= 2);
     DatanodeStorageInfo decommissionedNode = null;
     int alive = 0;
-    for (int i = 0; i < newStorageInfos.size();i ++) {
+    for (int i = 0; i < newStorageInfos.size(); i++) {
       DatanodeStorageInfo datanodeStorageInfo = newStorageInfos.get(i);
       if (datanodeStorageInfo.getDatanodeDescriptor().isDecommissioned()) {
         decommissionedNode = datanodeStorageInfo;
@@ -1286,7 +1285,7 @@ public class TestDecommissionWithStriped {
     assertTrue(newStorageInfos.size() >= 4);
     int alive = 0;
     int decommissioned = 0;
-    for (int i = 0; i < newStorageInfos.size();i ++) {
+    for (int i = 0; i < newStorageInfos.size(); i++) {
       DatanodeStorageInfo newDatanodeStorageInfo = newStorageInfos.get(i);
       if (newDatanodeStorageInfo.getDatanodeDescriptor().isDecommissioned()) {
         assertTrue(newDatanodeStorageInfo.equals(storageInfos.get(0)) ||

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithStriped.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommissionWithStriped.java
@@ -63,6 +63,7 @@ import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.util.Lists;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -1159,9 +1160,9 @@ public class TestDecommissionWithStriped {
   }
 
   @Test(timeout = 120000)
-  public void testDecommissionBusyNodeWithErasureCodeWorkBackOff() throws Exception {
+  public void testDecommissionBusyNodeWithECReconstruction1() throws Exception {
     bm.setDecommissionECReconstruction(false);
-    byte index = 6;
+    byte[] indices = new byte[]{6};
     // 1 create EC file
     final Path ecFile = new Path(ecDir, "testDecommission2NodeWithBusyNode");
     int writeBytes = cellSize * dataBlocks;
@@ -1175,16 +1176,13 @@ public class TestDecommissionWithStriped {
         cluster.getNamesystem().getFSDirectory().getINode4Write(ecFile.toString()).asFile();
     BlockInfo firstBlock = fileNode.getBlocks()[0];
     List<DatanodeStorageInfo> storageInfos =
-        getStorageInfoForBlockIndex((BlockInfoStriped) firstBlock, index);
+        getStorageInfoForBlockIndex((BlockInfoStriped) firstBlock, indices);
     assertEquals(1, storageInfos.size());
     DatanodeDescriptor busyNode = storageInfos.get(0).getDatanodeDescriptor();
     for (int j = 0; j < replicationStreamsHardLimit; j++) {
       busyNode.incrementPendingReplicationWithoutTargets();
     }
-    List<DatanodeStorageInfo> datanodeStorageInfos =
-        getStorageInfoForBlockIndex((BlockInfoStriped) firstBlock, index);
-    assertEquals(1, datanodeStorageInfos.size());
-    DatanodeStorageInfo toDecommissionStorage = datanodeStorageInfos.get(0);
+    DatanodeStorageInfo toDecommissionStorage = storageInfos.get(0);
 
     // 3 decommissioning one datanode
     List<DatanodeInfo> decommissionNodes = new ArrayList<>();
@@ -1203,17 +1201,22 @@ public class TestDecommissionWithStriped {
     decommissionNode(0, decommissionNodes, AdminStates.DECOMMISSIONED);
     assertEquals(9, bm.countNodes(firstBlock).liveReplicas());
     assertEquals(1, bm.countNodes(firstBlock).decommissioned());
+    assertEquals(0, cluster.getDataNodes().stream()
+        .mapToLong(dn -> dn.getMetrics().getBlocksReplicated()).sum());
     assertTrue(cluster.getDataNodes().stream()
         .mapToLong(dn -> dn.getMetrics().getECReconstructionTasks()).sum() > 0);
 
+    // 6 Get getBlocks again, verity that the decommissioned index already has a LIVE replica,
+    // and confirm verify the DECOMMISSIONED replica is the previously offline replica
     fileNode = cluster.getNamesystem().getFSDirectory().getINode(ecFile.toString()).asFile();
     firstBlock = fileNode.getBlocks()[0];
-    datanodeStorageInfos = getStorageInfoForBlockIndex((BlockInfoStriped) firstBlock, index);
-    assertTrue(datanodeStorageInfos.size() >= 2);
+    List<DatanodeStorageInfo> newStorageInfos =
+        getStorageInfoForBlockIndex((BlockInfoStriped) firstBlock, indices);
+    assertTrue(newStorageInfos.size() >= 2);
     DatanodeStorageInfo decommissionedNode = null;
     int alive = 0;
-    for (int i = 0; i < datanodeStorageInfos.size();i ++) {
-      DatanodeStorageInfo datanodeStorageInfo = datanodeStorageInfos.get(i);
+    for (int i = 0; i < newStorageInfos.size();i ++) {
+      DatanodeStorageInfo datanodeStorageInfo = newStorageInfos.get(i);
       if (datanodeStorageInfo.getDatanodeDescriptor().isDecommissioned()) {
         decommissionedNode = datanodeStorageInfo;
       } else if (datanodeStorageInfo.getDatanodeDescriptor().isAlive()) {
@@ -1224,9 +1227,81 @@ public class TestDecommissionWithStriped {
     assertEquals(toDecommissionStorage, decommissionedNode);
     assertTrue(alive >= 1);
 
-    // 6  check the checksum of a file
+    // 7  check the checksum of a file
     FileChecksum fileChecksum2 = dfs.getFileChecksum(ecFile, writeBytes);
     Assert.assertEquals("Checksum mismatches!", fileChecksum1, fileChecksum2);
+
+    // 8 check the data is correct
+    StripedFileTestUtil.checkData(dfs, ecFile, writeBytes, decommissionNodes,
+        null, blockGroupSize);
+  }
+
+  @Test(timeout = 120000)
+  public void testDecommissionBusyNodeWithECReconstruction2() throws Exception {
+    bm.setDecommissionECReconstruction(false);
+    byte[] indices = new byte[]{5, 6};
+    // 1 create EC file
+    final Path ecFile = new Path(ecDir, "testDecommission2NodeWithBusyNode");
+    int writeBytes = cellSize * dataBlocks;
+    writeStripedFile(dfs, ecFile, writeBytes);
+
+    assertEquals(0, bm.numOfUnderReplicatedBlocks());
+    FileChecksum fileChecksum1 = dfs.getFileChecksum(ecFile, writeBytes);
+
+    // 2 make one datanode busy
+    INodeFile fileNode =
+        cluster.getNamesystem().getFSDirectory().getINode4Write(ecFile.toString()).asFile();
+    BlockInfo firstBlock = fileNode.getBlocks()[0];
+    List<DatanodeStorageInfo> storageInfos =
+        getStorageInfoForBlockIndex((BlockInfoStriped) firstBlock, indices);
+    assertEquals(2, storageInfos.size());
+    DatanodeDescriptor busyNode = storageInfos.get(0).getDatanodeDescriptor();
+    for (int j = 0; j < replicationStreamsHardLimit; j++) {
+      busyNode.incrementPendingReplicationWithoutTargets();
+    }
+
+    // 3 decommissioning two datanode
+    List<DatanodeInfo> decommissionNodes = new ArrayList<>();
+    decommissionNodes.add(storageInfos.get(0).getDatanodeDescriptor());
+    decommissionNodes.add(storageInfos.get(1).getDatanodeDescriptor());
+    decommissionNode(0, decommissionNodes, AdminStates.DECOMMISSION_INPROGRESS);
+
+    // 4 Verify that the non-busy replica has been copied and the busy replica is
+    // reconstructed after decommissionECReconstruction is enabled.
+    bm.setDecommissionECReconstruction(true);
+    decommissionNode(0, decommissionNodes, AdminStates.DECOMMISSIONED);
+    assertEquals(9, bm.countNodes(firstBlock).liveReplicas());
+    assertEquals(2, bm.countNodes(firstBlock).decommissioned());
+    assertTrue(cluster.getDataNodes().stream()
+        .mapToLong(dn -> dn.getMetrics().getBlocksReplicated()).sum() > 0);
+    assertTrue(cluster.getDataNodes().stream()
+        .mapToLong(dn -> dn.getMetrics().getECReconstructionTasks()).sum() > 0);
+
+    // 5 Get getBlocks again, verity that the decommissioned index already has a LIVE replica,
+    // and confirm verify the DECOMMISSIONED replica is the previously offline replica
+    fileNode = cluster.getNamesystem().getFSDirectory().getINode(ecFile.toString()).asFile();
+    firstBlock = fileNode.getBlocks()[0];
+    List<DatanodeStorageInfo> newStorageInfos =
+        getStorageInfoForBlockIndex((BlockInfoStriped) firstBlock, indices);
+    assertTrue(newStorageInfos.size() >= 4);
+    int alive = 0;
+    int decommissioned = 0;
+    for (int i = 0; i < newStorageInfos.size();i ++) {
+      DatanodeStorageInfo newDatanodeStorageInfo = newStorageInfos.get(i);
+      if (newDatanodeStorageInfo.getDatanodeDescriptor().isDecommissioned()) {
+        assertTrue(newDatanodeStorageInfo.equals(storageInfos.get(0)) ||
+            newDatanodeStorageInfo.equals(storageInfos.get(1)));
+        decommissioned++;
+      } else if (newDatanodeStorageInfo.getDatanodeDescriptor().isAlive()) {
+        alive++;
+      }
+    }
+    assertTrue(alive >= 2);
+    assertEquals(2, decommissioned);
+
+    // 6  check the checksum of a file
+    FileChecksum fileChecksum2 = dfs.getFileChecksum(ecFile, writeBytes);
+    assertEquals("Checksum mismatches!", fileChecksum1, fileChecksum2);
 
     // 7 check the data is correct
     StripedFileTestUtil.checkData(dfs, ecFile, writeBytes, decommissionNodes,
@@ -1234,14 +1309,16 @@ public class TestDecommissionWithStriped {
   }
 
   private List<DatanodeStorageInfo> getStorageInfoForBlockIndex(BlockInfoStriped block,
-                                                                int blockIndex) {
+      byte[] blockIndices) {
     List<DatanodeStorageInfo> storageInfos = new ArrayList<>();
     Iterator<BlockInfoStriped.StorageAndBlockIndex> iterator =
         block.getStorageAndIndexInfos().iterator();
     while (iterator.hasNext()) {
       BlockInfoStriped.StorageAndBlockIndex storageAndBlockIndex = iterator.next();
-      if (storageAndBlockIndex.getBlockIndex() == blockIndex) {
-        storageInfos.add(storageAndBlockIndex.getStorage());
+      for (int blockIndex : blockIndices) {
+        if (storageAndBlockIndex.getBlockIndex() == blockIndex) {
+          storageInfos.add(storageAndBlockIndex.getStorage());
+        }
       }
     }
     return storageInfos;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -39,6 +39,7 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_DEFAUL
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_IMAGE_PARALLEL_LOAD_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_BLOCKPLACEMENTPOLICY_MIN_BLOCKS_FOR_WRITE_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_EC_RECONSTRUCTION_ENABLE;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_HEARTBEAT_RECHECK_INTERVAL_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_BLOCK_PLACEMENT_EC_CLASSNAME_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_BLOCK_REPLICATOR_CLASSNAME_KEY;
@@ -444,7 +445,7 @@ public class TestDFSAdmin {
     final List<String> outs = Lists.newArrayList();
     final List<String> errs = Lists.newArrayList();
     getReconfigurableProperties("namenode", address, outs, errs);
-    assertEquals(29, outs.size());
+    assertEquals(30, outs.size());
     assertTrue(outs.get(0).contains("Reconfigurable properties:"));
     assertEquals(DFS_BLOCK_INVALIDATE_LIMIT_KEY, outs.get(1));
     assertEquals(DFS_BLOCK_PLACEMENT_EC_CLASSNAME_KEY, outs.get(2));
@@ -458,8 +459,9 @@ public class TestDFSAdmin {
     assertEquals(DFS_NAMENODE_BLOCKPLACEMENTPOLICY_MIN_BLOCKS_FOR_WRITE_KEY, outs.get(10));
     assertEquals(DFS_NAMENODE_DECOMMISSION_BACKOFF_MONITOR_PENDING_BLOCKS_PER_LOCK, outs.get(11));
     assertEquals(DFS_NAMENODE_DECOMMISSION_BACKOFF_MONITOR_PENDING_LIMIT, outs.get(12));
-    assertEquals(DFS_NAMENODE_HEARTBEAT_RECHECK_INTERVAL_KEY, outs.get(13));
-    assertEquals(DFS_NAMENODE_LOCK_DETAILED_METRICS_KEY, outs.get(14));
+    assertEquals(DFS_NAMENODE_DECOMMISSION_EC_RECONSTRUCTION_ENABLE, outs.get(13));
+    assertEquals(DFS_NAMENODE_HEARTBEAT_RECHECK_INTERVAL_KEY, outs.get(14));
+    assertEquals(DFS_NAMENODE_LOCK_DETAILED_METRICS_KEY, outs.get(15));
     assertEquals(errs.size(), 0);
   }
 


### PR DESCRIPTION

### Description of PR

By enabling reconstruction to decommissioning datanode, the speed increased by 12 times on a small-scale cluster with only 100 machines dedicated to storing EC data. I think in prodcution cluster with thousands of clusters, there will be hundreds of times growth.


### How was this patch tested?

unit test and test in cluster

### For code changes:

- [x] Support decommissioning DataNode by EC block reconstruction.
- [x] `liveBusyBlockIndices` rename to `liveAndDecommissioningBusyIndices`.
- [x] remove `excludeReconstructedIndices` which is duplicate with `liveAndDecommissioningBusyIndices`
- [x] add new `liveAndDecommissioningBusyIndices` which is used when reconstruct the busy decommissioning block.

