### PR TITLE
HDFS-17679 Use saslClient#hasInitialResponse() instead of heuristics in SaslParticipant#createFirstMessage()

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslParticipant.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslParticipant.java
@@ -127,8 +127,13 @@ class SaslParticipant {
   }
 
   byte[] createFirstMessage() throws SaslException {
-    return SaslMechanismFactory.isDefaultMechanism(MECHANISM_ARRAY[0]) ? EMPTY_BYTE_ARRAY
-        : evaluateChallengeOrResponse(EMPTY_BYTE_ARRAY);
+    if (saslClient != null) {
+      return saslClient.hasInitialResponse()
+          ? saslClient.evaluateChallenge(EMPTY_BYTE_ARRAY)
+          : EMPTY_BYTE_ARRAY;
+    }
+    throw new IllegalStateException(
+        "createFirstMessage must only be called for clients");
   }
 
   /**


### PR DESCRIPTION
### Description of PR

HDFS-17679
Use the proper SASL API to determine if SASL Client sends a non-empty inital response

### How was this patch tested?

Not tested manually, CI should tell us if more changes are needed.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

