### PR TITLE
HADOOP-???? - adding ARC Managed Identity support to hadoop-azure ABFS

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.fs.azurebfs.oauth2.AccessTokenProvider;
 import org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider;
 import org.apache.hadoop.fs.azurebfs.oauth2.CustomTokenProviderAdapter;
 import org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider;
+import org.apache.hadoop.fs.azurebfs.oauth2.ArcMsiTokenProvider;
 import org.apache.hadoop.fs.azurebfs.oauth2.RefreshTokenBasedTokenProvider;
 import org.apache.hadoop.fs.azurebfs.oauth2.UserPasswordTokenProvider;
 import org.apache.hadoop.fs.azurebfs.oauth2.WorkloadIdentityTokenProvider;
@@ -961,6 +962,9 @@ public class AbfsConfiguration{
           String authEndpoint = getTrimmedPasswordString(
               FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT,
               AuthConfigurations.DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT);
+          String apiVersion = getTrimmedPasswordString(
+              FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT_API_VERSION,
+              AuthConfigurations.DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT_API_VERSION);
           String tenantGuid =
               getPasswordString(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT);
           String clientId =
@@ -969,9 +973,27 @@ public class AbfsConfiguration{
               FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY,
               AuthConfigurations.DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY);
           authority = appendSlashIfNeeded(authority);
-          tokenProvider = new MsiTokenProvider(authEndpoint, tenantGuid,
+          tokenProvider = new MsiTokenProvider(authEndpoint, apiVersion, tenantGuid,
               clientId, authority);
           LOG.trace("MsiTokenProvider initialized");
+        } else if (tokenProviderClass == ArcMsiTokenProvider.class) {
+          String authEndpoint = getTrimmedPasswordString(
+                  FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT,
+                  AuthConfigurations.DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT);
+          String apiVersion = getTrimmedPasswordString(
+                  FS_AZURE_ACCOUNT_OAUTH_ARC_MSI_ENDPOINT_API_VERSION,
+                  AuthConfigurations.DEFAULT_FS_AZURE_ACCOUNT_OAUTH_ARC_MSI_ENDPOINT_API_VERSION);
+          String tenantGuid =
+                  getPasswordString(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT);
+          String clientId =
+                  getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID);
+          String authority = getTrimmedPasswordString(
+                  FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY,
+                  AuthConfigurations.DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY);
+          authority = appendSlashIfNeeded(authority);
+          tokenProvider = new ArcMsiTokenProvider(authEndpoint, apiVersion, tenantGuid,
+                  clientId, authority);
+          LOG.trace("ArcMsiTokenProvider initialized");
         } else if (tokenProviderClass == RefreshTokenBasedTokenProvider.class) {
           String authEndpoint = getTrimmedPasswordString(
               FS_AZURE_ACCOUNT_OAUTH_REFRESH_TOKEN_ENDPOINT,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AuthConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AuthConfigurations.java
@@ -43,6 +43,14 @@ public final class AuthConfigurations {
   public static final String
       DEFAULT_FS_AZURE_ACCOUNT_OAUTH_TOKEN_FILE =
       "/var/run/secrets/azure/tokens/azure-identity-token";
+  /** Default OAuth api-version end point for the MSI flow. */
+  public static final String
+      DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT_API_VERSION =
+      "2018-02-01";
+  /** Default OAuth api-version end point for the ARC MSI flow. */
+  public static final String
+      DEFAULT_FS_AZURE_ACCOUNT_OAUTH_ARC_MSI_ENDPOINT_API_VERSION =
+      "2021-02-01";
 
   private AuthConfigurations() {
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -258,6 +258,10 @@ public final class ConfigurationKeys {
   public static final String FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT = "fs.azure.account.oauth2.msi.endpoint";
   /** Key for oauth msi Authority: {@value}. */
   public static final String FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY = "fs.azure.account.oauth2.msi.authority";
+  /** Key for oauth msi endpoint api version: {@value}. */
+  public static final String FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT_API_VERSION = "fs.azure.account.oauth2.msi.endpoint.api.version";
+  /** Key for oauth arc msi endpoint api version: {@value}. */
+  public static final String FS_AZURE_ACCOUNT_OAUTH_ARC_MSI_ENDPOINT_API_VERSION = "fs.azure.account.oauth2.arc.msi.endpoint.api.version";
   /** Key for oauth user name: {@value}. */
   public static final String FS_AZURE_ACCOUNT_OAUTH_USER_NAME = "fs.azure.account.oauth2.user.name";
   /** Key for oauth user password: {@value}. */

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/ArcMsiTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/ArcMsiTokenProvider.java
@@ -18,15 +18,15 @@
 
 package org.apache.hadoop.fs.azurebfs.oauth2;
 
-import java.io.IOException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 /**
  * Provides tokens based on Azure VM's Managed Service Identity.
  */
-public class MsiTokenProvider extends AccessTokenProvider {
+public class ArcMsiTokenProvider extends AccessTokenProvider {
 
   private final String authEndpoint;
 
@@ -44,8 +44,8 @@ public class MsiTokenProvider extends AccessTokenProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(AccessTokenProvider.class);
 
-  public MsiTokenProvider(final String authEndpoint, final String apiVersion, final String tenantGuid,
-      final String clientId, final String authority) {
+  public ArcMsiTokenProvider(final String authEndpoint, final String apiVersion, final String tenantGuid,
+                             final String clientId, final String authority) {
     this.authEndpoint = authEndpoint;
     this.tenantGuid = tenantGuid;
     this.clientId = clientId;
@@ -55,9 +55,9 @@ public class MsiTokenProvider extends AccessTokenProvider {
 
   @Override
   protected AzureADToken refreshToken() throws IOException {
-    LOG.debug("AADToken: refreshing token from MSI");
+    LOG.debug("AADToken: refreshing token from ARC MSI");
     AzureADToken token = AzureADAuthenticator
-        .getTokenFromMsi(authEndpoint, apiVersion, tenantGuid, clientId, authority, false);
+        .getTokenFromArcMsi(authEndpoint, apiVersion, tenantGuid, clientId, authority, false);
     tokenFetchTime = System.currentTimeMillis();
     return token;
   }
@@ -83,7 +83,7 @@ public class MsiTokenProvider extends AccessTokenProvider {
     // In case of, Token is not refreshed for 1 hr or any clock skew issues,
     // refresh token.
     if (expiring) {
-      LOG.debug("MSIToken: token renewing. Time elapsed since last token fetch:"
+      LOG.debug("ARCMSIToken: token renewing. Time elapsed since last token fetch:"
           + " {} milli seconds", elapsedTimeSinceLastTokenRefreshInMillis);
     }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsMsiTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsMsiTokenProvider.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.azurebfs;
 import java.io.IOException;
 import java.util.Date;
 
+import org.apache.hadoop.fs.azurebfs.constants.AuthConfigurations;
 import org.junit.Test;
 
 import org.apache.commons.lang3.StringUtils;
@@ -28,6 +29,7 @@ import org.apache.hadoop.fs.azurebfs.oauth2.AccessTokenProvider;
 import org.apache.hadoop.fs.azurebfs.oauth2.AzureADToken;
 import org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider;
 
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.*;
 import static org.junit.Assume.assumeThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -36,10 +38,7 @@ import static org.hamcrest.Matchers.isEmptyString;
 
 import static org.apache.hadoop.fs.azurebfs.constants.AuthConfigurations.DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY;
 import static org.apache.hadoop.fs.azurebfs.constants.AuthConfigurations.DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT;
+import static org.apache.hadoop.fs.azurebfs.constants.AuthConfigurations.DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT_API_VERSION;
 
 /**
  * Test MsiTokenProvider.
@@ -56,6 +55,8 @@ public final class ITestAbfsMsiTokenProvider
     AbfsConfiguration conf = getConfiguration();
     assumeThat(conf.get(FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT),
         not(isEmptyOrNullString()));
+    assumeThat(conf.get(FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT_API_VERSION),
+        not(isEmptyOrNullString()));
     assumeThat(conf.get(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT),
         not(isEmptyOrNullString()));
     assumeThat(conf.get(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID),
@@ -69,10 +70,13 @@ public final class ITestAbfsMsiTokenProvider
     String authEndpoint = getTrimmedPasswordString(conf,
         FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT,
         DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT);
+    String apiVersion = getTrimmedPasswordString(conf,
+        FS_AZURE_ACCOUNT_OAUTH_ARC_MSI_ENDPOINT_API_VERSION,
+        DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT_API_VERSION);
     String authority = getTrimmedPasswordString(conf,
         FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY,
         DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY);
-    AccessTokenProvider tokenProvider = new MsiTokenProvider(authEndpoint,
+    AccessTokenProvider tokenProvider = new MsiTokenProvider(authEndpoint, apiVersion,
         tenantGuid, clientId, authority);
 
     AzureADToken token = null;


### PR DESCRIPTION
### Description of PR

Please note that I am a DevOps engineer and not a Java developer. Therefore, certain aspects (such as writing tests) might be incomplete. While I am not trying to delegate this responsibility entirely, I would greatly appreciate support in writing tests for the introduced changes.

Additionally, there is no JIRA ticket associated with this pull request as I have not been granted access, nor did I receive a response to the email I sent to the Hadoop community mailing list at `core-user@hadoop.apache.org`. I would also appreciate any assistance in creating a corresponding JIRA ticket.

In any case, I welcome and am grateful for any feedback. Thank you!

### Changes Introduced in This Pull Request
- **Addition of ARC MSI Provider**: Enables support for Managed Identity on Azure ARC servers (on-premises servers connected to the Azure ecosystem).
- **Dynamic Variable for API Version**: Adds support for dynamically defining the `api-version` of the MSI endpoint for both MSI and ARC MSI.

Details regarding the motivation for this pull request can be found here: [StackOverflow discussion](https://stackoverflow.com/questions/79205684/how-to-set-api-version-dynamically-in-fs-azure-account-oauth2-msi-endpoint).

### How was this patch tested?

`hadoop-azure` was built and connected to `pyspark` on an on-premises server with installed ARC libraries for testing the connection to ABFS. Example code:
```python
from pyspark.sql import SparkSession

# Spark add-ons
path_to_hadoop_azure_jar = "/tmp/hadoop-azure-3.4.1-custom.jar"
path_to_hadoop_common_jar = "/opt/hadoop-common-3.4.1.jar"
path_to_azure_storage_jar = "/opt/azure-storage-8.6.6.jar"
path_to_azure_datalake_jar = "/opt/hadoop-azure-datalake-3.4.1.jar"

# ABFS variables
account_name = "***"
container_name = "***"
container_path = "***"
abfs_path=f"abfss://{container_name}@{account_name}.dfs.core.windows.net/{container_path}"

# Spark Session setting up
spark = SparkSession.builder.appName("AzureDataRead") \
    .config("spark.jars", f"{path_to_hadoop_common_jar},{path_to_hadoop_azure_jar},{path_to_azure_storage_jar},{path_to_azure_datalake_jar}") \
    .getOrCreate()
spark.conf.set("fs.azure.createRemoteFileSystemDuringInitialization", "true")

spark.conf.set(f"fs.azure.account.auth.type.{account_name}.dfs.core.windows.net", "OAuth")
spark.conf.set(f"fs.azure.account.oauth.provider.type.{account_name}.dfs.core.windows.net", "org.apache.hadoop.fs.azurebfs.oauth2.ArcMsiTokenProvider")
spark.conf.set(f"fs.azure.account.oauth2.msi.endpoint.{account_name}.dfs.core.windows.net", "http://127.0.0.1:40342/metadata/identity/oauth2/token")

# Logging
spark.sparkContext.setLogLevel("DEBUG")

# Create a simple DataFrame
data = [("Alice", 25), ("Bob", 30), ("Cathy", 28)]
columns = ["Name", "Age"]
df = spark.createDataFrame(data, columns)

# Write the DataFrame to ABFS as Parquet
try:
    df.write.parquet(abfs_path)
    print(f"Parquet file successfully written to {abfs_path}")
except Exception as e:
    print(f"Error writing Parquet file: {e}")
 # Register the Parquet file as a table
table_name = "my_second_table"
spark.sql(f"""
    CREATE TABLE IF NOT EXISTS {table_name}
    USING PARQUET
    LOCATION '{abfs_path}'
""")
print(f"Table '{table_name}' created successfully!")

# Query the table
spark.sql(f"SELECT * FROM {table_name}").show()

# List files in the directory
try:
    print(f"Listing files in directory: {abfs_path}")
    fs = spark._jvm.org.apache.hadoop.fs.FileSystem.get(spark._jsc.hadoopConfiguration())
    files = fs.listStatus(spark._jvm.org.apache.hadoop.fs.Path(abfs_path.rsplit("/", 1)[0]))
    for file in files:
        print(file.getPath().getName())
except Exception as e:
    print(f"Error listing files: {e}")
```

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

