### PR TITLE
YARN-11738 Modernize SecretManager config

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -1006,7 +1006,7 @@ public class CommonConfigurationKeysPublic {
       "hadoop.security.credstore.java-keystore-provider.password-file";
 
   public static final String HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_KEY =
-    "secret-manager.key-generator.algorith";
+    "secret-manager.key-generator.algorithm";
   public static final String HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_DEFAULT =
     "HmacSHA1";
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -1005,21 +1005,14 @@ public class CommonConfigurationKeysPublic {
   public static final String  HADOOP_SECURITY_CREDENTIAL_PASSWORD_FILE_KEY =
       "hadoop.security.credstore.java-keystore-provider.password-file";
 
-  /**
-   * @see
-   * <a href="{@docRoot}/../hadoop-project-dist/hadoop-common/core-default.xml">
-   * core-default.xml</a>
-   */
-  public static final String HMAC_ALGORITHM = "hadoop.security.hmac-algorithm";
-  public static final String DEFAULT_HMAC_ALGORITHM = "HmacSHA1";
+  public static final String HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_KEY =
+    "secret-manager.key-generator.algorith";
+  public static final String HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_DEFAULT =
+    "HmacSHA1";
 
-  /**
-   * @see
-   * <a href="{@docRoot}/../hadoop-project-dist/hadoop-common/core-default.xml">
-   * core-default.xml</a>
-   */
-  public static final String HMAC_LENGTH = "hadoop.security.hmac-length";
-  public static final int DEFAULT_HMAC_LENGTH = 64;
+  public static final String HADOOP_SECURITY_SECRET_MANAGER_KEY_LENGTH_KEY =
+    "hadoop.security.secret-manager.key-length";
+  public static final int HADOOP_SECURITY_SECRET_MANAGER_KEY_LENGTH_DEFAULT = 64;
 
   /**
    * @see

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -1006,7 +1006,7 @@ public class CommonConfigurationKeysPublic {
       "hadoop.security.credstore.java-keystore-provider.password-file";
 
   public static final String HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_KEY =
-    "secret-manager.key-generator.algorithm";
+    "hadoop.security.secret-manager.key-generator.algorithm";
   public static final String HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_DEFAULT =
     "HmacSHA1";
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -1010,6 +1010,22 @@ public class CommonConfigurationKeysPublic {
    * <a href="{@docRoot}/../hadoop-project-dist/hadoop-common/core-default.xml">
    * core-default.xml</a>
    */
+  public static final String HMAC_ALGORITHM = "hadoop.security.hmac-algorithm";
+  public static final String DEFAULT_HMAC_ALGORITHM = "HmacSHA1";
+
+  /**
+   * @see
+   * <a href="{@docRoot}/../hadoop-project-dist/hadoop-common/core-default.xml">
+   * core-default.xml</a>
+   */
+  public static final String HMAC_LENGTH = "hadoop.security.hmac-length";
+  public static final int DEFAULT_HMAC_LENGTH = 64;
+
+  /**
+   * @see
+   * <a href="{@docRoot}/../hadoop-project-dist/hadoop-common/core-default.xml">
+   * core-default.xml</a>
+   */
   public static final String HADOOP_SECURITY_SENSITIVE_CONFIG_KEYS =
       "hadoop.security.sensitive-config-keys";
   public static final String HADOOP_SECURITY_SENSITIVE_CONFIG_KEYS_DEFAULT =

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/SecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/SecretManager.java
@@ -27,8 +27,13 @@ import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.ipc.StandbyException;
 
@@ -40,6 +45,8 @@ import org.apache.hadoop.ipc.StandbyException;
 @InterfaceAudience.Public
 @InterfaceStability.Evolving
 public abstract class SecretManager<T extends TokenIdentifier> {
+
+  public static final Logger LOG = LoggerFactory.getLogger(SecretManager.class);
   /**
    * The token was invalid and the message explains why.
    */
@@ -107,16 +114,23 @@ public abstract class SecretManager<T extends TokenIdentifier> {
   public void checkAvailableForRead() throws StandbyException {
     // Default to being available for read.
   }
-  
-  /**
-   * The name of the hashing algorithm.
-   */
-  private static final String DEFAULT_HMAC_ALGORITHM = "HmacSHA1";
 
-  /**
-   * The length of the random keys to use.
-   */
-  private static final int KEY_LENGTH = 64;
+  private static final String SELECTED_ALGORITHM;
+  private static final int SELECTED_LENGTH;
+
+  static {
+    Configuration conf = new Configuration();
+    String algorithm = conf.get(
+      CommonConfigurationKeysPublic.HMAC_ALGORITHM,
+      CommonConfigurationKeysPublic.DEFAULT_HMAC_ALGORITHM);
+    LOG.info("Selected hash algorithm: {}", algorithm);
+    SELECTED_ALGORITHM = algorithm;
+    int length = conf.getInt(
+      CommonConfigurationKeysPublic.HMAC_LENGTH,
+      CommonConfigurationKeysPublic.DEFAULT_HMAC_LENGTH);
+    LOG.info("Selected hash key length:{}", length);
+    SELECTED_LENGTH = length;
+  }
 
   /**
    * A thread local store for the Macs.
@@ -126,10 +140,9 @@ public abstract class SecretManager<T extends TokenIdentifier> {
     @Override
     protected Mac initialValue() {
       try {
-        return Mac.getInstance(DEFAULT_HMAC_ALGORITHM);
+        return Mac.getInstance(SELECTED_ALGORITHM);
       } catch (NoSuchAlgorithmException nsa) {
-        throw new IllegalArgumentException("Can't find " + DEFAULT_HMAC_ALGORITHM +
-                                           " algorithm.");
+        throw new IllegalArgumentException("Can't find " + SELECTED_ALGORITHM + " algorithm.");
       }
     }
   };
@@ -140,11 +153,10 @@ public abstract class SecretManager<T extends TokenIdentifier> {
   private final KeyGenerator keyGen;
   {
     try {
-      keyGen = KeyGenerator.getInstance(DEFAULT_HMAC_ALGORITHM);
-      keyGen.init(KEY_LENGTH);
+      keyGen = KeyGenerator.getInstance(SELECTED_ALGORITHM);
+      keyGen.init(SELECTED_LENGTH);
     } catch (NoSuchAlgorithmException nsa) {
-      throw new IllegalArgumentException("Can't find " + DEFAULT_HMAC_ALGORITHM +
-      " algorithm.");
+      throw new IllegalArgumentException("Can't find " + SELECTED_ALGORITHM + " algorithm.");
     }
   }
 
@@ -185,6 +197,6 @@ public abstract class SecretManager<T extends TokenIdentifier> {
    * @return the secret key
    */
   protected static SecretKey createSecretKey(byte[] key) {
-    return new SecretKeySpec(key, DEFAULT_HMAC_ALGORITHM);
+    return new SecretKeySpec(key, SELECTED_ALGORITHM);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/SecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/SecretManager.java
@@ -121,13 +121,13 @@ public abstract class SecretManager<T extends TokenIdentifier> {
   static {
     Configuration conf = new Configuration();
     String algorithm = conf.get(
-      CommonConfigurationKeysPublic.HMAC_ALGORITHM,
-      CommonConfigurationKeysPublic.DEFAULT_HMAC_ALGORITHM);
+      CommonConfigurationKeysPublic.HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_KEY,
+      CommonConfigurationKeysPublic.HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_DEFAULT);
     LOG.info("Selected hash algorithm: {}", algorithm);
     SELECTED_ALGORITHM = algorithm;
     int length = conf.getInt(
-      CommonConfigurationKeysPublic.HMAC_LENGTH,
-      CommonConfigurationKeysPublic.DEFAULT_HMAC_LENGTH);
+      CommonConfigurationKeysPublic.HADOOP_SECURITY_SECRET_MANAGER_KEY_LENGTH_KEY,
+      CommonConfigurationKeysPublic.HADOOP_SECURITY_SECRET_MANAGER_KEY_LENGTH_DEFAULT);
     LOG.info("Selected hash key length:{}", length);
     SELECTED_LENGTH = length;
   }
@@ -142,7 +142,7 @@ public abstract class SecretManager<T extends TokenIdentifier> {
       try {
         return Mac.getInstance(SELECTED_ALGORITHM);
       } catch (NoSuchAlgorithmException nsa) {
-        throw new IllegalArgumentException("Can't find " + SELECTED_ALGORITHM + " algorithm.");
+        throw new IllegalArgumentException("Can't find " + SELECTED_ALGORITHM, nsa);
       }
     }
   };
@@ -156,7 +156,7 @@ public abstract class SecretManager<T extends TokenIdentifier> {
       keyGen = KeyGenerator.getInstance(SELECTED_ALGORITHM);
       keyGen.init(SELECTED_LENGTH);
     } catch (NoSuchAlgorithmException nsa) {
-      throw new IllegalArgumentException("Can't find " + SELECTED_ALGORITHM + " algorithm.");
+      throw new IllegalArgumentException("Can't find " + SELECTED_ALGORITHM, nsa);
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1047,7 +1047,7 @@
 </property>
 
 <property>
-  <name>secret-manager.key-generator.algorith</name>
+  <name>secret-manager.key-generator.algorithm</name>
   <value>HmacSHA1</value>
   <description>
     The configuration key specifying the KeyGenerator algorithm used in SecretManager

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1046,6 +1046,32 @@
   </description>
 </property>
 
+<property>
+  <name>hadoop.security.hmac-algorithm</name>
+  <value>HmacSHA1</value>
+  <description>The configuration key specifying the hashing algorithm used for
+    HMAC (Hash-based Message Authentication Code) operations.
+
+    The HMAC algorithm is used in token management to compute secure
+    message digests. This configuration allows users to specify the
+    algorithm to be used for HMAC operations. The algorithm must be a
+    valid cryptographic hash algorithm supported by the Java Cryptography
+    Architecture (JCA). Common examples include "HmacSHA1", "HmacSHA256",
+    and "HmacSHA512".</description>
+</property>
+
+<property>
+  <name>hadoop.security.hmac-length</name>
+  <value>64</value>
+  <description>The configuration key specifying the key length for HMAC (Hash-based
+    Message Authentication Code) operations.
+
+    This property determines the size of the secret keys generated
+    for HMAC computations. The key length must be appropriate for the
+    selected HMAC algorithm. For example, longer keys are generally
+    more secure but may not be supported by all algorithms.</description>
+</property>
+
   <!-- file system properties -->
 
 <property>

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1047,7 +1047,7 @@
 </property>
 
 <property>
-  <name>secret-manager.key-generator.algorithm</name>
+  <name>hadoop.security.secret-manager.key-generator.algorithm</name>
   <value>HmacSHA1</value>
   <description>
     The configuration key specifying the KeyGenerator algorithm used in SecretManager

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1047,29 +1047,25 @@
 </property>
 
 <property>
-  <name>hadoop.security.hmac-algorithm</name>
+  <name>secret-manager.key-generator.algorith</name>
   <value>HmacSHA1</value>
-  <description>The configuration key specifying the hashing algorithm used for
-    HMAC (Hash-based Message Authentication Code) operations.
-
-    The HMAC algorithm is used in token management to compute secure
-    message digests. This configuration allows users to specify the
-    algorithm to be used for HMAC operations. The algorithm must be a
-    valid cryptographic hash algorithm supported by the Java Cryptography
-    Architecture (JCA). Common examples include "HmacSHA1", "HmacSHA256",
-    and "HmacSHA512".</description>
+  <description>
+    The configuration key specifying the KeyGenerator algorithm used in SecretManager
+    for generating secret keys. The algorithm must be a KeyGenerator algorithm supported by
+    the Java Cryptography Architecture (JCA). Common examples include "HmacSHA1",
+    "HmacSHA256", and "HmacSHA512".
+  </description>
 </property>
 
 <property>
-  <name>hadoop.security.hmac-length</name>
+  <name>hadoop.security.secret-manager.key-length</name>
   <value>64</value>
-  <description>The configuration key specifying the key length for HMAC (Hash-based
-    Message Authentication Code) operations.
-
-    This property determines the size of the secret keys generated
-    for HMAC computations. The key length must be appropriate for the
-    selected HMAC algorithm. For example, longer keys are generally
-    more secure but may not be supported by all algorithms.</description>
+  <description>
+    The configuration key specifying the key length of the generated secret keys
+    in SecretManager. The key length must be appropriate for the algorithm.
+    For example, longer keys are generally more secure but may not be supported
+    by all algorithms.
+  </description>
 </property>
 
   <!-- file system properties -->

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/security/TestNMTokenSecretManagerInNM.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/security/TestNMTokenSecretManagerInNM.java
@@ -60,6 +60,8 @@ public class TestNMTokenSecretManagerInNM {
     secretMgr.setNodeId(nodeId);
     MasterKey currentKey = keygen.generateKey();
     secretMgr.setMasterKey(currentKey);
+    // check key is 64 bit long (8 byte)
+    assertEquals(8, currentKey.getBytes().array().length);
     NMTokenIdentifier attemptToken1 =
         getNMTokenId(secretMgr.createNMToken(attempt1, nodeId, "user1"));
     NMTokenIdentifier attemptToken2 =


### PR DESCRIPTION
### Description of PR

YARN-11738

Make hash algorithm at SecretManager configurable.
- **hadoop.security.secret-manager.key-generator.algorithm**: The name of the hashing algorithm. Default: HmacSHA1
- **hadoop.security.secret-manager.key-length**: The length of the random keys to use. Default: 64

### How was this patch tested?

- unit test modified
- deployed and run mapred PI example, while i modified the yarn-site.xml and mapred-site.xml with HmacSHA256 and 1024 key length
