### PR TITLE
HADOOP-19351. S3A: Add config option to skip test with performance mode

### DIFF
--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
@@ -295,7 +295,7 @@ understands the risks.
 * If an option is to be tuned which may relax semantics, a new option MUST be defined.
 * Unknown flags are ignored; this is to avoid compatibility.
 * The option `*` means "turn everything on". This is implicitly unstable across releases.
-* Other stores may retain stricter semantics. 
+* Other stores may retain stricter semantics.
 
 | *Option* | *Meaning*          | Since |
 |----------|--------------------|:------|

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
@@ -295,6 +295,7 @@ understands the risks.
 * If an option is to be tuned which may relax semantics, a new option MUST be defined.
 * Unknown flags are ignored; this is to avoid compatibility.
 * The option `*` means "turn everything on". This is implicitly unstable across releases.
+* Other stores may retain stricter semantics. 
 
 | *Option* | *Meaning*          | Since |
 |----------|--------------------|:------|

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
@@ -774,7 +774,7 @@ Tests in `ITestS3AContentEncoding` may need disabling
 
 ### Disabling tests running in performance mode
 
-Some tests running in performance mode turn off the safety checks. They expect breaking posix semantics.
+Some tests running in performance mode turn off the safety checks. They expect operations which break POSIX semantics to succeed.
 For stores with stricter semantics, these test cases must be disabled.
 ```xml
   <property>

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
@@ -778,7 +778,7 @@ Some tests running in performance mode turn off the safety checks. They expect o
 For stores with stricter semantics, these test cases must be disabled.
 ```xml
   <property>
-    <name>test.fs.s3a.perf.enabled</name>
+    <name>test.fs.s3a.performance.enabled</name>
     <value>false</value>
   </property>
 ```

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
@@ -629,7 +629,7 @@ on third party stores.
     <value>false</value>
   </property>
   <property>
-    <name>test.fs.s3a.perf.enabled</name>
+    <name>test.fs.s3a.performance.enabled</name>
     <value>false</value>
   </property>
 ```

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
@@ -628,6 +628,10 @@ on third party stores.
     <name>test.fs.s3a.create.create.acl.enabled</name>
     <value>false</value>
   </property>
+  <property>
+    <name>test.fs.s3a.perf.enabled</name>
+    <value>false</value>
+  </property>
 ```
 
 See [Third Party Stores](third_party_stores.html) for more on this topic.
@@ -767,6 +771,18 @@ Tests in `ITestS3AContentEncoding` may need disabling
     <value>false</value>
   </property>
 ```
+
+### Disabling tests running in performance mode
+
+Some tests running in performance mode turn off the safety checks. They expect breaking posix semantics.
+For stores with stricter semantics, these test cases must be disabled.
+```xml
+  <property>
+    <name>test.fs.s3a.perf.enabled</name>
+    <value>false</value>
+  </property>
+```
+
 ### Tests which may fail (and which you can ignore)
 
 * `ITestS3AContractMultipartUploader` tests `testMultipartUploadAbort` and `testSingleUpload` raising `FileNotFoundException`

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractCreate.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractCreate.java
@@ -29,9 +29,11 @@ import org.apache.hadoop.fs.contract.AbstractContractCreateTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
 
+import static org.apache.hadoop.fs.s3a.S3ATestConstants.KEY_PERFORMANCE_TESTS_ENABLED;
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_EXPECT_CONTINUE;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.setPerformanceFlags;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfNotEnabled;
 
 /**
  * S3A contract tests creating files.
@@ -84,6 +86,9 @@ public class ITestS3AContractCreate extends AbstractContractCreateTest {
         conf,
         CONNECTION_EXPECT_CONTINUE);
     conf.setBoolean(CONNECTION_EXPECT_CONTINUE, expectContinue);
+    if (createPerformance) {
+      skipIfNotEnabled(conf, KEY_PERFORMANCE_TESTS_ENABLED, "Skipping tests running in performance mode");
+    }
     S3ATestUtils.disableFilesystemCaching(conf);
     return conf;
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractMkdirWithCreatePerf.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractMkdirWithCreatePerf.java
@@ -29,7 +29,9 @@ import org.apache.hadoop.fs.contract.ContractTestUtils;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.apache.hadoop.fs.s3a.S3ATestConstants.KEY_PERFORMANCE_TESTS_ENABLED;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.setPerformanceFlags;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfNotEnabled;
 
 /**
  * Test mkdir operations on S3A with create performance mode.
@@ -50,6 +52,8 @@ public class ITestS3AContractMkdirWithCreatePerf extends AbstractContractMkdirTe
 
   @Test
   public void testMkdirOverParentFile() throws Throwable {
+    skipIfNotEnabled(getContract().getConf(), KEY_PERFORMANCE_TESTS_ENABLED,
+        "Skipping tests running in performance mode");
     describe("try to mkdir where a parent is a file, should pass");
     FileSystem fs = getFileSystem();
     Path path = methodPath();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestConstants.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestConstants.java
@@ -64,6 +64,11 @@ public interface S3ATestConstants {
   String KEY_ACL_TESTS_ENABLED = TEST_FS_S3A + "create.acl.enabled";
 
   /**
+   * A property set to true if tests running in performance mode are enabled: {@value }
+   */
+  String KEY_PERFORMANCE_TESTS_ENABLED = TEST_FS_S3A + "perf.enabled";
+
+  /**
    * A property set to true if V1 tests are enabled: {@value}.
    */
   String KEY_LIST_V1_ENABLED = TEST_FS_S3A + "list.v1.enabled";

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestConstants.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestConstants.java
@@ -66,7 +66,7 @@ public interface S3ATestConstants {
   /**
    * A property set to true if tests running in performance mode are enabled: {@value }
    */
-  String KEY_PERFORMANCE_TESTS_ENABLED = TEST_FS_S3A + "perf.enabled";
+  String KEY_PERFORMANCE_TESTS_ENABLED = TEST_FS_S3A + "performance.enabled";
 
   /**
    * A property set to true if V1 tests are enabled: {@value}.


### PR DESCRIPTION
### Description of PR

Stores with posix semantics can't overwrite tests. Some tests will fail in performance mode. Add a configuration option to skip running tests in performance mode.

### How was this patch tested?

Tested in ap-southeast-2.
Tested against Ozone FSO bucket with `test.fs.s3a.perf.enabled` set to false.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

