### PR TITLE
HDFS-17671 Suppress callstack when adding a datanode to deadnodes

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -672,9 +672,9 @@ public class DFSInputStream extends FSInputStream
           fetchBlockAt(target);
         } else {
           connectFailedOnce = true;
-          DFSClient.LOG.warn("Failed to connect to {} for file {} for block "
-                  + "{}, add to deadNodes and continue. ", targetAddr, src,
-              targetBlock.getBlock(), ex);
+          DFSClient.LOG.warn("Failed to connect to {} for file {} for block {}. Error is {}. "
+              + "Add to deadNodes and continue with other datanodes. ", targetAddr, src,
+              targetBlock.getBlock(), ex.getMessage());
           // Put chosen node into dead list, continue
           addToLocalDeadNodes(chosenNode);
           dfsClient.addNodeToDeadNodeDetector(this, chosenNode);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
HDFS-17671 Suppress callstack when adding a datanode to deadnodes. These are non-fatal errors and showing callstack in the log confuses users. 

### How was this patch tested?
mvn package 

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

