### PR TITLE
HADOOP-19371. JVM GC Metrics supports ZGC pause time and count

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/source/JvmMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/source/JvmMetrics.java
@@ -181,6 +181,13 @@ public class JvmMetrics implements MetricsSource {
     long count = 0;
     long timeMillis = 0;
     for (GarbageCollectorMXBean gcBean : gcBeans) {
+      if (gcBean.getName() != null) {
+        String name = gcBean.getName();
+        // JDK-8265136 Skip concurrent phase
+        if ((name.startsWith("ZGC") && name.endsWith("Cycles"))) {
+          continue;
+        }
+      }
       long c = gcBean.getCollectionCount();
       long t = gcBean.getCollectionTime();
       MetricsInfo[] gcInfo = getGcInfo(gcBean.getName());

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/source/JvmMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/source/JvmMetrics.java
@@ -184,7 +184,7 @@ public class JvmMetrics implements MetricsSource {
       if (gcBean.getName() != null) {
         String name = gcBean.getName();
         // JDK-8265136 Skip concurrent phase
-        if ((name.startsWith("ZGC") && name.endsWith("Cycles"))) {
+        if (name.startsWith("ZGC") && name.endsWith("Cycles")) {
           continue;
         }
       }


### PR DESCRIPTION
### Description of PR
8265136: ZGC: Expose GarbageCollectorMXBeans for both pauses and cycles

https://bugs.openjdk.org/browse/JDK-8265136

### How was this patch tested?
Local testing and production environment verification

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

