### PR TITLE
YARN-11744. Tackle flaky test testGetRunningContainersToKill

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestAbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestAbstractYarnScheduler.java
@@ -1584,12 +1584,16 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
         node.getContainersToKill());
   }
 
+  private static long LAST_TIMESTAMP = 0L;
   private static RMContainer newMockRMContainer(boolean isAMContainer,
       ExecutionType executionType, String name) {
+    long now = Time.now();
+    while (now <= LAST_TIMESTAMP) { now = Time.now(); }
+    LAST_TIMESTAMP = now;
     RMContainer container = mock(RMContainer.class);
     when(container.isAMContainer()).thenReturn(isAMContainer);
     when(container.getExecutionType()).thenReturn(executionType);
-    when(container.getCreationTime()).thenReturn(Time.now());
+    when(container.getCreationTime()).thenReturn(now);
     when(container.toString()).thenReturn(name);
     return container;
   }
@@ -1597,7 +1601,7 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
   /**
    * SchedulerNode mock to test launching containers.
    */
-  class MockSchedulerNode extends SchedulerNode {
+  static class MockSchedulerNode extends SchedulerNode {
     private final List<RMContainer> containers = new ArrayList<>();
 
     MockSchedulerNode() {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

I saw the test `TestAbstractYarnScheduler.testGetRunningContainersToKill[FAIR]` fails occasionally

```
Error:  org.apache.hadoop.yarn.server.resourcemanager.scheduler.TestAbstractYarnScheduler.testGetRunningContainersToKill[FAIR] -- Time elapsed: 0.016 s <<< FAILURE!
java.lang.AssertionError: expected:<[OPPORTUNISTIC1, OPPORTUNISTIC0, GUARANTEED1, GUARANTEED0, AM1, AM0]> but was:<[OPPORTUNISTIC0, OPPORTUNISTIC1, GUARANTEED1, GUARANTEED0, AM1, AM0]>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at org.apache.hadoop.yarn.server.resourcemanager.scheduler.TestAbstractYarnScheduler.testGetRunningContainersToKill(TestAbstractYarnScheduler.java:1583)
...
```
this is likely due to the two `System.currentTimeMillis()` return same value.

> Returns the current time in milliseconds. Note that while the unit of time of the return value is a millisecond, the granularity of the value depends on the underlying operating system and may be larger. For example, many operating systems measure time in units of tens of milliseconds.

### How was this patch tested?

Run the modified test locally multi times.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

