### PR TITLE
HDFS-17682. Fix incorrect command of fs2img tool.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HdfsProvidedStorage.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HdfsProvidedStorage.md
@@ -124,7 +124,7 @@ Assign all files to be owned by "rmarathe", write to gzip compressed text:
 hadoop org.apache.hadoop.hdfs.server.namenode.FileSystemImage \
   -Dhdfs.image.writer.ugi.single.user=rmarathe \
   -Ddfs.provided.aliasmap.text.codec=gzip \
-  -Ddfs.provided.aliasmap.text.write.dir=file:///tmp/
+  -Ddfs.provided.aliasmap.text.write.dir=file:///tmp/ \
   -b org.apache.hadoop.hdfs.server.common.blockaliasmap.impl.TextFileRegionAliasMap \
   -u org.apache.hadoop.hdfs.server.namenode.SingleUGIResolver \
   -o file:///tmp/name \


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/949ee81d-7c74-49ad-a6e7-88753b8dbe14)

  ` -Ddfs.provided.aliasmap.text.write.dir=file:///tmp/`  should add '\\' at the end.