### PR TITLE
HDFS-17668 Treat null SASL negotiated QOP as auth in DataTransferSasl…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
@@ -104,7 +104,12 @@ public final class DataTransferSaslUtil {
     String negotiatedQop = sasl.getNegotiatedQop();
     LOG.debug("{}: Verifying QOP: requested = {}, negotiated = {}",
         sasl, requestedQop, negotiatedQop);
-    if (negotiatedQop != null && !requestedQop.contains(negotiatedQop)) {
+    // Treat null negotiated QOP as "auth" for the purpose of verification
+    // Code elsewhere does the same implicitly
+    if(negotiatedQop == null) {
+      negotiatedQop = "auth";
+    }
+    if (!requestedQop.contains(negotiatedQop)) {
       throw new IOException(String.format("SASL handshake completed, but " +
           "channel does not have acceptable quality of protection, " +
           "requested = %s, negotiated = %s", requestedQop, negotiatedQop));

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
@@ -112,7 +112,7 @@ public final class DataTransferSaslUtil {
     if (!requestedQop.contains(negotiatedQop)) {
       throw new IOException(String.format("SASL handshake completed, but " +
           "channel does not have acceptable quality of protection, " +
-          "requested = %s, negotiated = %s", requestedQop, negotiatedQop));
+          "requested = %s, negotiated(effective) = %s", requestedQop, negotiatedQop));
     }
   }
 


### PR DESCRIPTION
…Util#checkSaslComplete()

### Description of PR

HDFS-17668 
Fixes handling of null negotiated QOP value for HDFS

### How was this patch tested?

The specific test was not tested beyond the test suite, but the issues was detected on a cluster configured with a broken SASL mechanism.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

