### PR TITLE
HADOOP-19339. OutofBounds Exception due to assumption about buffer size in BlockCompressorStream.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/BlockCompressorStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/BlockCompressorStream.java
@@ -54,7 +54,11 @@ public class BlockCompressorStream extends CompressorStream {
   public BlockCompressorStream(OutputStream out, Compressor compressor, 
                                int bufferSize, int compressionOverhead) {
     super(out, compressor, bufferSize);
-    MAX_INPUT_SIZE = bufferSize - compressionOverhead;
+    if (bufferSize - compressionOverhead >= 0) {
+      MAX_INPUT_SIZE = bufferSize - compressionOverhead;
+    } else {
+      throw new IllegalArgumentException("buffer size is less than compression overhead");
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of PR

JIRA Issue: https://issues.apache.org/jira/browse/HADOOP-19339

BlockCompressorStream assumes that the buffer size will always be greater than the compression overhead, and consequently MAX_INPUT_SIZE will always be greater than or equal to 0. 

### How was this patch tested?

(1) Set io.compression.codec.snappy.buffersize to 7
(2) Run test: org.apache.hadoop.io.compress.TestCodec#testSnappyMapFile

Instead of an OOB exception, the code now throws an IllegalArgumentException with a relevant message. 


### For code changes:

- [x ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

