### PR TITLE
HADOOP-19379. [ABFS] Support Azurite storage emulator

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/AzureNativeFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/AzureNativeFileSystemStore.java
@@ -110,6 +110,7 @@ public class AzureNativeFileSystemStore implements NativeFileSystemStore {
   static final String KEY_STORE_BLOB_MD5 = "fs.azure.store.blob.md5";
   static final String DEFAULT_STORAGE_EMULATOR_ACCOUNT_NAME = "storageemulator";
   static final String STORAGE_EMULATOR_ACCOUNT_NAME_PROPERTY_NAME = "fs.azure.storage.emulator.account.name";
+  static final String STORAGE_EMULATOR_PROXY_URL = "fs.azure.storage.emulator.proxy.url";
 
   /**
    * Configuration for User-Agent field.
@@ -912,8 +913,14 @@ public class AzureNativeFileSystemStore implements NativeFileSystemStore {
     URI blobEndPoint;
     if (isStorageEmulatorAccount(accountName)) {
       isStorageEmulator = true;
-      CloudStorageAccount account =
-          CloudStorageAccount.getDevelopmentStorageAccount();
+      String storageEmulatorProxyUrl = getStorageEmulatorProxyUrl();
+      CloudStorageAccount account;
+      if (storageEmulatorProxyUrl == null) {
+        account = CloudStorageAccount.getDevelopmentStorageAccount();
+      } else {
+        account =
+            CloudStorageAccount.getDevelopmentStorageAccount(URI.create(storageEmulatorProxyUrl));
+      }
       storageInteractionLayer.createBlobClient(account);
     } else {
       blobEndPoint = new URI(getHTTPScheme() + "://" + accountName);
@@ -986,6 +993,10 @@ public class AzureNativeFileSystemStore implements NativeFileSystemStore {
     return accountName.equalsIgnoreCase(sessionConfiguration.get(
         STORAGE_EMULATOR_ACCOUNT_NAME_PROPERTY_NAME,
         DEFAULT_STORAGE_EMULATOR_ACCOUNT_NAME));
+  }
+
+  private String getStorageEmulatorProxyUrl() {
+    return sessionConfiguration.get(STORAGE_EMULATOR_PROXY_URL);
   }
 
   @VisibleForTesting


### PR DESCRIPTION
### Description of PR
In the integration test case, we will start the Azurite using test container, and we need to access Azurite at another container.
Now, the Azurite emulator uri values is fixed 127.0.0.1, so at another container, it can't access the Azurite service.

So I want to introduce a new config `fs.azure.storage.emulator.proxy.url`, so that I can config `fs.azure.storage.emulator.proxy.url=http://{AzuriteIp}`, then it can access the Azurite service.


### How was this patch tested?


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

