### PR TITLE
YARN-11752: Global Scheduler: Improve the container allocation time

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
@@ -604,7 +604,10 @@ public class CapacityScheduler extends
           if (candidates == null) {
             continue;
           }
-          cs.allocateContainersToNode(candidates, false);
+          int nodesPerPartitionCount = candidates.getAllNodes().size();
+          for (int i = 0; i < nodesPerPartitionCount; i++) {
+            cs.allocateContainersToNode(candidates, false);
+          }
         }
       }
 
@@ -620,7 +623,10 @@ public class CapacityScheduler extends
         if (candidates == null) {
           continue;
         }
-        cs.allocateContainersToNode(candidates, false);
+        int nodesPerPartitionCount = candidates.getAllNodes().size();
+        for (int i = 0; i < nodesPerPartitionCount; i++) {
+          cs.allocateContainersToNode(candidates, false);
+        }
       }
 
     }


### PR DESCRIPTION
### Description of PR
After every 2 container allocation, The global scheduling strategy for capacity scheduler waits for 5 milliseconds. This affects the container allocation time as well the throughput. This commit tries to fix the same by following the same model as that of async scheduling where containers are allocated as many times as the number of the nodes in one wave before waiting for 5 milliseconds.

Similarly for global scheduling, all nodes in all partitions are iterated and the containers are allocated as many times as the number of the nodes in all the partition in one wave before waiting for 5 milliseconds.

Refer YARN-11752 for more details.

### How was this patch tested?
1. Existing unit test
2. Manual verification using YARN SLS benchmark

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

