### PR TITLE
HADOOP-19366. (3.4) Install OpenJDK 17 in default ubuntu build container

### DIFF
--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -261,11 +261,13 @@
     "debian:10": "openjdk-11-jdk",
     "ubuntu:focal": [
       "openjdk-8-jdk",
-      "openjdk-11-jdk"
+      "openjdk-11-jdk",
+      "openjdk-17-jdk"
     ],
     "ubuntu:focal::arch64": [
       "openjdk-8-jdk",
-      "openjdk-11-jdk"
+      "openjdk-11-jdk",
+      "openjdk-17-jdk"
     ]
   },
   "pinentry-curses": {


### PR DESCRIPTION
Backport #7226 to branch-3.4

Jira: HADOOP-19366. (3.4) Install OpenJDK 17 in default ubuntu build container.
