### PR TITLE
YARN-11726: Add logging statements for successful and unsuccessful password retrieval operation

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
@@ -47,10 +47,9 @@ import org.apache.hadoop.yarn.webapp.BadRequestException;
 import org.apache.hadoop.yarn.webapp.NotFoundException;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
+import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.servlet.http.HttpServletRequest;
 
 @Private
 @Evolving
@@ -512,16 +511,14 @@ public class WebAppUtils {
       char[] passchars = conf.getPassword(alias);
       if (passchars != null) {
         password = new String(passchars);
-        LOG.info("Successful password retrieval for alias: {}", alias);
+        LOG.debug("Successful password retrival for alias: {}", alias);
+      } else {
+        LOG.warn("Password retrieval failed, no password found for alias: {}", alias);
       }
     }
     catch (IOException ioe) {
       password = null;
       LOG.error("Unable to retrieve password for alias: {}", alias, ioe);
-    }
-
-    if (password == null) {
-      LOG.error("Password does not exist for alias: {}", alias);
     }
 
     return password;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
@@ -512,13 +512,18 @@ public class WebAppUtils {
       char[] passchars = conf.getPassword(alias);
       if (passchars != null) {
         password = new String(passchars);
-        LOG.debug("Successful password retrieval for alias: {}", alias);
+        LOG.info("Successful password retrieval for alias: {}", alias);
       }
     }
     catch (IOException ioe) {
       password = null;
       LOG.error("Unable to retrieve password for alias: {}", alias, ioe);
     }
+
+    if (password == null) {
+      LOG.error("Password does not exist for alias: {}", alias);
+    }
+
     return password;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
@@ -47,6 +47,8 @@ import org.apache.hadoop.yarn.webapp.BadRequestException;
 import org.apache.hadoop.yarn.webapp.NotFoundException;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -61,6 +63,7 @@ public class WebAppUtils {
       "ssl.server.keystore.keypassword";
   public static final String HTTPS_PREFIX = "https://";
   public static final String HTTP_PREFIX = "http://";
+  public static final Logger LOG = LoggerFactory.getLogger(WebAppUtils.class);
 
   public static void setRMWebAppPort(Configuration conf, int port) {
     String hostname = getRMWebAppURLWithoutScheme(conf);
@@ -509,10 +512,12 @@ public class WebAppUtils {
       char[] passchars = conf.getPassword(alias);
       if (passchars != null) {
         password = new String(passchars);
+        LOG.debug("Successful password retrieval for alias: {}", alias);
       }
     }
     catch (IOException ioe) {
       password = null;
+      LOG.error("Unable to retrieve password for alias: {}", alias, ioe);
     }
     return password;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/util/TestWebAppUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/util/TestWebAppUtils.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.hadoop.yarn.util.TestBoundedAppender;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
 
 public class TestWebAppUtils {
   private static final String RM1_NODE_ID = "rm1";
@@ -107,6 +109,15 @@ public class TestWebAppUtils {
 
     // let's make sure that a password that doesn't exist returns null
     assertNull(WebAppUtils.getPassword(conf, "invalid-alias"));
+  }
+
+  @Test
+  void testGetPasswordIOException() throws Exception {
+    Configuration mockConf = Mockito.mock(Configuration.class);
+
+    when(mockConf.getPassword("error-alias")).thenThrow(new IOException("Simulated IO error"));
+
+    assertNull(WebAppUtils.getPassword(mockConf, "error-alias"));
   }
 
   @Test
@@ -186,7 +197,7 @@ public class TestWebAppUtils {
   void testAppendQueryParams() throws Exception {
     HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
     String targetUri = "/test/path";
-    Mockito.when(request.getCharacterEncoding()).thenReturn(null);
+    when(request.getCharacterEncoding()).thenReturn(null);
     Map<String, String> paramResultMap = new HashMap<>();
     paramResultMap.put("param1=x", targetUri + "?" + "param1=x");
     paramResultMap
@@ -195,7 +206,7 @@ public class TestWebAppUtils {
         targetUri + "?" + "param1=x&param2=y&param3=x+y");
 
     for (Map.Entry<String, String> entry : paramResultMap.entrySet()) {
-      Mockito.when(request.getQueryString()).thenReturn(entry.getKey());
+      when(request.getQueryString()).thenReturn(entry.getKey());
       String uri = WebAppUtils.appendQueryParams(request, targetUri);
       assertEquals(entry.getValue(), uri);
     }
@@ -205,8 +216,8 @@ public class TestWebAppUtils {
   void testGetHtmlEscapedURIWithQueryString() throws Exception {
     HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
     String targetUri = "/test/path";
-    Mockito.when(request.getCharacterEncoding()).thenReturn(null);
-    Mockito.when(request.getRequestURI()).thenReturn(targetUri);
+    when(request.getCharacterEncoding()).thenReturn(null);
+    when(request.getRequestURI()).thenReturn(targetUri);
     Map<String, String> paramResultMap = new HashMap<>();
     paramResultMap.put("param1=x", targetUri + "?" + "param1=x");
     paramResultMap
@@ -215,7 +226,7 @@ public class TestWebAppUtils {
         targetUri + "?" + "param1=x&amp;param2=y&amp;param3=x+y");
 
     for (Map.Entry<String, String> entry : paramResultMap.entrySet()) {
-      Mockito.when(request.getQueryString()).thenReturn(entry.getKey());
+      when(request.getQueryString()).thenReturn(entry.getKey());
       String uri = WebAppUtils.getHtmlEscapedURIWithQueryString(request);
       assertEquals(entry.getValue(), uri);
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/util/TestWebAppUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/util/TestWebAppUtils.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.hadoop.yarn.util.TestBoundedAppender;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -44,7 +43,6 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.when;
 
 public class TestWebAppUtils {
   private static final String RM1_NODE_ID = "rm1";
@@ -115,7 +113,7 @@ public class TestWebAppUtils {
   void testGetPasswordIOException() throws Exception {
     Configuration mockConf = Mockito.mock(Configuration.class);
 
-    when(mockConf.getPassword("error-alias")).thenThrow(new IOException("Simulated IO error"));
+    Mockito.when(mockConf.getPassword("error-alias")).thenThrow(new IOException("Simulated IO error"));
 
     assertNull(WebAppUtils.getPassword(mockConf, "error-alias"));
   }
@@ -197,7 +195,7 @@ public class TestWebAppUtils {
   void testAppendQueryParams() throws Exception {
     HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
     String targetUri = "/test/path";
-    when(request.getCharacterEncoding()).thenReturn(null);
+    Mockito.when(request.getCharacterEncoding()).thenReturn(null);
     Map<String, String> paramResultMap = new HashMap<>();
     paramResultMap.put("param1=x", targetUri + "?" + "param1=x");
     paramResultMap
@@ -206,7 +204,7 @@ public class TestWebAppUtils {
         targetUri + "?" + "param1=x&param2=y&param3=x+y");
 
     for (Map.Entry<String, String> entry : paramResultMap.entrySet()) {
-      when(request.getQueryString()).thenReturn(entry.getKey());
+      Mockito.when(request.getQueryString()).thenReturn(entry.getKey());
       String uri = WebAppUtils.appendQueryParams(request, targetUri);
       assertEquals(entry.getValue(), uri);
     }
@@ -216,8 +214,8 @@ public class TestWebAppUtils {
   void testGetHtmlEscapedURIWithQueryString() throws Exception {
     HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
     String targetUri = "/test/path";
-    when(request.getCharacterEncoding()).thenReturn(null);
-    when(request.getRequestURI()).thenReturn(targetUri);
+    Mockito.when(request.getCharacterEncoding()).thenReturn(null);
+    Mockito.when(request.getRequestURI()).thenReturn(targetUri);
     Map<String, String> paramResultMap = new HashMap<>();
     paramResultMap.put("param1=x", targetUri + "?" + "param1=x");
     paramResultMap
@@ -226,7 +224,7 @@ public class TestWebAppUtils {
         targetUri + "?" + "param1=x&amp;param2=y&amp;param3=x+y");
 
     for (Map.Entry<String, String> entry : paramResultMap.entrySet()) {
-      when(request.getQueryString()).thenReturn(entry.getKey());
+      Mockito.when(request.getQueryString()).thenReturn(entry.getKey());
       String uri = WebAppUtils.getHtmlEscapedURIWithQueryString(request);
       assertEquals(entry.getValue(), uri);
     }


### PR DESCRIPTION
### Description of PR

Improve `getPassword` method in WebAppUtils class by adding logging for password retrieval operations. Previously, if the password retrieval failed due to a misconfiguration or other issues, it failed silently, without any indication of the error. This update adds:

* **DEBUG Logging**: Logs successful password retrieval attempts, showing which alias was retrieved.
* **WARN Logging**: Logs when there is not password for the alias.
* **ERROR Logging**: Logs failures when unable to  passwords along with the alias and error details.

### How was this patch tested?

The changes were tested using the unit tests for the `getPassword` method, and was added new `getPasswordIOException` for checking the error log when exception happens. These methods performed successfully showing the added logging functionality. No additional integration tests were required since this change only affects logging behavior.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?


