### PR TITLE
HDFS-17695. Fix javadoc for FSDirectory#resolvePath method.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -695,7 +695,7 @@ public class FSDirectory implements Closeable {
    * accessible path that also passed additional sanity checks based on how
    * the path will be used as specified by the DirOp.
    *   READ:   Expands reserved paths and performs permission checks
-   *           during traversal.  Raw paths are only accessible by a superuser.
+   *           during traversal.
    *   WRITE:  In addition to READ checks, ensures the path is not a
    *           snapshot path.
    *   CREATE: In addition to WRITE checks, ensures path does not contain


### PR DESCRIPTION
### Description of PR
After [HDFS-12907](https://issues.apache.org/jira/browse/HDFS-12907),  /.reserved/raw path can be accessed by non-superuser.

So we should update document for FSDirectory#resolvePath method.

![image](https://github.com/user-attachments/assets/70245460-b019-47ca-8110-db406eb35549)
