### PR TITLE
HADOOP-19329. Remove usage of sun.misc.Signal

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -521,6 +521,11 @@ junit:junit:4.13.2
 org.jacoco:org.jacoco.agent:0.8.5
 
 
+Eclipse Public License 2.0
+--------------------------
+
+com.github.jnr:jnr-posix:3.1.20
+
 
 HSQL License
 ------------

--- a/hadoop-client-modules/hadoop-client-minicluster/pom.xml
+++ b/hadoop-client-modules/hadoop-client-minicluster/pom.xml
@@ -709,6 +709,7 @@
                       <exclude>org.bouncycastle:*</exclude>
                       <!-- Leave snappy that includes native methods which cannot be relocated. -->
                       <exclude>org.xerial.snappy:*</exclude>
+                      <exclude>com.github.jnr:*</exclude>
                     </excludes>
                   </artifactSet>
                   <filters>

--- a/hadoop-client-modules/hadoop-client-runtime/pom.xml
+++ b/hadoop-client-modules/hadoop-client-runtime/pom.xml
@@ -159,6 +159,7 @@
                       <exclude>org.xerial.snappy:*</exclude>
                       <!-- leave out kotlin classes -->
                       <exclude>org.jetbrains.kotlin:*</exclude>
+                      <exclude>com.github.jnr:*</exclude>
                     </excludes>
                   </artifactSet>
                   <filters>

--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -416,6 +416,11 @@
       <artifactId>lz4-java</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-posix</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/service/launcher/InterruptEscalator.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/service/launcher/InterruptEscalator.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import jnr.constants.platform.Signal;
 import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,7 +141,7 @@ public class InterruptEscalator implements IrqHandler.Interrupted {
    * @throws IllegalArgumentException if the registration failed
    */
   public synchronized void register(String signalName) {
-    IrqHandler handler = new IrqHandler(signalName, this);
+    IrqHandler handler = new IrqHandler(Signal.valueOf(signalName), this);
     handler.bind();
     interruptHandlers.add(handler);
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/service/launcher/IrqHandler.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/service/launcher/IrqHandler.java
@@ -20,11 +20,13 @@ package org.apache.hadoop.service.launcher;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import jnr.constants.platform.Signal;
+import jnr.posix.POSIX;
+import jnr.posix.POSIXFactory;
+import jnr.posix.SignalHandler;
 import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.misc.Signal;
-import sun.misc.SignalHandler;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -45,22 +47,18 @@ public final class IrqHandler implements SignalHandler {
   /**
    * Definition of the Control-C handler name: {@value}.
    */
-  public static final String CONTROL_C = "INT";
+  public static final String CONTROL_C = "SIGINT";
 
   /**
    * Definition of default <code>kill</code> signal: {@value}.
    */
-  public static final String SIGTERM = "TERM";
-
-  /**
-   * Signal name.
-   */
-  private final String name;
+  public static final String SIGTERM = "SIGTERM";
 
   /**
    * Handler to relay to.
    */
   private final Interrupted handler;
+  private static final POSIX POSIX_IMPL = POSIXFactory.getNativePOSIX();
 
   /** Count of how many times a signal has been raised. */
   private final AtomicInteger signalCount = new AtomicInteger(0);
@@ -72,14 +70,14 @@ public final class IrqHandler implements SignalHandler {
 
   /**
    * Create an IRQ handler bound to the specific interrupt.
-   * @param name signal name
+   * @param signal signal
    * @param handler handler
    */
-  public IrqHandler(String name, Interrupted handler) {
-    Preconditions.checkArgument(name != null, "Null \"name\"");
+  public IrqHandler(Signal signal, Interrupted handler) {
+    Preconditions.checkArgument(signal != null, "Null \"signal\"");
     Preconditions.checkArgument(handler != null, "Null \"handler\"");
     this.handler = handler;
-    this.name = name;
+    this.signal = signal;
   }
 
   /**
@@ -87,13 +85,11 @@ public final class IrqHandler implements SignalHandler {
    * @throws IllegalArgumentException if the exception could not be set
    */
   public void bind() {
-    Preconditions.checkState(signal == null, "Handler already bound");
     try {
-      signal = new Signal(name);
-      Signal.handle(signal, this);
+      POSIX_IMPL.signal(signal, this);
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
-          "Could not set handler for signal \"" + name + "\"."
+          "Could not set handler for signal \"" + signal + "\"."
           + "This can happen if the JVM has the -Xrs set.",
           e);
     }
@@ -103,29 +99,29 @@ public final class IrqHandler implements SignalHandler {
    * @return the signal name.
    */
   public String getName() {
-    return name;
+    return signal.name();
   }
 
   /**
    * Raise the signal.
    */
   public void raise() {
-    Signal.raise(signal);
+    POSIX_IMPL.kill(POSIX_IMPL.getpid(), signal.intValue());
   }
 
   @Override
   public String toString() {
-    return "IrqHandler for signal " + name;
+    return "IrqHandler for signal " + signal.name();
   }
 
   /**
    * Handler for the JVM API for signal handling.
-   * @param s signal raised
+   * @param signalNumber signal raised
    */
   @Override
-  public void handle(Signal s) {
+  public void handle(int signalNumber) {
     signalCount.incrementAndGet();
-    InterruptData data = new InterruptData(s.getName(), s.getNumber());
+    InterruptData data = new InterruptData(signal.name(), signalNumber);
     LOG.info("Interrupted: {}", data);
     handler.interrupted(data);
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalLogger.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalLogger.java
@@ -18,12 +18,16 @@
 
 package org.apache.hadoop.util;
 
+import jnr.constants.platform.Signal;
+import jnr.posix.POSIX;
+import jnr.posix.POSIXFactory;
+import jnr.posix.SignalHandler;
 import org.slf4j.Logger;
-import sun.misc.Signal;
-import sun.misc.SignalHandler;
-
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+
+import java.util.EnumSet;
+import java.util.Set;
 
 /**
  * This class logs a message whenever we're about to exit on a UNIX signal.
@@ -35,6 +39,10 @@ import org.apache.hadoop.classification.InterfaceStability;
 @InterfaceStability.Unstable
 public enum SignalLogger {
   INSTANCE;
+  private static final Set<Signal> SIGNALS =
+          EnumSet.of(Signal.SIGHUP, Signal.SIGINT, Signal.SIGTERM);
+  private static final POSIX POSIX_IMPL = POSIXFactory.getJavaPOSIX();
+  private static final SignalHandler DEFAULT_HANDLER = System::exit;
 
   private boolean registered = false;
 
@@ -45,9 +53,10 @@ public enum SignalLogger {
     final private Logger log;
     final private SignalHandler prevHandler;
 
-    Handler(String name, Logger log) {
+    Handler(Signal signal, Logger log) {
       this.log = log;
-      prevHandler = Signal.handle(new Signal(name), this);
+      SignalHandler handler = POSIX_IMPL.signal(signal, this);
+      prevHandler = handler != null ? handler : DEFAULT_HANDLER;
     }
 
     /**
@@ -56,9 +65,8 @@ public enum SignalLogger {
      * @param signal    The incoming signal
      */
     @Override
-    public void handle(Signal signal) {
-      log.error("RECEIVED SIGNAL " + signal.getNumber() +
-          ": SIG" + signal.getName());
+    public void handle(int signal) {
+      log.error("RECEIVED SIGNAL {}: {}", signal, Signal.valueOf(signal));
       prevHandler.handle(signal);
     }
   }
@@ -75,16 +83,15 @@ public enum SignalLogger {
     registered = true;
     StringBuilder bld = new StringBuilder();
     bld.append("registered UNIX signal handlers for [");
-    final String SIGNALS[] = { "TERM", "HUP", "INT" };
     String separator = "";
-    for (String signalName : SIGNALS) {
+    for (Signal signal : SIGNALS) {
       try {
-        new Handler(signalName, log);
+        new Handler(signal, log);
         bld.append(separator)
-            .append(signalName);
+            .append(signal.name());
         separator = ", ";
       } catch (Exception e) {
-        log.debug("Error: ", e);
+        log.info("Error installing UNIX signal handler for {}", signal, e);
       }
     }
     bld.append("]");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/service/launcher/TestServiceInterruptHandling.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/service/launcher/TestServiceInterruptHandling.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.service.launcher;
 
+import jnr.constants.platform.Signal;
 import org.apache.hadoop.service.BreakableService;
 import org.apache.hadoop.service.launcher.testservices.FailureTestService;
 import org.apache.hadoop.test.GenericTestUtils;
@@ -38,8 +39,8 @@ public class TestServiceInterruptHandling
   @Test
   public void testRegisterAndRaise() throws Throwable {
     InterruptCatcher catcher = new InterruptCatcher();
-    String name = "USR2";
-    IrqHandler irqHandler = new IrqHandler(name, catcher);
+    String name = "SIGINT";
+    IrqHandler irqHandler = new IrqHandler(Signal.valueOf(name), catcher);
     irqHandler.bind();
     assertEquals(0, irqHandler.getSignalCount());
     irqHandler.raise();
@@ -61,7 +62,7 @@ public class TestServiceInterruptHandling
 
     // call the interrupt operation directly
     try {
-      escalator.interrupted(new IrqHandler.InterruptData("INT", 3));
+      escalator.interrupted(new IrqHandler.InterruptData("SIGINT", 3));
       fail("Expected an exception to be raised in " + escalator);
     } catch (ExitUtil.ExitException e) {
       assertExceptionDetails(EXIT_INTERRUPTED, "", e);
@@ -75,7 +76,7 @@ public class TestServiceInterruptHandling
 
     // now interrupt it a second time and expect it to escalate to a halt
     try {
-      escalator.interrupted(new IrqHandler.InterruptData("INT", 3));
+      escalator.interrupted(new IrqHandler.InterruptData("SIGINT", 3));
       fail("Expected an exception to be raised in " + escalator);
     } catch (ExitUtil.HaltException e) {
       assertExceptionDetails(EXIT_INTERRUPTED, "", e);
@@ -93,7 +94,7 @@ public class TestServiceInterruptHandling
     InterruptEscalator escalator = new InterruptEscalator(launcher, 500);
     // call the interrupt operation directly
     try {
-      escalator.interrupted(new IrqHandler.InterruptData("INT", 3));
+      escalator.interrupted(new IrqHandler.InterruptData("SIGINT", 3));
       fail("Expected an exception to be raised from " + escalator);
     } catch (ExitUtil.ExitException e) {
       assertExceptionDetails(EXIT_INTERRUPTED, "", e);

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -222,7 +222,7 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
   final ClientProtocol namenode;
   /* The service used for delegation tokens */
   private Text dtService;
-
+  
   final UserGroupInformation ugi;
   volatile boolean clientRunning = true;
   volatile long lastLeaseRenewal;

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -238,6 +238,7 @@
     <yarnpkg.version>v1.22.5</yarnpkg.version>
     <apache-ant.version>1.10.13</apache-ant.version>
     <jmh.version>1.20</jmh.version>
+    <jnr.posix.version>3.1.20</jnr.posix.version>
   </properties>
 
   <dependencyManagement>
@@ -2146,6 +2147,11 @@
         <groupId>javax.cache</groupId>
         <artifactId>cache-api</artifactId>
         <version>${cache.api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.jnr</groupId>
+        <artifactId>jnr-posix</artifactId>
+        <version>${jnr.posix.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
@@ -86,6 +86,16 @@
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>javax-websocket-server-impl</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>asm-commons</artifactId>
+          <groupId>org.ow2.asm</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>asm-tree</artifactId>
+          <groupId>org.ow2.asm</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop.thirdparty</groupId>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: [HADOOP-19329](https://issues.apache.org/jira/browse/HADOOP-19329). Remove usage of sun.misc.Signal

Fix compilation errors during the upgrade process, because sun.misc is not supported after jdk11.

we replace sun.misc.Signal and sum.misc.SignalHandler using jnr-posix



### How was this patch tested?
exist ut test

### For code changes:

replace sun.misc.Signal and sum.misc.SignalHandler using jnr.constants.platform.Signal and jnr.posix.SignalHandler in jnr-posix

