### PR TITLE
HADOOP-19366. Install OpenJDK 17 in default ubuntu build container

### DIFF
--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -261,11 +261,13 @@
     "debian:10": "openjdk-11-jdk",
     "ubuntu:focal": [
       "openjdk-8-jdk",
-      "openjdk-11-jdk"
+      "openjdk-11-jdk",
+      "openjdk-17-jdk"
     ],
     "ubuntu:focal::arch64": [
       "openjdk-8-jdk",
-      "openjdk-11-jdk"
+      "openjdk-11-jdk",
+      "openjdk-17-jdk"
     ]
   },
   "pinentry-curses": {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Install OpenJDK 17 alongside existing OpenJDK 8 and 11 in the default ubuntu build container. This helps developers who use `start-build-env.sh` to build and test Hadoop locally with Java 17.

Note: the default JAVA_HOME inside the container still points to OpenJDK 8, devs should manually run `export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-arm64` to switch to OpenJDK 17

### How was this patch tested?

Run `./start-build-env.sh` on macOS M1

```
chengpan@4a45572c864f:~/hadoop$ echo $JAVA_HOME
/usr/lib/jvm/java-8-openjdk-arm64
chengpan@4a45572c864f:~/hadoop$ ls /usr/lib/jvm/ | grep openjdk
java-1.11.0-openjdk-arm64
java-1.17.0-openjdk-arm64
java-11-openjdk-arm64
java-17-openjdk-arm64
java-1.8.0-openjdk-arm64
java-8-openjdk-arm64
openjdk-11
openjdk-17
chengpan@4a45572c864f:~/hadoop$
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

