### PR TITLE
HADOOP-19384: Add support for ProfileCredentialsProvider

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1430,7 +1430,8 @@
     org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider,
     org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider,
     software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider,
-    org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider
+    org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider,
+    org.apache.hadoop.fs.s3a.ProfileAWSCredentialsProvider
   </value>
   <description>
     Comma-separated class names of credential provider classes which implement

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/PathOutputCommitterFactory.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/PathOutputCommitterFactory.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.mapreduce.lib.output;
 
 import java.io.IOException;
 
+import org.apache.hadoop.mapreduce.JobContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,6 +119,19 @@ public class PathOutputCommitterFactory extends Configured {
   }
 
   /**
+   * Create an output committer for a job.
+   * @param outputPath output path. This may be null.
+   * @param context context
+   * @return a new committer
+   * @throws IOException problems instantiating the committer
+   */
+  public PathOutputCommitter createOutputCommitter(
+      Path outputPath,
+      JobContext context) throws IOException {
+    return createFileOutputCommitter(outputPath, context);
+  }
+
+  /**
    * Create an instance of the default committer, a {@link FileOutputCommitter}
    * for a task.
    * @param outputPath the task's output path, or or null if no output path
@@ -131,6 +145,14 @@ public class PathOutputCommitterFactory extends Configured {
       TaskAttemptContext context) throws IOException {
     LOG.debug("Creating FileOutputCommitter for path {} and context {}",
         outputPath, context);
+    return new FileOutputCommitter(outputPath, context);
+  }
+
+  protected final PathOutputCommitter createFileOutputCommitter(
+          Path outputPath,
+          JobContext context) throws IOException {
+    LOG.debug("Creating FileOutputCommitter for path {} and context {}",
+            outputPath, context);
     return new FileOutputCommitter(outputPath, context);
   }
 
@@ -183,6 +205,13 @@ public class PathOutputCommitterFactory extends Configured {
           factory, key);
     }
     return ReflectionUtils.newInstance(factory, conf);
+  }
+
+  public static PathOutputCommitter createCommitter(Path outputPath,
+                                                    JobContext context) throws IOException {
+    return getCommitterFactory(outputPath,
+            context.getConfiguration())
+            .createOutputCommitter(outputPath, context);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -459,6 +459,7 @@
                     <exclusion>org.apache.hadoop.fs.s3a.commit.S3ACommitterFactory</exclusion>
                     <exclusion>org.apache.hadoop.fs.s3a.commit.impl.*</exclusion>
                     <exclusion>org.apache.hadoop.fs.s3a.commit.magic.*</exclusion>
+                    <exclusion>org.apache.hadoop.fs.s3a.commit.magic.mapred.*</exclusion>
                     <exclusion>org.apache.hadoop.fs.s3a.commit.staging.*</exclusion>
                   </exclusions>
                   <bannedImports>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/ProfileAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/ProfileAWSCredentialsProvider.java
@@ -1,0 +1,46 @@
+package org.apache.hadoop.fs.s3a;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.profiles.ProfileFile;
+
+import java.net.URI;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+
+@InterfaceAudience.Public
+@InterfaceStability.Stable
+public class ProfileAWSCredentialsProvider implements AwsCredentialsProvider {
+    public static final String NAME
+            = "org.apache.hadoop.fs.s3a.ProfileAWSCredentialsProvider";
+
+    private ProfileCredentialsProvider pcp;
+
+    private static Path getCredentialsPath() {
+        String credentialsFile = SystemUtils.getEnvironmentVariable("AWS_SHARED_CREDENTIALS_FILE", null);
+        Path path = (credentialsFile == null) ?
+                FileSystems.getDefault().getPath(SystemUtils.getUserHome().getPath(),".aws","credentials")
+                : FileSystems.getDefault().getPath(credentialsFile);
+        return path;
+    }
+
+    public ProfileAWSCredentialsProvider(URI uri, Configuration conf) {
+        ProfileCredentialsProvider.Builder builder = ProfileCredentialsProvider.builder();
+        builder.profileName("default").profileFile(ProfileFile.builder().content(getCredentialsPath()).type(ProfileFile.Type.CREDENTIALS).build());
+        pcp = builder.build();
+    }
+
+    public ProfileAWSCredentialsProvider(Configuration conf) {
+        ProfileCredentialsProvider.Builder builder = ProfileCredentialsProvider.builder();
+        builder.profileName("default").profileFile(ProfileFile.builder().content(getCredentialsPath()).build());
+        pcp = builder.build();
+    }
+    public AwsCredentials resolveCredentials() {
+        return pcp.resolveCredentials();
+    }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/CredentialProviderListFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/CredentialProviderListFactory.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
+import org.apache.hadoop.fs.s3a.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -39,12 +40,6 @@ import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.s3a.AWSCredentialProviderList;
-import org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider;
-import org.apache.hadoop.fs.s3a.Constants;
-import org.apache.hadoop.fs.s3a.S3AUtils;
-import org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider;
-import org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider;
 import org.apache.hadoop.fs.s3a.adapter.AwsV1BindingSupport;
 import org.apache.hadoop.fs.s3a.impl.InstantiationIOException;
 import org.apache.hadoop.fs.s3native.S3xLoginHelper;
@@ -84,7 +79,8 @@ public final class CredentialProviderListFactory {
           EnvironmentVariableCredentialsProvider.class,
           IAMInstanceCredentialsProvider.class,
           SimpleAWSCredentialsProvider.class,
-          TemporaryAWSCredentialsProvider.class));
+          TemporaryAWSCredentialsProvider.class,
+          ProfileAWSCredentialsProvider.class));
 
   /** V1 credential provider: {@value}. */
   public static final String ANONYMOUS_CREDENTIALS_V1 =

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/InternalCommitterConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/InternalCommitterConstants.java
@@ -117,6 +117,12 @@ public final class InternalCommitterConstants {
   public static final String SPARK_WRITE_UUID =
       "spark.sql.sources.writeJobUUID";
 
+  /*
+  * The UUID for jobs set by Tez
+  */
+  public static final String JOB_TEZ_UUID =
+          "job.committer.uuid";
+
   /**
    * Java temp dir: {@value}.
    */

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/MagicS3GuardCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/MagicS3GuardCommitter.java
@@ -84,6 +84,22 @@ public class MagicS3GuardCommitter extends AbstractS3ACommitter {
         getWorkPath());
   }
 
+  /**
+   * Create a job committer.
+   * @param outputPath the job's output path
+   * @param context the job's context
+   * @throws IOException on a failure
+   */
+  public MagicS3GuardCommitter(Path outputPath,
+                               JobContext context) throws IOException {
+    super(outputPath, context);
+    setWorkPath(getJobAttemptPath(context));
+    verifyIsMagicCommitPath(getDestS3AFS(), getWorkPath());
+    LOG.debug("Job attempt {} has work path {}",
+            context.getJobID(),
+            getWorkPath());
+  }
+
   @Override
   public String getName() {
     return NAME;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/MagicS3GuardCommitterFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/MagicS3GuardCommitterFactory.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.commit.AbstractS3ACommitterFactory;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.PathOutputCommitter;
 
@@ -41,6 +42,13 @@ public class MagicS3GuardCommitterFactory
   public PathOutputCommitter createTaskCommitter(S3AFileSystem fileSystem,
       Path outputPath,
       TaskAttemptContext context) throws IOException {
+    return new MagicS3GuardCommitter(outputPath, context);
+  }
+
+  @Override
+  public PathOutputCommitter createJobCommitter(S3AFileSystem fileSystem,
+      Path outputPath,
+      JobContext context) throws IOException {
     return new MagicS3GuardCommitter(outputPath, context);
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/mapred/MagicS3GuardCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/mapred/MagicS3GuardCommitter.java
@@ -1,0 +1,72 @@
+package org.apache.hadoop.fs.s3a.commit.magic.mapred;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitterFactory;
+import org.apache.hadoop.mapred.JobContext;
+import org.apache.hadoop.mapred.OutputCommitter;
+import org.apache.hadoop.mapred.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.PathOutputCommitterFactory;
+
+import java.io.IOException;
+
+public class MagicS3GuardCommitter extends OutputCommitter {
+
+    org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter committer = null;
+
+    private org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter getWrapped(JobContext context) throws IOException {
+        if (committer == null) {
+            committer = (org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter) PathOutputCommitterFactory.createCommitter(new Path(context.getConfiguration().get("mapred.output.dir")), context);
+        }
+        return committer;
+    }
+
+    private org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter getWrapped(TaskAttemptContext context) throws IOException {
+        if (committer == null) {
+            committer = (org.apache.hadoop.fs.s3a.commit.magic.MagicS3GuardCommitter) MagicS3GuardCommitterFactory.createCommitter(new Path(context.getConfiguration().get("mapred.output.dir")), context);
+        }
+        return committer;
+    }
+
+    @Override
+    public void setupJob(JobContext context) throws IOException {
+        getWrapped(context).setupJob(context);
+    }
+
+    @Override
+    public void setupTask(TaskAttemptContext context) throws IOException {
+        getWrapped(context).setupTask(context);
+    }
+
+    @Override
+    public boolean needsTaskCommit(TaskAttemptContext context) throws IOException {
+        return getWrapped(context).needsTaskCommit(context);
+    }
+
+    @Override
+    public void commitTask(TaskAttemptContext context) throws IOException {
+        getWrapped(context).commitTask(context);
+    }
+
+    @Override
+    public void abortTask(TaskAttemptContext context) throws IOException {
+        getWrapped(context).abortTask(context);
+    }
+
+    @Override
+    public void cleanupJob(JobContext context) throws IOException {
+        getWrapped(context).cleanupJob(context);
+    }
+
+    @Override
+    public void commitJob(JobContext context) throws IOException {
+        getWrapped(context).commitJob(context);
+    }
+
+    public final Path getWorkPath() {
+        return committer.getWorkPath();
+    }
+
+    public final Path getOutputPath() {
+        return committer.getOutputPath();
+    }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/DirectoryStagingCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/DirectoryStagingCommitter.java
@@ -58,6 +58,11 @@ public class DirectoryStagingCommitter extends StagingCommitter {
     super(outputPath, context);
   }
 
+  public DirectoryStagingCommitter(Path outputPath, JobContext context)
+          throws IOException {
+    super(outputPath, context);
+  }
+
   @Override
   public String getName() {
     return NAME;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/DirectoryStagingCommitterFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/DirectoryStagingCommitterFactory.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.commit.AbstractS3ACommitterFactory;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.PathOutputCommitter;
 
@@ -42,6 +43,12 @@ public class DirectoryStagingCommitterFactory
   public PathOutputCommitter createTaskCommitter(S3AFileSystem fileSystem,
       Path outputPath,
       TaskAttemptContext context) throws IOException {
+    return new DirectoryStagingCommitter(outputPath, context);
+  }
+
+  public PathOutputCommitter createJobCommitter(S3AFileSystem fileSystem,
+                                                 Path outputPath,
+                                                 JobContext context) throws IOException {
     return new DirectoryStagingCommitter(outputPath, context);
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/PartitionedStagingCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/PartitionedStagingCommitter.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.hadoop.mapreduce.JobContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,6 +72,12 @@ public class PartitionedStagingCommitter extends StagingCommitter {
   public PartitionedStagingCommitter(Path outputPath,
       TaskAttemptContext context)
       throws IOException {
+    super(outputPath, context);
+  }
+
+  public PartitionedStagingCommitter(Path outputPath,
+                                     JobContext context)
+          throws IOException {
     super(outputPath, context);
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/PartitionedStagingCommitterFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/PartitionedStagingCommitterFactory.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.commit.AbstractS3ACommitterFactory;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.PathOutputCommitter;
 
@@ -42,6 +43,12 @@ public class PartitionedStagingCommitterFactory
   public PathOutputCommitter createTaskCommitter(S3AFileSystem fileSystem,
       Path outputPath,
       TaskAttemptContext context) throws IOException {
+    return new PartitionedStagingCommitter(outputPath, context);
+  }
+
+  public PathOutputCommitter createJobCommitter(S3AFileSystem fileSystem,
+                                                 Path outputPath,
+                                                 JobContext context) throws IOException {
     return new PartitionedStagingCommitter(outputPath, context);
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/StagingCommitterFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/StagingCommitterFactory.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.commit.AbstractS3ACommitterFactory;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.PathOutputCommitter;
 
@@ -43,6 +44,12 @@ public class StagingCommitterFactory
   public PathOutputCommitter createTaskCommitter(S3AFileSystem fileSystem,
       Path outputPath,
       TaskAttemptContext context) throws IOException {
+    return new StagingCommitter(outputPath, context);
+  }
+
+  public PathOutputCommitter createJobCommitter(S3AFileSystem fileSystem,
+                                                 Path outputPath,
+                                                 JobContext context) throws IOException {
     return new StagingCommitter(outputPath, context);
   }
 


### PR DESCRIPTION

### Description of PR


### How was this patch tested?

This patch was tested by running the hadoop-aws integration tests with fs.s3a.aws.credentials.provider and fs.s3a.assumed.role.credentials.provider configured to only include org.apache.hadoop.fs.s3a.ProfileAWSCredentialsProvider . The tests utilized endpoints in the us-east-1 region. The details of a couple of seemingly irrelevant failures from the test runs are posted in the JIRA.

