### PR TITLE
HDFS-17701. [FGL] Fix some javadocs

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/RwLock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/RwLock.java
@@ -29,13 +29,16 @@ public interface RwLock {
    */
   void readLock(RwLockMode lockMode);
 
-  /** Acquire read lock, unless interrupted while waiting.  */
+  /** Acquire read lock, unless interrupted while waiting.
+   * @throws InterruptedException if the thread is interrupted
+   */
   default void readLockInterruptibly() throws InterruptedException {
     readLockInterruptibly(RwLockMode.GLOBAL);
   }
 
   /** Acquire read lock, unless interrupted while waiting.
    * @param lockMode The lock type for acquiring a read lock
+   * @throws InterruptedException if the thread is interrupted
    */
   void readLockInterruptibly(RwLockMode lockMode) throws InterruptedException;
 
@@ -82,13 +85,16 @@ public interface RwLock {
    */
   void writeLock(RwLockMode lockMode);
   
-  /** Acquire write lock, unless interrupted while waiting.  */
+  /** Acquire write lock, unless interrupted while waiting.
+   * @throws InterruptedException if the thread is interrupted
+   */
   default void writeLockInterruptibly() throws InterruptedException {
     writeLockInterruptibly(RwLockMode.GLOBAL);
   }
 
   /** Acquire write lock, unless interrupted while waiting.
    * @param lockMode The lock type for acquiring a write lock
+   * @throws InterruptedException if the thread is interrupted
    */
   void writeLockInterruptibly(RwLockMode lockMode) throws InterruptedException;
 


### PR DESCRIPTION
### Description of PR
HDFS-17701. [FGL] Fix some javadocs.

- hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/RwLock.java:86: warning: no @throws for java.lang.InterruptedException

- hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/RwLock.java:93: warning: no @throws for java.lang.InterruptedException


