### PR TITLE
HDFS-17669 Do not reqest SASL QOP when using CryptoInput/OutputStream

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
@@ -104,7 +104,12 @@ public final class DataTransferSaslUtil {
     String negotiatedQop = sasl.getNegotiatedQop();
     LOG.debug("{}: Verifying QOP: requested = {}, negotiated = {}",
         sasl, requestedQop, negotiatedQop);
-    if (negotiatedQop != null && !requestedQop.contains(negotiatedQop)) {
+    // Treat null negotiated QOP as "auth" for the purpose of verification
+    // Code elsewhere does the same implicitly
+    if(negotiatedQop == null) {
+      negotiatedQop = "auth";
+    }
+    if (!requestedQop.contains(negotiatedQop)) {
       throw new IOException(String.format("SASL handshake completed, but " +
           "channel does not have acceptable quality of protection, " +
           "requested = %s, negotiated = %s", requestedQop, negotiatedQop));

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
@@ -112,7 +112,7 @@ public final class DataTransferSaslUtil {
     if (!requestedQop.contains(negotiatedQop)) {
       throw new IOException(String.format("SASL handshake completed, but " +
           "channel does not have acceptable quality of protection, " +
-          "requested = %s, negotiated = %s", requestedQop, negotiatedQop));
+          "requested = %s, negotiated(effective) = %s", requestedQop, negotiatedQop));
     }
   }
 
@@ -135,12 +135,11 @@ public final class DataTransferSaslUtil {
    * @param encryptionAlgorithm to use for SASL negotation
    * @return properties of encrypted SASL negotiation
    */
-  public static Map<String, String> createSaslPropertiesForEncryption(
-      String encryptionAlgorithm) {
-    Map<String, String> saslProps = Maps.newHashMapWithExpectedSize(3);
-    saslProps.put(Sasl.QOP, QualityOfProtection.PRIVACY.getSaslQop());
+  public static Map<String, String> createSaslPropertiesForEncryption() {
+    Map<String, String> saslProps = Maps.newHashMapWithExpectedSize(2);
+    // This is equivalent to not setting QOP, but the rest of Hadoop expects this to be set
+    saslProps.put(Sasl.QOP, QualityOfProtection.AUTHENTICATION.getSaslQop());
     saslProps.put(Sasl.SERVER_AUTH, "true");
-    saslProps.put("com.sun.security.sasl.digest.cipher", encryptionAlgorithm);
     return saslProps;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferClient.java
@@ -315,8 +315,7 @@ public class SaslDataTransferClient {
       Token<BlockTokenIdentifier> accessToken,
       SecretKey secretKey)
       throws IOException {
-    Map<String, String> saslProps = createSaslPropertiesForEncryption(
-        encryptionKey.encryptionAlgorithm);
+    Map<String, String> saslProps = createSaslPropertiesForEncryption();
     if (secretKey != null) {
       LOG.debug("DataNode overwriting downstream QOP" +
           saslProps.get(Sasl.QOP));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
@@ -173,8 +173,7 @@ public class SaslDataTransferServer {
       return new IOStreamPair(underlyingIn, underlyingOut);
     }
 
-    Map<String, String> saslProps = createSaslPropertiesForEncryption(
-      dnConf.getEncryptionAlgorithm());
+    Map<String, String> saslProps = createSaslPropertiesForEncryption();
 
     if (LOG.isDebugEnabled()) {
       LOG.debug("Server using encryption algorithm " +


### PR DESCRIPTION
### Description of PR

Do not reqest SASL QOP when using CryptoInput/OutputStream

### How was this patch tested?

It wasn't tested yet, this is a draft

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

