### PR TITLE
HDFS-17690. Avoid redundant EC reconstruction tasks after timeouts

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -2698,7 +2698,7 @@ public class BlockManager implements BlockStatsMXBean {
           if (bi == null || bi.isDeleted()) {
             continue;
           }
-          NumberReplicas num = countNodes(timedOutItems[i]);
+          NumberReplicas num = countNodes(bi);
           if (isNeededReconstruction(bi, num)) {
             neededReconstruction.add(bi, num.liveReplicas(),
                 num.readOnlyReplicas(), num.outOfServiceReplicas(),
@@ -5148,6 +5148,15 @@ public class BlockManager implements BlockStatsMXBean {
     return storedBlock.isComplete() && (numberReplicas.liveReplicas() <
         getMinMaintenanceStorageNum(storedBlock) ||
         !isPlacementPolicySatisfied(storedBlock));
+  }
+
+  boolean isNeededReconstruction(Block block) {
+    BlockInfo storedBlock = blocksMap.getStoredBlock(block);
+    if (storedBlock == null || storedBlock.isDeleted()) {
+      return false;
+    }
+    NumberReplicas num = countNodes(storedBlock);
+    return isNeededReconstruction(storedBlock, num);
   }
 
   boolean isNeededReconstruction(BlockInfo storedBlock,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -1927,10 +1927,10 @@ public class DatanodeManager {
 
       // Collect pending EC tasks, excluding the ones that are no longer needed
       List<BlockECReconstructionInfo> pendingECList = new ArrayList<>();
-      while (pendingECList.size() < numECReconstructedTasks) {
+      do {
         List<BlockECReconstructionInfo> list =
             nodeinfo.getErasureCodeCommand(numECReconstructedTasks - pendingECList.size());
-        if (list == null) {
+        if (list == null || list.isEmpty()) {
           break;
         }
         list.removeIf(ecRecon -> {
@@ -1958,7 +1958,7 @@ public class DatanodeManager {
           return true;
         });
         pendingECList.addAll(list);
-      }
+      } while (pendingECList.size() < numECReconstructedTasks);
       if (!pendingECList.isEmpty()) {
         cmds.add(new BlockECReconstructionCommand(
             DNA_ERASURE_CODING_RECONSTRUCTION, pendingECList));


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Avoid processing redundant BlockECReconstructionInfo from the queue. Check again if the task is really needed just before we dispatch the tasks to the datanodes.


### How was this patch tested?

Tested on a 3.4.1 cluster with 21 datanodes. Shutted down 2 datanodes holding 4~5TB of data and observed the reconstruction progress.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

