### PR TITLE
YARN-11741 Follow-up on ResourceManager quit due to ApplicationStateD…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/RMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/RMStateStore.java
@@ -247,7 +247,7 @@ public abstract class RMStateStore extends AbstractService {
         LOG.error("Error storing app: " + appId, e);
         if (e instanceof StoreLimitException) {
           store.notifyApplication(
-              new RMAppEvent(appId, RMAppEventType.APP_SAVE_FAILED,
+              new RMAppEvent(appId, RMAppEventType.APP_REJECTED,
                   e.getMessage()));
         } else {
           isFenced = store.notifyStoreOperationFailedInternal(e);
@@ -294,7 +294,12 @@ public abstract class RMStateStore extends AbstractService {
       } catch (Exception e) {
         String msg = "Error updating app: " + appId;
         LOG.error(msg, e);
-        isFenced = store.notifyStoreOperationFailedInternal(e);
+        if (e instanceof StoreLimitException) {
+          store.notifyApplication(new RMAppEvent(appId,
+                  RMAppEventType.APP_REJECTED));
+        } else {
+          isFenced = store.notifyStoreOperationFailedInternal(e);
+        }
         if (result != null) {
           result.setException(new YarnException(msg, e));
         }
@@ -385,7 +390,13 @@ public abstract class RMStateStore extends AbstractService {
                RMAppAttemptEventType.ATTEMPT_NEW_SAVED));
       } catch (Exception e) {
         LOG.error("Error storing appAttempt: " + attemptState.getAttemptId(), e);
-        isFenced = store.notifyStoreOperationFailedInternal(e);
+        if (e instanceof StoreLimitException) {
+          store.notifyApplicationAttempt(new RMAppAttemptEvent
+                  (attemptState.getAttemptId(),
+                          RMAppAttemptEventType.ATTEMPT_UPDATE_SAVED));
+        } else {
+          isFenced = store.notifyStoreOperationFailedInternal(e);
+        }
       }
       return finalState(isFenced);
     };
@@ -415,7 +426,13 @@ public abstract class RMStateStore extends AbstractService {
                RMAppAttemptEventType.ATTEMPT_UPDATE_SAVED));
       } catch (Exception e) {
         LOG.error("Error updating appAttempt: " + attemptState.getAttemptId(), e);
-        isFenced = store.notifyStoreOperationFailedInternal(e);
+        if (e instanceof StoreLimitException) {
+          store.notifyApplicationAttempt(new RMAppAttemptEvent
+                  (attemptState.getAttemptId(),
+                          RMAppAttemptEventType.ATTEMPT_UPDATE_SAVED));
+        } else {
+          isFenced = store.notifyStoreOperationFailedInternal(e);
+        }
       }
       return finalState(isFenced);
     };

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
@@ -896,16 +896,33 @@ public class ZKRMStateStore extends RMStateStore {
 
     byte[] appStateData = appStateDataPB.getProto().toByteArray();
 
-    if (pathExists) {
-      zkManager.safeSetData(nodeUpdatePath, appStateData, -1, zkAcl,
-          fencingNodePath);
+    if (appStateData.length <= zknodeLimit) {
+      if (pathExists) {
+        zkManager.safeSetData(nodeUpdatePath, appStateData, -1, zkAcl,
+            fencingNodePath);
+      } else {
+        zkManager.safeCreate(nodeUpdatePath, appStateData, zkAcl,
+            CreateMode.PERSISTENT, zkAcl, fencingNodePath);
+        LOG.debug("Path {} for {} didn't exist. Creating a new znode to update"
+            + " the application state.", nodeUpdatePath, appId);
+      }
+      opDurations.addUpdateApplicationStateCallDuration(clock.getTime() - start);
     } else {
-      zkManager.safeCreate(nodeUpdatePath, appStateData, zkAcl,
-          CreateMode.PERSISTENT, zkAcl, fencingNodePath);
-      LOG.debug("Path {} for {} didn't exist. Creating a new znode to update"
-          + " the application state.", nodeUpdatePath, appId);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Application state data size for " + appId + " is "
+                + appStateData.length);
+      }
+      LOG.error("Application " + appId.toString()
+              + " exceeds the maximum allowed size for application data. "
+              + "The length is " + appStateData.length
+              + ", The node update path is " + nodeUpdatePath
+              + ". Current yarn.resourcemanager.zk-max-znode-size.bytes is " + zknodeLimit);
+      throw new StoreLimitException("Application " + appId.toString()
+              + " exceeds the maximum allowed size for application data. "
+              + "The length is " + appStateData.length
+              + ", The node update path is " + nodeUpdatePath
+              + ". Current yarn.resourcemanager.zk-max-znode-size.bytes is " + zknodeLimit);
     }
-    opDurations.addUpdateApplicationStateCallDuration(clock.getTime() - start);
   }
 
   /*
@@ -940,20 +957,54 @@ public class ZKRMStateStore extends RMStateStore {
 
     switch (operation) {
     case UPDATE:
-      if (exists(path)) {
-        zkManager.safeSetData(path, attemptStateData, -1, zkAcl,
-            fencingNodePath);
-      } else {
-        zkManager.safeCreate(path, attemptStateData, zkAcl,
-            CreateMode.PERSISTENT, zkAcl, fencingNodePath);
-        LOG.debug("Path {} for {} didn't exist. Created a new znode to update"
-            + " the application attempt state.", path, appAttemptId);
+      if (appStateData.length <= zknodeLimit) {
+        if (exists(path)) {
+          zkManager.safeSetData(path, attemptStateData, -1, zkAcl,
+                  fencingNodePath);
+        } else {
+          zkManager.safeCreate(path, attemptStateData, zkAcl,
+                  CreateMode.PERSISTENT, zkAcl, fencingNodePath);
+          LOG.debug("Path {} for {} didn't exist. Created a new znode to update"
+                  + " the application attempt state.", path, appAttemptId);
 
+        }
+      } else {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Application state data size for " + appId + " is "
+                  + appStateData.length);
+        }
+        LOG.error("Application " + appId.toString()
+                + " exceeds the maximum allowed size for application data. "
+                + "The length is " + appStateData.length
+                + ", The node update path is " + nodeUpdatePath
+                + ". Current yarn.resourcemanager.zk-max-znode-size.bytes is " + zknodeLimit);
+        throw new StoreLimitException("Application " + appId.toString()
+                + " exceeds the maximum allowed size for application data. "
+                + "The length is " + appStateData.length
+                + ", The node update path is " + nodeUpdatePath
+                + ". Current yarn.resourcemanager.zk-max-znode-size.bytes is " + zknodeLimit);
       }
       break;
     case STORE:
-      zkManager.safeCreate(path, attemptStateData, zkAcl, CreateMode.PERSISTENT,
-          zkAcl, fencingNodePath);
+      if (appStateData.length <= zknodeLimit) {
+        zkManager.safeCreate(path, attemptStateData, zkAcl, CreateMode.PERSISTENT,
+                zkAcl, fencingNodePath);
+      } else {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Application state data size for " + appId + " is "
+                  + appStateData.length);
+        }
+        LOG.error("Application " + appId.toString()
+                + " exceeds the maximum allowed size for application data. "
+                + "The length is " + appStateData.length
+                + ", The node update path is " + nodeUpdatePath
+                + ". Current yarn.resourcemanager.zk-max-znode-size.bytes is " + zknodeLimit);
+        throw new StoreLimitException("Application " + appId.toString()
+                + " exceeds the maximum allowed size for application data. "
+                + "The length is " + appStateData.length
+                + ", The node update path is " + nodeUpdatePath
+                + ". Current yarn.resourcemanager.zk-max-znode-size.bytes is " + zknodeLimit);
+      }
       break;
     case REMOVE:
       safeDeleteAndCheckNode(path, zkAcl, fencingNodePath);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
@@ -959,7 +959,7 @@ public class ZKRMStateStore extends RMStateStore {
 
     switch (operation) {
     case UPDATE:
-      if (appStateData.length <= zknodeLimit) {
+      if (attemptStateData.length <= zknodeLimit) {
         if (exists(path)) {
           zkManager.safeSetData(path, attemptStateData, -1, zkAcl,
                   fencingNodePath);
@@ -973,37 +973,37 @@ public class ZKRMStateStore extends RMStateStore {
       } else {
         if (LOG.isDebugEnabled()) {
           LOG.debug("Application state data size for " + appId + " is "
-                  + appStateData.length);
+                  + attemptStateData.length);
         }
         LOG.error("Application " + appId.toString()
                 + " exceeds the maximum allowed size for application data. "
-                + "The length is " + appStateData.length
+                + "The length is " + attemptStateData.length
                 + ", The node update path is " + nodeUpdatePath
                 + ". Current yarn.resourcemanager.zk-max-znode-size.bytes is " + zknodeLimit);
         throw new StoreLimitException("Application " + appId.toString()
                 + " exceeds the maximum allowed size for application data. "
-                + "The length is " + appStateData.length
+                + "The length is " + attemptStateData.length
                 + ", The node update path is " + nodeUpdatePath
                 + ". Current yarn.resourcemanager.zk-max-znode-size.bytes is " + zknodeLimit);
       }
       break;
     case STORE:
-      if (appStateData.length <= zknodeLimit) {
+      if (attemptStateData.length <= zknodeLimit) {
         zkManager.safeCreate(path, attemptStateData, zkAcl, CreateMode.PERSISTENT,
                 zkAcl, fencingNodePath);
       } else {
         if (LOG.isDebugEnabled()) {
           LOG.debug("Application state data size for " + appId + " is "
-                  + appStateData.length);
+                  + attemptStateData.length);
         }
         LOG.error("Application " + appId.toString()
                 + " exceeds the maximum allowed size for application data. "
-                + "The length is " + appStateData.length
+                + "The length is " + attemptStateData.length
                 + ", The node update path is " + nodeUpdatePath
                 + ". Current yarn.resourcemanager.zk-max-znode-size.bytes is " + zknodeLimit);
         throw new StoreLimitException("Application " + appId.toString()
                 + " exceeds the maximum allowed size for application data. "
-                + "The length is " + appStateData.length
+                + "The length is " + attemptStateData.length
                 + ", The node update path is " + nodeUpdatePath
                 + ". Current yarn.resourcemanager.zk-max-znode-size.bytes is " + zknodeLimit);
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
@@ -857,9 +857,11 @@ public class ZKRMStateStore extends RMStateStore {
       LOG.debug("Application state data size for {} is {}",
           appId, appStateData.length);
 
-      throw new StoreLimitException("Application " + appId
-          + " exceeds the maximum allowed size for application data. "
-          + "See yarn.resourcemanager.zk-max-znode-size.bytes.");
+      throw new StoreLimitException("Application " + appId.toString()
+              + " exceeds the maximum allowed size for application data. "
+              + "The length is " + appStateData.length
+              + ", The node update path is " + nodeCreatePath
+              + ". Current yarn.resourcemanager.zk-max-znode-size.bytes is " + zknodeLimit);
     }
     opDurations.addStoreApplicationStateCallDuration(clock.getTime() - start);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
@@ -978,12 +978,12 @@ public class ZKRMStateStore extends RMStateStore {
         LOG.error("Application " + appId.toString()
                 + " exceeds the maximum allowed size for application data. "
                 + "The length is " + attemptStateData.length
-                + ", The node update path is " + nodeUpdatePath
+                + ", The node update path is " + path
                 + ". Current yarn.resourcemanager.zk-max-znode-size.bytes is " + zknodeLimit);
         throw new StoreLimitException("Application " + appId.toString()
                 + " exceeds the maximum allowed size for application data. "
                 + "The length is " + attemptStateData.length
-                + ", The node update path is " + nodeUpdatePath
+                + ", The node update path is " + path
                 + ". Current yarn.resourcemanager.zk-max-znode-size.bytes is " + zknodeLimit);
       }
       break;
@@ -999,12 +999,12 @@ public class ZKRMStateStore extends RMStateStore {
         LOG.error("Application " + appId.toString()
                 + " exceeds the maximum allowed size for application data. "
                 + "The length is " + attemptStateData.length
-                + ", The node update path is " + nodeUpdatePath
+                + ", The node update path is " + path
                 + ". Current yarn.resourcemanager.zk-max-znode-size.bytes is " + zknodeLimit);
         throw new StoreLimitException("Application " + appId.toString()
                 + " exceeds the maximum allowed size for application data. "
                 + "The length is " + attemptStateData.length
-                + ", The node update path is " + nodeUpdatePath
+                + ", The node update path is " + path
                 + ". Current yarn.resourcemanager.zk-max-znode-size.bytes is " + zknodeLimit);
       }
       break;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/YARN-11741

In [YARN-5006](https://issues.apache.org/jira/browse/YARN-5006) the issue "ResourceManager quit due to ApplicationStateData exceeding znode limit" has been addressed , specifically in the storeApplicationStateInternal() method of the ZKRMStateStore class. However, the methods updateApplicationStateInternal(), storeApplicationAttemptStateInternal(), and updateApplicationAttemptStateInternal() also need to incorporate checks for the ZNode size limit in  ZKRMStateStore class. This will help prevent scenarios where excessive data written to a single ZNode causes the ResourceManager (RM) and ZooKeeper (ZK) services to become unavailable.
