### PR TITLE
HDFS-17697. [FGL] hasWriteLock and hasReadLock in FineGrainedFSNamesystemLock shouldn't throw assert error

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/fgl/FSNLockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/fgl/FSNLockManager.java
@@ -35,6 +35,7 @@ public interface FSNLockManager {
   /**
    * Acquire read lock according to the lock mode, unless interrupted while waiting.
    * @param lockMode locking mode
+   * @throws InterruptedException If the thread is interrupted, an InterruptedException is thrown.
    */
   void readLockInterruptibly(RwLockMode lockMode) throws InterruptedException;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/RwLock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/RwLock.java
@@ -59,13 +59,16 @@ public interface RwLock {
    */
   void readUnlock(RwLockMode lockMode, String opName);
 
-  /** Check if the current thread holds read lock. */
+  /** Check if the current thread holds read lock.
+   * @return true if the read lock is held by the current thread, else false
+   */
   default boolean hasReadLock() {
     return hasReadLock(RwLockMode.GLOBAL);
   }
 
   /** Check if the current thread holds read lock.
    * @param lockMode The lock type used to check whether a read lock is held
+   * @return true if the read lock is held by the current thread, else false
    */
   boolean hasReadLock(RwLockMode lockMode);
 
@@ -109,13 +112,16 @@ public interface RwLock {
    */
   void writeUnlock(RwLockMode lockMode, String opName);
 
-  /** Check if the current thread holds write lock. */
+  /** Check if the current thread holds write lock.
+   * @return true if the write lock is held by the current thread, else false
+   */
   default boolean hasWriteLock() {
     return hasWriteLock(RwLockMode.GLOBAL);
   }
 
   /** Check if the current thread holds write lock.
    * @param lockMode The lock type used to check whether a write lock is held
+   * @return true if the write lock is held by the current thread, else false.
    */
   boolean hasWriteLock(RwLockMode lockMode);
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/RwLock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/RwLock.java
@@ -24,7 +24,9 @@ public interface RwLock {
     readLock(RwLockMode.GLOBAL);
   }
 
-  /** Acquire read lock. */
+  /** Acquire read lock.
+   * @param lockMode The lock type for acquiring a read lock
+   */
   void readLock(RwLockMode lockMode);
 
   /** Acquire read lock, unless interrupted while waiting.  */
@@ -32,7 +34,9 @@ public interface RwLock {
     readLockInterruptibly(RwLockMode.GLOBAL);
   }
 
-  /** Acquire read lock, unless interrupted while waiting.  */
+  /** Acquire read lock, unless interrupted while waiting.
+   * @param lockMode The lock type for acquiring a read lock
+   */
   void readLockInterruptibly(RwLockMode lockMode) throws InterruptedException;
 
   /** Release read lock. */
@@ -50,6 +54,7 @@ public interface RwLock {
 
   /**
    * Release read lock with operation name.
+   * @param lockMode The lock type for releasing the read lock
    * @param opName Option name.
    */
   void readUnlock(RwLockMode lockMode, String opName);
@@ -59,7 +64,9 @@ public interface RwLock {
     return hasReadLock(RwLockMode.GLOBAL);
   }
 
-  /** Check if the current thread holds read lock. */
+  /** Check if the current thread holds read lock.
+   * @param lockMode The lock type used to check whether a read lock is held
+   */
   boolean hasReadLock(RwLockMode lockMode);
 
   /** Acquire write lock. */
@@ -67,7 +74,9 @@ public interface RwLock {
     writeLock(RwLockMode.GLOBAL);
   }
 
-  /** Acquire write lock. */
+  /** Acquire write lock.
+   * @param lockMode The lock type for acquiring a write lock
+   */
   void writeLock(RwLockMode lockMode);
   
   /** Acquire write lock, unless interrupted while waiting.  */
@@ -75,7 +84,9 @@ public interface RwLock {
     writeLockInterruptibly(RwLockMode.GLOBAL);
   }
 
-  /** Acquire write lock, unless interrupted while waiting.  */
+  /** Acquire write lock, unless interrupted while waiting.
+   * @param lockMode The lock type for acquiring a write lock
+   */
   void writeLockInterruptibly(RwLockMode lockMode) throws InterruptedException;
 
   /** Release write lock. */
@@ -93,6 +104,7 @@ public interface RwLock {
 
   /**
    * Release write lock with operation name.
+   * @param lockMode The lock type for releasing the write lock
    * @param opName Option name.
    */
   void writeUnlock(RwLockMode lockMode, String opName);
@@ -102,6 +114,8 @@ public interface RwLock {
     return hasWriteLock(RwLockMode.GLOBAL);
   }
 
-  /** Check if the current thread holds write lock. */
+  /** Check if the current thread holds write lock.
+   * @param lockMode The lock type used to check whether a write lock is held
+   */
   boolean hasWriteLock(RwLockMode lockMode);
 }


### PR DESCRIPTION
### Description of PR

hasWriteLock and hasReadLock in FineGrainedFSNamesystemLock shouldn't throw assert error

The hasWriteLock(RwLockMode lockMode) and hasReadLock(RwLockMode lockMode) methods should strictly return true or false and never throw an AssertionError
