### PR TITLE
HADOOP-19254: Implement bulk delete command as hadoop fs command operation

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
@@ -40,22 +40,29 @@ public class BulkDeleteCommand extends FsCommand {
 
   private static final Logger LOG = LoggerFactory.getLogger(BulkDeleteCommand.class.getName());
 
-  public static final String name = "bulkDelete";
+  public static final String NAME = "bulkDelete";
 
   /**
-   * File Name parameter to be specified at command line
+   * File Name parameter to be specified at command line.
    */
   public static final String READ_FROM_FILE = "readFromFile";
 
   /**
-   * Page size parameter specified at command line
+   * Page size parameter specified at command line.
    */
   public static final String PAGE_SIZE = "pageSize";
 
 
-  public static final String USAGE = "-[ " + READ_FROM_FILE + "] [<file>] [" + PAGE_SIZE + "] [<pageSize>] [<basePath> <paths>]";
+  public static final String USAGE = "-[ " + READ_FROM_FILE + "] [<file>] [" + PAGE_SIZE
+          + "] [<pageSize>] [<basePath> <paths>]";
 
-  public static final String DESCRIPTION = "Deletes the set of files under the given <path>.\n" + "If a list of paths is provided at command line then the paths are deleted directly.\n" + "User can also point to the file where the paths are listed as full object names using the \"fileName\"" + "parameter. The presence of a file name takes precedence over the list of objects.\n" + "Page size refers to the size of each bulk delete batch." + "Users can specify the page size using \"pageSize\" command parameter." + "Default value is 1.\n";
+  public static final String DESCRIPTION = "Deletes the set of files under the given <path>.\n" +
+          "If a list of paths is provided at command line then the paths are deleted directly.\n" +
+          "User can also point to the file where the paths are listed as full object names using the \"fileName\"" +
+          "parameter. The presence of a file name takes precedence over the list of objects.\n" +
+          "Page size refers to the size of each bulk delete batch." +
+          "Users can specify the page size using \"pageSize\" command parameter." +
+          "Default value is 1.\n";
 
   private String fileName;
 
@@ -74,7 +81,7 @@ public class BulkDeleteCommand extends FsCommand {
   }
 
   /**
-   * Processes the command line options and initialize the variables
+   * Processes the command line options and initialize the variables.
    *
    * @param args the command line arguments
    * @throws IOException in case of wrong arguments passed
@@ -94,7 +101,7 @@ public class BulkDeleteCommand extends FsCommand {
   }
 
   /**
-   * Processes the command line arguments and stores the child arguments in a list
+   * Processes the command line arguments and stores the child arguments in a list.
    *
    * @param args strings to expand into {@link PathData} objects
    * @return the base path of the bulk delete command.
@@ -113,7 +120,7 @@ public class BulkDeleteCommand extends FsCommand {
   }
 
   /**
-   * Deletes the objects using the bulk delete api
+   * Deletes the objects using the bulk delete api.
    *
    * @param bulkDelete Bulkdelete object exposing the API
    * @param paths      list of paths to be deleted in the base path
@@ -139,7 +146,8 @@ public class BulkDeleteCommand extends FsCommand {
     if (fileName != null) {
       LOG.info("Reading from file:{}", fileName);
       FileSystem localFile = FileSystem.get(getConf());
-      BufferedReader br = new BufferedReader(new InputStreamReader(localFile.open(new Path(fileName)), StandardCharsets.UTF_8));
+      BufferedReader br = new BufferedReader(new InputStreamReader(
+              localFile.open(new Path(fileName)), StandardCharsets.UTF_8));
       String line;
       while ((line = br.readLine()) != null) {
         if (!line.startsWith("#")) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
@@ -1,11 +1,22 @@
-package org.apache.hadoop.fs.shell;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.BulkDelete;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+package org.apache.hadoop.fs.shell;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -14,6 +25,11 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.BulkDelete;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 
 public class BulkDeleteCommand extends FsCommand {
     public static void registerCommands(CommandFactory factory) {
@@ -73,7 +89,9 @@ public class BulkDeleteCommand extends FsCommand {
             BufferedReader br = new BufferedReader(new InputStreamReader(localFile.open(new Path(fileName))));
             String line;
             while((line = br.readLine()) != null) {
-                pathList.add(new Path(line));
+                if(!line.startsWith("#")) {
+                    pathList.add(new Path(line));
+                }
             }
         } else {
             pathList.addAll(this.childArgs.stream().map(Path::new).collect(Collectors.toList()));

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
@@ -117,7 +117,7 @@ public class BulkDeleteCommand extends FsCommand {
   @Override
   protected LinkedList<PathData> expandArguments(LinkedList<String> args) throws IOException {
     if (fileName == null && args.size() < 2) {
-      throw new IOException("Invalid Number of Arguments. Expected more");
+      throw new IOException("Invalid Number of Arguments. Expected :" + USAGE);
     }
     LinkedList<PathData> pathData = new LinkedList<>();
     pathData.add(new PathData(args.get(0), getConf()));
@@ -138,11 +138,14 @@ public class BulkDeleteCommand extends FsCommand {
     while (batches.hasNext()) {
       try {
         List<Map.Entry<Path, String>> result = bulkDelete.bulkDelete(batches.next());
-        LOG.warn("Number of failed deletions:{}", result.size());
-        LOG.debug("Deleted Result:{}", result.toString());
+        if(!result.isEmpty()) {
+          LOG.warn("Number of failed deletions:{}", result.size());
+          for(Map.Entry<Path, String> singleResult: result) {
+            LOG.info("{}: {}", singleResult.getKey(), singleResult.getValue());
+          }
+        }
       } catch (IllegalArgumentException e) {
-        LOG.error("Exception while deleting", e);
-        throw new IOException(e);
+        throw new IOException("Exception while deleting: ", e);
       }
     }
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
@@ -34,161 +34,162 @@ import org.slf4j.LoggerFactory;
 
 public class BulkDeleteCommand extends FsCommand {
 
-    public static void registerCommands(CommandFactory factory) {
-        factory.addClass(BulkDeleteCommand.class, "-bulkDelete");
+  public static void registerCommands(CommandFactory factory) {
+    factory.addClass(BulkDeleteCommand.class, "-bulkDelete");
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(BulkDeleteCommand.class.getName());
+
+  public static final String name = "bulkDelete";
+
+  /**
+   * File Name parameter to be specified at command line
+   */
+  public static final String READ_FROM_FILE = "readFromFile";
+
+  /**
+   * Page size parameter specified at command line
+   */
+  public static final String PAGE_SIZE = "pageSize";
+
+
+  public static final String USAGE = "-[ " + READ_FROM_FILE + "] [<file>] [" + PAGE_SIZE + "] [<pageSize>] [<basePath> <paths>]";
+
+  public static final String DESCRIPTION = "Deletes the set of files under the given <path>.\n" + "If a list of paths is provided at command line then the paths are deleted directly.\n" + "User can also point to the file where the paths are listed as full object names using the \"fileName\"" + "parameter. The presence of a file name takes precedence over the list of objects.\n" + "Page size refers to the size of each bulk delete batch." + "Users can specify the page size using \"pageSize\" command parameter." + "Default value is 1.\n";
+
+  private String fileName;
+
+  private int pageSize;
+
+  /*
+  Making the class stateful as the PathData initialization for all args is not needed
+   */ LinkedList<String> childArgs;
+
+  protected BulkDeleteCommand() {
+    this.childArgs = new LinkedList<>();
+  }
+
+  protected BulkDeleteCommand(Configuration conf) {
+    super(conf);
+  }
+
+  /**
+   * Processes the command line options and initialize the variables
+   *
+   * @param args the command line arguments
+   * @throws IOException in case of wrong arguments passed
+   */
+  @Override
+  protected void processOptions(LinkedList<String> args) throws IOException {
+    CommandFormat cf = new CommandFormat(0, Integer.MAX_VALUE);
+    cf.addOptionWithValue(READ_FROM_FILE);
+    cf.addOptionWithValue(PAGE_SIZE);
+    cf.parse(args);
+    fileName = cf.getOptValue(READ_FROM_FILE);
+    if (cf.getOptValue(PAGE_SIZE) != null) {
+      pageSize = Integer.parseInt(cf.getOptValue(PAGE_SIZE));
+    } else {
+      pageSize = 1;
     }
+  }
 
-    private static final Logger LOG = LoggerFactory.getLogger(BulkDeleteCommand.class.getName());
+  /**
+   * Processes the command line arguments and stores the child arguments in a list
+   *
+   * @param args strings to expand into {@link PathData} objects
+   * @return the base path of the bulk delete command.
+   * @throws IOException if the wrong number of arguments specified
+   */
+  @Override
+  protected LinkedList<PathData> expandArguments(LinkedList<String> args) throws IOException {
+    if (fileName == null && args.size() < 2) {
+      throw new IOException("Invalid Number of Arguments. Expected more");
+    }
+    LinkedList<PathData> pathData = new LinkedList<>();
+    pathData.add(new PathData(args.get(0), getConf()));
+    args.remove(0);
+    this.childArgs = args;
+    return pathData;
+  }
 
-    public static final String name = "bulkDelete";
+  /**
+   * Deletes the objects using the bulk delete api
+   *
+   * @param bulkDelete Bulkdelete object exposing the API
+   * @param paths      list of paths to be deleted in the base path
+   * @throws IOException on error in execution of the delete command
+   */
+  void deleteInBatches(BulkDelete bulkDelete, List<Path> paths) throws IOException {
+    Batch<Path> batches = new Batch<>(paths, pageSize);
+    while (batches.hasNext()) {
+      try {
+        List<Map.Entry<Path, String>> result = bulkDelete.bulkDelete(batches.next());
+        LOG.debug("Deleted Result:{}", result.toString());
+      } catch (IllegalArgumentException e) {
+        LOG.error("Caught exception while deleting", e);
+      }
+    }
+  }
+
+  @Override
+  protected void processArguments(LinkedList<PathData> args) throws IOException {
+    PathData basePath = args.get(0);
+    LOG.info("Deleting files under:{}", basePath);
+    List<Path> pathList = new ArrayList<>();
+    if (fileName != null) {
+      LOG.info("Reading from file:{}", fileName);
+      FileSystem localFile = FileSystem.get(getConf());
+      BufferedReader br = new BufferedReader(new InputStreamReader(localFile.open(new Path(fileName)), StandardCharsets.UTF_8));
+      String line;
+      while ((line = br.readLine()) != null) {
+        if (!line.startsWith("#")) {
+          pathList.add(new Path(line));
+        }
+      }
+      br.close();
+    } else {
+      pathList.addAll(this.childArgs.stream().map(Path::new).collect(Collectors.toList()));
+    }
+    LOG.debug("Deleting:{}", pathList);
+    BulkDelete bulkDelete = basePath.fs.createBulkDelete(basePath.path);
+    deleteInBatches(bulkDelete, pathList);
+  }
+
+  /**
+   * Batch class for deleting files in batches, once initialized the inner list can't be modified.
+   *
+   * @param <T> template type for batches
+   */
+  static class Batch<T> {
+    private final List<T> data;
+    private final int batchSize;
+    private int currentLocation;
+
+    Batch(List<T> data, int batchSize) {
+      this.data = Collections.unmodifiableList(data);
+      this.batchSize = batchSize;
+      this.currentLocation = 0;
+    }
 
     /**
-     * File Name parameter to be specified at command line
+     * @return If there is a next batch present
      */
-    public static final String READ_FROM_FILE = "readFromFile";
-
-    /**
-     * Page size parameter specified at command line
-     */
-    public static final String PAGE_SIZE = "pageSize";
-
-
-    public static final String USAGE = "-[ " + READ_FROM_FILE + "] [<file>] [" +
-        PAGE_SIZE + "] [<pageSize>] [<basePath> <paths>]";
-
-    public static final String DESCRIPTION = "Deletes the set of files under the given <path>.\n" +
-            "If a list of paths is provided at command line then the paths are deleted directly.\n" +
-            "User can also point to the file where the paths are listed as full object names using the \"fileName\"" +
-            "parameter. The presence of a file name takes precedence over the list of objects.\n" +
-            "Page size refers to the size of each bulk delete batch." +
-            "Users can specify the page size using \"pageSize\" command parameter." +
-            "Default value is 1.\n";
-
-    private String fileName;
-
-    private int pageSize;
-
-    /*
-    Making the class stateful as the PathData initialization for all args is not needed
-     */
-    LinkedList<String> childArgs;
-
-    protected BulkDeleteCommand() {
-        this.childArgs = new LinkedList<>();
-    }
-
-    protected BulkDeleteCommand(Configuration conf) {super(conf);}
-
-    /**
-     * Processes the command line options and initialize the variables
-     * @param args the command line arguments
-     * @throws IOException in case of wrong arguments passed
-     */
-    @Override
-    protected void processOptions(LinkedList<String> args) throws IOException {
-        CommandFormat cf = new CommandFormat(0, Integer.MAX_VALUE);
-        cf.addOptionWithValue(READ_FROM_FILE);
-        cf.addOptionWithValue(PAGE_SIZE);
-        cf.parse(args);
-        fileName = cf.getOptValue(READ_FROM_FILE);
-        if(cf.getOptValue(PAGE_SIZE) != null) {
-            pageSize = Integer.parseInt(cf.getOptValue(PAGE_SIZE));
-        } else {
-            pageSize = 1;
-        }
+    boolean hasNext() {
+      return currentLocation < data.size();
     }
 
     /**
-     * Processes the command line arguments and stores the child arguments in a list
-     * @param args strings to expand into {@link PathData} objects
-     * @return the base path of the bulk delete command.
-     * @throws IOException if the wrong number of arguments specified
+     * @return Compute and return a new batch
      */
-    @Override
-    protected LinkedList<PathData> expandArguments(LinkedList<String> args) throws IOException {
-        if(fileName == null && args.size() < 2) {
-            throw new IOException("Invalid Number of Arguments. Expected more");
-        }
-        LinkedList<PathData> pathData = new LinkedList<>();
-        pathData.add(new PathData(args.get(0), getConf()));
-        args.remove(0);
-        this.childArgs = args;
-        return pathData;
+    List<T> next() {
+      List<T> ret = new ArrayList<>();
+      int i = 0;
+      while (i < batchSize && currentLocation < data.size()) {
+        ret.add(data.get(currentLocation));
+        i++;
+        currentLocation++;
+      }
+      return ret;
     }
-
-    /**
-     * Deletes the objects using the bulk delete api
-     * @param bulkDelete Bulkdelete object exposing the API
-     * @param paths list of paths to be deleted in the base path
-     * @throws IOException on error in execution of the delete command
-     */
-    void deleteInBatches(BulkDelete bulkDelete, List<Path> paths) throws IOException {
-        Batch<Path> batches = new Batch<>(paths, pageSize);
-        while(batches.hasNext()) {
-            List<Map.Entry<Path, String>> result = bulkDelete.bulkDelete(batches.next());
-            LOG.debug(result.toString());
-        }
-    }
-
-    @Override
-    protected void processArguments(LinkedList<PathData> args) throws IOException {
-        PathData basePath = args.get(0);
-        LOG.info("Deleting files under:{}", basePath);
-        List<Path> pathList = new ArrayList<>();
-        if(fileName != null) {
-            LOG.info("Reading from file:{}", fileName);
-            FileSystem localFile = FileSystem.get(getConf());
-            BufferedReader br = new BufferedReader(new InputStreamReader(localFile.open(new Path(fileName)),
-                    StandardCharsets.UTF_8));
-            String line;
-            while((line = br.readLine()) != null) {
-                if(!line.startsWith("#")) {
-                    pathList.add(new Path(line));
-                }
-            }
-            br.close();
-        } else {
-            pathList.addAll(this.childArgs.stream().map(Path::new).collect(Collectors.toList()));
-        }
-        LOG.debug("Deleting:{}", pathList);
-        BulkDelete bulkDelete = basePath.fs.createBulkDelete(basePath.path);
-        deleteInBatches(bulkDelete, pathList);
-    }
-
-    /**
-     * Batch class for deleting files in batches, once initialized the inner list can't be modified.
-     * @param <T> template type for batches
-     */
-    static class Batch<T> {
-        private final List<T> data;
-        private final int batchSize;
-        private int currentLocation;
-
-        Batch(List<T> data, int batchSize) {
-            this.data = Collections.unmodifiableList(data);
-            this.batchSize = batchSize;
-            this.currentLocation = 0;
-        }
-
-        /**
-         * @return If there is a next batch present
-         */
-        boolean hasNext() {
-            return currentLocation < data.size();
-        }
-
-        /**
-         * @return Compute and return a new batch
-         */
-        List<T> next() {
-            List<T> ret = new ArrayList<>();
-            int i = 0;
-            while(i < batchSize && currentLocation < data.size()) {
-                ret.add(data.get(currentLocation));
-                i++;
-                currentLocation++;
-            }
-            return ret;
-        }
-    }
+  }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
@@ -68,9 +68,10 @@ public class BulkDeleteCommand extends FsCommand {
 
   private int pageSize;
 
-  /*
-  Making the class stateful as the PathData initialization for all args is not needed
-   */ LinkedList<String> childArgs;
+  /**
+   * Making the class stateful as the PathData initialization for all args is not needed
+   */
+  LinkedList<String> childArgs;
 
   protected BulkDeleteCommand() {
     this.childArgs = new LinkedList<>();
@@ -78,6 +79,8 @@ public class BulkDeleteCommand extends FsCommand {
 
   protected BulkDeleteCommand(Configuration conf) {
     super(conf);
+    this.childArgs = new LinkedList<>();
+    this.pageSize = 1;
   }
 
   /**
@@ -134,6 +137,7 @@ public class BulkDeleteCommand extends FsCommand {
         LOG.debug("Deleted Result:{}", result.toString());
       } catch (IllegalArgumentException e) {
         LOG.error("Caught exception while deleting", e);
+        throw new IOException(e);
       }
     }
   }
@@ -197,6 +201,8 @@ public class BulkDeleteCommand extends FsCommand {
         i++;
         currentLocation++;
       }
+      LOG.warn(ret.toString());
+      assert(ret.size() == this.batchSize);
       return ret;
     }
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.shell;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -81,7 +82,7 @@ public class BulkDeleteCommand extends FsCommand {
     /**
      * Processes the command line options and initialize the variables
      * @param args the command line arguments
-     * @throws IOException
+     * @throws IOException in case of wrong arguments passed
      */
     @Override
     protected void processOptions(LinkedList<String> args) throws IOException {
@@ -137,13 +138,15 @@ public class BulkDeleteCommand extends FsCommand {
         if(fileName != null) {
             LOG.info("Reading from file:{}", fileName);
             FileSystem localFile = FileSystem.get(getConf());
-            BufferedReader br = new BufferedReader(new InputStreamReader(localFile.open(new Path(fileName))));
+            BufferedReader br = new BufferedReader(new InputStreamReader(localFile.open(new Path(fileName)),
+                    StandardCharsets.UTF_8));
             String line;
             while((line = br.readLine()) != null) {
                 if(!line.startsWith("#")) {
                     pathList.add(new Path(line));
                 }
             }
+            br.close();
         } else {
             pathList.addAll(this.childArgs.stream().map(Path::new).collect(Collectors.toList()));
         }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class BulkDeleteCommand extends FsCommand {
-    Logger LOG = LoggerFactory.getLogger(BulkDeleteCommand.class.getName());
     public static void registerCommands(CommandFactory factory) {
         factory.addClass(BulkDeleteCommand.class, "-bulkDelete");
     }
@@ -38,22 +37,22 @@ public class BulkDeleteCommand extends FsCommand {
      */
     LinkedList<String> childArgs;
 
-    protected BulkDeleteCommand() {}
+    protected BulkDeleteCommand() {
+        this.childArgs = new LinkedList<>();
+    }
 
     protected BulkDeleteCommand(Configuration conf) {super(conf);}
 
     @Override
     protected void processOptions(LinkedList<String> args) throws IOException {
-        CommandFormat cf = new CommandFormat(1, Integer.MAX_VALUE);
+        CommandFormat cf = new CommandFormat(0, Integer.MAX_VALUE);
         cf.addOptionWithValue(READ_FROM_FILE);
         cf.parse(args);
         fileName = cf.getOptValue(READ_FROM_FILE);
-        LOG.warn(fileName);
     }
 
     @Override
     protected LinkedList<PathData> expandArguments(LinkedList<String> args) throws IOException {
-        LOG.warn(args.toString());
         if(fileName == null && args.size() < 2) {
             throw new IOException("Invalid Number of Arguments. Expected more");
         }
@@ -66,12 +65,10 @@ public class BulkDeleteCommand extends FsCommand {
 
     @Override
     protected void processArguments(LinkedList<PathData> args) throws IOException {
-        System.out.println(args.toString());
         PathData basePath = args.get(0);
         out.println("Deleting files under:" + basePath);
         List<Path> pathList = new ArrayList<>();
         if(fileName != null) {
-            LOG.warn("IN here");
             FileSystem localFile = FileSystem.get(getConf());
             BufferedReader br = new BufferedReader(new InputStreamReader(localFile.open(new Path(fileName))));
             String line;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
@@ -1,0 +1,87 @@
+package org.apache.hadoop.fs.shell;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.BulkDelete;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BulkDeleteCommand extends FsCommand {
+    Logger LOG = LoggerFactory.getLogger(BulkDeleteCommand.class.getName());
+    public static void registerCommands(CommandFactory factory) {
+        factory.addClass(BulkDeleteCommand.class, "-bulkDelete");
+    }
+
+    public static final String name = "bulkDelete";
+
+    public static final String READ_FROM_FILE = "readFromFile";
+
+    public static final String USAGE = "-[ " + READ_FROM_FILE + "] [<file>] [<basePath> <paths>]";
+
+    public static final String DESCRIPTION = "Deletes the set of files under the given path. If a list of paths " +
+            "is provided then the paths are deleted directly. User can also point to the file where the paths are" +
+            "listed as full object names.";
+
+    private String fileName;
+
+    /*
+    Making the class stateful as the PathData initialization for all args is not needed
+     */
+    LinkedList<String> childArgs;
+
+    protected BulkDeleteCommand() {}
+
+    protected BulkDeleteCommand(Configuration conf) {super(conf);}
+
+    @Override
+    protected void processOptions(LinkedList<String> args) throws IOException {
+        CommandFormat cf = new CommandFormat(1, Integer.MAX_VALUE);
+        cf.addOptionWithValue(READ_FROM_FILE);
+        cf.parse(args);
+        fileName = cf.getOptValue(READ_FROM_FILE);
+        LOG.warn(fileName);
+    }
+
+    @Override
+    protected LinkedList<PathData> expandArguments(LinkedList<String> args) throws IOException {
+        LOG.warn(args.toString());
+        if(fileName == null && args.size() < 2) {
+            throw new IOException("Invalid Number of Arguments. Expected more");
+        }
+        LinkedList<PathData> pathData = new LinkedList<>();
+        pathData.add(new PathData(args.get(0), getConf()));
+        args.remove(0);
+        this.childArgs = args;
+        return pathData;
+    }
+
+    @Override
+    protected void processArguments(LinkedList<PathData> args) throws IOException {
+        System.out.println(args.toString());
+        PathData basePath = args.get(0);
+        out.println("Deleting files under:" + basePath);
+        List<Path> pathList = new ArrayList<>();
+        if(fileName != null) {
+            LOG.warn("IN here");
+            FileSystem localFile = FileSystem.get(getConf());
+            BufferedReader br = new BufferedReader(new InputStreamReader(localFile.open(new Path(fileName))));
+            String line;
+            while((line = br.readLine()) != null) {
+                pathList.add(new Path(line));
+            }
+        } else {
+            pathList.addAll(this.childArgs.stream().map(Path::new).collect(Collectors.toList()));
+        }
+        BulkDelete bulkDelete = basePath.fs.createBulkDelete(basePath.path);
+        bulkDelete.bulkDelete(pathList);
+    }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
@@ -21,9 +21,7 @@ package org.apache.hadoop.fs.shell;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.conf.Configuration;
@@ -40,13 +38,18 @@ public class BulkDeleteCommand extends FsCommand {
 
     public static final String READ_FROM_FILE = "readFromFile";
 
-    public static final String USAGE = "-[ " + READ_FROM_FILE + "] [<file>] [<basePath> <paths>]";
+    public static final String PAGE_SIZE = "pageSize";
+
+    public static final String USAGE = "-[ " + READ_FROM_FILE + "] [<file>] [" +
+        PAGE_SIZE + "] [<pageSize>] [<basePath> <paths>]";
 
     public static final String DESCRIPTION = "Deletes the set of files under the given path. If a list of paths " +
             "is provided then the paths are deleted directly. User can also point to the file where the paths are" +
             "listed as full object names.";
 
     private String fileName;
+
+    private int pageSize;
 
     /*
     Making the class stateful as the PathData initialization for all args is not needed
@@ -63,8 +66,14 @@ public class BulkDeleteCommand extends FsCommand {
     protected void processOptions(LinkedList<String> args) throws IOException {
         CommandFormat cf = new CommandFormat(0, Integer.MAX_VALUE);
         cf.addOptionWithValue(READ_FROM_FILE);
+        cf.addOptionWithValue(PAGE_SIZE);
         cf.parse(args);
         fileName = cf.getOptValue(READ_FROM_FILE);
+        if(cf.getOptValue(PAGE_SIZE) != null) {
+            pageSize = Integer.parseInt(cf.getOptValue(PAGE_SIZE));
+        } else {
+            pageSize = 1;
+        }
     }
 
     @Override
@@ -77,6 +86,13 @@ public class BulkDeleteCommand extends FsCommand {
         args.remove(0);
         this.childArgs = args;
         return pathData;
+    }
+
+    void deleteInBatches(BulkDelete bulkDelete, List<Path> paths) throws IOException {
+        Batch<Path> batches = new Batch<>(paths, pageSize);
+        while(batches.hasNext()) {
+            bulkDelete.bulkDelete(batches.next());
+        }
     }
 
     @Override
@@ -97,6 +113,32 @@ public class BulkDeleteCommand extends FsCommand {
             pathList.addAll(this.childArgs.stream().map(Path::new).collect(Collectors.toList()));
         }
         BulkDelete bulkDelete = basePath.fs.createBulkDelete(basePath.path);
-        bulkDelete.bulkDelete(pathList);
+        deleteInBatches(bulkDelete, pathList);
+    }
+
+    static class Batch<T> {
+        List<T> data;
+        int batchSize;
+        int currentLocation;
+
+        Batch(List<T> data, int batchSize) {
+            this.data = Collections.unmodifiableList(data);
+            this.batchSize = batchSize;
+            this.currentLocation = 0;
+        }
+
+        boolean hasNext() {
+            return this.currentLocation < this.data.size();
+        }
+
+        List<T> next() {
+            List<T> ret = new ArrayList<>();
+            int i = currentLocation;
+            for(; i < Math.min(currentLocation + batchSize, data.size()); i++) {
+                ret.add(this.data.get(i));
+            }
+            currentLocation = i;
+            return ret;
+        }
     }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/BulkDeleteCommand.java
@@ -201,8 +201,6 @@ public class BulkDeleteCommand extends FsCommand {
         i++;
         currentLocation++;
       }
-      LOG.warn(ret.toString());
-      assert(ret.size() == this.batchSize);
       return ret;
     }
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/FsCommand.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/FsCommand.java
@@ -51,6 +51,7 @@ abstract public class FsCommand extends Command {
    */
   public static void registerCommands(CommandFactory factory) {
     factory.registerCommands(AclCommands.class);
+    factory.registerCommands(BulkDeleteCommand.class);
     factory.registerCommands(CopyCommands.class);
     factory.registerCommands(Count.class);
     factory.registerCommands(Delete.class);
@@ -71,7 +72,6 @@ abstract public class FsCommand extends Command {
     factory.registerCommands(SnapshotCommands.class);
     factory.registerCommands(XAttrCommands.class);
     factory.registerCommands(Concat.class);
-    factory.registerCommands(BulkDeleteCommand.class);
   }
 
   protected FsCommand() {}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/FsCommand.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/FsCommand.java
@@ -71,6 +71,7 @@ abstract public class FsCommand extends Command {
     factory.registerCommands(SnapshotCommands.class);
     factory.registerCommands(XAttrCommands.class);
     factory.registerCommands(Concat.class);
+    factory.registerCommands(BulkDeleteCommand.class);
   }
 
   protected FsCommand() {}

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/bulkdelete.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/bulkdelete.md
@@ -72,6 +72,18 @@ public interface BulkDelete extends IOStatisticsSource, Closeable {
 }
 
 ```
+### Shell Command `hadoop fs -bulkdelete <options> base_path`
+
+This is the command line implementation of the bulkdelete API, the user can specify a base path and the underlying 
+paths for deletion. The list of paths can also be read from a file with each line containing
+a separate path for deletion.
+
+```angular2html
+hadoop fs -bulkdelete <basePath> <path1> <path2> <path3>.....
+hadoop fs -bulkdelete -pageSize 10 <basePath> <path1> <path2> <path3>.....
+hadoop fs -bulkdelete -fileName <fileName> <basePath>
+```
+
 
 ### `bulkDelete(paths)`
 

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/bulkdelete.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/bulkdelete.md
@@ -81,7 +81,7 @@ a separate path for deletion.
 ```angular2html
 hadoop fs -bulkdelete <basePath> <path1> <path2> <path3>.....
 hadoop fs -bulkdelete -pageSize 10 <basePath> <path1> <path2> <path3>.....
-hadoop fs -bulkdelete -fileName <fileName> <basePath>
+hadoop fs -bulkdelete -readFromFile <fileName> <basePath>
 ```
 
 

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/bulkdelete.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/bulkdelete.md
@@ -74,7 +74,7 @@ public interface BulkDelete extends IOStatisticsSource, Closeable {
 ```
 ### Shell Command `hadoop fs -bulkdelete <options> base_path`
 
-This is the command line implementation of the bulkdelete API, the user can specify a base path and the underlying 
+This is the command line implementation of the bulkdelete API, the user can specify a base path and the underlying
 paths for deletion. The list of paths can also be read from a file with each line containing
 a separate path for deletion.
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestBulkDeleteCommand.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestBulkDeleteCommand.java
@@ -1,0 +1,45 @@
+package org.apache.hadoop.fs.shell;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.LinkedList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestBulkDeleteCommand {
+    private static Configuration conf;
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        conf = new Configuration();
+    }
+
+    @Test
+    public void testDefaults() throws IOException {
+        LinkedList<String> options = new LinkedList<>();
+        BulkDeleteCommand bulkDeleteCommand = new BulkDeleteCommand();
+        bulkDeleteCommand.processOptions(options);
+        assertTrue(bulkDeleteCommand.childArgs.isEmpty());
+    }
+
+    @Test
+    public void testArguments() throws IOException, URISyntaxException {
+        BulkDeleteCommand bulkDeleteCommand = new BulkDeleteCommand(conf);
+        LinkedList<String> arguments = new LinkedList<>();
+        String arg1 = "file:///file/name/1";
+        String arg2 = "file:///file/name/2";
+        arguments.add(arg1);
+        arguments.add(arg2);
+        LinkedList<PathData> pathData = bulkDeleteCommand.expandArguments(arguments);
+        assertEquals(1, pathData.size());
+        assertEquals(new URI(arg1).getPath(), pathData.get(0).path.toUri().getPath());
+        assertEquals(1, bulkDeleteCommand.childArgs.size());
+        assertEquals(arg2, bulkDeleteCommand.childArgs.get(0));
+    }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestBulkDeleteCommand.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestBulkDeleteCommand.java
@@ -22,18 +22,14 @@ import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import com.jcraft.jsch.Buffer;
-import com.jcraft.jsch.IO;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.HadoopTestBase;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestBulkDeleteCommand.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestBulkDeleteCommand.java
@@ -1,18 +1,35 @@
-package org.apache.hadoop.fs.shell;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import org.apache.hadoop.conf.Configuration;
-import org.junit.BeforeClass;
-import org.junit.Test;
+package org.apache.hadoop.fs.shell;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.LinkedList;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.HadoopTestBase;
+import org.assertj.core.api.Assertions;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
-public class TestBulkDeleteCommand {
+public class TestBulkDeleteCommand extends HadoopTestBase  {
     private static Configuration conf;
 
     @BeforeClass
@@ -37,9 +54,14 @@ public class TestBulkDeleteCommand {
         arguments.add(arg1);
         arguments.add(arg2);
         LinkedList<PathData> pathData = bulkDeleteCommand.expandArguments(arguments);
-        assertEquals(1, pathData.size());
-        assertEquals(new URI(arg1).getPath(), pathData.get(0).path.toUri().getPath());
-        assertEquals(1, bulkDeleteCommand.childArgs.size());
-        assertEquals(arg2, bulkDeleteCommand.childArgs.get(0));
+        Assertions.assertThat(pathData.size()).
+                describedAs("Only one root path must be present").isEqualTo(1);
+        Assertions.assertThat(pathData.get(0).path.toUri().getPath()).
+                describedAs("Base path of the command should match").isEqualTo(new URI(arg1).getPath());
+        Assertions.assertThat(bulkDeleteCommand.childArgs.size()).
+                describedAs("Only one other argument was passed to the command").
+                isEqualTo(1);
+        Assertions.assertThat(bulkDeleteCommand.childArgs.get(0)).
+                describedAs("Children arguments must match").isEqualTo(arg2);
     }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestBulkDeleteCommand.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestBulkDeleteCommand.java
@@ -33,97 +33,113 @@ import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestBulkDeleteCommand extends HadoopTestBase  {
-    private static Configuration conf;
-    private static FsShell shell;
-    private static LocalFileSystem lfs;
-    private static Path testRootDir;
+public class TestBulkDeleteCommand extends HadoopTestBase {
+  private static Configuration conf;
+  private static FsShell shell;
+  private static LocalFileSystem lfs;
+  private static Path testRootDir;
 
-    @BeforeClass
-    public static void setup() throws IOException {
-        conf = new Configuration();
-        shell = new FsShell(conf);
-        lfs = FileSystem.getLocal(conf);
-        testRootDir = lfs.makeQualified(new Path(GenericTestUtils.getTempPath(
-                "testFsShellBulkDelete")));
-        lfs.delete(testRootDir, true);
-        lfs.mkdirs(testRootDir);
-        lfs.setWorkingDirectory(testRootDir);
+  @BeforeClass
+  public static void setup() throws IOException {
+    conf = new Configuration();
+    shell = new FsShell(conf);
+    lfs = FileSystem.getLocal(conf);
+    testRootDir = lfs.makeQualified(new Path(GenericTestUtils.getTempPath(
+            "testFsShellBulkDelete")));
+    lfs.delete(testRootDir, true);
+    lfs.mkdirs(testRootDir);
+    lfs.setWorkingDirectory(testRootDir);
+  }
+
+  @Test
+  public void testDefaults() throws IOException {
+    LinkedList<String> options = new LinkedList<>();
+    BulkDeleteCommand bulkDeleteCommand = new BulkDeleteCommand();
+    bulkDeleteCommand.processOptions(options);
+    assertTrue(bulkDeleteCommand.childArgs.isEmpty());
+  }
+
+  @Test
+  public void testArguments() throws IOException, URISyntaxException {
+    BulkDeleteCommand bulkDeleteCommand = new BulkDeleteCommand(conf);
+    LinkedList<String> arguments = new LinkedList<>();
+    String arg1 = "file:///file/name/1";
+    String arg2 = "file:///file/name/2";
+    arguments.add(arg1);
+    arguments.add(arg2);
+    LinkedList<PathData> pathData = bulkDeleteCommand.expandArguments(arguments);
+    Assertions.assertThat(pathData.size()).
+            describedAs("Only one root path must be present").isEqualTo(1);
+    Assertions.assertThat(pathData.get(0).path.toUri().getPath()).
+            describedAs("Base path of the command should match").isEqualTo(new URI(arg1).getPath());
+    Assertions.assertThat(bulkDeleteCommand.childArgs.size()).
+            describedAs("Only one other argument was passed to the command").
+            isEqualTo(1);
+    Assertions.assertThat(bulkDeleteCommand.childArgs.get(0)).
+            describedAs("Children arguments must match").isEqualTo(arg2);
+  }
+
+  @Test
+  public void testWrongArguments() throws IOException, URISyntaxException {
+    BulkDeleteCommand bulkDeleteCommand = new BulkDeleteCommand(conf);
+    LinkedList<String> arguments = new LinkedList<>();
+    String arg1 = "file:///file/name/1";
+    arguments.add(arg1);
+    Assertions.assertThatThrownBy(() -> bulkDeleteCommand.expandArguments(arguments)).
+            describedAs("No children to be deleted specified in the command.").
+            isInstanceOf(IOException.class);
+  }
+
+  @Test
+  public void testLocalFileDeletion() throws IOException {
+    String deletionDir = "toDelete";
+    String baseFileName = "file_";
+    Path baseDir = new Path(testRootDir, deletionDir);
+    List<String> listOfPaths = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      Path p = new Path(baseDir, baseFileName + i);
+      lfs.create(p);
     }
-
-    @Test
-    public void testDefaults() throws IOException {
-        LinkedList<String> options = new LinkedList<>();
-        BulkDeleteCommand bulkDeleteCommand = new BulkDeleteCommand();
-        bulkDeleteCommand.processOptions(options);
-        assertTrue(bulkDeleteCommand.childArgs.isEmpty());
+    RemoteIterator<LocatedFileStatus> remoteIterator = lfs.listFiles(baseDir, false);
+    while (remoteIterator.hasNext()) {
+      listOfPaths.add(remoteIterator.next().getPath().toUri().toString());
     }
+    List<String> finalCommandList = new ArrayList<>();
+    finalCommandList.add("-bulkDelete");
+    finalCommandList.add(baseDir.toUri().toString());
+    finalCommandList.addAll(listOfPaths);
+    shell.run(finalCommandList.toArray(new String[0]));
+    Assertions.assertThat(lfs.listFiles(baseDir, false).hasNext())
+            .as("All the files should have been deleted under the path:" +
+                    baseDir).isEqualTo(false);
 
-    @Test
-    public void testArguments() throws IOException, URISyntaxException {
-        BulkDeleteCommand bulkDeleteCommand = new BulkDeleteCommand(conf);
-        LinkedList<String> arguments = new LinkedList<>();
-        String arg1 = "file:///file/name/1";
-        String arg2 = "file:///file/name/2";
-        arguments.add(arg1);
-        arguments.add(arg2);
-        LinkedList<PathData> pathData = bulkDeleteCommand.expandArguments(arguments);
-        Assertions.assertThat(pathData.size()).
-                describedAs("Only one root path must be present").isEqualTo(1);
-        Assertions.assertThat(pathData.get(0).path.toUri().getPath()).
-                describedAs("Base path of the command should match").isEqualTo(new URI(arg1).getPath());
-        Assertions.assertThat(bulkDeleteCommand.childArgs.size()).
-                describedAs("Only one other argument was passed to the command").
-                isEqualTo(1);
-        Assertions.assertThat(bulkDeleteCommand.childArgs.get(0)).
-                describedAs("Children arguments must match").isEqualTo(arg2);
+  }
+
+  @Test
+  public void testLocalFileDeletionWithFileName() throws IOException {
+    String deletionDir = "toDelete";
+    String baseFileName = "file_";
+    Path baseDir = new Path(testRootDir, deletionDir);
+    Path fileWithDeletePaths = new Path(testRootDir, "fileWithDeletePaths");
+    FSDataOutputStream fsDataOutputStream = lfs.create(fileWithDeletePaths, true);
+    BufferedWriter br = new BufferedWriter(new OutputStreamWriter(fsDataOutputStream));
+    for (int i = 0; i < 100; i++) {
+      Path p = new Path(baseDir, baseFileName + i);
+      lfs.create(p);
+      br.write(p.toUri().toString());
+      br.newLine();
     }
+    br.flush(); // flush the file to write the contents
+    br.close(); // close the writer
+    List<String> finalCommandList = new ArrayList<>();
+    finalCommandList.add("-bulkDelete");
+    finalCommandList.add("-readFromFile");
+    finalCommandList.add(fileWithDeletePaths.toUri().toString());
+    finalCommandList.add(baseDir.toUri().toString());
+    shell.run(finalCommandList.toArray(new String[0]));
+    Assertions.assertThat(lfs.listFiles(baseDir, false).hasNext())
+            .as("All the files should have been deleted under the path:" +
+                    baseDir).isEqualTo(false);
 
-    @Test
-    public void testLocalFileDeletion() throws IOException {
-        String deletionDir = "toDelete";
-        String baseFileName = "file_";
-        Path baseDir = new Path(testRootDir, deletionDir);
-        List<String> listOfPaths = new ArrayList<>();
-        for(int i = 0; i < 100; i++) {
-            Path p = new Path(baseDir, baseFileName + i);
-            lfs.create(p);
-            listOfPaths.add(p.toUri().toString());
-        }
-        List<String> finalCommandList = new ArrayList<>();
-        finalCommandList.add("-bulkDelete");
-        finalCommandList.add(baseDir.toUri().toString());
-        finalCommandList.addAll(listOfPaths);
-        shell.run(finalCommandList.toArray(new String[0]));
-        Assertions.assertThat(lfs.listFiles(baseDir, false).hasNext())
-                .as("All the files should have been deleted").isEqualTo(false);
-
-    }
-
-    @Test
-    public void testLocalFileDeletionWithFileName() throws IOException {
-        String deletionDir = "toDelete";
-        String baseFileName = "file_";
-        Path baseDir = new Path(testRootDir, deletionDir);
-        Path fileWithDeletePaths = new Path(testRootDir, "fileWithDeletePaths");
-        FSDataOutputStream fsDataOutputStream = lfs.create(fileWithDeletePaths, true);
-        BufferedWriter br = new BufferedWriter(new OutputStreamWriter(fsDataOutputStream));
-        for(int i = 0; i < 100; i++) {
-            Path p = new Path(baseDir, baseFileName + i);
-            lfs.create(p);
-            br.write(p.toUri().toString());
-            br.newLine();
-        }
-        br.flush(); // flush the file to write the contents
-        br.close(); // close the writer
-        List<String> finalCommandList = new ArrayList<>();
-        finalCommandList.add("-bulkDelete");
-        finalCommandList.add("-readFromFile");
-        finalCommandList.add(fileWithDeletePaths.toUri().toString());
-        finalCommandList.add(baseDir.toUri().toString());
-        shell.run(finalCommandList.toArray(new String[0]));
-        Assertions.assertThat(lfs.listFiles(baseDir, false).hasNext())
-                .as("All the files should have been deleted").isEqualTo(false);
-
-    }
+  }
 }


### PR DESCRIPTION
### Description of PR
 Implement bulk delete command as hadoop fs command operation

### How was this patch tested?
Patch was tested in local by building the entire stack and against a s3 bucket.
Added a unit test for functionality testing.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

