### PR TITLE
YARN-11740. Resolve the issue that app cannot be submitted due to timeline server abnormalities

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/YarnClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/YarnClientImpl.java
@@ -451,8 +451,11 @@ public class YarnClientImpl extends YarnClient {
       }
     }
     org.apache.hadoop.security.token.Token<TimelineDelegationTokenIdentifier>
-        timelineDelegationToken = getTimelineDelegationToken();
-    if (timelineDelegationToken == null) {
+            timelineDelegationToken = null;
+    try{
+      timelineDelegationToken = getTimelineDelegationToken();
+    }catch (Exception e){
+      LOG.error("Failed to get delegation token: {}", e.getMessage());
       return;
     }
     credentials.addToken(timelineService, timelineDelegationToken);


### PR DESCRIPTION
When yarn.timeline-service.enabled is set to true, and the timeline server encounters  exception which can not be connected, app will can not be submitted.  I think that the timeline server's failure should not affect app‘’s submission.

test with pi task:
yarn jar $HADOOP_HOME/share/hadoop/mapreduce/hadoop-mapreduce-examples-*.jar  pi  1 1