### PR TITLE
YARN-11746. NodeManager should shutdown when PublicLocalizer is exiting.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer;
 import static org.apache.hadoop.fs.CreateFlag.CREATE;
 import static org.apache.hadoop.fs.CreateFlag.OVERWRITE;
 
+import org.apache.hadoop.util.ShutdownHookManager;
 import org.apache.hadoop.yarn.exceptions.ConfigurationException;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.RecoveryIterator;
 import org.slf4j.Logger;
@@ -1016,6 +1017,17 @@ public class ResourceLocalizationService extends CompositeService
       } finally {
         LOG.info("Public cache exiting");
         threadPool.shutdownNow();
+        if ((ShutdownHookManager.get().isShutdownInProgress()) == false) {
+          Thread shutDownThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+              LOG.info("PublicLocalizer is missing. Exiting, bbye..");
+              System.exit(-1);
+            }
+          });
+          shutDownThread.setName("PublicLocalizer ShutDown handler");
+          shutDownThread.start();
+        }
       }
     }
 


### PR DESCRIPTION
### Description of PR

I found that PublicLocalizer is exiting, because of the /tmp directory was deleted by mistake, then throw NPE, then causing spark job to be stuck.

[YARN-9968](https://issues.apache.org/jira/browse/YARN-9968) have resolve the NPE problem. For me, I think when the `PublicLocalizer` thread exits, the NM should be shut down, because there is no point in keeping an abnormal NM running.

### How was this patch tested?

manual test

### For code changes:

- [x] When PublicLocalizer is exiting, shutdown the NodeManager.
