### PR TITLE
HDFS-17681. dfs.datanode.max.slowdisks.to.exclude should not be larger than the count of datanode dirs.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -955,6 +955,11 @@ public class DataNode extends ReconfigurableBase
         checkNotNull(diskMetrics, "DataNode disk stats may be disabled.");
         int maxSlowDisksToExclude = (newVal == null ?
             DFS_DATANODE_MAX_SLOWDISKS_TO_EXCLUDE_DEFAULT : Integer.parseInt(newVal));
+        if (maxSlowDisksToExclude > DataNode.getStorageLocations(dnConf.getConf()).size()) {
+          LOG.warn("Can not set {} larger than the count of datanode data dirs. Set it to {}",
+              DFS_DATANODE_MAX_SLOWDISKS_TO_EXCLUDE_KEY, DFS_DATANODE_MAX_SLOWDISKS_TO_EXCLUDE_DEFAULT);
+          maxSlowDisksToExclude = 0;
+        }
         result = Integer.toString(maxSlowDisksToExclude);
         diskMetrics.setMaxSlowDisksToExclude(maxSlowDisksToExclude);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeDiskMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeDiskMetrics.java
@@ -43,6 +43,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_MAX_SLOWDISKS_TO_EXCLUDE_DEFAULT;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_MAX_SLOWDISKS_TO_EXCLUDE_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_MIN_OUTLIER_DETECTION_DISKS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_SLOWDISK_LOW_THRESHOLD_MS_KEY;
 
@@ -99,6 +101,10 @@ public class DataNodeDiskMetrics {
     maxSlowDisksToExclude =
         conf.getInt(DFSConfigKeys.DFS_DATANODE_MAX_SLOWDISKS_TO_EXCLUDE_KEY,
             DFSConfigKeys.DFS_DATANODE_MAX_SLOWDISKS_TO_EXCLUDE_DEFAULT);
+    if (maxSlowDisksToExclude > DataNode.getStorageLocations(conf).size()) {
+      LOG.warn("Can not set {} larger than the count of datanode data dirs. Set it to {}",
+          DFS_DATANODE_MAX_SLOWDISKS_TO_EXCLUDE_KEY, DFS_DATANODE_MAX_SLOWDISKS_TO_EXCLUDE_DEFAULT);
+    }
     slowDiskDetector =
         new OutlierDetector(minOutlierDetectionDisks, lowThresholdMs);
     shouldRun = true;


### PR DESCRIPTION
### Description of PR
We should limit `dfs.datanode.max.slowdisks.to.exclude` be smaller than the count of datanode dirs, otherwise datanode may be not able to choose an avaliable volume and throw DiskOutOfSpaceException to rebuild pipeline.  If retry count exceeds max retry count, the write operation will fail.

```java
  @Override
  public V chooseVolume(List<V> volumes, long replicaSize, String storageId)
      throws IOException {
    if (volumes.size() < 1) {
      throw new DiskOutOfSpaceException("No more available volumes");
    }
    // As all the items in volumes are with the same storage type,
    // so only need to get the storage type index of the first item in volumes
    StorageType storageType = volumes.get(0).getStorageType();
    int index = storageType != null ?
            storageType.ordinal() : StorageType.DEFAULT.ordinal();

    synchronized (syncLocks[index]) {
      return doChooseVolume(volumes, replicaSize, storageId);
    }
  }
```