### PR TITLE
YARN-11749. Skip unnecessary node-askingRequest match in RegularContainerAllocator

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/allocator/RegularContainerAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/allocator/RegularContainerAllocator.java
@@ -100,7 +100,7 @@ public class RegularContainerAllocator extends AbstractContainerAllocator {
    * We will consider stuffs like exclusivity, pending resource, node partition,
    * headroom, etc.
    */
-  private ContainerAllocation preCheckForNodeCandidateSet(FiCaSchedulerNode node,
+  private ContainerAllocation preCheckForApp(FiCaSchedulerNode node,
       SchedulingMode schedulingMode, ResourceLimits resourceLimits,
       SchedulerRequestKey schedulerKey) {
     PendingAsk offswitchPendingAsk = application.getPendingAsk(schedulerKey,
@@ -141,21 +141,6 @@ public class RegularContainerAllocator extends AbstractContainerAllocator {
             ActivityLevel.REQUEST);
         return ContainerAllocation.APP_SKIPPED;
       }
-    }
-
-    // Is the nodePartition of pending request matches the node's partition
-    // If not match, jump to next priority.
-    Optional<DiagnosticsCollector> dcOpt = activitiesManager == null ?
-        Optional.empty() :
-        activitiesManager.getOptionalDiagnosticsCollector();
-    if (!appInfo.precheckNode(schedulerKey, node, schedulingMode, dcOpt)) {
-      ActivitiesLogger.APP.recordSkippedAppActivityWithoutAllocation(
-          activitiesManager, node, application, schedulerKey,
-          ActivityDiagnosticConstant.
-              NODE_DO_NOT_MATCH_PARTITION_OR_PLACEMENT_CONSTRAINTS
-              + ActivitiesManager.getDiagnostics(dcOpt),
-          ActivityLevel.NODE);
-      return ContainerAllocation.PRIORITY_SKIPPED;
     }
 
     if (!application.getCSLeafQueue().isReservationsContinueLooking()) {
@@ -872,9 +857,24 @@ public class RegularContainerAllocator extends AbstractContainerAllocator {
       }
 
       if (reservedContainer == null) {
-        result = preCheckForNodeCandidateSet(node,
-            schedulingMode, resourceLimits, schedulerKey);
-        if (null != result) {
+        // If there is no need of resources for app's resource request, fast skip the loop
+        if (null != preCheckForApp(node, schedulingMode, resourceLimits, schedulerKey)) {
+          break;
+        }
+
+        // Is pending request matches the node's partition or placement constraint
+        // If not match, jump to next node.
+        Optional<DiagnosticsCollector> dcOpt = activitiesManager == null ?
+                Optional.empty() :
+                activitiesManager.getOptionalDiagnosticsCollector();
+        if (!appInfo.precheckNode(schedulerKey, node, schedulingMode, dcOpt)) {
+          ActivitiesLogger.APP.recordSkippedAppActivityWithoutAllocation(
+                  activitiesManager, node, application, schedulerKey,
+                  ActivityDiagnosticConstant.
+                          NODE_DO_NOT_MATCH_PARTITION_OR_PLACEMENT_CONSTRAINTS
+                          + ActivitiesManager.getDiagnostics(dcOpt),
+                  ActivityLevel.NODE);
+          result = ContainerAllocation.PRIORITY_SKIPPED;
           continue;
         }
       } else {


### PR DESCRIPTION
### Description of PR

For multi node placement, if there is no need of resource for one app, it should fast skip out the node matching loop to save the async scheduling thread effective cpu time.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

