### PR TITLE
HDFS-17685: Option to explicitly choose DFS client lease renewal interval

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -202,6 +202,9 @@ public interface HdfsClientConfigKeys {
   long DFS_CLIENT_DEAD_NODE_DETECTION_PROBE_SUSPECT_NODE_INTERVAL_MS_DEFAULT =
       300; // 300ms
 
+  String DFS_CLIENT_LEASE_RENEWAL_INTERVAL_KEY = "dfs.client.lease.renewal.interval.ms";
+  int DFS_CLIENT_LEASE_RENEWAL_INTERVAL_DEFAULT = 0;
+
   // refreshing LocatedBlocks period. A value of 0 disables the feature.
   String  DFS_CLIENT_REFRESH_READ_BLOCK_LOCATIONS_MS_KEY =
       "dfs.client.refresh.read-block-locations.ms";

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
@@ -108,6 +108,7 @@ public class DfsClientConf {
                                                                 .class);
 
   private final int hdfsTimeout;    // timeout value for a DFS operation.
+  private final int leaseRenewalIntervalMs;
 
   private final int maxFailoverAttempts;
   private final int maxRetryAttempts;
@@ -171,6 +172,9 @@ public class DfsClientConf {
   public DfsClientConf(Configuration conf) {
     // The hdfsTimeout is currently the same as the ipc timeout
     hdfsTimeout = Client.getRpcTimeout(conf);
+    leaseRenewalIntervalMs = conf.getInt(
+        HdfsClientConfigKeys.DFS_CLIENT_LEASE_RENEWAL_INTERVAL_KEY,
+        HdfsClientConfigKeys.DFS_CLIENT_LEASE_RENEWAL_INTERVAL_DEFAULT);
 
     maxRetryAttempts = conf.getInt(
         Retry.MAX_ATTEMPTS_KEY,
@@ -435,6 +439,10 @@ public class DfsClientConf {
    */
   public int getHdfsTimeout() {
     return hdfsTimeout;
+  }
+
+  public int getLeaseRenewalIntervalMs() {
+    return leaseRenewalIntervalMs;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
@@ -175,7 +175,6 @@ public class DfsClientConf {
     leaseRenewalIntervalMs = conf.getInt(
         HdfsClientConfigKeys.DFS_CLIENT_LEASE_RENEWAL_INTERVAL_KEY,
         HdfsClientConfigKeys.DFS_CLIENT_LEASE_RENEWAL_INTERVAL_DEFAULT);
-
     maxRetryAttempts = conf.getInt(
         Retry.MAX_ATTEMPTS_KEY,
         Retry.MAX_ATTEMPTS_DEFAULT);
@@ -188,7 +187,6 @@ public class DfsClientConf {
     retryIntervalForGetLastBlockLength = conf.getInt(
         Retry.INTERVAL_GET_LAST_BLOCK_LENGTH_KEY,
         Retry.INTERVAL_GET_LAST_BLOCK_LENGTH_DEFAULT);
-
     maxFailoverAttempts = conf.getInt(
         Failover.MAX_ATTEMPTS_KEY,
         Failover.MAX_ATTEMPTS_DEFAULT);

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/LeaseRenewer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/LeaseRenewer.java
@@ -378,10 +378,13 @@ public class LeaseRenewer {
   @VisibleForTesting
   static long getNewRenewalIntervalMs(Collection<DFSClient> dfsClients) {
     // Update renewal time to the first applicable of:
-    //   1. Requested renewal time amongst all DFSClients, if requested and smaller than the default renewal interval
-    //   2. Half the HDFS timeout amongst all DFSClients, if requested and smaller than the default renewal interval
+    //   1. Requested renewal time amongst all DFSClients, if requested and smaller than the default
+    //      renewal interval
+    //   2. Half the HDFS timeout amongst all DFSClients, if requested and smaller than the default
+    //      renewal interval
     //   3. Default renewal time of HdfsConstants.LEASE_SOFTLIMIT_PERIOD / 2
-    // #2 exists because users with small timeouts want to find out quickly when a NameNode dies, and a small lease renewal interval will help to inform them quickly. See HDFS-278.
+    // #2 exists because users with small timeouts want to find out quickly when a NameNode dies,
+    // and a small lease renewal interval will help to inform them quickly. See HDFS-278.
     long min = HdfsConstants.LEASE_SOFTLIMIT_PERIOD / 2;
     boolean leaseOverrideSet = false;
     for (DFSClient c : dfsClients) {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/LeaseRenewer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/LeaseRenewer.java
@@ -383,13 +383,15 @@ public class LeaseRenewer {
     //   3. Default renewal time of HdfsConstants.LEASE_SOFTLIMIT_PERIOD / 2
     // #2 exists because users with small timeouts want to find out quickly when a NameNode dies, and a small lease renewal interval will help to inform them quickly. See HDFS-278.
     long min = HdfsConstants.LEASE_SOFTLIMIT_PERIOD / 2;
+    boolean leaseOverrideSet = false;
     for (DFSClient c : dfsClients) {
       final int newLeaseRenewalInterval = c.getConf().getLeaseRenewalIntervalMs();
-      if (newLeaseRenewalInterval > 0 && newLeaseRenewalInterval < min) {
+      if (newLeaseRenewalInterval > 0 && newLeaseRenewalInterval <= min) {
         min = newLeaseRenewalInterval;
+        leaseOverrideSet = true;
       }
     }
-    if (min <= HdfsConstants.LEASE_SOFTLIMIT_PERIOD / 2) {
+    if (leaseOverrideSet) {
       return min;
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/client/impl/TestLeaseRenewer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/client/impl/TestLeaseRenewer.java
@@ -17,11 +17,12 @@
  */
 package org.apache.hadoop.hdfs.client.impl;
 
-import java.util.function.Supplier;
 import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.DFSOutputStream;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.doReturn;
 
 public class TestLeaseRenewer {
   private final String FAKE_AUTHORITY="hdfs://nn1/";
@@ -284,5 +287,60 @@ public class TestLeaseRenewer {
       }
     }
     return count;
+  }
+
+  @Test
+  public void testDefaultRenewalInterval() {
+    final DfsClientConf mockConf = Mockito.mock(DfsClientConf.class);
+    doReturn(0).when(mockConf).getLeaseRenewalIntervalMs();
+    doReturn(0).when(mockConf).getHdfsTimeout();
+    DFSClient dfsClient = Mockito.mock(DFSClient.class);
+    doReturn(mockConf).when(dfsClient).getConf();
+    // Use default renewal interval if both explicit renewal interval and HDFS timeout are not set
+    assertEquals(HdfsConstants.LEASE_SOFTLIMIT_PERIOD / 2, LeaseRenewer.getNewRenewalIntervalMs(ImmutableList.of(dfsClient)));
+  }
+
+  @Test
+  public void testShortExplicitRenewalInterval() {
+    final DfsClientConf mockConf = Mockito.mock(DfsClientConf.class);
+    doReturn(37).when(mockConf).getLeaseRenewalIntervalMs();
+    doReturn(100).when(mockConf).getHdfsTimeout();
+    DFSClient dfsClient = Mockito.mock(DFSClient.class);
+    doReturn(mockConf).when(dfsClient).getConf();
+    // Explicit renewal interval is shorter than half the HDFS timeout, renewer should use it
+    assertEquals(37, LeaseRenewer.getNewRenewalIntervalMs(ImmutableList.of(dfsClient)));
+  }
+
+  @Test
+  public void testMediumExplicitRenewalInterval() {
+    final DfsClientConf mockConf = Mockito.mock(DfsClientConf.class);
+    doReturn(370).when(mockConf).getLeaseRenewalIntervalMs();
+    doReturn(100).when(mockConf).getHdfsTimeout();
+    DFSClient dfsClient = Mockito.mock(DFSClient.class);
+    doReturn(mockConf).when(dfsClient).getConf();
+    // Explicit renewal interval is longer than half the HDFS timeout, renewer should use it regardless
+    assertEquals(370, LeaseRenewer.getNewRenewalIntervalMs(ImmutableList.of(dfsClient)));
+  }
+
+  @Test
+  public void testLongExplicitRenewalIntervalWithShortHdfsTimeout() {
+    final DfsClientConf mockConf = Mockito.mock(DfsClientConf.class);
+    doReturn(37000).when(mockConf).getLeaseRenewalIntervalMs();
+    doReturn(100).when(mockConf).getHdfsTimeout();
+    DFSClient dfsClient = Mockito.mock(DFSClient.class);
+    doReturn(mockConf).when(dfsClient).getConf();
+    // Explicit renewal interval is longer than HdfsConstants.LEASE_SOFTLIMIT_PERIOD / 2, but half the HDFS timeout is shorter, so renewer should use the HDFS timeout
+    assertEquals(50, LeaseRenewer.getNewRenewalIntervalMs(ImmutableList.of(dfsClient)));
+  }
+
+  @Test
+  public void testLongExplicitRenewalIntervalWithLongHdfsTimeout() {
+    final DfsClientConf mockConf = Mockito.mock(DfsClientConf.class);
+    doReturn(37000).when(mockConf).getLeaseRenewalIntervalMs();
+    doReturn(120000).when(mockConf).getHdfsTimeout();
+    DFSClient dfsClient = Mockito.mock(DFSClient.class);
+    doReturn(mockConf).when(dfsClient).getConf();
+    // Explicit renewal interval and HDFS timeout is longer than HdfsConstants.LEASE_SOFTLIMIT_PERIOD / 2, so renewer should use default renewal interval
+    assertEquals(HdfsConstants.LEASE_SOFTLIMIT_PERIOD / 2, LeaseRenewer.getNewRenewalIntervalMs(ImmutableList.of(dfsClient)));
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -3445,6 +3445,16 @@
   </property>
 
   <property>
+    <name>dfs.client.lease.renewal.interval.ms</name>
+    <value>0</value>
+    <description>
+      If set between 0 and 30000, HDFS clients will renew leases for files they are writing at this interval.
+      If dfs.client.lease.renewal.interval.ms is not set and ipc.client.rpc-timeout.ms is set between 0 and 60000,
+      then the value of ipc.client.rpc-timeout.ms / 2 will be used as the lease renewal interval.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.client.refresh.read-block-locations.ms</name>
     <value>0</value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -3448,7 +3448,7 @@
     <name>dfs.client.lease.renewal.interval.ms</name>
     <value>0</value>
     <description>
-      If set between 0 and 30000, HDFS clients will renew leases for files they are writing at this interval.
+      If set between 0 and 30000 inclusive, HDFS clients will renew leases for files they are writing at this interval.
       If dfs.client.lease.renewal.interval.ms is not set and ipc.client.rpc-timeout.ms is set between 0 and 60000,
       then the value of ipc.client.rpc-timeout.ms / 2 will be used as the lease renewal interval.
     </description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -3480,7 +3480,7 @@
     <name>dfs.client.lease.renewal.interval.ms</name>
     <value>0</value>
     <description>
-      If set between 0 and 30000, HDFS clients will renew leases for files they are writing at this interval.
+      If set between 0 and 30000 inclusive, HDFS clients will renew leases for files they are writing at this interval.
       If dfs.client.lease.renewal.interval.ms is not set and ipc.client.rpc-timeout.ms is set between 0 and 60000,
       then the value of ipc.client.rpc-timeout.ms / 2 will be used as the lease renewal interval.
     </description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -3477,6 +3477,16 @@
   </property>
 
   <property>
+    <name>dfs.client.lease.renewal.interval.ms</name>
+    <value>0</value>
+    <description>
+      If set between 0 and 30000, HDFS clients will renew leases for files they are writing at this interval.
+      If dfs.client.lease.renewal.interval.ms is not set and ipc.client.rpc-timeout.ms is set between 0 and 60000,
+      then the value of ipc.client.rpc-timeout.ms / 2 will be used as the lease renewal interval.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.client.refresh.read-block-locations.ms</name>
     <value>0</value>
     <description>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Currently, DFSClients send lease renewals to the NameNode at an interval equal to half of `ipc.client.rpc-timeout.ms`. This logic dates back to 2009 in [HDFS-278](https://issues.apache.org/jira/browse/HDFS-278). At my company, we are interested in using short DFS client timeouts (< 10 seconds). However, we're currently hesitant to do so because that would flood the NameNode with lease renewals.

I propose a setting `dfs.client.lease.renewal.interval.ms` that, if nonzero, would be used as the lease renewal interval instead of `ipc.client.rpc-timeout.ms / 2`. This would be useful for advanced users that want to control their RPC timeout and lease renewals separately.

### How was this patch tested?

Unit tests are included in this PR for the new logic. I have also tested the new feature in my company's HBase infrastructure.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] ~Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?~ not applicable
- [ ] ~If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?~ not applicable
- [ ] ~If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?~ not applicable

