### PR TITLE
HDFS-17689. RBF:Add some docs for RouterRpcServer#getRPCMetrics method.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -1893,8 +1893,10 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
 
   /**
    * Get RPC metrics info.
+   * May return null if `dfs.federation.router.metrics.enable` is false.
    * @return The instance of FederationRPCMetrics.
    */
+  @VisibleForTesting
   public FederationRPCMetrics getRPCMetrics() {
     return this.rpcMonitor.getRPCMetrics();
   }


### PR DESCRIPTION
### Description of PR
Add some docs for RouterRpcServer#getRPCMetrics method because this method may return null if `dfs.federation.router.metrics.enable` is false.