### PR TITLE
HDFS-17702. [ARR] RouterRpcClient doesn't handle AsyncCallLimitExceededException correctly.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/retry/RetryPolicies.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/retry/RetryPolicies.java
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.security.sasl.SaslException;
 
-import org.apache.hadoop.ipc.AsyncCallLimitExceededException;
 import org.apache.hadoop.ipc.ObserverRetryOnActiveException;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ipc.RetriableException;
@@ -736,10 +735,6 @@ public class RetryPolicies {
             "Access denied");
       } else if (e instanceof SocketException
           || (e instanceof IOException && !(e instanceof RemoteException))) {
-        if (e instanceof AsyncCallLimitExceededException) {
-          return new RetryAction(RetryAction.RetryDecision.FAILOVER_AND_RETRY,
-              getFailoverOrRetrySleepTime(failovers));
-        }
         if (isIdempotentOrAtMostOnce) {
           return new RetryAction(RetryAction.RetryDecision.FAILOVER_AND_RETRY,
               getFailoverOrRetrySleepTime(retries));

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/retry/RetryPolicies.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/retry/RetryPolicies.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.security.sasl.SaslException;
 
+import org.apache.hadoop.ipc.AsyncCallLimitExceededException;
 import org.apache.hadoop.ipc.ObserverRetryOnActiveException;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ipc.RetriableException;
@@ -735,6 +736,10 @@ public class RetryPolicies {
             "Access denied");
       } else if (e instanceof SocketException
           || (e instanceof IOException && !(e instanceof RemoteException))) {
+        if (e instanceof AsyncCallLimitExceededException) {
+          return new RetryAction(RetryAction.RetryDecision.FAILOVER_AND_RETRY,
+              getFailoverOrRetrySleepTime(failovers));
+        }
         if (isIdempotentOrAtMostOnce) {
           return new RetryAction(RetryAction.RetryDecision.FAILOVER_AND_RETRY,
               getFailoverOrRetrySleepTime(retries));

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/AsyncCallLimitExceededException.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/AsyncCallLimitExceededException.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * established async calls to avoid buffer overflow in order for follow-on async
  * calls going correctly.
  */
-public class AsyncCallLimitExceededException extends IOException {
+public class AsyncCallLimitExceededException extends StandbyException {
   private static final long serialVersionUID = 1L;
 
   public AsyncCallLimitExceededException(String message) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/AsyncCallLimitExceededException.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/AsyncCallLimitExceededException.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.ipc;
 
-import java.io.IOException;
-
 /**
  * Signals that an AsyncCallLimitExceededException has occurred. This class is
  * used to make application code using async RPC aware that limit of max async


### PR DESCRIPTION
### Description of PR
RouterRpcClient doesn't handle AsyncCallLimitExceededException correctly.