### PR TITLE
HADOOP-19338. Null Pointer Exception in KeyProviderCryptoExtension due to Class Not Found Exception.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyProviderCryptoExtension.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/KeyProviderCryptoExtension.java
@@ -292,15 +292,20 @@ public class KeyProviderCryptoExtension extends
       // Generate random bytes for new key and IV
 
       CryptoCodec cc = CryptoCodec.getInstance(keyProvider.getConf());
-      try {
-        final byte[] newKey = new byte[encryptionKey.getMaterial().length];
-        cc.generateSecureRandom(newKey);
-        final byte[] iv = new byte[cc.getCipherSuite().getAlgorithmBlockSize()];
-        cc.generateSecureRandom(iv);
-        Encryptor encryptor = cc.createEncryptor();
-        return generateEncryptedKey(encryptor, encryptionKey, newKey, iv);
-      } finally {
-        cc.close();
+
+      if (cc != null){
+        try {
+          final byte[] newKey = new byte[encryptionKey.getMaterial().length];
+          cc.generateSecureRandom(newKey);
+          final byte[] iv = new byte[cc.getCipherSuite().getAlgorithmBlockSize()];
+          cc.generateSecureRandom(iv);
+          Encryptor encryptor = cc.createEncryptor();
+          return generateEncryptedKey(encryptor, encryptionKey, newKey, iv);
+        } finally {
+          cc.close();
+        }
+      } else {
+        throw new IOException("CyrptoCode object is null");
       }
     }
 


### PR DESCRIPTION
### Description of PR

https://issues.apache.org/jira/browse/HADOOP-19338

A null pointer exception occurs in KeyProviderExtension when trying to close a null CryptoCodec object. If supplied with an invalid class name for hadoop.security.crypto.codec.classes.aes.ctr.nopadding getClassbyName throws a ClassNotFound exception and consequently the CryptoCodec object is not created. 

### How was this patch tested?

(1) Set hadoop.security.crypto.codec.classes.aes.ctr.nopadding to org.apache.hadoop.crypto.OpensslAesCtrCryptoCodec/
(2) Run test: org.apache.hadoop.crypto.key.TestKeyProviderCryptoExtension#testReencryptEncryptedKeys

Instead of throwing NPE, the test now throws a new IO exception which informs that the CryptoCodec object is null.


### For code changes:

- [x ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

