### PR TITLE
HADOOP-19360. Disable releases for apache.snapshots repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
       <id>${distMgmtSnapshotsId}</id>
       <name>${distMgmtSnapshotsName}</name>
       <url>${distMgmtSnapshotsUrl}</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
     </repository>
     <repository>
       <id>repository.jboss.org</id>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Apache snapshot repository should be enabled only for snapshots.

https://issues.apache.org/jira/browse/HADOOP-19360

## How was this patch tested?

local build