### PR TITLE
HADOOP-19346. ViewFileSystem.InnerCache: Replaced ReentrantReadWriteLock with ConcurrentHashMap/putIfAbsent()

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -128,7 +128,7 @@ public class ViewFileSystem extends FileSystem {
 
     // computeIfAbsent() does not support a mapping function which throws IOException.
     // Wrap fsCreator.getNewInstance() to not throw IOException and return null instead.
-    FileSystem getNewFileSystem(FsGetter fsCreator, URI uri, Configuration config) {
+    FileSystem getNewFileSystem(URI uri, Configuration config) {
       try {
         return fsCreator.getNewInstance(uri, config);
       } catch (IOException e) {
@@ -140,7 +140,7 @@ public class ViewFileSystem extends FileSystem {
     FileSystem get(URI uri, Configuration config) throws IOException {
       Key key = new Key(uri);
 
-      FileSystem fs = map.computeIfAbsent(key, k -> getNewFileSystem(fsCreator, uri, config));
+      FileSystem fs = map.computeIfAbsent(key, k -> getNewFileSystem(uri, config));
       if (fs == null) {
         throw new IOException("Failed to create new FileSystem instance for " + uri);
       }
@@ -158,7 +158,7 @@ public class ViewFileSystem extends FileSystem {
     }
 
     void clear() {
-        map.clear();
+      map.clear();
     }
 
     /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -29,6 +29,7 @@ import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_FORCE_IN
 import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT_DEFAULT;
 
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -118,7 +119,7 @@ public class ViewFileSystem extends FileSystem {
    * Caching children filesystems. HADOOP-15565.
    */
   static class InnerCache {
-    private ConcurrentHashMap<Key, FileSystem> map = new ConcurrentHashMap<>();
+    private ConcurrentMap<Key, FileSystem> map = new ConcurrentHashMap<>();
     private FsGetter fsCreator;
 
     InnerCache(FsGetter fsCreator) {
@@ -138,9 +139,6 @@ public class ViewFileSystem extends FileSystem {
 
     FileSystem get(URI uri, Configuration config) throws IOException {
       Key key = new Key(uri);
-      if (map.contains(key)) {
-        return map.get(key);
-      }
 
       FileSystem fs = map.computeIfAbsent(key, k -> getNewFileSystem(fsCreator, uri, config));
       if (fs == null) {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
HADOOP-19346. ViewFileSystem.InnerCache: Replaced ReentrantReadWriteLock with ConcurrentHashMap/putIfAbsent()

### How was this patch tested?

mvn package -Pdist -PskipTests

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

