### PR TITLE
HADOOP-19357. ABFS: Optimizations for Retry Handling and Throttling

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -40,7 +40,7 @@ public final class FileSystemConfigurations {
 
   // Retry parameter defaults.
   public static final int DEFAULT_MIN_BACKOFF_INTERVAL = 500;  // 500ms
-  public static final int DEFAULT_MAX_BACKOFF_INTERVAL = 25 * 1000;  // 25s
+  public static final int DEFAULT_MAX_BACKOFF_INTERVAL = 25_000;  // 25s
   public static final boolean DEFAULT_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = true;
   public static final int DEFAULT_STATIC_RETRY_INTERVAL = 1_000; // 1s
   public static final int DEFAULT_BACKOFF_INTERVAL = 500;  // 500ms

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -39,11 +39,11 @@ public final class FileSystemConfigurations {
   private static final int SIXTY_SECONDS = 60_000;
 
   // Retry parameter defaults.
-  public static final int DEFAULT_MIN_BACKOFF_INTERVAL = 3_000;  // 3s
-  public static final int DEFAULT_MAX_BACKOFF_INTERVAL = 30_000;  // 30s
+  public static final int DEFAULT_MIN_BACKOFF_INTERVAL = 500;  // 500ms
+  public static final int DEFAULT_MAX_BACKOFF_INTERVAL = 25 * 1000;  // 25s
   public static final boolean DEFAULT_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = true;
   public static final int DEFAULT_STATIC_RETRY_INTERVAL = 1_000; // 1s
-  public static final int DEFAULT_BACKOFF_INTERVAL = 3_000;  // 3s
+  public static final int DEFAULT_BACKOFF_INTERVAL = 500;  // 500ms
   public static final int DEFAULT_MAX_RETRY_ATTEMPTS = 30;
   public static final int DEFAULT_CUSTOM_TOKEN_FETCH_RETRY_COUNT = 3;
 
@@ -108,7 +108,7 @@ public final class FileSystemConfigurations {
 
   public static final boolean DEFAULT_ENABLE_FLUSH = true;
   public static final boolean DEFAULT_DISABLE_OUTPUTSTREAM_FLUSH = true;
-  public static final boolean DEFAULT_ENABLE_AUTOTHROTTLING = true;
+  public static final boolean DEFAULT_ENABLE_AUTOTHROTTLING = false;
   public static final int DEFAULT_METRIC_IDLE_TIMEOUT_MS = 60_000;
   public static final int DEFAULT_METRIC_ANALYSIS_TIMEOUT_MS = 60_000;
   public static final boolean DEFAULT_FS_AZURE_ACCOUNT_LEVEL_THROTTLING_ENABLED = true;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestExponentialRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestExponentialRetryPolicy.java
@@ -97,13 +97,21 @@ public class ITestExponentialRetryPolicy extends AbstractAbfsIntegrationTest {
   }
 
   @Test
-  public void testDefaultClientSideThrottling() throws Exception {
+  public void testClientSideThrottlingConfigs() throws Exception {
     final Configuration configuration = new Configuration();
+    configuration.setBoolean(FS_AZURE_ENABLE_AUTOTHROTTLING, true);
     AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration,
             DUMMY_ACCOUNT_NAME);
-    Assume.assumeTrue(configuration.get(FS_AZURE_ENABLE_AUTOTHROTTLING) == null);
-    Assertions.assertThat(abfsConfiguration.isAutoThrottlingEnabled())
-            .describedAs("Client-side throttling should be disabled by default").isFalse();
+   Assertions.assertThat(abfsConfiguration.isAutoThrottlingEnabled())
+            .describedAs("Client-side throttling enabled by configuration key")
+            .isTrue();
+
+    configuration.unset(FS_AZURE_ENABLE_AUTOTHROTTLING);
+    AbfsConfiguration abfsConfiguration2 = new AbfsConfiguration(configuration,
+            DUMMY_ACCOUNT_NAME);
+    Assertions.assertThat(abfsConfiguration2.isAutoThrottlingEnabled())
+            .describedAs("Client-side throttling should be disabled by default")
+            .isFalse();
   }
 
   @Test

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestExponentialRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestExponentialRetryPolicy.java
@@ -97,6 +97,16 @@ public class ITestExponentialRetryPolicy extends AbstractAbfsIntegrationTest {
   }
 
   @Test
+  public void testDefaultClientSideThrottling() throws Exception {
+    final Configuration configuration = new Configuration();
+    AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration,
+            DUMMY_ACCOUNT_NAME);
+    Assume.assumeTrue(configuration.get(FS_AZURE_ENABLE_AUTOTHROTTLING) == null);
+    Assertions.assertThat(abfsConfiguration.isAutoThrottlingEnabled())
+            .describedAs("Client-side throttling should be disabled by default").isFalse();
+  }
+
+  @Test
   public void testThrottlingIntercept() throws Exception {
     AzureBlobFileSystem fs = getFileSystem();
     final Configuration configuration = new Configuration();


### PR DESCRIPTION
### Description of PR
JIRA: https://issues.apache.org/jira/browse/HADOOP-19357

Given the significant improvements on the service side over the past few years, the current client-side retry mechanism, which enforces 5-6 minutes of sleep time with jitter, is now excessive. Therefore, we are realigning the retry and throttling logic thresholds.
Since the service can now handle higher traffic rates, we aim to enhance driver performance by setting the following configurations as default:

**Client-side throttling (CST):** Off
**Client Backoff -** 500ms (reduced from 3sec)
**Max Backoff -** 25s (reduced from 30sec)
**Min Backoff -** 500ms (reduced from 3sec)

## The test results are as follows:
============================================================
HNS-OAuth
============================================================

[WARNING] Tests run: 157, Failures: 0, Errors: 0, Skipped: 3
[WARNING] Tests run: 645, Failures: 0, Errors: 0, Skipped: 85
[WARNING] Tests run: 171, Failures: 0, Errors: 0, Skipped: 25
[WARNING] Tests run: 262, Failures: 0, Errors: 0, Skipped: 32

============================================================
HNS-SharedKey
============================================================

[WARNING] Tests run: 157, Failures: 0, Errors: 0, Skipped: 4
[WARNING] Tests run: 648, Failures: 0, Errors: 0, Skipped: 35
[WARNING] Tests run: 171, Failures: 0, Errors: 0, Skipped: 25
[WARNING] Tests run: 262, Failures: 0, Errors: 0, Skipped: 19

============================================================
NonHNS-SharedKey
============================================================

[WARNING] Tests run: 157, Failures: 0, Errors: 0, Skipped: 10
[WARNING] Tests run: 632, Failures: 0, Errors: 0, Skipped: 275
[WARNING] Tests run: 171, Failures: 0, Errors: 0, Skipped: 27
[WARNING] Tests run: 262, Failures: 0, Errors: 0, Skipped: 20

============================================================
AppendBlob-HNS-OAuth
============================================================

[WARNING] Tests run: 157, Failures: 0, Errors: 0, Skipped: 3
[WARNING] Tests run: 653, Failures: 0, Errors: 0, Skipped: 87
[WARNING] Tests run: 171, Failures: 0, Errors: 0, Skipped: 49
[WARNING] Tests run: 262, Failures: 0, Errors: 0, Skipped: 32


