### PR TITLE
HADOOP-19337. Fix ZKFailoverController NPE issue due to integer overflow in parseInt when initHM.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/ZKFailoverController.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/ZKFailoverController.java
@@ -263,8 +263,11 @@ public abstract class ZKFailoverController {
       rpcServer.stopAndJoin();
       
       elector.quitElection(true);
-      healthMonitor.shutdown();
-      healthMonitor.join();
+
+      if (healthMonitor != null) {
+        healthMonitor.shutdown();
+        healthMonitor.join();
+      }
     }
     return 0;
   }


### PR DESCRIPTION
### Description of PR

Jira Issue: https://issues.apache.org/jira/browse/HADOOP-19337. 

Null Pointer Exception in ZKFailloverController. 


### How was this patch tested?

(1) Set ha.health-monitor.rpc-timeout.ms to 4294967295.  
(2) Run: test: org.apache.hadoop.ha.TestZKFailoverController#testVerifyObserverState. 

Instead of throwing a NPE, the test passes. 

### For code changes:

- [ x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

