### PR TITLE
HDFS-17707. TestStateStoreFileSystem fails after HDFS-17496.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/FileIoProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/FileIoProvider.java
@@ -243,7 +243,7 @@ public class FileIoProvider {
     final long begin = profilingEventHook.beforeMetadataOp(volume, DELETE);
     try {
       faultInjectorEventHook.beforeMetadataOp(volume, DELETE);
-      boolean deleted = !f.exists() || f.delete();
+      boolean deleted = !f.exists() || f.delete() || !f.exists();
       profilingEventHook.afterMetadataOp(volume, DELETE, begin);
       if (!deleted) {
         LOG.warn("Failed to delete file {}", f);
@@ -686,7 +686,7 @@ public class FileIoProvider {
     boolean succeeded = false;
     try {
       faultInjectorEventHook.beforeMetadataOp(volume, MKDIRS);
-      succeeded = dir.isDirectory() || dir.mkdirs();
+      succeeded = dir.isDirectory() || dir.mkdirs() || dir.isDirectory();
       profilingEventHook.afterMetadataOp(volume, MKDIRS, begin);
     } catch(Exception e) {
       onFailure(volume, begin);


### PR DESCRIPTION
### Description of PR

JIRA: HDFS-17707. TestStateStoreFileSystem fails after HDFS-17496.(https://github.com/apache/hadoop/pull/6764) 

Cause is race condition when multiple instances of FileIoProvider#mkdirsWithExistsCheck are called for the same directory on different DIR locks.

Actually, ModDataSetSubLockStrategy is thread-safe.

There can be two ways to solve this problem, I prefer to the first approach:
1. use DIR lock align with datanode two-level layout, like subdir0/subdir0
2. modify the logic of mkdirsWithExistsCheck and other methods in FileIoProvider like below:
![image](https://github.com/user-attachments/assets/23682015-9059-4a40-aba5-b19e9f491527)

File#mkdirs() will return false when dir is already existed.