### PR TITLE
HADOOP-19376. Add fs.hdfs.impl.disable.cache to core-default.xml

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -4471,10 +4471,11 @@ The switch to turn S3A auditing on or off.
   <property>
     <name>fs.hdfs.impl.disable.cache</name>
     <value>false</value>
-    <description>Whether cache hdfs filesystem instances or not.
-      If false, there will be a cached hdfs fileSystem instance and return it to the caller,
-      Otherwise, a new hdfs fileSystem instance will be created,
-      initialized with the configuration and URI, cached and returned to the caller.
+    <description>Whether disable cached hdfs filesystem instances or not.
+      If false, return a cached hdfs fileSystem instance to the caller if exists.
+      If true, a new hdfs fileSystem instance will be created,
+      initialized with the configuration and URI, cached and returned to the caller,
+      it is slower than using cached hdfs filesystme instances.
       </description>
   </property>
 

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -4469,9 +4469,9 @@ The switch to turn S3A auditing on or off.
   </property>
 
   <property>
-    <name>fs.$SCHEME.impl.disable.cache</name>
+    <name>fs.$SCHEMA.impl.disable.cache</name>
     <value>false</value>
-    <description>Whether create a new FileSystem instance for schema specified by $SCHEME or not.
+    <description>Whether create a new FileSystem instance for schema specified by $SCHEMA or not.
       </description>
   </property>
 

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -4472,6 +4472,9 @@ The switch to turn S3A auditing on or off.
     <name>fs.$SCHEMA.impl.disable.cache</name>
     <value>false</value>
     <description>Whether create a new FileSystem instance for schema specified by $SCHEMA or not.
+      If false and there is a cached FileSystem instance matching the same schema of the URI,
+      it will be returned. Otherwise,a new FileSystem instance will be created,
+      initialized with the configuration and URI, cached and returned to the caller.
       </description>
   </property>
 

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -4469,10 +4469,10 @@ The switch to turn S3A auditing on or off.
   </property>
 
   <property>
-    <name>fs.$SCHEMA.impl.disable.cache</name>
+    <name>fs.$SCHEME.impl.disable.cache</name>
     <value>false</value>
-    <description>Whether create a new FileSystem instance for schema specified by $SCHEMA or not.
-      If false and there is a cached FileSystem instance matching the same schema of the URI,
+    <description>Whether create a new FileSystem instance for scheme specified by $SCHEME or not.
+      If false and there is a cached FileSystem instance matching the same scheme of the URI,
       it will be returned. Otherwise,a new FileSystem instance will be created,
       initialized with the configuration and URI, cached and returned to the caller.
       </description>

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -4469,11 +4469,11 @@ The switch to turn S3A auditing on or off.
   </property>
 
   <property>
-    <name>fs.$SCHEME.impl.disable.cache</name>
+    <name>fs.hdfs.impl.disable.cache</name>
     <value>false</value>
-    <description>Whether create a new FileSystem instance for scheme specified by $SCHEME or not.
-      If false and there is a cached FileSystem instance matching the same scheme of the URI,
-      it will be returned. Otherwise,a new FileSystem instance will be created,
+    <description>Whether cache hdfs filesystem instances or not.
+      If false, there will be a cached hdfs fileSystem instance and return it to the caller,
+      Otherwise, a new hdfs fileSystem instance will be created,
       initialized with the configuration and URI, cached and returned to the caller.
       </description>
   </property>

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -4468,4 +4468,11 @@ The switch to turn S3A auditing on or off.
     <description>The AbstractFileSystem for Ozone FileSystem o3fs uri</description>
   </property>
 
+  <property>
+    <name>fs.$SCHEME.impl.disable.cache</name>
+    <value>false</value>
+    <description>Whether create a new FileSystem instance for schema specified by $SCHEME or not.
+      </description>
+  </property>
+
 </configuration>

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestCommonConfigurationFields.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestCommonConfigurationFields.java
@@ -250,6 +250,6 @@ public class TestCommonConfigurationFields extends TestConfigurationFieldsBase {
     xmlPropsToSkipCompare.add("io.seqfile.local.dir");
 
     xmlPropsToSkipCompare.add("hadoop.http.sni.host.check.enabled");
-    xmlPropsToSkipCompare.add("fs.$SCHEMA.impl.disable.cache");
+    xmlPropsToSkipCompare.add("fs.$SCHEME.impl.disable.cache");
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestCommonConfigurationFields.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestCommonConfigurationFields.java
@@ -250,5 +250,6 @@ public class TestCommonConfigurationFields extends TestConfigurationFieldsBase {
     xmlPropsToSkipCompare.add("io.seqfile.local.dir");
 
     xmlPropsToSkipCompare.add("hadoop.http.sni.host.check.enabled");
+    xmlPropsToSkipCompare.add("fs.$SCHEMA.impl.disable.cache");
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestCommonConfigurationFields.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestCommonConfigurationFields.java
@@ -227,6 +227,7 @@ public class TestCommonConfigurationFields extends TestConfigurationFieldsBase {
     xmlPropsToSkipCompare.add("hadoop.common.configuration.version");
     // - org.apache.hadoop.fs.FileSystem
     xmlPropsToSkipCompare.add("fs.har.impl.disable.cache");
+    xmlPropsToSkipCompare.add("fs.hdfs.impl.disable.cache");
 
     // - package org.apache.hadoop.tracing.TraceUtils ?
     xmlPropsToSkipCompare.add("hadoop.htrace.span.receiver.classes");
@@ -250,6 +251,5 @@ public class TestCommonConfigurationFields extends TestConfigurationFieldsBase {
     xmlPropsToSkipCompare.add("io.seqfile.local.dir");
 
     xmlPropsToSkipCompare.add("hadoop.http.sni.host.check.enabled");
-    xmlPropsToSkipCompare.add("fs.$SCHEME.impl.disable.cache");
   }
 }


### PR DESCRIPTION
### Description of PR
We need to add `fs.$SCHEME.impl.disable.cache` configuration entry to core-default.xml.

This is a frequently used configuration entry but end user could not find it in core-default.xml