### PR TITLE
HADOOP-19352. Hadoop OSS Connector adds support for V4 signatures.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1663,7 +1663,7 @@
       <dependency>
         <groupId>com.aliyun.oss</groupId>
         <artifactId>aliyun-sdk-oss</artifactId>
-        <version>3.13.2</version>
+        <version>3.18.1</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.httpcomponents</groupId>

--- a/hadoop-tools/hadoop-aliyun/pom.xml
+++ b/hadoop-tools/hadoop-aliyun/pom.xml
@@ -165,5 +165,31 @@
       <scope>test</scope>
       <type>jar</type>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystemStore.java
+++ b/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystemStore.java
@@ -120,7 +120,7 @@ public class AliyunOSSFileSystemStore {
       clientConf.setSignatureVersion(SignVersion.V4);
       if (StringUtils.isEmpty(region)) {
         LOG.error("Signature version is V4 ,but region is empty.");
-        throw new IllegalArgumentException("SignVersion is V4 but region is empty");
+        throw new IOException("SignVersion is V4 but region is empty");
       }
     }
 

--- a/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystemStore.java
+++ b/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystemStore.java
@@ -181,7 +181,7 @@ public class AliyunOSSFileSystemStore {
       ossClient.setBucketAcl(bucketName, cannedACL);
       statistics.incrementWriteOps(1);
     }
-    
+
     if (StringUtils.isNotEmpty(region)) {
       ossClient.setRegion(region);
       LOG.debug("ossClient setRegion {}", region);

--- a/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/Constants.java
+++ b/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/Constants.java
@@ -211,4 +211,19 @@ public final class Constants {
   public static final String LIST_VERSION = "fs.oss.list.version";
 
   public static final int DEFAULT_LIST_VERSION = 2;
+
+  /**
+   * OSS signature version.
+   */
+  public static final String SIGNATURE_VERSION_KEY = "fs.oss.signatureversion";
+
+  /**
+   * OSS signature version DEFAULT {@value}
+   */
+  public static final String SIGNATURE_VERSION_DEFAULT = "V1";
+
+  /**
+   * OSS region {@value}
+   */
+  public static final String REGION_KEY = "fs.oss.region";
 }

--- a/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/Constants.java
+++ b/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/Constants.java
@@ -218,12 +218,12 @@ public final class Constants {
   public static final String SIGNATURE_VERSION_KEY = "fs.oss.signatureversion";
 
   /**
-   * OSS signature version DEFAULT {@value}
+   * OSS signature version DEFAULT {@value}.
    */
   public static final String SIGNATURE_VERSION_DEFAULT = "V1";
 
   /**
-   * OSS region {@value}
+   * OSS region {@value}.
    */
   public static final String REGION_KEY = "fs.oss.region";
 }

--- a/hadoop-tools/hadoop-aliyun/src/test/java/org/apache/hadoop/fs/aliyun/oss/ITAliyunOSSSignatureV4.java
+++ b/hadoop-tools/hadoop-aliyun/src/test/java/org/apache/hadoop/fs/aliyun/oss/ITAliyunOSSSignatureV4.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.aliyun.oss;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileSystemContractBaseTest;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
+
+import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeNotNull;
+import static org.junit.Assume.assumeTrue;
+
+import static org.apache.hadoop.fs.aliyun.oss.Constants.SIGNATURE_VERSION_KEY;
+import static org.apache.hadoop.fs.aliyun.oss.Constants.REGION_KEY;
+
+/**
+ * Tests Aliyun OSS system.
+ */
+public class ITAliyunOSSSignatureV4 {
+  private static final Logger LOG = LoggerFactory.getLogger(ITAliyunOSSSignatureV4.class);
+  private Configuration conf;
+  private URI testURI;
+  private Path testFile = new Path("ITAliyunOSSSignatureV4/atestr");
+
+  @Before
+  public void setUp() throws Exception {
+    conf = new Configuration();
+    String bucketUri = conf.get("test.fs.oss.name");
+    LOG.debug("bucketUri={}", bucketUri);
+    testURI = URI.create(bucketUri);
+  }
+
+  @Test
+  public void testV4() throws IOException {
+    conf.set(SIGNATURE_VERSION_KEY, "V4");
+    conf.set(REGION_KEY, "cn-hongkong");
+    AliyunOSSFileSystem fs = new AliyunOSSFileSystem();
+    fs.initialize(testURI, conf);
+    assumeNotNull(fs);
+
+    createFile(fs, testFile, true, dataset(256, 0, 255));
+    FileStatus status = fs.getFileStatus(testFile);
+    fs.delete(testFile);
+    fs.close();
+  }
+
+  @Test
+  public void testDefaultSignatureVersion() throws IOException {
+    AliyunOSSFileSystem fs = new AliyunOSSFileSystem();
+    fs.initialize(testURI, conf);
+    assumeNotNull(fs);
+
+    Path testFile = new Path("/test/atestr");
+    createFile(fs, testFile, true, dataset(256, 0, 255));
+    FileStatus status = fs.getFileStatus(testFile);
+    fs.delete(testFile);
+    fs.close();
+  }
+
+  @Test
+  public void testV4WithoutRegion() throws IOException {
+    conf.set(SIGNATURE_VERSION_KEY, "V4");
+    AliyunOSSFileSystem fs = new AliyunOSSFileSystem();
+    try {
+      fs.initialize(testURI, conf);
+    } catch (IllegalArgumentException e) {
+      LOG.warn("use V4 , but do not set region, get exception={}", e);
+      assertEquals("se V4 , but do not set region", e.getMessage(), "SignVersion is V4 but region is empty");
+    }
+  }
+}

--- a/hadoop-tools/hadoop-aliyun/src/test/java/org/apache/hadoop/fs/aliyun/oss/ITAliyunOSSSignatureV4.java
+++ b/hadoop-tools/hadoop-aliyun/src/test/java/org/apache/hadoop/fs/aliyun/oss/ITAliyunOSSSignatureV4.java
@@ -19,35 +19,22 @@
 package org.apache.hadoop.fs.aliyun.oss;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.FileSystemContractBaseTest;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.FSDataOutputStream;
-import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
-import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
-
-import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.io.FileNotFoundException;
+
 import java.io.IOException;
 import java.net.URI;
-import java.util.Arrays;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeNotNull;
-import static org.junit.Assume.assumeTrue;
-
-import static org.apache.hadoop.fs.aliyun.oss.Constants.SIGNATURE_VERSION_KEY;
 import static org.apache.hadoop.fs.aliyun.oss.Constants.REGION_KEY;
+import static org.apache.hadoop.fs.aliyun.oss.Constants.SIGNATURE_VERSION_KEY;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeNotNull;
 
 /**
  * Tests Aliyun OSS system.
@@ -86,10 +73,10 @@ public class ITAliyunOSSSignatureV4 {
     fs.initialize(testURI, conf);
     assumeNotNull(fs);
 
-    Path testFile = new Path("/test/atestr");
-    createFile(fs, testFile, true, dataset(256, 0, 255));
-    FileStatus status = fs.getFileStatus(testFile);
-    fs.delete(testFile);
+    Path testFile2 = new Path("/test/atestr");
+    createFile(fs, testFile2, true, dataset(256, 0, 255));
+    FileStatus status = fs.getFileStatus(testFile2);
+    fs.delete(testFile2);
     fs.close();
   }
 
@@ -97,11 +84,15 @@ public class ITAliyunOSSSignatureV4 {
   public void testV4WithoutRegion() throws IOException {
     conf.set(SIGNATURE_VERSION_KEY, "V4");
     AliyunOSSFileSystem fs = new AliyunOSSFileSystem();
+    IOException expectedException = null;
     try {
       fs.initialize(testURI, conf);
-    } catch (IllegalArgumentException e) {
+    } catch (IOException e) {
       LOG.warn("use V4 , but do not set region, get exception={}", e);
-      assertEquals("se V4 , but do not set region", e.getMessage(), "SignVersion is V4 but region is empty");
+      expectedException = e;
+      assertEquals("use V4 , but do not set region", e.getMessage(),
+              "SignVersion is V4 but region is empty");
     }
+    assertNotNull(expectedException);
   }
 }

--- a/hadoop-tools/hadoop-aliyun/src/test/resources/log4j.properties
+++ b/hadoop-tools/hadoop-aliyun/src/test/resources/log4j.properties
@@ -21,3 +21,6 @@ log4j.threshold=ALL
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
+
+# Log all oss classes
+log4j.logger.org.apache.hadoop.fs.aliyun.oss=DEBUG


### PR DESCRIPTION
### Description of PR
AliyunOSS is about to adjust its security policy: only V4 signature requests will be supported in the public cloud. Therefore, support for V4 signatures is also required in Hadoop, and V4 signatures will be the default.

Change 1: Upgraded the OSS SDK version to 3.18.1 to support V4 authentication, while also fixing some bugs inherent in the SDK.
Change 2: Added configuration options to enable V4 authentication support in the hadoop-oss-connector.


### How was this patch tested?
Integrated testing was conducted to test V4 authentication. A new test, ITAliyunOSSSignatureV4, is added, which verifies the authentication method using V4. Additionally, it confirms that V1 authentication is still used by default.

```shell
mvn test  -Dtest=org.apache.hadoop.fs.aliyun.oss.ITAliyunOSSSignatureV4  -pl hadoop-tools/hadoop-aliyun

[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.fs.aliyun.oss.ITAliyunOSSSignatureV4
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.934 s - in org.apache.hadoop.fs.aliyun.oss.ITAliyunOSSSignatureV4
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.655 s
[INFO] Finished at: 2024-12-03T09:01:00Z
[INFO] ------------------------------------------------------------------------
``` 


Other Aliyun oss integration tests are also executed. 
```shell
mvn test  -pl hadoop-tools/hadoop-aliyun

[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.fs.aliyun.oss.TestAliyunOSSBlockOutputStream
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 37.258 s - in org.apache.hadoop.fs.aliyun.oss.TestAliyunOSSBlockOutputStream
[INFO] Running org.apache.hadoop.fs.aliyun.oss.yarn.TestOSS
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.808 s - in org.apache.hadoop.fs.aliyun.oss.yarn.TestOSS
[INFO] Running org.apache.hadoop.fs.aliyun.oss.yarn.TestOSSMiniYarnCluster
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.128 s - in org.apache.hadoop.fs.aliyun.oss.yarn.TestOSSMiniYarnCluster
[INFO] Running org.apache.hadoop.fs.aliyun.oss.TestAliyunOSSFileSystemContract
[INFO] Tests run: 53, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 22.578 s - in org.apache.hadoop.fs.aliyun.oss.TestAliyunOSSFileSystemContract
[INFO] Running org.apache.hadoop.fs.aliyun.oss.TestAliyunOSSFileSystemStore
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.816 s - in org.apache.hadoop.fs.aliyun.oss.TestAliyunOSSFileSystemStore
[INFO] Running org.apache.hadoop.fs.aliyun.oss.fileContext.TestOSSFileContext
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.262 s - in org.apache.hadoop.fs.aliyun.oss.fileContext.TestOSSFileContext
[INFO] Running org.apache.hadoop.fs.aliyun.oss.fileContext.TestOSSFileContextCreateMkdir
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.784 s - in org.apache.hadoop.fs.aliyun.oss.fileContext.TestOSSFileContextCreateMkdir
[INFO] Running org.apache.hadoop.fs.aliyun.oss.fileContext.TestOSSFileContextMainOperations
[WARNING] Tests run: 73, Failures: 0, Errors: 0, Skipped: 4, Time elapsed: 16.198 s - in org.apache.hadoop.fs.aliyun.oss.fileContext.TestOSSFileContextMainOperations
[INFO] Running org.apache.hadoop.fs.aliyun.oss.fileContext.TestOSSFileContextStatistics
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.682 s - in org.apache.hadoop.fs.aliyun.oss.fileContext.TestOSSFileContextStatistics
[INFO] Running org.apache.hadoop.fs.aliyun.oss.fileContext.TestOSSFileContextUtil
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.23 s - in org.apache.hadoop.fs.aliyun.oss.fileContext.TestOSSFileContextUtil
[INFO] Running org.apache.hadoop.fs.aliyun.oss.fileContext.TestOSSFileContextURI
[WARNING] Tests run: 17, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 6.146 s - in org.apache.hadoop.fs.aliyun.oss.fileContext.TestOSSFileContextURI
[INFO] Running org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractDelete
[WARNING] Tests run: 8, Failures: 0, Errors: 0, Skipped: 8, Time elapsed: 0.158 s - in org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractDelete
[INFO] Running org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractOpen
[WARNING] Tests run: 19, Failures: 0, Errors: 0, Skipped: 19, Time elapsed: 0.201 s - in org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractOpen
[INFO] Running org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractSeek
[WARNING] Tests run: 19, Failures: 0, Errors: 0, Skipped: 19, Time elapsed: 0.204 s - in org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractSeek
[INFO] Running org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractGetFileStatus
[WARNING] Tests run: 20, Failures: 0, Errors: 0, Skipped: 20, Time elapsed: 0.197 s - in org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractGetFileStatus
[INFO] Running org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractDistCp
[WARNING] Tests run: 13, Failures: 0, Errors: 0, Skipped: 13, Time elapsed: 0.179 s - in org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractDistCp
[INFO] Running org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractMkdir
[WARNING] Tests run: 8, Failures: 0, Errors: 0, Skipped: 8, Time elapsed: 0.164 s - in org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractMkdir
[INFO] Running org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractRootDir
[WARNING] Tests run: 9, Failures: 0, Errors: 0, Skipped: 9, Time elapsed: 0.164 s - in org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractRootDir
[INFO] Running org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractRename
[WARNING] Tests run: 10, Failures: 0, Errors: 0, Skipped: 10, Time elapsed: 0.167 s - in org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractRename
[INFO] Running org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractCreate
[WARNING] Tests run: 16, Failures: 0, Errors: 0, Skipped: 16, Time elapsed: 0.182 s - in org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractCreate
[INFO] Running org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractGetFileStatusV1List
[WARNING] Tests run: 20, Failures: 0, Errors: 0, Skipped: 20, Time elapsed: 0.199 s - in org.apache.hadoop.fs.aliyun.oss.contract.TestAliyunOSSContractGetFileStatusV1List
[INFO] Running org.apache.hadoop.fs.aliyun.oss.TestAliyunOSSInputStream
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.352 s - in org.apache.hadoop.fs.aliyun.oss.TestAliyunOSSInputStream
[INFO] Running org.apache.hadoop.fs.aliyun.oss.TestAliyunCredentials
[WARNING] Tests run: 2, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 0.131 s - in org.apache.hadoop.fs.aliyun.oss.TestAliyunCredentials

[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 328, Failures: 0, Errors: 0, Skipped: 150
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:12 min
[INFO] Finished at: 2024-12-03T08:15:52Z
[INFO] ------------------------------------------------------------------------
``` 

### For code changes:
- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

