### PR TITLE
HADOOP-19031. Enhance access control for RunJar.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/RunJar.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/RunJar.java
@@ -28,10 +28,14 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
@@ -287,20 +291,18 @@ public class RunJar {
 
     final File workDir;
     try {
-      workDir = File.createTempFile("hadoop-unjar", "", tmpDir);
-    } catch (IOException ioe) {
+      FileAttribute<Set<PosixFilePermission>> perms = PosixFilePermissions
+              .asFileAttribute(PosixFilePermissions.fromString("rwx------"));
+      workDir = Files.createTempDirectory(tmpDir.toPath(), "hadoop-unjar", perms).toFile();
+    } catch (IOException | SecurityException e) {
       // If user has insufficient perms to write to tmpDir, default
       // "Permission denied" message doesn't specify a filename.
       System.err.println("Error creating temp dir in java.io.tmpdir "
-                         + tmpDir + " due to " + ioe.getMessage());
+              + tmpDir + " due to " + e.getMessage());
       System.exit(-1);
       return;
     }
 
-    if (!workDir.delete()) {
-      System.err.println("Delete failed for " + workDir);
-      System.exit(-1);
-    }
     ensureDirectory(workDir);
 
     ShutdownHookManager.get().addShutdownHook(

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -213,7 +213,7 @@
     <openssl-wildfly.version>1.1.3.Final</openssl-wildfly.version>
     <woodstox.version>5.4.0</woodstox.version>
     <nimbus-jose-jwt.version>9.8.1</nimbus-jose-jwt.version>
-    <nodejs.version>v12.22.1</nodejs.version>
+    <nodejs.version>v16.20.2</nodejs.version>
     <yarnpkg.version>v1.22.5</yarnpkg.version>
     <apache-ant.version>1.10.13</apache-ant.version>
     <jmh.version>1.20</jmh.version>


### PR DESCRIPTION
Change backported from v3.4.0

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

