### PR TITLE
HADOOP-19382. [ABFS][FnsOverBlob] Test Fix for ITestAzureBlobFileSystemInitAndCreate failure

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
@@ -118,7 +118,7 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
   // TODO: [FnsOverBlob][HADOOP-19179] Remove this test case once Blob Endpoint Support is enabled.
   @Test
   public void testFileSystemInitFailsWithBlobEndpointUrl() throws Exception {
-    Configuration configuration = getRawConfiguration();
+    Configuration configuration = new Configuration(getRawConfiguration());
     String defaultUri = configuration.get(FS_DEFAULT_NAME_KEY);
     String accountKey = configuration.get(
         accountProperty(FS_AZURE_ACCOUNT_KEY_PROPERTY_NAME, getAccountName()),

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
@@ -42,6 +42,8 @@ import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_IS_HNS_ENABLED;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_KEY_PROPERTY_NAME;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.accountProperty;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_BLOB_DOMAIN_NAME;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_DFS_DOMAIN_NAME;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
@@ -115,9 +117,14 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
 
   // TODO: [FnsOverBlob][HADOOP-19179] Remove this test case once Blob Endpoint Support is enabled.
   @Test
-  public void testFileSystemInitFailsWithBlobEndpoitUrl() throws Exception {
+  public void testFileSystemInitFailsWithBlobEndpointUrl() throws Exception {
     Configuration configuration = getRawConfiguration();
     String defaultUri = configuration.get(FS_DEFAULT_NAME_KEY);
+    String accountKey = configuration.get(
+        accountProperty(FS_AZURE_ACCOUNT_KEY_PROPERTY_NAME, getAccountName()),
+        configuration.get(FS_AZURE_ACCOUNT_KEY_PROPERTY_NAME));
+    configuration.set(FS_AZURE_ACCOUNT_KEY_PROPERTY_NAME,
+        accountKey.replace(ABFS_DFS_DOMAIN_NAME, ABFS_BLOB_DOMAIN_NAME));
     String blobUri = defaultUri.replace(ABFS_DFS_DOMAIN_NAME, ABFS_BLOB_DOMAIN_NAME);
     intercept(InvalidConfigurationValueException.class,
         "Blob Endpoint Support not yet available", () ->


### PR DESCRIPTION
### Description of PR
Jira: https://issues.apache.org/jira/browse/HADOOP-19382
`ITestAzureBlobFileSystemInitAndCreate.testFileSystemInitFailsWithBlobEndpoitUrl` was reported to be failing when account key was not configured with blob endpoint url of account.
The failure was due to missing account specific shared key for blob endpoint url.

Fix is to get the account key configured with whatever endpoint user configures with and set it as an account agnostic setting just for the test.
If none of the acount key is configured, test will continue to be skipped.

### How was this patch tested?
Fixed test was ran, no production code change was needed.
Existing Test suite was ran and results added.