### PR TITLE
HDFS-17658. HDFS decommissioning does not consider if Under Construction blocks are sufficiently replicated which causes HDFS Data Loss

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1744,6 +1744,27 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final boolean
       DFS_DATANODE_LOCKMANAGER_TRACE_DEFAULT = false;
 
+  /**
+   * A datanode should only enter decommissioned state if all blocks
+   * on the datanode are sufficiently replicated to other live datanodes.
+   *
+   * When this setting is disabled, the Namenode does not consider
+   * Under Construction blocks in determining if a datanode can be
+   * decommissioned; this results in scenarios where datanodes enter
+   * decommissioned state before their blocks are sufficiently replicated
+   * to other live datanodes. This can lead to HDFS write failures & data loss,
+   * if all the datanodes in the block write pipeline are decommissioned
+   * & terminated at around the same time.
+   *
+   * Enable the following setting to have the Namenode track & consider
+   * Under Construction blocks when identifying if a datanode can be
+   * decommissioned.
+   */
+  public static final String DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS =
+          "dfs.namenode.decommission.track.underconstructionblocks";
+  public static final boolean DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS_DEFAULT =
+          false;
+
   // dfs.client.retry confs are moved to HdfsClientConfigKeys.Retry
   @Deprecated
   public static final String  DFS_CLIENT_RETRY_POLICY_ENABLED_KEY

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1745,23 +1745,35 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       DFS_DATANODE_LOCKMANAGER_TRACE_DEFAULT = false;
 
   /**
-   * A datanode should only enter decommissioned state if all blocks
-   * on the datanode are sufficiently replicated to other live datanodes.
+   * Determines whether the NameNode tracks under-construction blocks
+   * when decommissioning DataNodes.
    *
-   * When this setting is disabled, the Namenode does not consider
-   * Under Construction blocks in determining if a datanode can be
-   * decommissioned; this results in scenarios where datanodes enter
-   * decommissioned state before their blocks are sufficiently replicated
-   * to other live datanodes. This can lead to HDFS write failures and
-   * data loss, if all the datanodes in the block write pipeline are
-   * decommissioned and terminated at around the same time.
+   * A DataNode should only enter decommissioned state if all blocks on
+   * the DataNode are sufficiently replicated to other live DataNodes.
    *
-   * Enable the following setting to have the Namenode track and consider
-   * Under Construction blocks when identifying if a datanode can be
-   * decommissioned.
+   * When this setting is disabled, the NameNode does not consider
+   * under-construction blocks in determining if a DataNode can be
+   * decommissioned. This can result in scenarios where DataNodes
+   * enter decommissioned state before their blocks are sufficiently
+   * replicated to other live DataNodes.
+   *
+   * This situation can lead to HDFS write failures and data loss if
+   * all the DataNodes in the block write pipeline are decommissioned
+   * and terminated at around the same time.
+   *
+   * Enable this setting to have the NameNode track and consider
+   * under-construction blocks when identifying if a DataNode can
+   * be decommissioned.
    */
   public static final String DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS =
           "dfs.namenode.decommission.track.underconstructionblocks";
+  /**
+   * "dfs.namenode.decommission.track.underconstructionblocks" feature is
+   * disabled by default. Enabling this feature will benefit HDFS clusters
+   * with datanode decommissioning operations and HDFS blocks/files held
+   * open for extended periods of time. These HDFS clusters will see
+   * reduction in HDFS write failures & HDFS data loss.
+   */
   public static final boolean DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS_DEFAULT =
           false;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1770,9 +1770,9 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   /**
    * "dfs.namenode.decommission.track.underconstructionblocks" feature is
    * disabled by default. Enabling this feature will benefit HDFS clusters
-   * with datanode decommissioning operations and HDFS blocks/files held
+   * with datanode decommissioning operations and HDFS blocks held
    * open for extended periods of time. These HDFS clusters will see
-   * reduction in HDFS write failures & HDFS data loss.
+   * reduction in HDFS write failures and HDFS data loss.
    */
   public static final boolean DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS_DEFAULT =
           false;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1752,11 +1752,11 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
    * Under Construction blocks in determining if a datanode can be
    * decommissioned; this results in scenarios where datanodes enter
    * decommissioned state before their blocks are sufficiently replicated
-   * to other live datanodes. This can lead to HDFS write failures & data loss,
-   * if all the datanodes in the block write pipeline are decommissioned
-   * & terminated at around the same time.
+   * to other live datanodes. This can lead to HDFS write failures and
+   * data loss, if all the datanodes in the block write pipeline are
+   * decommissioned and terminated at around the same time.
    *
-   * Enable the following setting to have the Namenode track & consider
+   * Enable the following setting to have the Namenode track and consider
    * Under Construction blocks when identifying if a datanode can be
    * decommissioned.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -211,12 +211,17 @@ public class BlockManager implements BlockStatsMXBean {
    * When an HDFS client notifies the Namenode a block is closed/committed,
    * the block is added to the StorageInfos and therefore needs to be
    * removed from UnderConstructionBlocks.
+   *
+   * @param dn - datanode storing the Under Construction block.
+   * @param block - Under Construction block to stop tracking for the datanode.
    */
   public void removeUcBlock(DatanodeDescriptor dn, Block block) {
     ucBlocks.removeUcBlock(dn, block);
   }
 
-  @VisibleForTesting
+  /**
+   * @return - the data structure for tracking Under Construction block replicas.
+   */
   public UnderConstructionBlocks getUnderConstructionBlocks() {
     return ucBlocks;
   }
@@ -1840,24 +1845,6 @@ public class BlockManager implements BlockStatsMXBean {
 
     node.resetBlocks();
     invalidateBlocks.remove(node);
-  }
-
-  /** Count how many Under Construction blocks there are per datanode. */
-  Map<DatanodeDescriptor, List<Block>> countUnderConstructionBlocksByDatanode() {
-    final Map<DatanodeDescriptor, List<Block>> result =
-        ucBlocks.getUnderConstructionBlocksByDatanode();
-    if (LOG.isDebugEnabled()) {
-      String ucBlockCounts = result.entrySet().stream()
-          .map(e -> String.format("%s=%d", e.getKey(), e.getValue().size()))
-          .collect(Collectors.joining(",", "{", "}"));
-      LOG.debug("Under Construction block counts: [{}]", ucBlockCounts);
-    }
-    return result;
-  }
-
-  /** Log warning for each block open for longer than fixed time threshold. */
-  void logWarningForLongUnderConstructionBlocks() {
-    ucBlocks.logWarningForLongUnderConstructionBlocks();
   }
 
   /** Remove the blocks associated to the given DatanodeStorageInfo. */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -3731,16 +3731,16 @@ public class BlockManager implements BlockStatsMXBean {
     block.getUnderConstructionFeature().addReplicaIfNotPresent(
         storageInfo, ucBlock.reportedBlock, ucBlock.reportedState);
 
-    // Add replica if appropriate. If the replica was previously corrupt
-    // but now okay, it might need to be updated.
-    if (ucBlock.reportedState == ReplicaState.FINALIZED && (
-        block.findStorageInfo(storageInfo) < 0) || corruptReplicas
-        .isReplicaCorrupt(block, storageInfo.getDatanodeDescriptor())) {
-      addStoredBlock(block, ucBlock.reportedBlock, storageInfo, null, true);
-    } else {
+    if (ucBlock.reportedState == ReplicaState.RBW) {
       // Non-finalized Under Construction blocks are not added to the StorageInfos.
       // They are instead tracked via UnderConstructionBlocks data structure.
       ucBlocks.addUcBlock(storageInfo.getDatanodeDescriptor(), ucBlock.reportedBlock);
+    } else if (ucBlock.reportedState == ReplicaState.FINALIZED && (
+        block.findStorageInfo(storageInfo) < 0) || corruptReplicas
+        .isReplicaCorrupt(block, storageInfo.getDatanodeDescriptor())) {
+      // Add replica if appropriate. If the replica was previously corrupt
+      // but now okay, it might need to be updated.
+      addStoredBlock(block, ucBlock.reportedBlock, storageInfo, null, true);
     }
   } 
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminBackoffMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminBackoffMonitor.java
@@ -169,7 +169,8 @@ public class DatanodeAdminBackoffMonitor extends DatanodeAdminMonitorBase
           "decommissioning/maintenance checks.");
       return;
     }
-    blockManager.logWarningForLongUnderConstructionBlocks();
+    blockManager.getUnderConstructionBlocks()
+        .logWarningForLongUnderConstructionBlocks();
     // Reset the checked count at beginning of each iteration
     numBlocksChecked = 0;
     // Check decommission or maintenance progress.
@@ -369,7 +370,7 @@ public class DatanodeAdminBackoffMonitor extends DatanodeAdminMonitorBase
       // Prepare a lookup map to determine if a datanode
       // has any blocks Under Construction.
       final Map<DatanodeDescriptor, List<Block>> ucBlocksByDatanode =
-          blockManager.countUnderConstructionBlocksByDatanode();
+          blockManager.getUnderConstructionBlocks().getUnderConstructionBlocksByDatanode();
       for (DatanodeDescriptor dn : toRemove) {
         final boolean isHealthy =
             blockManager.isNodeHealthyForDecommissionOrMaintenance(dn);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
@@ -180,7 +180,8 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
           "decommissioning/maintenance checks.");
       return;
     }
-    blockManager.logWarningForLongUnderConstructionBlocks();
+    blockManager.getUnderConstructionBlocks()
+        .logWarningForLongUnderConstructionBlocks();
     // Reset the checked count at beginning of each iteration
     numBlocksChecked = 0;
     numBlocksCheckedPerLock = 0;
@@ -242,7 +243,8 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
     // Prepare a lookup map to determine if a datanode
     // has any blocks Under Construction.
     final Map<DatanodeDescriptor, List<Block>> ucBlocksByDatanode =
-        blockManager.countUnderConstructionBlocksByDatanode();
+        blockManager.getUnderConstructionBlocks()
+            .getUnderConstructionBlocksByDatanode();
     while (it.hasNext() && !exceededNumBlocksPerCheck() && namesystem
         .isRunning()) {
       numNodesChecked++;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/UnderConstructionBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/UnderConstructionBlocks.java
@@ -1,0 +1,328 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.blockmanagement;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.protocol.Block;
+import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * The BlockManager will not add an Under Construction
+ * block to the DatanodeDescriptor StorageInfos until
+ * the block is fully committed & finalized.
+ * The UC block replicas are instead tracked here
+ * for the DatanodeAdminManager to use.
+ * Note that this is tracked in-memory only, as such
+ * some Under Construction blocks may be missed under
+ * scenarios where Namenode is restarted.
+ **/
+public class UnderConstructionBlocks {
+  private static final Logger LOG =
+          LoggerFactory.getLogger(UnderConstructionBlocks.class);
+
+  // Amount of time to wait in between checking all block replicas
+  private static final Duration LONG_UNDER_CONSTRUCTION_BLOCK_CHECK_INTERVAL
+          = Duration.ofMinutes(5);
+  // Amount of time to wait before logging each individual block replica
+  // as warning.
+  private static final Duration LONG_UNDER_CONSTRUCTION_BLOCK_WARN_THRESHOLD
+      = Duration.ofHours(2);
+  private static final Duration LONG_UNDER_CONSTRUCTION_BLOCK_WARN_INTERVAL
+      = Duration.ofMinutes(30);
+
+  private final Map<Block, Set<BlockReplica>> replicasByBlockId =
+      Maps.newHashMap();
+  private final boolean enabled;
+  private int count = 0;
+  // DatanodeAdminMonitor invokes logWarningForLongUnderConstructionBlocks every 30 seconds.
+  // To reduce the number of times this method loops through the Under Construction blocks,
+  // the interval is limited by LONG_UNDER_CONSTRUCTION_BLOCK_CHECK_INTERVAL.
+  private Instant nextWarnLogCheck =
+      Instant.now().plus(LONG_UNDER_CONSTRUCTION_BLOCK_CHECK_INTERVAL);
+
+  static class BlockReplica {
+    private final Block block;
+    private final DatanodeDescriptor dn;
+    private final Instant firstReportedTime;
+    private Instant nextWarnLog;
+
+    BlockReplica(Block block,
+                 DatanodeDescriptor dn) {
+      this.block = block;
+      this.dn = dn;
+      this.firstReportedTime = Instant.now();
+      this.nextWarnLog = firstReportedTime.plus(LONG_UNDER_CONSTRUCTION_BLOCK_WARN_THRESHOLD);
+    }
+
+    Block getBlock() {
+      return block;
+    }
+
+    DatanodeDescriptor getDatanode() {
+      return dn;
+    }
+
+    boolean shouldLogWarning() {
+      if (Instant.now().isBefore(nextWarnLog)) {
+        return false;
+      }
+      nextWarnLog = Instant.now().plus(LONG_UNDER_CONSTRUCTION_BLOCK_WARN_INTERVAL);
+      return true;
+    }
+
+    Duration getDurationSinceReporting() {
+      return Duration.between(firstReportedTime, Instant.now());
+    }
+
+    @Override
+    public String toString() {
+      return String.format("ReportedBlockInfo [block=%s, dn=%s]", block, dn);
+    }
+  }
+
+  UnderConstructionBlocks(Configuration conf) {
+    this.enabled = conf.getBoolean(
+        DFSConfigKeys.DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS,
+        DFSConfigKeys.DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS_DEFAULT);
+    if (enabled) {
+      LOG.info("Tracking Under Construction blocks for DatanodeAdminManager");
+    } else {
+      LOG.debug("DatanodeAdminManager will not track Under Construction blocks");
+    }
+  }
+
+  /**
+   * Remove an Under Construction block replica.
+   * This method is called when an Under Construction block replica
+   * transitions from UC state to states like: finalized/complete,
+   * corrupt, invalidated, and deleted.
+   */
+  void removeUcBlock(DatanodeDescriptor reportingNode, Block reportedBlock) {
+    if (!enabled) {
+      return;
+    }
+    if (reportingNode == null || reportedBlock == null) {
+      LOG.warn("Unexpected null input {} , {}", reportingNode, reportedBlock);
+    }
+    try {
+      Set<BlockReplica> replicas;
+      if (BlockIdManager.isStripedBlockID(reportedBlock.getBlockId())) {
+        Block blkId = new Block(BlockIdManager.convertToStripedID(reportedBlock
+                .getBlockId()));
+        replicas = getBlockReplicas(blkId);
+      } else {
+        reportedBlock = new Block(reportedBlock);
+        replicas = getBlockReplicas(reportedBlock);
+      }
+      if (replicas.isEmpty()) {
+        replicasByBlockId.remove(reportedBlock);
+        LOG.debug("UC block {} not found on {}, total is [replicas={} / blocks={}]",
+                reportedBlock, reportingNode, count, replicasByBlockId.size());
+      } else {
+        removeUcBlockFromSet(reportingNode, reportedBlock, replicas);
+      }
+    } catch (Exception e) {
+      // Observed during testing that exception thrown here
+      // are caught & never logged
+      LOG.error("Remove UnderConstruction block {} {} failed",
+          reportedBlock, reportingNode, e);
+    }
+  }
+
+  private void removeUcBlockFromSet(DatanodeDescriptor reportingNode,
+                                    Block reportedBlock,
+                                    Set<BlockReplica> storedReplicasForBlock) {
+    final List<BlockReplica> storedBlocks = storedReplicasForBlock.stream()
+            .filter(replica -> reportingNode.equals(replica.getDatanode())
+                && reportedBlock.getGenerationStamp() >= replica.getBlock().getGenerationStamp())
+            .collect(Collectors.toList());
+    storedReplicasForBlock.removeIf(replica -> reportingNode.equals(replica.getDatanode())
+        && reportedBlock.getGenerationStamp() >= replica.getBlock().getGenerationStamp());
+    if (storedReplicasForBlock.isEmpty()) {
+      replicasByBlockId.remove(reportedBlock);
+    }
+    final String storedBlockString = storedBlocks.stream()
+            .map(br -> br.getBlock().toString())
+            .collect(Collectors.joining(","));
+    if (storedBlocks.size() > 1) {
+      LOG.warn("Removed multiple UC block [{}->{}] from {}, total is [replicas={} / blocks={}]",
+              storedBlockString, reportedBlock, reportingNode, count, replicasByBlockId.size());
+    } else if (storedBlocks.size() == 1) {
+      count--;
+      LOG.debug("Removed UC block [{}->{}] from {}, new total is [replicas={} / blocks={}]",
+              storedBlockString, reportedBlock, reportingNode, count, replicasByBlockId.size());
+    } else {
+      // Not found on specific datanode
+      LOG.debug("UC block {} not found on {}, total is [replicas={} / blocks={}]",
+              reportedBlock, reportingNode, count, replicasByBlockId.size());
+    }
+  }
+
+  /**
+   * If the datanode goes DEAD, the Namenode makes an assumption that
+   * any write operations have failed.
+   */
+  void removeAllUcBlocksForDatanode(DatanodeDescriptor reportingNode) {
+    if (!enabled) {
+      return;
+    }
+    if (reportingNode == null) {
+      LOG.warn("Unexpected null input {}", reportingNode);
+    }
+    try {
+      Set<Block> toRemoveFromMap = new HashSet<>();
+      Set<BlockReplica> removedReplicas = new HashSet<>();
+      for (Map.Entry<Block, Set<BlockReplica>> entry: replicasByBlockId.entrySet()) {
+        final List<BlockReplica> storedBlocks = entry.getValue().stream()
+                .filter(replica -> reportingNode.equals(replica.getDatanode()))
+                .collect(Collectors.toList());
+        entry.getValue().removeIf(replica -> reportingNode.equals(replica.getDatanode()));
+        removedReplicas.addAll(storedBlocks);
+        count -= storedBlocks.size();
+        if (entry.getValue().isEmpty()) {
+          toRemoveFromMap.add(entry.getKey());
+        }
+      }
+      for (Block remove: toRemoveFromMap) {
+        replicasByBlockId.remove(remove);
+      }
+      final String removedBlocksString = removedReplicas.stream()
+              .map(br -> br.getBlock().toString())
+              .collect(Collectors.joining(","));
+      LOG.debug("Removed [{}] UC blocks for {}, new total is [replicas={} / blocks={}]",
+              removedBlocksString, reportingNode, count, replicasByBlockId.size());
+    } catch (Exception e) {
+      // Observed during testing that exception thrown here
+      // are caught & never logged
+      LOG.error("Remove all UnderConstruction block failed for {}",
+          reportingNode, e);
+    }
+  }
+
+  /**
+   * Add an Under Construction block replicas for a given block.
+   */
+  void addUcBlock(DatanodeDescriptor reportingNode, Block reportedBlock) {
+    if (!enabled) {
+      return;
+    }
+    if (reportingNode == null || reportedBlock == null) {
+      LOG.warn("Unexpected null input {} , {}", reportingNode, reportedBlock);
+    }
+    try {
+      Set<BlockReplica> storedReplicasForBlock;
+      if (BlockIdManager.isStripedBlockID(reportedBlock.getBlockId())) {
+        Block blkId = new Block(BlockIdManager.convertToStripedID(reportedBlock
+                .getBlockId()));
+        storedReplicasForBlock = getBlockReplicas(blkId);
+      } else {
+        reportedBlock = new Block(reportedBlock);
+        storedReplicasForBlock = getBlockReplicas(reportedBlock);
+      }
+      addUcBlockToSet(reportingNode, reportedBlock, storedReplicasForBlock);
+    } catch (Exception e) {
+      // Observed during testing that exception thrown here
+      // are caught & never logged
+      LOG.error("Add UnderConstruction block {} on {} failed",
+          reportedBlock, reportingNode, e);
+    }
+  }
+
+  private void addUcBlockToSet(DatanodeDescriptor reportingNode,
+                               Block reportedBlock,
+                               Set<BlockReplica> storedReplicasForBlock) {
+    List<BlockReplica> storedBlocks = storedReplicasForBlock.stream()
+            .filter(replica -> reportingNode.equals(replica.getDatanode()))
+            .collect(Collectors.toList());
+    final String storedBlockString = storedBlocks.stream()
+            .map(br -> br.getBlock().toString())
+            .collect(Collectors.joining(","));
+    if (!storedBlocks.isEmpty()) {
+      if (storedBlocks.size() > 1) {
+        LOG.warn("UC block [{}->{}] multiple found on {}, total is [replicas={} / blocks={}]",
+                storedBlockString, reportedBlock, reportingNode, count, replicasByBlockId.size());
+      } else {
+        LOG.debug("UC block [{}->{}] already found on {}, total is [replicas={} / blocks={}]",
+                storedBlockString, reportedBlock, reportingNode, count, replicasByBlockId.size());
+      }
+      // Remove any replicas with older/stale GenerationStamp
+      storedReplicasForBlock.removeIf(replica -> replica.getDatanode().equals(reportingNode)
+          && replica.getBlock().getGenerationStamp() < reportedBlock.getGenerationStamp());
+    }
+    if (storedReplicasForBlock.stream().noneMatch(replica ->
+            reportingNode.equals(replica.getDatanode()))) {
+      storedReplicasForBlock.add(new BlockReplica(new Block(reportedBlock), reportingNode));
+      count++;
+      LOG.debug("Add UC block {} to {}, new total is [replicas={} / blocks={}]",
+              reportedBlock, reportingNode, count, replicasByBlockId.size());
+    }
+  }
+
+  private Set<BlockReplica> getBlockReplicas(Block block) {
+    Set<BlockReplica> replicas = replicasByBlockId.get(block);
+    if (replicas == null) {
+      replicas = new HashSet<>();
+      replicasByBlockId.put(block, replicas);
+    }
+    return replicas;
+  }
+
+  public Map<DatanodeDescriptor, List<Block>> getUnderConstructionBlocksByDatanode() {
+    if (!enabled) {
+      return Maps.newHashMap();
+    }
+    // Each block can have a ReportedBlockInfo for each block replica.
+    // Below is counting all the block replicas for all the open blocks.
+    return replicasByBlockId.values().stream()
+        .flatMap(Collection::stream)
+        .collect(Collectors.groupingBy(BlockReplica::getDatanode,
+            Collectors.mapping(BlockReplica::getBlock, Collectors.toList())));
+  }
+
+  public void logWarningForLongUnderConstructionBlocks() {
+    if (!enabled) {
+      return;
+    }
+    if (Instant.now().isBefore(nextWarnLogCheck)) {
+      return;
+    }
+    nextWarnLogCheck = Instant.now().plus(LONG_UNDER_CONSTRUCTION_BLOCK_CHECK_INTERVAL);
+    Stream<BlockReplica> allReplicas = replicasByBlockId.values()
+        .stream().flatMap(Collection::stream);
+    allReplicas.forEach(replica -> {
+      if (replica.shouldLogWarning()) {
+        LOG.warn("Block {} on {} has been UC for {} minutes",
+            replica.getBlock(), replica.getDatanode(),
+            replica.getDurationSinceReporting().toMinutes());
+      }
+    });
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/UnderConstructionBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/UnderConstructionBlocks.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
 /**
  * The BlockManager will not add an Under Construction
  * block to the DatanodeDescriptor StorageInfos until
- * the block is fully committed & finalized.
+ * the block is fully committed and finalized.
  * The UC block replicas are instead tracked here
  * for the DatanodeAdminManager to use.
  * Note that this is tracked in-memory only, as such
@@ -131,6 +131,7 @@ public class UnderConstructionBlocks {
     }
     if (reportingNode == null || reportedBlock == null) {
       LOG.warn("Unexpected null input {} , {}", reportingNode, reportedBlock);
+      return;
     }
     try {
       Set<BlockReplica> replicas;
@@ -196,6 +197,7 @@ public class UnderConstructionBlocks {
     }
     if (reportingNode == null) {
       LOG.warn("Unexpected null input {}", reportingNode);
+      return;
     }
     try {
       Set<Block> toRemoveFromMap = new HashSet<>();
@@ -236,6 +238,7 @@ public class UnderConstructionBlocks {
     }
     if (reportingNode == null || reportedBlock == null) {
       LOG.warn("Unexpected null input {} , {}", reportingNode, reportedBlock);
+      return;
     }
     try {
       Set<BlockReplica> storedReplicasForBlock;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/UnderConstructionBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/UnderConstructionBlocks.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -38,12 +39,18 @@ import java.util.stream.Stream;
  * The BlockManager will not add an Under Construction
  * block to the DatanodeDescriptor StorageInfos until
  * the block is fully committed and finalized.
- * The UC block replicas are instead tracked here
- * for the DatanodeAdminManager to use.
- * Note that this is tracked in-memory only, as such
- * some Under Construction blocks may be missed under
+ * The Under Construction block replicas are instead tracked
+ * here for the DatanodeAdminManager to use.
+ *
+ * Note that Under Construction is a term in the HDFS code
+ * base used to refer to a block replica which is held open
+ * by an HDFS client. The Under Construction block replica
+ * state is RBW (i.e. replica being written).
+ *
+ * Also note that this data structure is tracked in-memory only,
+ * as such some Under Construction blocks may be missed under
  * scenarios where Namenode is restarted.
- **/
+ */
 public class UnderConstructionBlocks {
   private static final Logger LOG =
           LoggerFactory.getLogger(UnderConstructionBlocks.class);
@@ -61,6 +68,10 @@ public class UnderConstructionBlocks {
   private final Map<Block, Set<BlockReplica>> replicasByBlockId =
       Maps.newHashMap();
   private final boolean enabled;
+  // Total count of Under Construction replicas. The count will match the sum
+  // of the sizes of all the sets of BlockReplicas in "replicasByBlockId".
+  // The count is stored here to avoid the cost of recomputing the sum
+  // each time it is needed.
   private int count = 0;
   // DatanodeAdminMonitor invokes logWarningForLongUnderConstructionBlocks every 30 seconds.
   // To reduce the number of times this method loops through the Under Construction blocks,
@@ -82,14 +93,22 @@ public class UnderConstructionBlocks {
       this.nextWarnLog = firstReportedTime.plus(LONG_UNDER_CONSTRUCTION_BLOCK_WARN_THRESHOLD);
     }
 
+    /** @return - block ID for the Under Construction block replica. */
     Block getBlock() {
       return block;
     }
 
+    /** @return - datanode ID for datanode storing the Under Construction block replica. */
     DatanodeDescriptor getDatanode() {
       return dn;
     }
 
+    /**
+     * Determines if a warning should be logged based on how long the Under Construction
+     * block replica has been in RBW state and when a warning was last logged.
+     *
+     * @return - boolean indicating if warning should be logged for this block replica.
+     */
     boolean shouldLogWarning() {
       if (Instant.now().isBefore(nextWarnLog)) {
         return false;
@@ -98,6 +117,7 @@ public class UnderConstructionBlocks {
       return true;
     }
 
+    /** @return - duration since the block replica was first reported as Under Construction. */
     Duration getDurationSinceReporting() {
       return Duration.between(firstReportedTime, Instant.now());
     }
@@ -108,6 +128,11 @@ public class UnderConstructionBlocks {
     }
   }
 
+  /**
+   * Initializes the data structure for tracking Under Construction block replicas.
+   *
+   * @param conf - the Hadoop HDFS configuration keys & values.
+   */
   UnderConstructionBlocks(Configuration conf) {
     this.enabled = conf.getBoolean(
         DFSConfigKeys.DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS,
@@ -120,20 +145,25 @@ public class UnderConstructionBlocks {
   }
 
   /**
-   * Remove an Under Construction block replica.
+   * Stop tracking an Under Construction block replica.
    * This method is called when an Under Construction block replica
-   * transitions from UC state to states like: finalized/complete,
-   * corrupt, invalidated, and deleted.
+   * transitions from Under Construction (a.k.a. RBW) state to
+   * states like: finalized/complete, corrupt, invalidated,
+   * and deleted.
+   *
+   * @param reportingNode - datanode which is storing the Under Construction block replica.
+   * @param reportedBlock - Under Construction block replica to stop tracking for the datanode.
    */
   void removeUcBlock(DatanodeDescriptor reportingNode, Block reportedBlock) {
     if (!enabled) {
       return;
     }
     if (reportingNode == null || reportedBlock == null) {
-      LOG.warn("Unexpected null input {} , {}", reportingNode, reportedBlock);
+      LOG.warn("Remove UnderConstruction block has unexpected null input");
       return;
     }
     try {
+      // Extract set of BlockReplicas matching the reportedBlock
       Set<BlockReplica> replicas;
       if (BlockIdManager.isStripedBlockID(reportedBlock.getBlockId())) {
         Block blkId = new Block(BlockIdManager.convertToStripedID(reportedBlock
@@ -144,44 +174,66 @@ public class UnderConstructionBlocks {
         replicas = getBlockReplicas(reportedBlock);
       }
       if (replicas.isEmpty()) {
+        // If the UC block replica is not stored on any datanodes,
+        // remove it from the "replicasByBlockId" map
         replicasByBlockId.remove(reportedBlock);
         LOG.debug("UC block {} not found on {}, total is [replicas={} / blocks={}]",
                 reportedBlock, reportingNode, count, replicasByBlockId.size());
       } else {
+        // If the UC block replica is stored on some datanodes, then remove
+        // the reportingNode from the set if present
         removeUcBlockFromSet(reportingNode, reportedBlock, replicas);
       }
     } catch (Exception e) {
       // Observed during testing that exception thrown here
       // are caught & never logged
-      LOG.error("Remove UnderConstruction block {} {} failed",
+      LOG.warn("Remove UnderConstruction block {} {} failed",
           reportedBlock, reportingNode, e);
     }
   }
 
+  /**
+   * Private helper method to stop tracking an Under Construction block replica.
+   *
+   * @param reportingNode - datanode which is storing the Under Construction block replica.
+   * @param reportedBlock - Under Construction block replica to stop tracking for the datanode.
+   * @param storedReplicasForBlock - list of BlockReplica objects associated with the reportedBlock.
+   */
   private void removeUcBlockFromSet(DatanodeDescriptor reportingNode,
                                     Block reportedBlock,
                                     Set<BlockReplica> storedReplicasForBlock) {
+    // Extract the set of block replicas for the reportedBlock stored on the reportingNode.
+    // This reference is used for validation after the block replica is removed from the set.
     final List<BlockReplica> storedBlocks = storedReplicasForBlock.stream()
             .filter(replica -> reportingNode.equals(replica.getDatanode())
                 && reportedBlock.getGenerationStamp() >= replica.getBlock().getGenerationStamp())
             .collect(Collectors.toList());
+    // Stop tracking the block replica for the reportedBlock stored on the reportingNode
     storedReplicasForBlock.removeIf(replica -> reportingNode.equals(replica.getDatanode())
         && reportedBlock.getGenerationStamp() >= replica.getBlock().getGenerationStamp());
     if (storedReplicasForBlock.isEmpty()) {
+      // If the UC block replica is not stored on any datanodes,
+      // remove it from the "replicasByBlockId" map
       replicasByBlockId.remove(reportedBlock);
     }
+
+    // Log appropriate message based on the number of existing replicas
     final String storedBlockString = storedBlocks.stream()
             .map(br -> br.getBlock().toString())
             .collect(Collectors.joining(","));
     if (storedBlocks.size() > 1) {
+      // Duplicate block replicas were found for the reportingNode. This should never occur
+      // because each UC replica should only have one copy stored in "replicasByBlockId".
+      // Log a warning for this unexpected case.
       LOG.warn("Removed multiple UC block [{}->{}] from {}, total is [replicas={} / blocks={}]",
               storedBlockString, reportedBlock, reportingNode, count, replicasByBlockId.size());
     } else if (storedBlocks.size() == 1) {
+      // Exactly one replica removed, decrement the total UC replica count & log a debug message
       count--;
       LOG.debug("Removed UC block [{}->{}] from {}, new total is [replicas={} / blocks={}]",
               storedBlockString, reportedBlock, reportingNode, count, replicasByBlockId.size());
     } else {
-      // Not found on specific datanode
+      // No replicas were found/removed for this block on the specific datanode
       LOG.debug("UC block {} not found on {}, total is [replicas={} / blocks={}]",
               reportedBlock, reportingNode, count, replicasByBlockId.size());
     }
@@ -190,16 +242,19 @@ public class UnderConstructionBlocks {
   /**
    * If the datanode goes DEAD, the Namenode makes an assumption that
    * any write operations have failed.
+   *
+   * @param reportingNode - datanode which no longer has any Under Construction blocks.
    */
   void removeAllUcBlocksForDatanode(DatanodeDescriptor reportingNode) {
     if (!enabled) {
       return;
     }
     if (reportingNode == null) {
-      LOG.warn("Unexpected null input {}", reportingNode);
+      LOG.warn("Remove all UnderConstruction block has unexpected null input");
       return;
     }
     try {
+      // Stop tracking all block replicas associated with the datanode
       Set<Block> toRemoveFromMap = new HashSet<>();
       Set<BlockReplica> removedReplicas = new HashSet<>();
       for (Map.Entry<Block, Set<BlockReplica>> entry: replicasByBlockId.entrySet()) {
@@ -213,6 +268,7 @@ public class UnderConstructionBlocks {
           toRemoveFromMap.add(entry.getKey());
         }
       }
+      // Remove map entries for block replicas which are no longer stored on any datanodes
       for (Block remove: toRemoveFromMap) {
         replicasByBlockId.remove(remove);
       }
@@ -224,23 +280,29 @@ public class UnderConstructionBlocks {
     } catch (Exception e) {
       // Observed during testing that exception thrown here
       // are caught & never logged
-      LOG.error("Remove all UnderConstruction block failed for {}",
+      LOG.warn("Remove all UnderConstruction block failed for {}",
           reportingNode, e);
     }
   }
 
   /**
-   * Add an Under Construction block replicas for a given block.
+   * Start tracking an Under Construction block replica.
+   * This method is called when a block replica is
+   * reported in RBW (i.e. replica being written) state.
+   *
+   * @param reportingNode - datanode which is storing the Under Construction block replica.
+   * @param reportedBlock - Under Construction block replica to start tracking for the datanode.
    */
   void addUcBlock(DatanodeDescriptor reportingNode, Block reportedBlock) {
     if (!enabled) {
       return;
     }
     if (reportingNode == null || reportedBlock == null) {
-      LOG.warn("Unexpected null input {} , {}", reportingNode, reportedBlock);
+      LOG.warn("Add UnderConstruction block has unexpected null input");
       return;
     }
     try {
+      // Extract set of block replicas matching the reportedBlock
       Set<BlockReplica> storedReplicasForBlock;
       if (BlockIdManager.isStripedBlockID(reportedBlock.getBlockId())) {
         Block blkId = new Block(BlockIdManager.convertToStripedID(reportedBlock
@@ -250,36 +312,57 @@ public class UnderConstructionBlocks {
         reportedBlock = new Block(reportedBlock);
         storedReplicasForBlock = getBlockReplicas(reportedBlock);
       }
+
+      // Start tracking the new BlockReplica if not already present
       addUcBlockToSet(reportingNode, reportedBlock, storedReplicasForBlock);
     } catch (Exception e) {
       // Observed during testing that exception thrown here
       // are caught & never logged
-      LOG.error("Add UnderConstruction block {} on {} failed",
+      LOG.warn("Add UnderConstruction block {} on {} failed",
           reportedBlock, reportingNode, e);
     }
   }
 
+  /**
+   * Private helper method to start tracking an Under Construction block replica.
+   *
+   * @param reportingNode - datanode which is storing the Under Construction block replica.
+   * @param reportedBlock - Under Construction block replica to start tracking for the datanode.
+   * @param storedReplicasForBlock - list of BlockReplica objects associated with the reportedBlock.
+   */
   private void addUcBlockToSet(DatanodeDescriptor reportingNode,
                                Block reportedBlock,
                                Set<BlockReplica> storedReplicasForBlock) {
+    // Extract the set of block replicas for the reportedBlock stored on the reportingNode.
+    // This reference is used for validations such as checking for duplicate entries.
     List<BlockReplica> storedBlocks = storedReplicasForBlock.stream()
             .filter(replica -> reportingNode.equals(replica.getDatanode()))
             .collect(Collectors.toList());
     final String storedBlockString = storedBlocks.stream()
             .map(br -> br.getBlock().toString())
             .collect(Collectors.joining(","));
+
+    // Log appropriate message based on the number of existing block replicas
     if (!storedBlocks.isEmpty()) {
       if (storedBlocks.size() > 1) {
+        // Duplicate block replicas were found for the reportingNode. This should never occur
+        // because each UC replica should only have one copy stored in "replicasByBlockId".
+        // Log a warning for this unexpected case
         LOG.warn("UC block [{}->{}] multiple found on {}, total is [replicas={} / blocks={}]",
                 storedBlockString, reportedBlock, reportingNode, count, replicasByBlockId.size());
       } else {
+        // Block replica is already being tracked for the datanode
         LOG.debug("UC block [{}->{}] already found on {}, total is [replicas={} / blocks={}]",
                 storedBlockString, reportedBlock, reportingNode, count, replicasByBlockId.size());
       }
-      // Remove any replicas with older/stale GenerationStamp
+      // Remove any replicas with older/stale GenerationStamp. These block replicas with older
+      // generation stamp should be replaced by newer block replica version with newer
+      // generation stamp
       storedReplicasForBlock.removeIf(replica -> replica.getDatanode().equals(reportingNode)
           && replica.getBlock().getGenerationStamp() < reportedBlock.getGenerationStamp());
     }
+
+    // Add the UC block replica, increment the total UC replica count, & log a debug message
     if (storedReplicasForBlock.stream().noneMatch(replica ->
             reportingNode.equals(replica.getDatanode()))) {
       storedReplicasForBlock.add(new BlockReplica(new Block(reportedBlock), reportingNode));
@@ -289,6 +372,12 @@ public class UnderConstructionBlocks {
     }
   }
 
+  /**
+   * Returns all the Under Construction block replicas associated with a given block ID.
+   *
+   * @param block - block ID to get the Under Construction block replicas for.
+   * @return - list of Under Construction BlockReplicas associated with the block ID.
+   */
   private Set<BlockReplica> getBlockReplicas(Block block) {
     Set<BlockReplica> replicas = replicasByBlockId.get(block);
     if (replicas == null) {
@@ -298,26 +387,52 @@ public class UnderConstructionBlocks {
     return replicas;
   }
 
+ /**
+  * Returns all the Under Construction block replicas in an immutable map keyed by datanode.
+  *
+  * @return - immutable map of Under Construction block replicas.
+  */
   public Map<DatanodeDescriptor, List<Block>> getUnderConstructionBlocksByDatanode() {
     if (!enabled) {
       return Maps.newHashMap();
     }
-    // Each block can have a ReportedBlockInfo for each block replica.
-    // Below is counting all the block replicas for all the open blocks.
-    return replicasByBlockId.values().stream()
+    // Create a map from DatanodeDescriptor to a list of all Under Construction block replicas
+    // stored on the associated datanode.
+    final Map<DatanodeDescriptor, List<Block>> result = replicasByBlockId.values().stream()
         .flatMap(Collection::stream)
         .collect(Collectors.groupingBy(BlockReplica::getDatanode,
             Collectors.mapping(BlockReplica::getBlock, Collectors.toList())));
+    // If debug logging is enabled, print the count of Under Construction block replicas
+    // for each datanode.
+    if (LOG.isDebugEnabled()) {
+      String ucBlockCounts = result.entrySet().stream()
+              .map(e -> String.format("%s=%d", e.getKey(), e.getValue().size()))
+              .collect(Collectors.joining(",", "{", "}"));
+      LOG.debug("Under Construction block counts: [{}]", ucBlockCounts);
+    }
+    // Return the result as an unmodifiable map
+    return Collections.unmodifiableMap(result);
   }
 
+  /**
+   * Log a warning for each block replica which has been Under Construction for
+   * longer than LONG_UNDER_CONSTRUCTION_BLOCK_WARN_THRESHOLD. For each Under
+   * Construction block replica, rate limit the frequency of this log to be
+   * printed to be once every LONG_UNDER_CONSTRUCTION_BLOCK_WARN_INTERVAL.
+   */
   public void logWarningForLongUnderConstructionBlocks() {
     if (!enabled) {
       return;
     }
+    // DatanodeAdminMonitor invokes logWarningForLongUnderConstructionBlocks every 30 seconds.
+    // To reduce the number of times this method loops through the Under Construction blocks,
+    // the interval is limited by LONG_UNDER_CONSTRUCTION_BLOCK_CHECK_INTERVAL.
     if (Instant.now().isBefore(nextWarnLogCheck)) {
       return;
     }
     nextWarnLogCheck = Instant.now().plus(LONG_UNDER_CONSTRUCTION_BLOCK_CHECK_INTERVAL);
+
+    // Log a warning for each Under Construction block replica which meets the conditions.
     Stream<BlockReplica> allReplicas = replicasByBlockId.values()
         .stream().flatMap(Collection::stream);
     allReplicas.forEach(replica -> {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -4104,12 +4104,18 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
             if (dsInfos[i] != null) {
               if(copyTruncate) {
                 dsInfos[i].addBlock(truncatedBlock, truncatedBlock);
+                // Once the block is added to StorageInfos, it no longer needs to be
+                // tracked in UnderConstructionBlocks data structure.
+                blockManager.removeUcBlock(dsInfos[i].getDatanodeDescriptor(), truncatedBlock);
               } else {
                 Block bi = new Block(storedBlock);
                 if (storedBlock.isStriped()) {
                   bi.setBlockId(bi.getBlockId() + i);
                 }
                 dsInfos[i].addBlock(storedBlock, bi);
+                // Once the block is added to StorageInfos, it no longer needs to be
+                // tracked in UnderConstructionBlocks data structure.
+                blockManager.removeUcBlock(dsInfos[i].getDatanodeDescriptor(), bi);
               }
             }
           }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -1234,6 +1234,27 @@
 </property>
 
 <property>
+  <name>dfs.namenode.decommission.track.underconstructionblocks</name>
+  <value>false</value>
+  <description>
+    A datanode should only enter decommissioned state if all blocks
+    on the datanode are sufficiently replicated to other live datanodes.
+
+    When this setting is disabled, the Namenode does not consider
+    Under Construction blocks in determining if a datanode can be
+    decommissioned; this results in scenarios where datanodes enter
+    decommissioned state before their blocks are sufficiently replicated
+    to other live datanodes. This can lead to HDFS write failures and
+    data loss, if all the datanodes in the block write pipeline are
+    decommissioned and terminated at around the same time.
+
+    Enable the following setting to have the Namenode track and consider
+    Under Construction blocks when identifying if a datanode can be
+    decommissioned.
+  </description>
+</property>
+
+<property>
   <name>dfs.namenode.redundancy.interval.seconds</name>
   <value>3</value>
   <description>The periodicity in seconds with which the namenode computes 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -1237,20 +1237,25 @@
   <name>dfs.namenode.decommission.track.underconstructionblocks</name>
   <value>false</value>
   <description>
-    A datanode should only enter decommissioned state if all blocks
-    on the datanode are sufficiently replicated to other live datanodes.
+    Determines whether the NameNode tracks under-construction blocks
+    when decommissioning DataNodes.
 
-    When this setting is disabled, the Namenode does not consider
-    Under Construction blocks in determining if a datanode can be
-    decommissioned; this results in scenarios where datanodes enter
-    decommissioned state before their blocks are sufficiently replicated
-    to other live datanodes. This can lead to HDFS write failures and
-    data loss, if all the datanodes in the block write pipeline are
-    decommissioned and terminated at around the same time.
+    A DataNode should only enter decommissioned state if all blocks on
+    the DataNode are sufficiently replicated to other live DataNodes.
 
-    Enable the following setting to have the Namenode track and consider
-    Under Construction blocks when identifying if a datanode can be
-    decommissioned.
+    When this setting is disabled, the NameNode does not consider
+    under-construction blocks in determining if a DataNode can be
+    decommissioned. This can result in scenarios where DataNodes
+    enter decommissioned state before their blocks are sufficiently
+    replicated to other live DataNodes.
+
+    This situation can lead to HDFS write failures and data loss if
+    all the DataNodes in the block write pipeline are decommissioned
+    and terminated at around the same time.
+
+    Enable this setting to have the NameNode track and consider
+    under-construction blocks when identifying if a DataNode can
+    be decommissioned.
   </description>
 </property>
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestUnderConstructionBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestUnderConstructionBlocks.java
@@ -1,0 +1,230 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.blockmanagement;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.protocol.Block;
+import org.apache.hadoop.hdfs.protocol.DatanodeID;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit test the methods of "UnderConstructionBlocks" class.
+ */
+public class TestUnderConstructionBlocks {
+  private static final Logger LOG = LoggerFactory.getLogger(TestUnderConstructionBlocks.class);
+
+  private static final DatanodeDescriptor DATANODE1 = new DatanodeDescriptor(
+      new DatanodeID("10.0.0.1", "host1", "UUID1", 8000, 8001, 8002, 8003));
+  private static final DatanodeDescriptor DATANODE2 = new DatanodeDescriptor(
+          new DatanodeID("10.0.0.2", "host2", "UUID2", 8000, 8001, 8002, 8003));
+
+  private static final Block BLOCK1 = new Block(123L, 1000L, 1001L);
+  private static final Block BLOCK1_V2 = new Block(123L, 1000L, 1002L);
+  private static final Block BLOCK1_V3 = new Block(123L, 1000L, 1003L);
+  private static final Block BLOCK2 = new Block(456L, 1000L, 1004L);
+
+  @Test
+  public void testFeatureDisabled() {
+    // Setup
+    Configuration conf = Mockito.mock(Configuration.class);
+    Mockito.when(conf.getBoolean(DFSConfigKeys.DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS,
+            DFSConfigKeys.DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS_DEFAULT))
+            .thenReturn(false);
+    final UnderConstructionBlocks ucBlocks = new UnderConstructionBlocks(conf);
+    // Validate all operations are no-ops
+    Assert.assertEquals(0, ucBlocks.getUnderConstructionBlocksByDatanode().size());
+    ucBlocks.addUcBlock(DATANODE1, BLOCK1);
+    ucBlocks.addUcBlock(DATANODE2, BLOCK2);
+    Assert.assertEquals(0, ucBlocks.getUnderConstructionBlocksByDatanode().size());
+    ucBlocks.removeUcBlock(DATANODE2, BLOCK2);
+    Assert.assertEquals(0, ucBlocks.getUnderConstructionBlocksByDatanode().size());
+    ucBlocks.removeAllUcBlocksForDatanode(DATANODE1);
+    Assert.assertEquals(0, ucBlocks.getUnderConstructionBlocksByDatanode().size());
+  }
+
+  @Test
+  public void testAddAndRemoveUcBlocks() {
+    // Setup
+    Configuration conf = Mockito.mock(Configuration.class);
+    Mockito.when(conf.getBoolean(DFSConfigKeys.DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS,
+            DFSConfigKeys.DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS_DEFAULT))
+            .thenReturn(true);
+    final UnderConstructionBlocks ucBlocks = new UnderConstructionBlocks(conf);
+    Assert.assertTrue(ucBlocks.getUnderConstructionBlocksByDatanode().isEmpty());
+    // Test Add
+    ucBlocks.addUcBlock(DATANODE1, BLOCK1);
+    ucBlocks.addUcBlock(DATANODE1, BLOCK2);
+    ucBlocks.addUcBlock(DATANODE2, BLOCK2);
+    Map<DatanodeDescriptor, List<Block>> byDatanode =
+        ucBlocks.getUnderConstructionBlocksByDatanode();
+    Assert.assertEquals(2, byDatanode.size());
+    Assert.assertEquals(2, byDatanode.get(DATANODE1).size());
+    Assert.assertTrue(byDatanode.get(DATANODE1).stream().anyMatch(b -> b.equals(BLOCK1)));
+    Assert.assertTrue(byDatanode.get(DATANODE1).stream().anyMatch(b -> b.equals(BLOCK2)));
+    Assert.assertEquals(1, byDatanode.get(DATANODE2).size());
+    Assert.assertEquals(BLOCK2, byDatanode.get(DATANODE2).get(0));
+    // Test Remove
+    ucBlocks.removeUcBlock(DATANODE1, BLOCK2);
+    ucBlocks.removeUcBlock(DATANODE2, BLOCK2);
+    byDatanode = ucBlocks.getUnderConstructionBlocksByDatanode();
+    Assert.assertEquals(1, byDatanode.size());
+    Assert.assertEquals(1, byDatanode.get(DATANODE1).size());
+    Assert.assertEquals(BLOCK1, byDatanode.get(DATANODE1).get(0));
+    Assert.assertNull(byDatanode.get(DATANODE2));
+    // Test Add (with duplicate)
+    ucBlocks.addUcBlock(DATANODE1, BLOCK1);
+    ucBlocks.addUcBlock(DATANODE1, BLOCK1);
+    ucBlocks.addUcBlock(DATANODE2, BLOCK1);
+    ucBlocks.addUcBlock(DATANODE2, BLOCK1);
+    byDatanode = ucBlocks.getUnderConstructionBlocksByDatanode();
+    Assert.assertEquals(2, byDatanode.size());
+    Assert.assertEquals(1, byDatanode.get(DATANODE1).size());
+    Assert.assertEquals(BLOCK1, byDatanode.get(DATANODE1).get(0));
+    Assert.assertEquals(1, byDatanode.get(DATANODE2).size());
+    Assert.assertEquals(BLOCK1, byDatanode.get(DATANODE2).get(0));
+    // Test Remove All
+    ucBlocks.removeAllUcBlocksForDatanode(DATANODE1);
+    byDatanode = ucBlocks.getUnderConstructionBlocksByDatanode();
+    Assert.assertEquals(1, byDatanode.size());
+    ucBlocks.removeAllUcBlocksForDatanode(DATANODE2);
+    byDatanode = ucBlocks.getUnderConstructionBlocksByDatanode();
+    Assert.assertEquals(0, byDatanode.size());
+  }
+
+  @Test
+  public void testRemoveUcBlocksWithOldGenerationStamp() {
+    // Setup
+    Configuration conf = Mockito.mock(Configuration.class);
+    Mockito.when(conf.getBoolean(DFSConfigKeys.DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS,
+            DFSConfigKeys.DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS_DEFAULT))
+            .thenReturn(true);
+    final UnderConstructionBlocks ucBlocks = new UnderConstructionBlocks(conf);
+    Assert.assertTrue(ucBlocks.getUnderConstructionBlocksByDatanode().isEmpty());
+    // Add with v2 Genstamp
+    ucBlocks.addUcBlock(DATANODE2, BLOCK1_V2);
+    Map<DatanodeDescriptor, List<Block>> byDatanode =
+        ucBlocks.getUnderConstructionBlocksByDatanode();
+    Assert.assertEquals(1, byDatanode.size());
+    Assert.assertEquals(1, byDatanode.get(DATANODE2).size());
+    Assert.assertEquals(BLOCK1_V2, byDatanode.get(DATANODE2).get(0));
+    Assert.assertEquals(BLOCK1_V2.getGenerationStamp(),
+        byDatanode.get(DATANODE2).get(0).getGenerationStamp());
+    // Remove with older Genstamp (should have no effect)
+    ucBlocks.removeUcBlock(DATANODE2, BLOCK1);
+    byDatanode = ucBlocks.getUnderConstructionBlocksByDatanode();
+    Assert.assertEquals(1, byDatanode.size());
+    Assert.assertEquals(1, byDatanode.get(DATANODE2).size());
+    Assert.assertEquals(BLOCK1_V2, byDatanode.get(DATANODE2).get(0));
+    Assert.assertEquals(BLOCK1_V2.getGenerationStamp(),
+        byDatanode.get(DATANODE2).get(0).getGenerationStamp());
+    // Remove with newer Genstamp (should have effect)
+    ucBlocks.removeUcBlock(DATANODE2, BLOCK1_V3);
+    byDatanode = ucBlocks.getUnderConstructionBlocksByDatanode();
+    Assert.assertEquals(0, byDatanode.size());
+  }
+
+  @Test
+  public void testAddUcBlocksWithOldGenerationStamp() {
+    // Setup
+    Configuration conf = Mockito.mock(Configuration.class);
+    Mockito.when(conf.getBoolean(DFSConfigKeys.DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS,
+            DFSConfigKeys.DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS_DEFAULT))
+            .thenReturn(true);
+    final UnderConstructionBlocks ucBlocks = new UnderConstructionBlocks(conf);
+    Assert.assertTrue(ucBlocks.getUnderConstructionBlocksByDatanode().isEmpty());
+    // Add with v2 Genstamp
+    ucBlocks.addUcBlock(DATANODE2, BLOCK1_V2);
+    Map<DatanodeDescriptor, List<Block>> byDatanode =
+        ucBlocks.getUnderConstructionBlocksByDatanode();
+    Assert.assertEquals(1, byDatanode.size());
+    Assert.assertEquals(1, byDatanode.get(DATANODE2).size());
+    Assert.assertEquals(BLOCK1_V2, byDatanode.get(DATANODE2).get(0));
+    Assert.assertEquals(BLOCK1_V2.getGenerationStamp(),
+            byDatanode.get(DATANODE2).get(0).getGenerationStamp());
+    // Add with older Genstamp (should have no effect)
+    ucBlocks.addUcBlock(DATANODE2, BLOCK1);
+    byDatanode = ucBlocks.getUnderConstructionBlocksByDatanode();
+    Assert.assertEquals(1, byDatanode.size());
+    Assert.assertEquals(1, byDatanode.get(DATANODE2).size());
+    Assert.assertEquals(BLOCK1_V2, byDatanode.get(DATANODE2).get(0));
+    Assert.assertEquals(BLOCK1_V2.getGenerationStamp(),
+            byDatanode.get(DATANODE2).get(0).getGenerationStamp());
+    // Add with newer Genstamp (should cause Genstamp to be updated)
+    ucBlocks.addUcBlock(DATANODE2, BLOCK1_V3);
+    byDatanode = ucBlocks.getUnderConstructionBlocksByDatanode();
+    Assert.assertEquals(1, byDatanode.size());
+    Assert.assertEquals(1, byDatanode.get(DATANODE2).size());
+    Assert.assertEquals(BLOCK1_V3, byDatanode.get(DATANODE2).get(0));
+    Assert.assertEquals(BLOCK1_V3.getGenerationStamp(),
+        byDatanode.get(DATANODE2).get(0).getGenerationStamp());
+  }
+
+  /**
+   * This is the actual sequence of events which occurs when a block
+   * has a new Genstamp created.
+   * - replica with old Genstamp is marked stale & removed
+   * - replica with new Genstamp is then added afterward
+   */
+  @Test
+  public void testGenstampPromotionScenario() {
+    // Setup
+    Configuration conf = Mockito.mock(Configuration.class);
+    Mockito.when(conf.getBoolean(DFSConfigKeys.DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS,
+            DFSConfigKeys.DFS_DECOMMISSION_TRACK_UNDER_CONSTRUCTION_BLOCKS_DEFAULT))
+            .thenReturn(true);
+    final UnderConstructionBlocks ucBlocks = new UnderConstructionBlocks(conf);
+    Assert.assertTrue(ucBlocks.getUnderConstructionBlocksByDatanode().isEmpty());
+    // Test Add
+    ucBlocks.addUcBlock(DATANODE1, BLOCK1);
+    ucBlocks.addUcBlock(DATANODE1, BLOCK2);
+    ucBlocks.addUcBlock(DATANODE2, BLOCK1);
+    Map<DatanodeDescriptor, List<Block>> byDatanode =
+        ucBlocks.getUnderConstructionBlocksByDatanode();
+    Assert.assertEquals(2, byDatanode.size());
+    Assert.assertEquals(2, byDatanode.get(DATANODE1).size());
+    Assert.assertTrue(byDatanode.get(DATANODE1).stream().anyMatch(b -> b.equals(BLOCK1)));
+    Assert.assertTrue(byDatanode.get(DATANODE1).stream().anyMatch(b -> b.equals(BLOCK2)));
+    Assert.assertEquals(1, byDatanode.get(DATANODE2).size());
+    Assert.assertEquals(BLOCK1, byDatanode.get(DATANODE2).get(0));
+    // Remove stale replica
+    ucBlocks.removeUcBlock(DATANODE1, BLOCK1);
+    ucBlocks.removeUcBlock(DATANODE2, BLOCK1_V2);
+    byDatanode = ucBlocks.getUnderConstructionBlocksByDatanode();
+    Assert.assertEquals(1, byDatanode.size());
+    Assert.assertEquals(1, byDatanode.get(DATANODE1).size());
+    Assert.assertEquals(BLOCK2, byDatanode.get(DATANODE1).get(0));
+    // Add v2 Genstamp replicas
+    ucBlocks.addUcBlock(DATANODE1, BLOCK1_V2);
+    ucBlocks.addUcBlock(DATANODE2, BLOCK1_V2);
+    byDatanode = ucBlocks.getUnderConstructionBlocksByDatanode();
+    Assert.assertEquals(2, byDatanode.size());
+    Assert.assertEquals(2, byDatanode.get(DATANODE1).size());
+    Assert.assertTrue(byDatanode.get(DATANODE1).stream().anyMatch(b -> b.equals(BLOCK1_V2)));
+    Assert.assertTrue(byDatanode.get(DATANODE1).stream().anyMatch(b -> b.equals(BLOCK2)));
+    Assert.assertEquals(1, byDatanode.get(DATANODE2).size());
+    Assert.assertEquals(BLOCK1_V2, byDatanode.get(DATANODE2).get(0));
+  }
+}


### PR DESCRIPTION
## Problem

Problem background:
- A datanode should only enter decommissioned state if all the blocks on the datanode are sufficiently replicated to other live datanodes.
- This expectation is violated for Under Construction blocks which are not considered by the DatanodeAdminMonitor at all.
- DatanodeAdminMonitor currently only considers blocks in the DatanodeDescriptor StorageInfos. This is because:
  - For a new HDFS block that was just created, it is not be added to the StorageInfos until the HDFS client closes the DFSOutputStream & the block becomes finalized
  - For an existing HDFS block that was opened for append:
    - First, the block version with the previous generation stamp is marked stale & removed from the StorageInfos
    - Next, the block version with the new generation stamp is not be added to the StorageInfos until the HDFS client closes the DFSOutputStream & the block becomes finalized

There is logic in the DatanodeAdminManager/DatanodeAdminMonitor to avoid transitioning datanodes to decommissioned state when they have open (i.e. Under Construction) blocks:
- https://github.com/apache/hadoop/blob/cd2cffe73f909a106ba47653acf525220f2665cf/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminManager.java#L357
- https://github.com/apache/hadoop/blob/cd2cffe73f909a106ba47653acf525220f2665cf/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminManager.java#L305

This logic does not work correctly because, as mentioned above, [DatanodeAdminMonitor currently only considers blocks in the DatanodeDescriptor StorageInfos](https://github.com/apache/hadoop/blob/cd2cffe73f909a106ba47653acf525220f2665cf/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java#L385) which does not include Under Construction blocks for which the DFSOutputStream has not been closed yet.

There is also logic in the HDFS [DataStreamer client which will replace bad/dead datanodes in the block write pipeline](https://github.com/apache/hadoop/blob/cd2cffe73f909a106ba47653acf525220f2665cf/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java#L1716). Note that:
- this logic does not work if the replication factor is 1
- if the replication factor is greater than 1, then this logic does not work if all the datanodes in the block write pipeline are decommissioned/terminated at around the same time

Overall, the Namenode should not be putting datanodes with open blocks into decommissioned state & hope that the DataStreamer client is able to replace them when the decommissioned datanodes are terminated. This will not work depending on the timing & therefore is not a solution which guarantees correctness.

The Namenode needs to honor the rule that "a datanode should only enter decommissioned state if all the blocks on the datanode are sufficiently replicated to other live datanodes", even for blocks which are currently Under Construction.


## Potential Solutions

One possible opinion is that if the DFSOutputStream has not been successfuly closed yet, then the client should be able to replay all the data if there is a failure. The client should not have any expectation the data is committed to HDFS until the DFSOutputStream is closed. There are a few reasons I do not think this makes sense:
- The methods hflush/hsync do not result in the data already appended to the DFSOutputStream being persisted/finalized. This is confusing when compared the standard experience of stream flush/sync methods.
- This does not handle the case where a block is re-opened by a new DFSOutputStream after having been previously closed (by another different client). In this case, the problem will lead to data loss for data that was previously committed by another client & cannot be replayed.
  - To solve this problem, we could try not removing old block version from StorageInfos when a new block version is created; however, this change is likely to have wider implications on block management.

Another possible option that comes to mind is to add blocks to StorageInfos before they are finalized. However, this change also is likely to have wider implications on block management.

Without modifying any existing block management logic, we can add a new data structure (UnderConstructionBlocks) which temporarily tracks the Under Construction blocks in-memory until they are committed/finalized & added to the StorageInfos.


## Solution

Add a new data structure (UnderConstructionBlocks) which temporarily tracks the Under Construction blocks in-memory until they are committed/finalized & added to the StorageInfos.

Pros:
- works for newly created HDFS block
- works for re-opened HDFS block (i.e. opened for append)
- works for block with any replication factor
- does not change logic in BlockManager, the new UnderConstructionBlocks data structure & associated logic is purely additive


## Implementation Details

- Feature is behind a configuration "dfs.namenode.decommission.track.underconstructionblocks" which is disabled by default.
  - When enabled, feature prevents HDFS data loss & write failures at the cost of potentially slowing down the decommissioning process.
  - Customer who do not use HDFS decommissioning feature can choose to leave the feature disabled as they will not benefit from the additional CPU/memory overhead consumed by UnderConstructionBlocks.
  - Customers who do use HDFS decommissioning feature but who do not care about HDFS data loss & write failures can choose to leave the feature disabled.
  - Main use-case for enabling the feature is for HDFS clusters with many concurrent write operations & datanode decommissioning operations. These clusters will see benefit of reduced HDFS data loss & write failures caused by decommissioning.

- In the regular case, when a DFSOutputStream is closed it takes 1-2 seconds for the block replicas to be removed from UnderConstructionBlocks & added to the StorageInfos. Therefore, datanode decommissioning is only blocked until the DFSOutputStream is closed & the write operation is finished, after this time there is minimal delay in unblocking decommissioning.

- In the unhappy case, when an HDFS client fails & the DFSOutputStream is never closed, then it takes `dfs.namenode.lease-hard-limit-sec = 20` minutes before the lease expires & the Namenode recovers the block. As part of block recovery, the block replicas are removed from UnderConstructionBlocks & added to the StorageInfos. Therefore, if an HDFS client fails it will (by default) take 20 minutes before decommissioning becomes unblocked.

- The UnderConstructionBlocks data structure is in-memory only & therefore if the Namenode is restarted then it will lose track of any previously reported Under Construction blocks. This means that datanodes can be decommissioned with Under Construction blocks if the Namenode is restarted (which makes HDFS data loss & write failures possible again).

- Testing shows that UnderConstructionBlocks should not leak any Under Construction blocks (i.e. which are never removed). However, as a safeguard to monitor for this issue, any block replica open for over 2 hours will have a WARN log printed by the Namenode every 30 minutes which mentions how long the block has been open for.

- The implementation of UnderConstructionBlocks was borrowed from existing code in [PendingDataNodeMessages](https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingDataNodeMessages.java). PendingDataNodeMessages is already used by the [BlockManager to track in-memory the block replicas which have been reported to the standby namenode out-of-order](https://github.com/apache/hadoop/blob/cd2cffe73f909a106ba47653acf525220f2665cf/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java#L3486).


### How was this patch tested?

#### Test Methodology

I have used the following HDFS client code to test various scenarios on a Hadoop 3.4.0 cluster with 6 datanodes:

```
import org.apache.hadoop.conf.Configuration;
import org.apache.hadoop.hdfs.DFSClient;
import org.apache.hadoop.hdfs.DFSOutputStream;
import org.apache.hadoop.hdfs.client.HdfsDataOutputStream;
import org.apache.hadoop.fs.CreateFlag;

import java.io.IOException;
import java.io.OutputStream;
import java.net.InetAddress;
import java.net.URI;
import java.nio.charset.StandardCharsets;
import java.time.format.DateTimeFormatter;
import java.time.Duration;
import java.time.Instant;
import java.time.ZoneId;
import java.util.EnumSet;
import java.util.UUID;

public class HdfsWrite {
    // Constants
    private static final String HDFS_URI = "hdfs://%s:8020";
    private static final String HDFS_PATH = "/tmp/testfile-" + UUID.randomUUID().toString();
    private static final int DATA_SIZE_KB = 100;
    private static final int BUFFER_SIZE_KB = 25;
    private static final int SLEEP_INTERVAL_SECONDS = 20;
    private static final short REPLICATION = (short) 3;
    private static final long BLOCK_SIZE = 256L * 1024 * 1024;
    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.of("UTC"));

    // Tunable Configs
    private static final Duration INITIAL_WRITE_DURATION = Duration.ofMinutes(2);
    private static final boolean shouldAppend = true;
    private static final Duration SECOND_WRITE_DURATION = Duration.ofMinutes(500);

    private static long totalSize = 0;

    public static void main(String[] args) {
        try {
            URI hdfsURI = new URI(String.format(HDFS_URI, InetAddress.getLocalHost().getHostName()));
            Configuration conf = new Configuration();
            DFSClient client = new DFSClient(hdfsURI, conf);

            // Initial Create/Write
            DFSOutputStream createStream = createFile(client);
            logLine(String.format("Created File %s", HDFS_PATH));
            Instant exitTime = Instant.now().plus(INITIAL_WRITE_DURATION);
            while (Instant.now().isBefore(exitTime)) {
                appendData(createStream);
                Thread.sleep(SLEEP_INTERVAL_SECONDS * 1000);
            }
            createStream.close();
            logLine(String.format("Closed File"));

            // Exit if append disabled
            if (!shouldAppend) {
                return;
            }

            // Second Append/Write
            DFSOutputStream outStream = openFileForAppend(client);
            logLine(String.format("Opened File %s", HDFS_PATH));
            exitTime = Instant.now().plus(SECOND_WRITE_DURATION);
            while (Instant.now().isBefore(exitTime)) {
                appendData(outStream);
                Thread.sleep(SLEEP_INTERVAL_SECONDS * 1000);
            }
            outStream.close();
            logLine(String.format("Closed File"));
        } catch (Exception e) {
            e.printStackTrace();
        }
    }

    private static DFSOutputStream createFile(DFSClient client) throws Exception {
        return (DFSOutputStream) client.create(HDFS_PATH, true, REPLICATION, BLOCK_SIZE);
    }

    private static DFSOutputStream openFileForAppend(DFSClient client) throws Exception {
        return (DFSOutputStream) ((HdfsDataOutputStream) client.append(HDFS_PATH, BUFFER_SIZE_KB * 1024, EnumSet.of(CreateFlag.APPEND), null, null)).getWrappedStream();
    }

    private static void appendData(DFSOutputStream outStream) {
        try {
            String data = generateData(DATA_SIZE_KB * 1024);
            outStream.write(data.getBytes(StandardCharsets.UTF_8));
            outStream.hflush();
            totalSize += DATA_SIZE_KB;
            logLine(String.format("Append Success  %d KB", totalSize));
        } catch (Exception e) {
            logLine(String.format("Append Failed   %d KB", totalSize));
            e.printStackTrace();
        }
    }

    private static String generateData(int size) {
        StringBuilder sb = new StringBuilder();
        while (sb.length() < size) {
            sb.append("A");
        }
        return sb.toString();
    }

    private static void logLine(String line) {
        Instant now = Instant.now();
        System.out.println(TIME_FORMAT.format(now) + " " + line);
    }
}
```

The code enables testing 2 key scenarios:
1. Decommissioning datanodes with block replicas that are actively being written by a DFSOutputStream
2. Decommissioning datanodes with block replicas that were previously written by a DFSOutputStream that has been closed

Both these scenarios can also be tested for:
- A new HDFS block/file which has just been created with HDFS client "create" method
- An existing HDFS block/file which was re-opened with HDFS client "append" method

#### Test Results Summary

Tests which show the behaviour before & after this change:

| Test # | Test Case | Test Script Configurations | Behaviour Before this Change | Behaviour After this Change |
| ------ | --------- | -------------------------- | --------------------------- | -------------------------- |
| 1      | Create & write new file, then close file, then decommission datanodes with the block replicas | INITIAL_WRITE_DURATION=2mins, shouldAppend=false, SECOND_WRITE_DURATION=n/a | DatanodeAdminMonitor moves block replicas to other live datanodes before decommissioning finishes. **No HDFS data loss. No HDFS write failures.** | DatanodeAdminMonitor moves block replicas to other live datanodes before decommissioning finishes. **No HDFS data loss. No HDFS write failures.** | 
| 2      | Create & repeatedly write file without closing, at the same time decommission datanodes with the block replicas | INITIAL_WRITE_DURATION=60mins, shouldAppend=false, SECOND_WRITE_DURATION=n/a | DatanodeAdminMonitor does not consider the under construction block replicas & the datanodes move to decommissioned immediately. When the decommissioned datanodes are terminated this **leads to HDFS write failures & HDFS data loss.** | DatanodeAdminMonitor does not transition datanodes to decommissioned if they have under construction block replicas. **No HDFS data loss. No HDFS write failures.** | 
| 3      | Create & write new file, then close file, then open file for append & write file, then close file, then decommission datanodes with the block replicas | INITIAL_WRITE_DURATION=2mins, shouldAppend=true, SECOND_WRITE_DURATION=2mins | DatanodeAdminMonitor moves block replicas to other live datanodes before decommissioning finishes. **No HDFS data loss. No HDFS write failures.** | DatanodeAdminMonitor moves block replicas to other live datanodes before decommissioning finishes. **No HDFS data loss. No HDFS write failures.** | 
| 4      | Create & write new file, then close file, then open file for append & repeatedly write file without closing, at the same time decommission datanodes with the block replicas | INITIAL_WRITE_DURATION=2mins, shouldAppend=true, SECOND_WRITE_DURATION=60mins | DatanodeAdminMonitor does not consider the under construction block replicas & the datanodes move to decommissioned immediately. When the decommissioned datanodes are terminated this **leads to HDFS write failures & HDFS data loss**. | DatanodeAdminMonitor does not transition datanodes to decommissioned if they have under construction block replicas. **No HDFS data loss. No HDFS write failures.** | 

Tests which show how long these changes can possibly block datanode decommissioning:

| Test # | Test Case | Test Script Configurations | Behaviour After this Change |
| ------ | --------- | -------------------------- |  -------------------------- |
| 5      | Create & repeatedly write file without closing, at the same time decommission datanodes with the block replicas, then close the file while datanodes are still decommissioning | INITIAL_WRITE_DURATION=10mins, shouldAppend=false, SECOND_WRITE_DURATION=n/a | DatanodeAdminMonitor does not transition datanodes to decommissioned while they have under construction block replicas. No HDFS data loss. No HDFS write failures. **When the DFSOutputStream is finally close, it takes 1-2 seconds before the replicas are reported to the Namenode as RECEIVED_BLOCK & the decommissioning process can then complete as-usual.** | 
| 6      | Create & repeatedly write file without closing, at the same time decommission datanodes with the block replicas, then kill the client abruptly | INITIAL_WRITE_DURATION=60mins, shouldAppend=false, SECOND_WRITE_DURATION=n/a | DatanodeAdminMonitor does not transition datanodes to decommissioned while they have under construction block replicas. No HDFS data loss. No HDFS write failures. **After `dfs.namenode.lease-hard-limit-sec = 20 minutes` from the time the client failed, the Namenode transitions the block replicas into recovery & the decommissioning process can then complete as-usual.** |

In other words:
- in the happy case, datanode decommissioning is unblocked 1-2 seconds after the DFSOutputStream is closed by the client
- in the worst case, datanode decommissioning is unblocked "dfs.namenode.lease-hard-limit-sec = 20 minutes" after the HDFS client fails abruptly

The above scenarios where tested with various different configurations:
- tested with different "dfs.replication" values of 1, 2, & 3
- tested with the following configurations:
  - "dfs.client.block.write.replace-datanode-on-failure.best-effort": "true"
  - "dfs.client.block.write.replace-datanode-on-failure.enable": "true"
  - "dfs.client.block.write.replace-datanode-on-failure.min-replication": "0"
  - "dfs.client.block.write.replace-datanode-on-failure.policy": "ALWAYS"
  - "dfs.client.block.write.retries": "10000"
  - "dfs.namenode.file.close.num-committed-allowed": "1"
- tested with "dfs.namenode.decommission.consider.openfiles = false" to confirm behaviour is same as before the change
- tested with Namenode restart and confirmed that this causes behaviour to be same as before the change
- tested & confirmed UnderConstructionBlocks is not leaking any entries when there are many concurrent writes, datanode decommissioning operations, and Namenode restarts

Below are the detailed logs for a single test case 4.

#### Test#4 Detailed Results , Before this Change

The following are the HDFS client logs for the duration of the test:

```
2024-12-05 15:51:08 Created File /tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2
2024-12-05 15:51:08 Append Success  100 KB
2024-12-05 15:51:28 Append Success  200 KB
2024-12-05 15:51:48 Append Success  300 KB
2024-12-05 15:52:08 Append Success  400 KB
2024-12-05 15:52:28 Append Success  500 KB
2024-12-05 15:52:48 Append Success  600 KB
2024-12-05 15:53:08 Closed File
2024-12-05 15:53:08 Opened File /tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2
2024-12-05 15:53:09 Append Success  700 KB
2024-12-05 15:53:29 Append Success  800 KB
2024-12-05 15:53:49 Append Success  900 KB
2024-12-05 15:54:09 Append Success  1000 KB
2024-12-05 15:54:29 Append Success  1100 KB
2024-12-05 15:54:49 Append Success  1200 KB
2024-12-05 15:55:09 Append Success  1300 KB
2024-12-05 15:55:29 Append Success  1400 KB
2024-12-05 15:55:49 Append Success  1500 KB
2024-12-05 15:56:09 Append Success  1600 KB
2024-12-05 15:56:29 Append Failed   1600 KB
java.net.ConnectException: Connection refused
        at sun.nio.ch.SocketChannelImpl.checkConnect(Native Method)
        at sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:716)
        at org.apache.hadoop.net.SocketIOWithTimeout.connect(SocketIOWithTimeout.java:205)
        at org.apache.hadoop.net.NetUtils.connect(NetUtils.java:635)
        at org.apache.hadoop.hdfs.DataStreamer.createSocketForPipeline(DataStreamer.java:256)
        at org.apache.hadoop.hdfs.DataStreamer$StreamerStreams.<init>(DataStreamer.java:165)
        at org.apache.hadoop.hdfs.DataStreamer.transfer(DataStreamer.java:1593)
        at org.apache.hadoop.hdfs.DataStreamer.addDatanode2ExistingPipeline(DataStreamer.java:1550)
        at org.apache.hadoop.hdfs.DataStreamer.handleDatanodeReplacement(DataStreamer.java:1758)
        at org.apache.hadoop.hdfs.DataStreamer.setupPipelineInternal(DataStreamer.java:1648)
        at org.apache.hadoop.hdfs.DataStreamer.setupPipelineForAppendOrRecovery(DataStreamer.java:1627)
        at org.apache.hadoop.hdfs.DataStreamer.processDatanodeOrExternalError(DataStreamer.java:1408)
        at org.apache.hadoop.hdfs.DataStreamer.run(DataStreamer.java:707)
2024-12-05 15:56:49 Append Failed   1600 KB
java.net.ConnectException: Connection refused
        ...
2024-12-05 15:57:09 Append Failed   1600 KB
java.net.ConnectException: Connection refused
        ...
2024-12-05 15:57:29 Append Failed   1600 KB
java.net.ConnectException: Connection refused
        ...
2024-12-05 15:57:49 Append Failed   1600 KB
java.net.ConnectException: Connection refused
        ...
2024-12-05 15:58:09 Append Failed   1600 KB
java.net.ConnectException: Connection refused
        ...
2024-12-05 15:58:29 Append Failed   1600 KB
java.net.ConnectException: Connection refused
        ...
2024-12-05 15:58:49 Append Failed   1600 KB
java.net.ConnectException: Connection refused
        ...
2024-12-05 15:59:09 Append Failed   1600 KB
java.net.ConnectException: Connection refused
        ...
2024-12-05 15:59:29 Append Failed   1600 KB
java.net.ConnectException: Connection refused
        ...
2024-12-05 15:59:49 Append Failed   1600 KB
java.net.ConnectException: Connection refused
        ...
```

First step is to identify the block locations:

```
> cat /var/log/hadoop-hdfs/hadoop-hdfs-namenode-ip-*.out | grep testfile | grep blk
...
2024-12-05 15:51:08,342 INFO hdfs.StateChange: BLOCK* allocate blk_1073741825_1001, replicas=172.31.86.141:9866, 172.31.93.89:9866, 172.31.87.40:9866 for /tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2
...
```

Then we wait for the block to be closed & re-opened. Once this is completed, we can start decommissioning the 3 datanodes with under construction block replicas:

```
> cat dfs.hosts.exclude
ip-172-31-86-141.ec2.internal
ip-172-31-93-89.ec2.internal
ip-172-31-87-40.ec2.internal

> export HADOOP_USER_NAME=hdfs

> hdfs dfsadmin -refreshNodes
...
2024-12-05 15:54:28,269 DEBUG ipc.ProtobufRpcEngine2: Call: refreshNodes took 100ms
Refresh nodes successful
...
```

Check the decommissioning status of the datanodes to confirm they are decommissioned:

```
> cat /var/log/hadoop-hdfs/hadoop-hdfs-namenode-ip-*.out | grep DatanodeAdmin
...
2024-12-05 15:53:32,804 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: DatanodeAdminMonitor is running.
2024-12-05 15:54:02,804 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: DatanodeAdminMonitor is running.
2024-12-05 15:54:28,264 INFO blockmanagement.DatanodeAdminManager: Starting decommission of 172.31.86.141:9866 [DISK]DS-723c51a0-a6ba-4f89-b394-66b750fc8506:NORMAL:172.31.86.141:9866 with 0 blocks
2024-12-05 15:54:28,264 INFO blockmanagement.DatanodeAdminManager: Starting decommission of 172.31.86.141:9866 [DISK]DS-29dcdc8e-7114-4eb4-adc0-4c64f9976afc:NORMAL:172.31.86.141:9866 with 0 blocks
2024-12-05 15:54:28,264 INFO blockmanagement.DatanodeAdminManager: Starting decommission of 172.31.93.89:9866 [DISK]DS-69dfe6d3-da97-4079-ab38-bdf48da523d0:NORMAL:172.31.93.89:9866 with 0 blocks
2024-12-05 15:54:28,264 INFO blockmanagement.DatanodeAdminManager: Starting decommission of 172.31.93.89:9866 [DISK]DS-1e28d508-5693-44e5-ada0-13f403130695:NORMAL:172.31.93.89:9866 with 0 blocks
2024-12-05 15:54:28,264 INFO blockmanagement.DatanodeAdminManager: Starting decommission of 172.31.87.40:9866 [DISK]DS-d7d188b2-1408-4a61-80ee-43dbb5982bff:NORMAL:172.31.87.40:9866 with 0 blocks
2024-12-05 15:54:28,264 INFO blockmanagement.DatanodeAdminManager: Starting decommission of 172.31.87.40:9866 [DISK]DS-2827b751-40f9-48fe-bb1e-f15db0c3f721:NORMAL:172.31.87.40:9866 with 0 blocks
2024-12-05 15:54:32,804 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: DatanodeAdminMonitor is running.
2024-12-05 15:54:32,806 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Newly-added node 172.31.86.141:9866, doing full scan to find insufficiently-replicated blocks.
2024-12-05 15:54:32,806 INFO blockmanagement.DatanodeAdminManager: Decommissioning complete for node 172.31.86.141:9866
2024-12-05 15:54:32,806 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.86.141:9866 is sufficiently replicated and healthy, marked as Decommissioned.
2024-12-05 15:54:32,806 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Newly-added node 172.31.87.40:9866, doing full scan to find insufficiently-replicated blocks.
2024-12-05 15:54:32,806 INFO blockmanagement.DatanodeAdminManager: Decommissioning complete for node 172.31.87.40:9866
2024-12-05 15:54:32,806 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.87.40:9866 is sufficiently replicated and healthy, marked as Decommissioned.
2024-12-05 15:54:32,806 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Newly-added node 172.31.93.89:9866, doing full scan to find insufficiently-replicated blocks.
2024-12-05 15:54:32,806 INFO blockmanagement.DatanodeAdminManager: Decommissioning complete for node 172.31.93.89:9866
2024-12-05 15:54:32,806 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.93.89:9866 is sufficiently replicated and healthy, marked as Decommissioned.
2024-12-05 15:54:32,806 INFO blockmanagement.DatanodeAdminDefaultMonitor: Checked 0 blocks and 3 nodes this tick. 0 nodes are now in maintenance or transitioning state. 0 nodes pending.
2024-12-05 15:55:02,806 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: DatanodeAdminMonitor is running.
2024-12-05 15:55:32,807 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: DatanodeAdminMonitor is running.
...
```

```
> hdfs dfsadmin -report | grep -i decommissioned -B 3
...
2024-12-05 15:54:52,548 DEBUG ipc.ProtobufRpcEngine2: Call: getDatanodeReport took 3ms

Name: 172.31.86.141:9866 (ip-172-31-86-141.ec2.internal)
Hostname: ip-172-31-86-141.ec2.internal
Decommission Status : Decommissioned
--

Name: 172.31.87.40:9866 (ip-172-31-87-40.ec2.internal)
Hostname: ip-172-31-87-40.ec2.internal
Decommission Status : Decommissioned
--

Name: 172.31.93.89:9866 (ip-172-31-93-89.ec2.internal)
Hostname: ip-172-31-93-89.ec2.internal
Decommission Status : Decommissioned
```

Then we stop/terminate all 3 decommissioned datanodes at the same time, this is expected to be safe since they are in decommissioned state:

```
> date
Thu Dec  5 15:56:17 UTC 2024
```

After this occurs, we see HDFS write failures from the client:

```
2024-12-05 15:55:49 Append Success  1500 KB
2024-12-05 15:56:09 Append Success  1600 KB
2024-12-05 15:56:29 Append Failed   1600 KB
java.net.ConnectException: Connection refused
        ...
2024-12-05 15:56:49 Append Failed   1600 KB
java.net.ConnectException: Connection refused
        ...
```

And we also see the underlying HDFS data is lost:

```
> hdfs dfs -get /tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2 /var/testfile
...
2024-12-05 15:58:07,912 DEBUG ipc.Client: Failed to connect to server: ip-172-31-87-40.ec2.internal/172.31.87.40:9867: retries get failed due to exceeded maximum allowed retries number: 10
java.net.NoRouteToHostException: No route to host
...
2024-12-05 15:58:42,232 DEBUG ipc.Client: Failed to connect to server: ip-172-31-93-89.ec2.internal/172.31.93.89:9867: retries get failed due to exceeded maximum allowed retries number: 10
java.net.NoRouteToHostException: No route to host
...
2024-12-05 15:59:16,562 DEBUG ipc.Client: Failed to connect to server: ip-172-31-86-141.ec2.internal/172.31.86.141:9867: retries get failed due to exceeded maximum allowed retries number: 10
java.net.NoRouteToHostException: No route to host
...
get: Cannot obtain block length for LocatedBlock{BP-571135626-172.31.88.138-1733413798130:blk_1073741825_1002; getBlockSize()=716800; corrupt=false; offset=0; locs=[DatanodeInfoWithStorage[172.31.87.40:9866,DS-2827b751-40f9-48fe-bb1e-f15db0c3f721,DISK], DatanodeInfoWithStorage[172.31.93.89:9866,DS-69dfe6d3-da97-4079-ab38-bdf48da523d0,DISK], DatanodeInfoWithStorage[172.31.86.141:9866,DS-29dcdc8e-7114-4eb4-adc0-4c64f9976afc,DISK]]; cachedLocs=[]} of /tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2
```

Introspecting further into the logs, we see that when the block was re-opened:
- the BlockInfo with previous GenerationStamp was removed from the StorageInfos due to being "stale"
- the BlockInfo with new GenerationStamp does not get added to the StorageInfos until the DFSOutputStream is closed and it transitions from RBW to FINALIZED

```
> cat /var/log/hadoop-hdfs/hadoop-hdfs-namenode-ip-*.out | grep blk_1073741825

2024-12-05 15:51:08,342 DEBUG hdfs.StateChange: DIR* FSDirectory.addBlock: /tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2 with blk_1073741825_1001 block is added to the in-memory file system
2024-12-05 15:51:08,342 INFO hdfs.StateChange: BLOCK* allocate blk_1073741825_1001, replicas=172.31.86.141:9866, 172.31.93.89:9866, 172.31.87.40:9866 for /tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2
2024-12-05 15:51:08,342 DEBUG namenode.FSEditLog: logEdit [RpcEdit op:AddBlockOp [path=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, penultimateBlock=NULL, lastBlock=blk_1073741825_1001, RpcClientId=, RpcCallId=-2] call:Call#1 Retry#0 org.apache.hadoop.hdfs.protocol.ClientProtocol.addBlock from ip-172-31-88-138.ec2.internal:58352 / 172.31.88.138:58352]
2024-12-05 15:51:08,342 DEBUG hdfs.StateChange: persistNewBlock: /tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2 with new block blk_1073741825_1001, current total block count is 1
2024-12-05 15:51:08,343 DEBUG namenode.FSEditLog: doEditTx() op=AddBlockOp [path=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, penultimateBlock=NULL, lastBlock=blk_1073741825_1001, RpcClientId=, RpcCallId=-2] txid=45
2024-12-05 15:51:08,879 DEBUG namenode.FSEditLog: logEdit [RpcEdit op:UpdateBlocksOp [path=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, blocks=[blk_1073741825_1001], RpcClientId=, RpcCallId=-2] call:Call#3 Retry#0 org.apache.hadoop.hdfs.protocol.ClientProtocol.fsync from ip-172-31-88-138.ec2.internal:58352 / 172.31.88.138:58352]
2024-12-05 15:51:08,879 DEBUG namenode.FSEditLog: doEditTx() op=UpdateBlocksOp [path=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, blocks=[blk_1073741825_1001], RpcClientId=, RpcCallId=-2] txid=46
2024-12-05 15:51:08,879 DEBUG namenode.FSEditLog: logSync [RpcEdit op:UpdateBlocksOp [path=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, blocks=[blk_1073741825_1001], RpcClientId=, RpcCallId=-2] call:Call#3 Retry#0 org.apache.hadoop.hdfs.protocol.ClientProtocol.fsync from ip-172-31-88-138.ec2.internal:58352 / 172.31.88.138:58352]
2024-12-05 15:51:09,399 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1001 on 172.31.93.89:9866 size 268435456 replicaState = RBW
2024-12-05 15:51:09,399 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1001 on 172.31.93.89:9866 size 268435456 replicaState = RBW
2024-12-05 15:51:09,399 DEBUG BlockStateChange: BLOCK* block RECEIVING_BLOCK: blk_1073741825_1001 is received from 172.31.93.89:9866
2024-12-05 15:51:09,889 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1001 on 172.31.86.141:9866 size 268435456 replicaState = RBW
2024-12-05 15:51:09,889 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1001 on 172.31.86.141:9866 size 268435456 replicaState = RBW
2024-12-05 15:51:09,889 DEBUG BlockStateChange: BLOCK* block RECEIVING_BLOCK: blk_1073741825_1001 is received from 172.31.86.141:9866
2024-12-05 15:51:09,952 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1001 on 172.31.87.40:9866 size 268435456 replicaState = RBW
2024-12-05 15:51:09,952 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1001 on 172.31.87.40:9866 size 268435456 replicaState = RBW
2024-12-05 15:51:09,952 DEBUG BlockStateChange: BLOCK* block RECEIVING_BLOCK: blk_1073741825_1001 is received from 172.31.87.40:9866
2024-12-05 15:53:08,926 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1001 on 172.31.87.40:9866 size 614400 replicaState = FINALIZED
2024-12-05 15:53:08,927 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1001 on 172.31.87.40:9866 size 614400 replicaState = FINALIZED
2024-12-05 15:53:08,927 INFO BlockStateChange: BLOCK* addStoredBlock: 172.31.87.40:9866 is added to blk_1073741825_1001 (size=614400)
2024-12-05 15:53:08,928 DEBUG BlockStateChange: BLOCK* block RECEIVED_BLOCK: blk_1073741825_1001 is received from 172.31.87.40:9866
2024-12-05 15:53:08,929 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1001 on 172.31.93.89:9866 size 614400 replicaState = FINALIZED
2024-12-05 15:53:08,929 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1001 on 172.31.93.89:9866 size 614400 replicaState = FINALIZED
2024-12-05 15:53:08,929 INFO BlockStateChange: BLOCK* addStoredBlock: 172.31.93.89:9866 is added to blk_1073741825_1001 (size=614400)
2024-12-05 15:53:08,929 DEBUG BlockStateChange: BLOCK* block RECEIVED_BLOCK: blk_1073741825_1001 is received from 172.31.93.89:9866
2024-12-05 15:53:08,933 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1001 on 172.31.86.141:9866 size 614400 replicaState = FINALIZED
2024-12-05 15:53:08,933 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1001 on 172.31.86.141:9866 size 614400 replicaState = FINALIZED
2024-12-05 15:53:08,933 INFO BlockStateChange: BLOCK* addStoredBlock: 172.31.86.141:9866 is added to blk_1073741825_1001 (size=614400)
2024-12-05 15:53:08,933 DEBUG BlockStateChange: BLOCK* block RECEIVED_BLOCK: blk_1073741825_1001 is received from 172.31.86.141:9866
2024-12-05 15:53:08,937 DEBUG namenode.FSEditLog: logEdit [RpcEdit op:CloseOp [length=0, inodeId=0, path=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, replication=3, mtime=1733413988937, atime=1733413868246, blockSize=268435456, blocks=[blk_1073741825_1001], permissions=root:hdfsadmingroup:rw-r--r--, aclEntries=null, clientName=null, clientMachine=null, overwrite=false, storagePolicyId=0, erasureCodingPolicyId=0, opCode=OP_CLOSE, txid=-12345] call:Call#8 Retry#0 org.apache.hadoop.hdfs.protocol.ClientProtocol.complete from ip-172-31-88-138.ec2.internal:33782 / 172.31.88.138:33782]
2024-12-05 15:53:08,937 DEBUG namenode.FSEditLog: doEditTx() op=CloseOp [length=0, inodeId=0, path=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, replication=3, mtime=1733413988937, atime=1733413868246, blockSize=268435456, blocks=[blk_1073741825_1001], permissions=root:hdfsadmingroup:rw-r--r--, aclEntries=null, clientName=null, clientMachine=null, overwrite=false, storagePolicyId=0, erasureCodingPolicyId=0, opCode=OP_CLOSE, txid=47] txid=47
2024-12-05 15:53:08,937 DEBUG namenode.FSEditLog: logSync [RpcEdit op:CloseOp [length=0, inodeId=0, path=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, replication=3, mtime=1733413988937, atime=1733413868246, blockSize=268435456, blocks=[blk_1073741825_1001], permissions=root:hdfsadmingroup:rw-r--r--, aclEntries=null, clientName=null, clientMachine=null, overwrite=false, storagePolicyId=0, erasureCodingPolicyId=0, opCode=OP_CLOSE, txid=47] call:Call#8 Retry#0 org.apache.hadoop.hdfs.protocol.ClientProtocol.complete from ip-172-31-88-138.ec2.internal:33782 / 172.31.88.138:33782]
2024-12-05 15:53:08,949 DEBUG hdfs.StateChange: DIR* NameSystem.appendFile: file /tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2 for DFSClient_NONMAPREDUCE_-958881537_1 at 172.31.88.138 block BP-571135626-172.31.88.138-1733413798130:blk_1073741825_1001 block size 614400
2024-12-05 15:53:08,960 INFO namenode.FSNamesystem: bumpBlockGenerationStamp(BP-571135626-172.31.88.138-1733413798130:blk_1073741825_1002, client=DFSClient_NONMAPREDUCE_-958881537_1) success
2024-12-05 15:53:09,020 INFO namenode.FSNamesystem: updatePipeline(blk_1073741825_1001, newGS=1002, newLength=614400, newNodes=[172.31.87.40:9866, 172.31.93.89:9866, 172.31.86.141:9866], client=DFSClient_NONMAPREDUCE_-958881537_1)
2024-12-05 15:53:09,020 DEBUG BlockStateChange: BLOCK* removeStoredBlock: blk_1073741825_1002 from 172.31.87.40:9866
2024-12-05 15:53:09,021 DEBUG BlockStateChange: BLOCK* Removing stale replica ReplicaUC[[DISK]DS-2827b751-40f9-48fe-bb1e-f15db0c3f721:NORMAL:172.31.87.40:9866|RBW] of blk_1073741825_1001
2024-12-05 15:53:09,021 DEBUG BlockStateChange: BLOCK* removeStoredBlock: blk_1073741825_1002 from 172.31.93.89:9866
2024-12-05 15:53:09,021 DEBUG BlockStateChange: BLOCK* Removing stale replica ReplicaUC[[DISK]DS-69dfe6d3-da97-4079-ab38-bdf48da523d0:NORMAL:172.31.93.89:9866|RBW] of blk_1073741825_1001
2024-12-05 15:53:09,021 DEBUG BlockStateChange: BLOCK* removeStoredBlock: blk_1073741825_1002 from 172.31.86.141:9866
2024-12-05 15:53:09,021 DEBUG BlockStateChange: BLOCK* Removing stale replica ReplicaUC[[DISK]DS-29dcdc8e-7114-4eb4-adc0-4c64f9976afc:NORMAL:172.31.86.141:9866|RBW] of blk_1073741825_1001
2024-12-05 15:53:09,021 DEBUG namenode.FSEditLog: logEdit [RpcEdit op:UpdateBlocksOp [path=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, blocks=[blk_1073741825_1002], RpcClientId=cd00dc8b-bb34-48b4-993b-326ef1e57052, RpcCallId=11] call:Call#11 Retry#0 org.apache.hadoop.hdfs.protocol.ClientProtocol.updatePipeline from ip-172-31-88-138.ec2.internal:33782 / 172.31.88.138:33782]
2024-12-05 15:53:09,021 DEBUG namenode.FSEditLog: logSync [RpcEdit op:UpdateBlocksOp [path=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, blocks=[blk_1073741825_1002], RpcClientId=cd00dc8b-bb34-48b4-993b-326ef1e57052, RpcCallId=11] call:Call#11 Retry#0 org.apache.hadoop.hdfs.protocol.ClientProtocol.updatePipeline from ip-172-31-88-138.ec2.internal:33782 / 172.31.88.138:33782]
2024-12-05 15:53:09,021 INFO namenode.FSNamesystem: updatePipeline(blk_1073741825_1001 => blk_1073741825_1002) success
2024-12-05 15:53:09,021 DEBUG namenode.FSEditLog: doEditTx() op=UpdateBlocksOp [path=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, blocks=[blk_1073741825_1002], RpcClientId=cd00dc8b-bb34-48b4-993b-326ef1e57052, RpcCallId=11] txid=50
2024-12-05 15:53:09,031 DEBUG namenode.FSEditLog: logEdit [RpcEdit op:UpdateBlocksOp [path=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, blocks=[blk_1073741825_1002], RpcClientId=, RpcCallId=-2] call:Call#12 Retry#0 org.apache.hadoop.hdfs.protocol.ClientProtocol.fsync from ip-172-31-88-138.ec2.internal:33782 / 172.31.88.138:33782]
2024-12-05 15:53:09,031 DEBUG namenode.FSEditLog: logSync [RpcEdit op:UpdateBlocksOp [path=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, blocks=[blk_1073741825_1002], RpcClientId=, RpcCallId=-2] call:Call#12 Retry#0 org.apache.hadoop.hdfs.protocol.ClientProtocol.fsync from ip-172-31-88-138.ec2.internal:33782 / 172.31.88.138:33782]
2024-12-05 15:53:09,031 DEBUG namenode.FSEditLog: doEditTx() op=UpdateBlocksOp [path=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, blocks=[blk_1073741825_1002], RpcClientId=, RpcCallId=-2] txid=51
2024-12-05 15:53:09,385 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1002 on 172.31.93.89:9866 size 268435456 replicaState = RBW
2024-12-05 15:53:09,385 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1002 on 172.31.93.89:9866 size 268435456 replicaState = RBW
2024-12-05 15:53:09,385 DEBUG BlockStateChange: BLOCK* block RECEIVING_BLOCK: blk_1073741825_1002 is received from 172.31.93.89:9866
2024-12-05 15:53:09,888 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1002 on 172.31.86.141:9866 size 268435456 replicaState = RBW
2024-12-05 15:53:09,888 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1002 on 172.31.86.141:9866 size 268435456 replicaState = RBW
2024-12-05 15:53:09,888 DEBUG BlockStateChange: BLOCK* block RECEIVING_BLOCK: blk_1073741825_1002 is received from 172.31.86.141:9866
2024-12-05 15:53:09,951 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1002 on 172.31.87.40:9866 size 268435456 replicaState = RBW
2024-12-05 15:53:09,951 DEBUG blockmanagement.BlockManager: Reported block blk_1073741825_1002 on 172.31.87.40:9866 size 268435456 replicaState = RBW
2024-12-05 15:53:09,951 DEBUG BlockStateChange: BLOCK* block RECEIVING_BLOCK: blk_1073741825_1002 is received from 172.31.87.40:9866
2024-12-05 15:56:13,956 DEBUG namenode.NameNode: getAdditionalDatanode: src=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, fileId=16403, blk=BP-571135626-172.31.88.138-1733413798130:blk_1073741825_1002, existings=[172.31.93.89:9866, 172.31.86.141:9866], excludes=[172.31.87.40:9866], numAdditionalNodes=1, clientName=DFSClient_NONMAPREDUCE_-958881537_1
2024-12-05 15:56:13,964 DEBUG namenode.NameNode: getAdditionalDatanode: src=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, fileId=16403, blk=BP-571135626-172.31.88.138-1733413798130:blk_1073741825_1002, existings=[172.31.93.89:9866, 172.31.86.141:9866], excludes=[172.31.87.40:9866, 172.31.92.246:9866], numAdditionalNodes=1, clientName=DFSClient_NONMAPREDUCE_-958881537_1
2024-12-05 15:56:13,967 DEBUG namenode.NameNode: getAdditionalDatanode: src=/tmp/testfile-03ed9b5c-e1f4-42ad-bca3-8a579ac9d8b2, fileId=16403, blk=BP-571135626-172.31.88.138-1733413798130:blk_1073741825_1002, existings=[172.31.93.89:9866, 172.31.86.141:9866], excludes=[172.31.87.40:9866, 172.31.92.246:9866, 172.31.95.50:9866], numAdditionalNodes=1, clientName=DFSClient_NONMAPREDUCE_-958881537_1
2024-12-05 15:57:33,493 DEBUG blockmanagement.BlockManager: blocks = [blk_1073741825_1002]
```

#### Test#5 Detailed Results , After this Change

The following are the HDFS client logs for the duration of the test:

```
2024-12-05 16:25:41 Created File /tmp/testfile-081431ba-2feb-4e0a-b23f-a3d3a73ed00e
2024-12-05 16:25:42 Append Success  100 KB
2024-12-05 16:26:02 Append Success  200 KB
2024-12-05 16:26:22 Append Success  300 KB
2024-12-05 16:26:42 Append Success  400 KB
2024-12-05 16:27:02 Append Success  500 KB
2024-12-05 16:27:22 Append Success  600 KB
2024-12-05 16:27:42 Closed File
2024-12-05 16:27:42 Opened File /tmp/testfile-081431ba-2feb-4e0a-b23f-a3d3a73ed00e
2024-12-05 16:27:42 Append Success  700 KB
2024-12-05 16:28:02 Append Success  800 KB
2024-12-05 16:28:22 Append Success  900 KB
2024-12-05 16:28:42 Append Success  1000 KB
2024-12-05 16:29:02 Append Success  1100 KB
2024-12-05 16:29:22 Append Success  1200 KB
2024-12-05 16:29:42 Append Success  1300 KB
2024-12-05 16:30:02 Append Success  1400 KB
2024-12-05 16:30:22 Append Success  1500 KB
2024-12-05 16:30:42 Append Success  1600 KB
2024-12-05 16:31:02 Append Success  1700 KB
2024-12-05 16:31:22 Append Success  1800 KB
2024-12-05 16:31:42 Append Success  1900 KB
2024-12-05 16:32:02 Append Success  2000 KB
2024-12-05 16:32:22 Append Success  2100 KB
2024-12-05 16:32:42 Append Success  2200 KB
2024-12-05 16:33:02 Append Success  2300 KB
2024-12-05 16:33:22 Append Success  2400 KB
2024-12-05 16:33:42 Append Success  2500 KB
2024-12-05 16:34:02 Append Success  2600 KB
2024-12-05 16:34:22 Append Success  2700 KB
2024-12-05 16:34:42 Append Success  2800 KB
2024-12-05 16:35:02 Append Success  2900 KB
2024-12-05 16:35:22 Append Success  3000 KB
2024-12-05 16:35:42 Append Success  3100 KB
2024-12-05 16:36:02 Append Success  3200 KB
2024-12-05 16:36:22 Append Success  3300 KB
2024-12-05 16:36:42 Append Success  3400 KB
2024-12-05 16:37:02 Append Success  3500 KB
2024-12-05 16:37:22 Append Success  3600 KB
2024-12-05 16:37:42 Append Success  3700 KB
2024-12-05 16:38:02 Append Success  3800 KB
2024-12-05 16:38:22 Append Success  3900 KB
2024-12-05 16:38:42 Append Success  4000 KB
2024-12-05 16:39:02 Append Success  4100 KB
2024-12-05 16:39:22 Append Success  4200 KB
2024-12-05 16:39:42 Append Success  4300 KB
2024-12-05 16:40:02 Append Success  4400 KB
2024-12-05 16:40:22 Append Success  4500 KB
2024-12-05 16:40:42 Append Success  4600 KB
2024-12-05 16:41:02 Append Success  4700 KB
2024-12-05 16:41:22 Append Success  4800 KB
2024-12-05 16:41:42 Append Success  4900 KB
2024-12-05 16:42:02 Append Success  5000 KB
2024-12-05 16:42:22 Append Success  5100 KB
2024-12-05 16:42:43 Closed File
```

First step is to identify the block locations:

```
> cat /var/log/hadoop-hdfs/hadoop-hdfs-namenode-ip-*.out | grep testfile | grep blk
...
2024-12-05 16:25:41,999 INFO hdfs.StateChange: BLOCK* allocate blk_1073741825_1001, replicas=172.31.81.166:9866, 172.31.84.85:9866, 172.31.82.31:9866 for /tmp/testfile-081431ba-2feb-4e0a-b23f-a3d3a73ed00e
...
```

Then we wait for the block to be closed & re-opened. Once this is completed, we can start decommissioning the 3 datanodes with under construction block replicas:

```
> cat dfs.hosts.exclude
ip-172-31-82-31.ec2.internal
ip-172-31-84-85.ec2.internal
ip-172-31-81-166.ec2.internal

> export HADOOP_USER_NAME=hdfs

> hdfs dfsadmin -refreshNodes
...
2024-12-05 16:28:21,849 DEBUG ipc.ProtobufRpcEngine2: Call: refreshNodes took 98ms
Refresh nodes successful
...
```

Check the decommissioning status of the datanodes to confirm they are not decommissioned. Wait for the DFSOutputStream to be closed & then confirm decommissioning finishes after this time:

```
> cat /var/log/hadoop-hdfs/hadoop-hdfs-namenode-ip-*.out | grep DatanodeAdmin
...
2024-12-05 16:26:55,256 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: DatanodeAdminMonitor is running.
2024-12-05 16:27:25,257 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: DatanodeAdminMonitor is running.
2024-12-05 16:27:55,257 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: DatanodeAdminMonitor is running.
2024-12-05 16:28:21,844 INFO blockmanagement.DatanodeAdminManager: Starting decommission of 172.31.82.31:9866 [DISK]DS-9dd3db74-f327-4b44-bc81-c611dbe144ec:NORMAL:172.31.82.31:9866 with 0 blocks
2024-12-05 16:28:21,844 INFO blockmanagement.DatanodeAdminManager: Starting decommission of 172.31.82.31:9866 [DISK]DS-38366739-8eef-4345-bd6a-184eb3ab8b3c:NORMAL:172.31.82.31:9866 with 0 blocks
2024-12-05 16:28:21,844 INFO blockmanagement.DatanodeAdminManager: Starting decommission of 172.31.84.85:9866 [DISK]DS-8bc5aaf9-db5d-4049-be89-67f35bb038d5:NORMAL:172.31.84.85:9866 with 0 blocks
2024-12-05 16:28:21,844 INFO blockmanagement.DatanodeAdminManager: Starting decommission of 172.31.84.85:9866 [DISK]DS-7be3f1ef-23f5-4d6c-9a60-7f8a1aa299c6:NORMAL:172.31.84.85:9866 with 0 blocks
2024-12-05 16:28:21,844 INFO blockmanagement.DatanodeAdminManager: Starting decommission of 172.31.81.166:9866 [DISK]DS-f5533115-a135-4db0-9086-c4e9243c719e:NORMAL:172.31.81.166:9866 with 0 blocks
2024-12-05 16:28:21,844 INFO blockmanagement.DatanodeAdminManager: Starting decommission of 172.31.81.166:9866 [DISK]DS-57c2a4cc-b235-4508-8ac0-f836f1485e5d:NORMAL:172.31.81.166:9866 with 0 blocks
2024-12-05 16:28:25,258 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: DatanodeAdminMonitor is running.
2024-12-05 16:28:25,259 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Newly-added node 172.31.81.166:9866, doing full scan to find insufficiently-replicated blocks.
2024-12-05 16:28:25,260 INFO blockmanagement.DatanodeAdminDefaultMonitor: Cannot decommission datanode 172.31.81.166:9866 with 1 UC blocks: [blk_1073741825_1002]
2024-12-05 16:28:25,260 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Newly-added node 172.31.82.31:9866, doing full scan to find insufficiently-replicated blocks.
2024-12-05 16:28:25,261 INFO blockmanagement.DatanodeAdminDefaultMonitor: Cannot decommission datanode 172.31.82.31:9866 with 1 UC blocks: [blk_1073741825_1002]
2024-12-05 16:28:25,261 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Newly-added node 172.31.84.85:9866, doing full scan to find insufficiently-replicated blocks.
2024-12-05 16:28:25,261 INFO blockmanagement.DatanodeAdminDefaultMonitor: Cannot decommission datanode 172.31.84.85:9866 with 1 UC blocks: [blk_1073741825_1002]
2024-12-05 16:28:25,261 INFO blockmanagement.DatanodeAdminDefaultMonitor: Checked 0 blocks and 3 nodes this tick. 3 nodes are now in maintenance or transitioning state. 0 nodes pending.
2024-12-05 16:28:55,261 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: DatanodeAdminMonitor is running.
2024-12-05 16:28:55,261 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Processing Decommission In Progress node 172.31.81.166:9866
2024-12-05 16:28:55,269 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.81.166:9866 has finished replicating current set of blocks, checking with the full block map.
2024-12-05 16:28:55,269 INFO blockmanagement.DatanodeAdminDefaultMonitor: Cannot decommission datanode 172.31.81.166:9866 with 1 UC blocks: [blk_1073741825_1002]
2024-12-05 16:28:55,269 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Processing Decommission In Progress node 172.31.82.31:9866
2024-12-05 16:28:55,269 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.82.31:9866 has finished replicating current set of blocks, checking with the full block map.
2024-12-05 16:28:55,269 INFO blockmanagement.DatanodeAdminDefaultMonitor: Cannot decommission datanode 172.31.82.31:9866 with 1 UC blocks: [blk_1073741825_1002]
2024-12-05 16:28:55,269 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Processing Decommission In Progress node 172.31.84.85:9866
2024-12-05 16:28:55,270 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.84.85:9866 has finished replicating current set of blocks, checking with the full block map.
2024-12-05 16:28:55,270 INFO blockmanagement.DatanodeAdminDefaultMonitor: Cannot decommission datanode 172.31.84.85:9866 with 1 UC blocks: [blk_1073741825_1002]
2024-12-05 16:28:55,270 INFO blockmanagement.DatanodeAdminDefaultMonitor: Checked 0 blocks and 3 nodes this tick. 3 nodes are now in maintenance or transitioning state. 0 nodes pending.
2024-12-05 16:29:25,270 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: DatanodeAdminMonitor is running.
2024-12-05 16:29:25,270 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Processing Decommission In Progress node 172.31.81.166:9866
2024-12-05 16:29:25,270 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.81.166:9866 has finished replicating current set of blocks, checking with the full block map.
2024-12-05 16:29:25,270 INFO blockmanagement.DatanodeAdminDefaultMonitor: Cannot decommission datanode 172.31.81.166:9866 with 1 UC blocks: [blk_1073741825_1002]
2024-12-05 16:29:25,270 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Processing Decommission In Progress node 172.31.82.31:9866
2024-12-05 16:29:25,270 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.82.31:9866 has finished replicating current set of blocks, checking with the full block map.
2024-12-05 16:29:25,270 INFO blockmanagement.DatanodeAdminDefaultMonitor: Cannot decommission datanode 172.31.82.31:9866 with 1 UC blocks: [blk_1073741825_1002]
2024-12-05 16:29:25,270 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Processing Decommission In Progress node 172.31.84.85:9866
2024-12-05 16:29:25,270 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.84.85:9866 has finished replicating current set of blocks, checking with the full block map.
2024-12-05 16:29:25,270 INFO blockmanagement.DatanodeAdminDefaultMonitor: Cannot decommission datanode 172.31.84.85:9866 with 1 UC blocks: [blk_1073741825_1002]
2024-12-05 16:29:25,270 INFO blockmanagement.DatanodeAdminDefaultMonitor: Checked 0 blocks and 3 nodes this tick. 3 nodes are now in maintenance or transitioning state. 0 nodes pending.
...
2024-12-05 16:42:25,289 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: DatanodeAdminMonitor is running.
2024-12-05 16:42:25,289 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Processing Decommission In Progress node 172.31.81.166:9866
2024-12-05 16:42:25,289 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.81.166:9866 has finished replicating current set of blocks, checking with the full block map.
2024-12-05 16:42:25,289 INFO blockmanagement.DatanodeAdminDefaultMonitor: Cannot decommission datanode 172.31.81.166:9866 with 1 UC blocks: [blk_1073741825_1002]
2024-12-05 16:42:25,289 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Processing Decommission In Progress node 172.31.82.31:9866
2024-12-05 16:42:25,289 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.82.31:9866 has finished replicating current set of blocks, checking with the full block map.
2024-12-05 16:42:25,289 INFO blockmanagement.DatanodeAdminDefaultMonitor: Cannot decommission datanode 172.31.82.31:9866 with 1 UC blocks: [blk_1073741825_1002]
2024-12-05 16:42:25,289 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Processing Decommission In Progress node 172.31.84.85:9866
2024-12-05 16:42:25,289 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.84.85:9866 has finished replicating current set of blocks, checking with the full block map.
2024-12-05 16:42:25,289 INFO blockmanagement.DatanodeAdminDefaultMonitor: Cannot decommission datanode 172.31.84.85:9866 with 1 UC blocks: [blk_1073741825_1002]
2024-12-05 16:42:25,289 INFO blockmanagement.DatanodeAdminDefaultMonitor: Checked 0 blocks and 3 nodes this tick. 3 nodes are now in maintenance or transitioning state. 0 nodes pending.
2024-12-05 16:42:55,289 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: DatanodeAdminMonitor is running.
2024-12-05 16:42:55,290 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Processing Decommission In Progress node 172.31.81.166:9866
2024-12-05 16:42:55,290 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.81.166:9866 has finished replicating current set of blocks, checking with the full block map.
2024-12-05 16:42:55,290 INFO blockmanagement.DatanodeAdminManager: Decommissioning complete for node 172.31.81.166:9866
2024-12-05 16:42:55,290 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.81.166:9866 is sufficiently replicated and healthy, marked as Decommissioned.
2024-12-05 16:42:55,290 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Processing Decommission In Progress node 172.31.82.31:9866
2024-12-05 16:42:55,290 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.82.31:9866 has finished replicating current set of blocks, checking with the full block map.
2024-12-05 16:42:55,291 INFO blockmanagement.DatanodeAdminManager: Decommissioning complete for node 172.31.82.31:9866
2024-12-05 16:42:55,291 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.82.31:9866 is sufficiently replicated and healthy, marked as Decommissioned.
2024-12-05 16:42:55,291 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Processing Decommission In Progress node 172.31.84.85:9866
2024-12-05 16:42:55,291 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.84.85:9866 has finished replicating current set of blocks, checking with the full block map.
2024-12-05 16:42:55,291 INFO blockmanagement.DatanodeAdminManager: Decommissioning complete for node 172.31.84.85:9866
2024-12-05 16:42:55,291 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: Node 172.31.84.85:9866 is sufficiently replicated and healthy, marked as Decommissioned.
2024-12-05 16:42:55,291 INFO blockmanagement.DatanodeAdminDefaultMonitor: Checked 3 blocks and 3 nodes this tick. 0 nodes are now in maintenance or transitioning state. 0 nodes pending.
2024-12-05 16:43:25,291 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: DatanodeAdminMonitor is running.
2024-12-05 16:43:55,291 DEBUG blockmanagement.DatanodeAdminDefaultMonitor: DatanodeAdminMonitor is running.
...
```

```
> hdfs dfsadmin -report | grep -i decommissioned -B 3
...
2024-12-05 16:45:07,815 DEBUG ipc.ProtobufRpcEngine2: Call: getDatanodeReport took 3ms

Name: 172.31.81.166:9866 (ip-172-31-81-166.ec2.internal)
Hostname: ip-172-31-81-166.ec2.internal
Decommission Status : Decommissioned
--

Name: 172.31.82.31:9866 (ip-172-31-82-31.ec2.internal)
Hostname: ip-172-31-82-31.ec2.internal
Decommission Status : Decommissioned
--

Name: 172.31.84.85:9866 (ip-172-31-84-85.ec2.internal)
Hostname: ip-172-31-84-85.ec2.internal
Decommission Status : Decommissioned
```

Then we stop/terminate all 3 decommissioned datanodes at the same time, this is expected to be safe since they are in decommissioned state:

```
> date
Thu Dec  5 16:46:01 UTC 2024
```

There is no HDFS data loss because the block replicas are moved to other live datanodes before decommissioning finishes:

```
> hdfs dfs -get /tmp/testfile-081431ba-2feb-4e0a-b23f-a3d3a73ed00e /var/testfile
...
2024-12-05 16:47:25,377 DEBUG ipc.Client: Stopping client
```

```
> ll -h /var/testfile
-rw-r--r--. 1 root root 5.0M Dec  5 16:47 /var/testfile
```

Introspecting further into the logs, we see that:
- when the block is opened in RBW state, it gets added to UnderConstructionBlocks
- when the block is transitioned to FINALIZED state, it gets removed from UnderConstructionBlocks (and added to StorageInfos)

```
> cat /var/log/hadoop-hdfs/hadoop-hdfs-namenode-ip-*.out | grep 'UnderConstructionBlocks\|Under Construction'

2024-12-05 16:25:24,504 INFO blockmanagement.UnderConstructionBlocks: Tracking Under Construction blocks for DatanodeAdminManager
2024-12-05 16:25:43,602 DEBUG blockmanagement.UnderConstructionBlocks: Add UC block blk_1073741825_1001 to 172.31.84.85:9866, new total is [replicas=1 / blocks=1]
2024-12-05 16:25:43,642 DEBUG blockmanagement.UnderConstructionBlocks: Add UC block blk_1073741825_1001 to 172.31.81.166:9866, new total is [replicas=2 / blocks=1]
2024-12-05 16:25:44,514 DEBUG blockmanagement.UnderConstructionBlocks: Add UC block blk_1073741825_1001 to 172.31.82.31:9866, new total is [replicas=3 / blocks=1]
2024-12-05 16:25:55,256 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:26:25,256 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:26:55,257 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:27:25,257 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:27:42,659 DEBUG blockmanagement.UnderConstructionBlocks: Removed UC block [blk_1073741825_1001->blk_1073741825_1001] from 172.31.82.31:9866, new total is [replicas=2 / blocks=1]
2024-12-05 16:27:42,661 DEBUG blockmanagement.UnderConstructionBlocks: Removed UC block [blk_1073741825_1001->blk_1073741825_1001] from 172.31.84.85:9866, new total is [replicas=1 / blocks=1]
2024-12-05 16:27:42,665 DEBUG blockmanagement.UnderConstructionBlocks: Removed UC block [blk_1073741825_1001->blk_1073741825_1001] from 172.31.81.166:9866, new total is [replicas=0 / blocks=0]
2024-12-05 16:27:42,753 DEBUG blockmanagement.UnderConstructionBlocks: UC block blk_1073741825_1002 not found on 172.31.82.31:9866, total is [replicas=0 / blocks=0]2024-12-05 16:27:42,754 DEBUG blockmanagement.UnderConstructionBlocks: UC block blk_1073741825_1002 not found on 172.31.84.85:9866, total is [replicas=0 / blocks=0]
2024-12-05 16:27:42,754 DEBUG blockmanagement.UnderConstructionBlocks: UC block blk_1073741825_1002 not found on 172.31.81.166:9866, total is [replicas=0 / blocks=0]
2024-12-05 16:27:43,586 DEBUG blockmanagement.UnderConstructionBlocks: Add UC block blk_1073741825_1002 to 172.31.84.85:9866, new total is [replicas=1 / blocks=1]
2024-12-05 16:27:43,641 DEBUG blockmanagement.UnderConstructionBlocks: Add UC block blk_1073741825_1002 to 172.31.81.166:9866, new total is [replicas=2 / blocks=1]
2024-12-05 16:27:44,515 DEBUG blockmanagement.UnderConstructionBlocks: Add UC block blk_1073741825_1002 to 172.31.82.31:9866, new total is [replicas=3 / blocks=1]2024-12-05 16:27:55,257 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:28:25,259 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:28:55,261 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:29:25,270 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:29:55,271 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:30:25,272 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:30:55,273 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:31:25,274 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:31:55,274 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:32:25,275 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:32:55,276 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:33:25,276 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:33:55,277 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]2024-12-05 16:34:25,278 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:34:55,279 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:35:25,280 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:35:55,280 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:36:25,281 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]2024-12-05 16:36:55,282 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]2024-12-05 16:37:25,282 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]2024-12-05 16:37:55,283 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]2024-12-05 16:38:25,284 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]2024-12-05 16:38:55,284 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:39:25,285 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:39:55,286 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]2024-12-05 16:40:25,286 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]2024-12-05 16:40:55,287 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]2024-12-05 16:41:25,288 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]2024-12-05 16:41:55,288 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]2024-12-05 16:42:25,289 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{172.31.82.31:9866=1,172.31.84.85:9866=1,172.31.81.166:9866=1}]
2024-12-05 16:42:42,995 DEBUG blockmanagement.UnderConstructionBlocks: Removed UC block [blk_1073741825_1002->blk_1073741825_1002] from 172.31.81.166:9866, new total is [replicas=2 / blocks=1]
2024-12-05 16:42:42,996 DEBUG blockmanagement.UnderConstructionBlocks: Removed UC block [blk_1073741825_1002->blk_1073741825_1002] from 172.31.84.85:9866, new total is [replicas=1 / blocks=1]
2024-12-05 16:42:42,997 DEBUG blockmanagement.UnderConstructionBlocks: Removed UC block [blk_1073741825_1002->blk_1073741825_1002] from 172.31.82.31:9866, new total is [replicas=0 / blocks=0]2024-12-05 16:42:44,879 DEBUG blockmanagement.UnderConstructionBlocks: UC block blk_1073741825_1002 not found on 172.31.87.161:9866, total is [replicas=0 / blocks=0]
2024-12-05 16:42:44,935 DEBUG blockmanagement.UnderConstructionBlocks: UC block blk_1073741825_1002 not found on 172.31.84.145:9866, total is [replicas=0 / blocks=0]
2024-12-05 16:42:44,935 DEBUG blockmanagement.UnderConstructionBlocks: UC block blk_1073741825_1002 not found on 172.31.93.40:9866, total is [replicas=0 / blocks=0]
2024-12-05 16:42:55,290 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{}]
2024-12-05 16:43:25,291 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{}]
2024-12-05 16:43:55,291 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{}]
2024-12-05 16:44:25,291 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{}]
2024-12-05 16:44:55,292 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{}]
2024-12-05 16:45:25,292 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{}]
2024-12-05 16:45:55,292 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{}]
2024-12-05 16:46:25,292 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{}]
2024-12-05 16:46:55,293 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{}]
2024-12-05 16:47:25,293 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{}]
2024-12-05 16:47:55,293 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{}]
2024-12-05 16:48:25,293 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{}]
2024-12-05 16:48:55,294 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{}]
2024-12-05 16:49:25,294 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{}]
2024-12-05 16:49:55,294 DEBUG blockmanagement.BlockManager: Under Construction block counts: [{}]
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [n/a] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

