### PR TITLE
YARN-11750. Initialize queues in parallel

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/dev-support/findbugs-exclude.xml
+++ b/hadoop-yarn-project/hadoop-yarn/dev-support/findbugs-exclude.xml
@@ -633,6 +633,11 @@
     <Method name="run" />
     <Bug pattern="UL_UNRELEASED_LOCK_EXCEPTION_PATH" />
   </Match>
+  <Match>
+    <Class name="org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.AbstractParentQueue"/>
+    <Method name="reinitialize" />
+    <Bug pattern="UL_UNRELEASED_LOCK_EXCEPTION_PATH" />
+  </Match>
 
   <Match>
     <Class name="org.apache.hadoop.yarn.server.nodemanager.amrmproxy.FederationInterceptor" />

--- a/hadoop-yarn-project/hadoop-yarn/dev-support/findbugs-exclude.xml
+++ b/hadoop-yarn-project/hadoop-yarn/dev-support/findbugs-exclude.xml
@@ -633,11 +633,6 @@
     <Method name="run" />
     <Bug pattern="UL_UNRELEASED_LOCK_EXCEPTION_PATH" />
   </Match>
-  <Match>
-    <Class name="org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.AbstractParentQueue"/>
-    <Method name="reinitialize" />
-    <Bug pattern="UL_UNRELEASED_LOCK_EXCEPTION_PATH" />
-  </Match>
 
   <Match>
     <Class name="org.apache.hadoop.yarn.server.nodemanager.amrmproxy.FederationInterceptor" />

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/QueueMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/QueueMetrics.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -196,7 +197,7 @@ public class QueueMetrics implements MetricsSource {
 
     this.parent = parent != null ? parent.getMetrics() : null;
     this.parentQueue = parent;
-    this.users = enableUserMetrics ? new HashMap<String, QueueMetrics>() : null;
+    this.users = enableUserMetrics ? new ConcurrentHashMap<String, QueueMetrics>() : null;
     this.enableUserMetrics = enableUserMetrics;
 
     metricsSystem = ms;
@@ -253,7 +254,7 @@ public class QueueMetrics implements MetricsSource {
    * Simple metrics cache to help prevent re-registrations.
    */
   private static final Map<String, QueueMetrics> QUEUE_METRICS =
-      new HashMap<String, QueueMetrics>();
+      new ConcurrentHashMap<String, QueueMetrics>();
 
   /**
    * Returns the metrics cache to help prevent re-registrations.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -302,6 +302,25 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
   public static final boolean DEFAULT_SCHEDULE_ASYNCHRONOUSLY_ENABLE = true;
 
   @Private
+  public static final String INITIALIZE_QUEUES_PARALLEL_PREFIX =
+      PREFIX + "initialize-queues-parallel";
+
+  @Private
+  public static final String INITIALIZE_QUEUES_PARALLEL_ENABLE =
+      INITIALIZE_QUEUES_PARALLEL_PREFIX + ".enable";
+
+  @Private
+  public static final boolean DEFAULT_INITIALIZE_QUEUES_PARALLEL_ENABLE = false;
+
+  @Private
+  public static final String INITIALIZE_QUEUES_PARALLEL_MAXIMUM_THREAD =
+      INITIALIZE_QUEUES_PARALLEL_PREFIX + ".maximum-threads";
+
+  @Private
+  public static final Integer
+      DEFAULT_INITIALIZE_QUEUES_PARALLEL_MAXIMUM_THREAD = 1;
+
+  @Private
   public static final String QUEUE_MAPPING = PREFIX + "queue-mappings";
 
   @Private

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerQueues.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerQueues.java
@@ -161,6 +161,26 @@ public class TestCapacitySchedulerQueues {
   }
 
   @Test
+  public void testParallelRefreshQueues() throws Exception {
+    CapacityScheduler cs = new CapacityScheduler();
+    conf.setBoolean(CapacitySchedulerConfiguration.INITIALIZE_QUEUES_PARALLEL_ENABLE, true);
+    conf.setInt(CapacitySchedulerConfiguration.INITIALIZE_QUEUES_PARALLEL_MAXIMUM_THREAD, 10);
+    setupQueueConfiguration(conf);
+    cs.setConf(new YarnConfiguration());
+    cs.setRMContext(rm.getRMContext());
+    cs.init(conf);
+    cs.start();
+    cs.reinitialize(conf, rm.getRMContext());
+    checkQueueStructureCapacities(cs);
+
+    conf.setCapacity(A, 80f);
+    conf.setCapacity(B, 20f);
+    cs.reinitialize(conf, rm.getRMContext());
+    checkQueueStructureCapacities(cs, getDefaultCapacities(80f / 100.0f, 20f / 100.0f));
+    cs.stop();
+  }
+
+  @Test
   public void testRefreshQueuesWithNewQueue() throws Exception {
     CapacityScheduler cs = new CapacityScheduler();
     cs.setConf(new YarnConfiguration());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestLeafQueue.java
@@ -3227,6 +3227,26 @@ public class TestLeafQueue {
   }
 
   @Test
+  public void testParallelInitializeQueues() throws Exception {
+
+    CSQueueStore serialQueues = new CSQueueStore();
+    CapacitySchedulerQueueManager.parseQueue(queueContext,
+        csConf, null, ROOT.getFullPath(), serialQueues, queues,
+        TestUtils.spyHook);
+
+    csConf.setBoolean(CapacitySchedulerConfiguration.INITIALIZE_QUEUES_PARALLEL_ENABLE, true);
+    csConf.setInt(CapacitySchedulerConfiguration.INITIALIZE_QUEUES_PARALLEL_MAXIMUM_THREAD, 10);
+
+    CSQueueStore parallelQueues = new CSQueueStore();
+    CapacitySchedulerQueueManager.parseQueue(queueContext,
+        csConf, null, ROOT.getFullPath(), parallelQueues, queues,
+        TestUtils.spyHook);
+
+    assertEquals(serialQueues.getFullNameQueues().keySet(),
+        parallelQueues.getFullNameQueues().keySet());
+  }
+
+  @Test
   public void testRackLocalityDelayScheduling() throws Exception {
 
     // Change parameter values for node locality and rack locality delay.


### PR DESCRIPTION
### Description of PR
In our scenario, a cluster may have thousands of queues. As a result, initialize/reinitialize queues can take several minutes. When queue configurations are frequently modified, this can severely block scheduling.

This jira provides config to initialize/reinitialize queues in parallel.

### How was this patch tested?
unit test


