### PR TITLE
HADOOP-19207: [ABFS][FNSOverBlob][Backport 3.4] Response Handling of Blob Endpoint APIs and Metadata APIs

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
@@ -50,6 +50,7 @@ public final class AbfsHttpConstants {
   public static final String DEFAULT_LEASE_BREAK_PERIOD = "0";
   public static final String DEFAULT_TIMEOUT = "90";
   public static final String APPEND_BLOB_TYPE = "appendblob";
+  public static final String LIST = "list";
 
   //Abfs Http Client Constants for Blob Endpoint APIs.
 
@@ -201,6 +202,40 @@ public final class AbfsHttpConstants {
 
   @Deprecated
   public static final String DECEMBER_2019_API_VERSION = ApiVersion.DEC_12_2019.toString();
+
+  /**
+   * List of Constants Used by Blob Endpoint Rest APIs.
+   */
+  public static final String XML_TAG_NAME = "Name";
+  public static final String XML_TAG_BLOB = "Blob";
+  public static final String XML_TAG_NEXT_MARKER = "NextMarker";
+  public static final String XML_TAG_METADATA = "Metadata";
+  public static final String XML_TAG_PROPERTIES = "Properties";
+  public static final String XML_TAG_BLOB_PREFIX = "BlobPrefix";
+  public static final String XML_TAG_CONTENT_LEN = "Content-Length";
+  public static final String XML_TAG_RESOURCE_TYPE = "ResourceType";
+  public static final String XML_TAG_INVALID_XML = "Invalid XML";
+  public static final String XML_TAG_HDI_ISFOLDER = "hdi_isfolder";
+  public static final String XML_TAG_ETAG = "Etag";
+  public static final String XML_TAG_LAST_MODIFIED_TIME = "Last-Modified";
+  public static final String XML_TAG_CREATION_TIME   = "Creation-Time";
+  public static final String XML_TAG_OWNER = "Owner";
+  public static final String XML_TAG_GROUP = "Group";
+  public static final String XML_TAG_PERMISSIONS = "Permissions";
+  public static final String XML_TAG_ACL = "Acl";
+  public static final String XML_TAG_COPY_ID = "CopyId";
+  public static final String XML_TAG_COPY_STATUS = "CopyStatus";
+  public static final String XML_TAG_COPY_SOURCE = "CopySource";
+  public static final String XML_TAG_COPY_PROGRESS = "CopyProgress";
+  public static final String XML_TAG_COPY_COMPLETION_TIME = "CopyCompletionTime";
+  public static final String XML_TAG_COPY_STATUS_DESCRIPTION = "CopyStatusDescription";
+  public static final String XML_TAG_BLOB_ERROR_CODE_START_XML = "<Code>";
+  public static final String XML_TAG_BLOB_ERROR_CODE_END_XML = "</Code>";
+  public static final String XML_TAG_BLOB_ERROR_MESSAGE_START_XML = "<Message>";
+  public static final String XML_TAG_BLOB_ERROR_MESSAGE_END_XML = "</Message>";
+  public static final String XML_TAG_COMMITTED_BLOCKS = "CommittedBlocks";
+  public static final String XML_TAG_BLOCK_NAME = "Block";
+  public static final String PUT_BLOCK_LIST = "PutBlockList";
 
   /**
    * Value that differentiates categories of the http_status.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FSOperationType.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FSOperationType.java
@@ -45,7 +45,8 @@ public enum FSOperationType {
     SET_OWNER("SO"),
     SET_ACL("SA"),
     TEST_OP("TS"),
-    WRITE("WR");
+    WRITE("WR"),
+    INIT("IN");
 
     private final String opCode;
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemUriSchemes.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemUriSchemes.java
@@ -38,8 +38,8 @@ public final class FileSystemUriSchemes {
   public static final String WASB_SECURE_SCHEME = "wasbs";
   public static final String WASB_DNS_PREFIX = "blob";
 
-  public static final String ABFS_DFS_DOMAIN_NAME = "dfs.core.windows.net";
-  public static final String ABFS_BLOB_DOMAIN_NAME = "blob.core.windows.net";
+  public static final String ABFS_DFS_DOMAIN_NAME = ".dfs.";
+  public static final String ABFS_BLOB_DOMAIN_NAME = ".blob.";
 
   private FileSystemUriSchemes() {}
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/HttpQueryParams.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/HttpQueryParams.java
@@ -67,6 +67,11 @@ public final class HttpQueryParams {
    * {@value}
    */
   public static final String QUERY_PARAM_BLOCKLISTTYPE = "blocklisttype";
+  public static final String QUERY_PARAM_INCLUDE = "include";
+  public static final String QUERY_PARAM_PREFIX = "prefix";
+  public static final String QUERY_PARAM_MARKER = "marker";
+  public static final String QUERY_PARAM_DELIMITER = "delimiter";
+  public static final String QUERY_PARAM_MAX_RESULTS = "maxresults";
 
   //query params for SAS
   public static final String QUERY_PARAM_SAOID = "saoid";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/BlobListResultEntrySchema.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/BlobListResultEntrySchema.java
@@ -1,0 +1,238 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.contracts.services;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.fs.Path;
+
+/**
+ * List Result Entry Schema for Blob Endpoint List Blob API
+ */
+public class BlobListResultEntrySchema implements ListResultEntrySchema {
+
+  private String name;
+  private Path path;
+  private String url;
+  private Boolean isDirectory = false;
+  private String eTag;
+  private String lastModifiedTime;
+  private String creationTime;
+  private String owner;
+  private String group;
+  private String permission;
+  private String acl;
+  private Long contentLength = 0L;
+  private String copyId;
+  private String copyStatus;
+  private String copySourceUrl;
+  private String copyProgress;
+  private String copyStatusDescription;
+  private long copyCompletionTime;
+  private Map<String, String> metadata = new HashMap<>();
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  public Path path() {
+    return path;
+  }
+
+  public String url() {
+    return url;
+  }
+
+  @Override
+  public Boolean isDirectory() {
+    return isDirectory;
+  }
+
+  @Override
+  public String eTag() {
+    return eTag;
+  }
+
+  @Override
+  public String lastModified() {
+    return String.valueOf(lastModifiedTime);
+  }
+
+  public String creation() {
+    return String.valueOf(lastModifiedTime);
+  }
+
+  public String lastModifiedTime() {
+    return lastModifiedTime;
+  }
+
+  public String creationTime() {
+    return creationTime;
+  }
+
+  @Override
+  public Long contentLength() {
+    return contentLength;
+  }
+
+  public String copyId() {
+    return copyId;
+  }
+
+  public String copyStatus() {
+    return copyStatus;
+  }
+
+  public String copySourceUrl() {
+    return copySourceUrl;
+  }
+
+  public String copyProgress() {
+    return copyProgress;
+  }
+
+  public String copyStatusDescription() {
+    return copyStatusDescription;
+  }
+
+  public long copyCompletionTime() {
+    return copyCompletionTime;
+  }
+
+  public Map<String, String> metadata() {
+    return metadata;
+  }
+
+  @Override
+  public String owner() {
+    return owner;
+  }
+
+  @Override
+  public String group() {
+    return group;
+  }
+
+  @Override
+  public String permissions() {
+    return permission;
+  }
+
+  @Override
+  public String getXMsEncryptionContext() {
+    return null;
+  }
+
+  @Override
+  public String getCustomerProvidedKeySha256() {
+    return null;
+  }
+
+  @Override
+  public ListResultEntrySchema withName(final String name) {
+    this.name = name;
+    return this;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public void setPath(final Path path) {
+    this.path = path;
+  }
+
+  public void setUrl(final String url) {
+    this.url = url;
+  }
+
+  public void setIsDirectory(final Boolean isDirectory) {
+    this.isDirectory = isDirectory;
+  }
+
+  public void setETag(final String eTag) {
+    this.eTag = eTag;
+  }
+
+  public void setLastModifiedTime(final String lastModifiedTime) {
+    this.lastModifiedTime = lastModifiedTime;
+  }
+
+  public void setCreationTime(final String creationTime) {
+    this.creationTime = creationTime;
+  }
+
+  public void setOwner(final String owner) {
+    this.owner = owner;
+  }
+
+  public void setGroup(final String group) {
+    this.group = group;
+  }
+
+  public void setPermission(final String permission) {
+    this.permission = permission;
+  }
+
+  public void setAcl(final String acl) {
+    this.acl = acl;
+  }
+
+  public void setContentLength(final Long contentLength) {
+    this.contentLength = contentLength;
+  }
+
+  public void setCopyId(final String copyId) {
+    this.copyId = copyId;
+  }
+
+  public void setCopyStatus(final String copyStatus) {
+    this.copyStatus = copyStatus;
+  }
+
+  public void setCopyProgress(final String copyProgress) {
+    this.copyProgress = copyProgress;
+  }
+
+  public void setCopySourceUrl(final String copySourceUrl) {
+    this.copySourceUrl = copySourceUrl;
+  }
+
+  public void setCopyStatusDescription(final String copyStatusDescription) {
+    this.copyStatusDescription = copyStatusDescription;
+  }
+
+  public void setCopyCompletionTime(final long copyCompletionTime) {
+    this.copyCompletionTime = copyCompletionTime;
+  }
+
+  public void setMetadata(final Map<String, String> metadata) {
+    this.metadata = metadata;
+  }
+
+  public void addMetadata(final String key, final String value) {
+    this.metadata.put(key, value);
+  }
+
+  public String getAcl() {
+    return acl;
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/BlobListResultSchema.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/BlobListResultSchema.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.contracts.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The ListResultSchema model for Blob Endpoint Listing.
+ */
+public class BlobListResultSchema implements ListResultSchema {
+
+  // List of paths returned by Blob Endpoint Listing.
+  private List<BlobListResultEntrySchema> paths;
+
+  // Continuation token for the next page of results.
+  private String nextMarker;
+
+  public BlobListResultSchema() {
+    this.paths = new ArrayList<>();
+    nextMarker = null;
+  }
+
+  /**
+   * Return the list of paths returned by Blob Endpoint Listing.
+   * @return the paths value
+   */
+  @Override
+  public List<BlobListResultEntrySchema> paths() {
+    return paths;
+  }
+
+  /**
+   * Set the paths value to list of paths returned by Blob Endpoint Listing.
+   * @param paths the paths value to set
+   * @return the ListSchema object itself.
+   */
+  @Override
+  public ListResultSchema withPaths(final List<? extends ListResultEntrySchema> paths) {
+    this.paths = (List<BlobListResultEntrySchema>) paths;
+    return this;
+  }
+
+  public void addBlobListEntry(final BlobListResultEntrySchema blobListEntry) {
+    this.paths.add(blobListEntry);
+  }
+
+  public String getNextMarker() {
+    return nextMarker;
+  }
+
+  public void setNextMarker(String nextMarker) {
+    this.nextMarker = nextMarker;
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/BlobListXmlParser.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/BlobListXmlParser.java
@@ -1,0 +1,304 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.contracts.services;
+
+import java.util.Stack;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
+import org.apache.hadoop.fs.azurebfs.utils.DateTimeUtils;
+
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
+
+/**
+ * Parses the response inputSteam and populates an object of {@link BlobListResultSchema}. Parsing
+ * creates a list of {@link BlobListResultEntrySchema}.<br>
+ * <a href="https://learn.microsoft.com/en-us/rest/api/storageservices/list-blobs?tabs=azure-ad#response-body">
+ * BlobList API XML response example</a>
+ * <pre>
+ *   {@code
+ *   <EnumerationResults ServiceEndpoint="http://myaccount.blob.core.windows.net/" ContainerName="mycontainer">
+ *    <Prefix>string-value</Prefix>
+ *    <Marker>string-value</Marker>
+ *    <MaxResults>int-value</MaxResults>
+ *    <Delimiter>string-value</Delimiter>
+ *    <Blobs>
+ *      <Blob> </Blob>
+ *      <BlobPrefix> </BlobPrefix>
+ *    </Blobs>
+ *    <NextMarker />
+ *   </EnumerationResults>
+ *   }
+ * </pre>
+ */
+
+
+public class BlobListXmlParser extends DefaultHandler {
+  /**
+   * Object that contains the parsed response.
+   */
+  private final BlobListResultSchema listResultSchema;
+  private final String url;
+  /**
+   * {@link BlobListResultEntrySchema} for which at a given moment, the parsing is going on.
+   *
+   * Following XML elements will be parsed and added in currentBlobEntry.
+   * 1. Blob: for explicit files and directories
+   * <Blob>
+   *   <Name>blob-name</name>
+   *   <Properties> </Properties>
+   *   <Metadata>
+   *     <Name>value</Name>
+   *   </Metadata>
+   * </Blob>
+   *
+   * 2. BlobPrefix: for directories both explicit and implicit
+   * <BlobPrefix>
+   *   <Name>blob-prefix</Name>
+   * </BlobPrefix>
+   */
+  private BlobListResultEntrySchema currentBlobEntry;
+  /**
+   * Maintains the value in a given XML-element.
+   */
+  private StringBuilder bld = new StringBuilder();
+  /**
+   * Maintains the stack of XML-elements in memory at a given moment.
+   */
+  private final Stack<String> elements = new Stack<>();
+
+  /**
+   * Set an object of {@link BlobListResultSchema} to populate from the parsing.
+   * Set the url for which GetBlobList API is called.
+   * @param listResultSchema Object to populate from the parsing.
+   * @param url URL for which GetBlobList API is called.
+   */
+  public BlobListXmlParser(final BlobListResultSchema listResultSchema, final String url) {
+    this.listResultSchema = listResultSchema;
+    this.url = url;
+  }
+
+  /**
+   * <pre>Receive notification of the start of an element.</pre>
+   * If the xml start tag is "Blob", it defines that a new BlobProperty information
+   * is going to be parsed.
+   */
+  @Override
+  public void startElement(final String uri,
+      final String localName,
+      final String qName,
+      final Attributes attributes) throws SAXException {
+    elements.push(localName);
+    if (AbfsHttpConstants.XML_TAG_BLOB.equals(localName) || AbfsHttpConstants.XML_TAG_BLOB_PREFIX.equals(localName)) {
+      currentBlobEntry = new BlobListResultEntrySchema();
+    }
+  }
+
+  /**
+   * <pre>Receive notification of the end of an element.</pre>
+   * Whenever an XML-tag is closed, the parent-tag and current-tag shall be
+   * checked and correct property shall be set in the active {@link #currentBlobEntry}.
+   * If the current-tag is "Blob", it means that there are no more properties to
+   * be set in the  the active {@link #currentBlobEntry}, and it shall be the
+   * {@link #listResultSchema}.
+   */
+  @Override
+  public void endElement(final String uri,
+      final String localName,
+      final String qName)
+      throws SAXException {
+    String currentNode = elements.pop();
+
+    // Check if the ending tag is correct to the starting tag in the stack.
+    if (!currentNode.equals(localName)) {
+      throw new SAXException(AbfsHttpConstants.XML_TAG_INVALID_XML);
+    }
+
+    String parentNode = EMPTY_STRING;
+    if (elements.size() > 0) {
+      parentNode = elements.peek();
+    }
+
+    String value = bld.toString();
+    if (value.isEmpty()) {
+      value = null;
+    }
+
+    /*
+     * If the closing tag is Blob, there are no more properties to be set in
+     * currentBlobEntry.
+     */
+    if (AbfsHttpConstants.XML_TAG_BLOB.equals(currentNode)) {
+      listResultSchema.addBlobListEntry(currentBlobEntry);
+      currentBlobEntry = null;
+    }
+
+    /*
+     * If the closing tag is BlobPrefix, there are no more properties to be set in
+     * currentBlobEntry and this is a directory (implicit or explicit)
+     * If implicit, it will be added only once/
+     * If explicit it will be added with Blob Tag as well.
+     */
+    if (AbfsHttpConstants.XML_TAG_BLOB_PREFIX.equals(currentNode)) {
+      currentBlobEntry.setIsDirectory(true);
+      listResultSchema.addBlobListEntry(currentBlobEntry);
+      currentBlobEntry = null;
+    }
+
+    /*
+     * If the closing tag is Next Marker, it needs to be saved with the
+     * list of blobs currently fetched
+     */
+    if (AbfsHttpConstants.XML_TAG_NEXT_MARKER.equals(currentNode)) {
+      listResultSchema.setNextMarker(value);
+    }
+
+    /*
+     * If the closing tag is Name, then it is either for a blob
+     * or for a blob prefix denoting a directory. We will save this
+     * in current BlobProperty for both
+     */
+    if (currentNode.equals(AbfsHttpConstants.XML_TAG_NAME)
+        && (parentNode.equals(AbfsHttpConstants.XML_TAG_BLOB)
+        || parentNode.equals(AbfsHttpConstants.XML_TAG_BLOB_PREFIX))) {
+      // In case of BlobPrefix Name will have a slash at the end
+      // Remove the "/" at the end of name
+      if (value.endsWith(AbfsHttpConstants.FORWARD_SLASH)) {
+        value = value.substring(0, value.length() - 1);
+      }
+
+      currentBlobEntry.setName(value);
+      currentBlobEntry.setPath(new Path(AbfsHttpConstants.ROOT_PATH + value));
+      currentBlobEntry.setUrl(url + AbfsHttpConstants.ROOT_PATH + value);
+    }
+
+    /*
+     * For case:
+     * <Blob>
+     * ...
+     *   <Metadata>
+     *     <key1>value</key1>
+     *     <keyN>value</keyN>
+     *   </Metadata>
+     *  ...
+     * </Blob>
+     * ParentNode will be Metadata for all key1, key2, ... , keyN.
+     */
+    if (parentNode.equals(AbfsHttpConstants.XML_TAG_METADATA)) {
+      currentBlobEntry.addMetadata(currentNode, value);
+      // For Marker blobs hdi_isFolder will be present as metadata
+      if (AbfsHttpConstants.XML_TAG_HDI_ISFOLDER.equals(currentNode)) {
+        currentBlobEntry.setIsDirectory(Boolean.valueOf(value));
+      }
+    }
+
+    /*
+     * For case:
+     * <Blob>
+     * ...
+     *   <Properties>
+     *     <Creation-Time>date-time-value</Creation-Time>
+     *     <Last-Modified>date-time-value</Last-Modified>
+     *     <Etag>Etag</Etag>
+     *     <Owner>owner user id</Owner>
+     *     <Group>owning group id</Group>
+     *     <Permissions>permission string</Permissions>
+     *     <Acl>access control list</Acl>
+     *     <ResourceType>file | directory</ResourceType>
+     *     <Content-Length>size-in-bytes</Content-Length>
+     *     <CopyId>id</CopyId>
+     *     <CopyStatus>pending | success | aborted | failed </CopyStatus>
+     *     <CopySource>source url</CopySource>
+     *     <CopyProgress>bytes copied/bytes total</CopyProgress>
+     *     <CopyCompletionTime>datetime</CopyCompletionTime>
+     *     <CopyStatusDescription>error string</CopyStatusDescription>
+     *   </Properties>
+     *  ...
+     * </Blob>
+     * ParentNode will be Properties for Content-Length, ResourceType.
+     */
+    if (parentNode.equals(AbfsHttpConstants.XML_TAG_PROPERTIES)) {
+      if (currentNode.equals(AbfsHttpConstants.XML_TAG_CREATION_TIME)) {
+        currentBlobEntry.setCreationTime(value);
+      }
+      if (currentNode.equals(AbfsHttpConstants.XML_TAG_LAST_MODIFIED_TIME)) {
+        currentBlobEntry.setLastModifiedTime(value);
+      }
+      if (currentNode.equals(AbfsHttpConstants.XML_TAG_ETAG)) {
+        currentBlobEntry.setETag(value);
+      }
+      if (currentNode.equals(AbfsHttpConstants.XML_TAG_OWNER)) {
+        currentBlobEntry.setOwner(value);
+      }
+      if (currentNode.equals(AbfsHttpConstants.XML_TAG_GROUP)) {
+        currentBlobEntry.setGroup(value);
+      }
+      if (currentNode.equals(AbfsHttpConstants.XML_TAG_PERMISSIONS)) {
+        currentBlobEntry.setPermission(value);
+      }
+      if (currentNode.equals(AbfsHttpConstants.XML_TAG_ACL)) {
+        currentBlobEntry.setAcl(value);
+      }
+      if (currentNode.equals(AbfsHttpConstants.XML_TAG_RESOURCE_TYPE)) {
+        if (AbfsHttpConstants.DIRECTORY.equals(value)) {
+          currentBlobEntry.setIsDirectory(true);
+        }
+      }
+      if (currentNode.equals(AbfsHttpConstants.XML_TAG_CONTENT_LEN)) {
+        currentBlobEntry.setContentLength(Long.parseLong(value));
+      }
+      if (currentNode.equals(AbfsHttpConstants.XML_TAG_COPY_ID)) {
+        currentBlobEntry.setCopyId(value);
+      }
+      if (currentNode.equals(AbfsHttpConstants.XML_TAG_COPY_STATUS)) {
+        currentBlobEntry.setCopyStatus(value);
+      }
+      if (currentNode.equals(AbfsHttpConstants.XML_TAG_COPY_SOURCE)) {
+        currentBlobEntry.setCopySourceUrl(value);
+      }
+      if (currentNode.equals(AbfsHttpConstants.XML_TAG_COPY_PROGRESS)) {
+        currentBlobEntry.setCopyProgress(value);
+      }
+      if (currentNode.equals(AbfsHttpConstants.XML_TAG_COPY_COMPLETION_TIME)) {
+        currentBlobEntry.setCopyCompletionTime(DateTimeUtils.parseLastModifiedTime(value));
+      }
+      if (currentNode.equals(AbfsHttpConstants.XML_TAG_COPY_STATUS_DESCRIPTION)) {
+        currentBlobEntry.setCopyStatusDescription(value);
+      }
+    }
+    /*
+     * refresh bld for the next XML-tag value
+     */
+    bld = new StringBuilder();
+  }
+
+  /**
+   * Receive notification of character data inside an element. No heuristics to
+   * apply. Just append the {@link #bld}.
+   */
+  @Override
+  public void characters(final char[] ch, final int start, final int length)
+      throws SAXException {
+    bld.append(ch, start, length);
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/DfsListResultEntrySchema.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/DfsListResultEntrySchema.java
@@ -1,0 +1,268 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.contracts.services;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * The ListResultEntrySchema model for DFS Endpoint
+ */
+@InterfaceStability.Evolving
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DfsListResultEntrySchema implements ListResultEntrySchema {
+  /**
+   * The name property.
+   */
+  @JsonProperty(value = "name")
+  private String name;
+
+  /**
+   * The isDirectory property.
+   */
+  @JsonProperty(value = "isDirectory")
+  private Boolean isDirectory;
+
+  /**
+   * The lastModified property.
+   */
+  @JsonProperty(value = "lastModified")
+  private String lastModified;
+
+  /**
+   * The eTag property.
+   */
+  @JsonProperty(value = "etag")
+  private String eTag;
+
+  /**
+   * The contentLength property.
+   */
+  @JsonProperty(value = "contentLength")
+  private Long contentLength;
+
+  /**
+   * The owner property.
+   */
+  @JsonProperty(value = "owner")
+  private String owner;
+
+  /**
+   * The group property.
+   */
+  @JsonProperty(value = "group")
+  private String group;
+
+  /**
+   * The permissions property.
+   */
+  @JsonProperty(value = "permissions")
+  private String permissions;
+
+  /**
+   *  The encryption context property
+   */
+  @JsonProperty(value = "EncryptionContext")
+  private String xMsEncryptionContext;
+
+  /**
+   * The customer-provided encryption-256 value
+   * */
+  @JsonProperty(value = "CustomerProvidedKeySha256")
+  private String customerProvidedKeySha256;
+
+  /**
+   * Get the name value.
+   * @return the name value
+   */
+  @Override
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Set the name value.
+   * @param name the name value to set
+   * @return the ListEntrySchema object itself.
+   */
+  @Override
+  public DfsListResultEntrySchema withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * Get the isDirectory value.
+   * @return the isDirectory value
+   */
+  @Override
+  public Boolean isDirectory() {
+    return isDirectory;
+  }
+
+  /**
+   * Set the isDirectory value.
+   *
+   * @param isDirectory the isDirectory value to set
+   * @return the ListEntrySchema object itself.
+   */
+  public DfsListResultEntrySchema withIsDirectory(final Boolean isDirectory) {
+    this.isDirectory = isDirectory;
+    return this;
+  }
+
+  /**
+   * Get the lastModified value.
+   * @return the lastModified value
+   */
+  @Override
+  public String lastModified() {
+    return lastModified;
+  }
+
+  /**
+   * Set the lastModified value.
+   *
+   * @param lastModified the lastModified value to set
+   * @return the ListEntrySchema object itself.
+   */
+  public DfsListResultEntrySchema withLastModified(String lastModified) {
+    this.lastModified = lastModified;
+    return this;
+  }
+
+  /**
+   * Get the etag value.
+   * @return the etag value
+   */
+  @Override
+  public String eTag() {
+    return eTag;
+  }
+
+  /**
+   * Set the eTag value.
+   * @param eTag the eTag value to set
+   * @return the ListEntrySchema object itself.
+   */
+  public DfsListResultEntrySchema withETag(final String eTag) {
+    this.eTag = eTag;
+    return this;
+  }
+
+  /**
+   * Get the contentLength value.
+   * @return the contentLength value
+   */
+  @Override
+  public Long contentLength() {
+    return contentLength;
+  }
+
+  /**
+   * Set the contentLength value.
+   *
+   * @param contentLength the contentLength value to set
+   * @return the ListEntrySchema object itself.
+   */
+  public DfsListResultEntrySchema withContentLength(final Long contentLength) {
+    this.contentLength = contentLength;
+    return this;
+  }
+
+  /**
+   * Get the owner value.
+   * @return the owner value
+   */
+  @Override
+  public String owner() {
+    return owner;
+  }
+
+  /**
+   * Set the owner value.
+   *
+   * @param owner the owner value to set
+   * @return the ListEntrySchema object itself.
+   */
+  public DfsListResultEntrySchema withOwner(final String owner) {
+    this.owner = owner;
+    return this;
+  }
+
+  /**
+   * Get the group value.
+   * @return the group value
+   */
+  @Override
+  public String group() {
+    return group;
+  }
+
+  /**
+   * Set the group value.
+   *
+   * @param group the group value to set
+   * @return the ListEntrySchema object itself.
+   */
+  public DfsListResultEntrySchema withGroup(final String group) {
+    this.group = group;
+    return this;
+  }
+
+  /**
+   * Get the permissions value.
+   * @return the permissions value
+   */
+  @Override
+  public String permissions() {
+    return permissions;
+  }
+
+  /**
+   * Set the permissions value.
+   *
+   * @param permissions the permissions value to set
+   * @return the ListEntrySchema object itself.
+   */
+  public DfsListResultEntrySchema withPermissions(final String permissions) {
+    this.permissions = permissions;
+    return this;
+  }
+
+  /**
+   * Get the x-ms-encryption-context value.
+   * @return the x-ms-encryption-context value.
+   */
+  @Override
+  public String getXMsEncryptionContext() {
+    return xMsEncryptionContext;
+  }
+
+  /**
+   * Get the customer-provided sha-256 key
+   * @return the x-ms-encryption-key-sha256 value used by client.
+   */
+  @Override
+  public String getCustomerProvidedKeySha256() {
+    return customerProvidedKeySha256;
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/DfsListResultSchema.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/DfsListResultSchema.java
@@ -20,20 +20,38 @@ package org.apache.hadoop.fs.azurebfs.contracts.services;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.apache.hadoop.classification.InterfaceStability;
+
 /**
- * The ListResultSchema model.
+ * The ListResultSchema model for DFS Endpoint Listing.
  */
-public interface ListResultSchema {
+@InterfaceStability.Evolving
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DfsListResultSchema implements ListResultSchema {
   /**
-   * Get the paths value.
-   * @return the paths value
+   * List of paths returned by DFS Endpoint Listing.
    */
-  List<? extends ListResultEntrySchema> paths();
+  @JsonProperty(value = "paths")
+  private List<DfsListResultEntrySchema> paths;
 
   /**
-   * Set the paths value.
+   * Get the list of paths returned by DFS Endpoint Listing.
+   * @return the paths value
+   */
+  public List<DfsListResultEntrySchema> paths() {
+    return this.paths;
+  }
+
+  /**
+   * Set the paths value to list of paths returned by DFS Endpoint Listing.
    * @param paths the paths value to set
    * @return the ListSchema object itself.
    */
-  ListResultSchema withPaths(List<? extends ListResultEntrySchema> paths);
+  public ListResultSchema withPaths(final List<? extends ListResultEntrySchema> paths) {
+    this.paths = (List<DfsListResultEntrySchema>) paths;
+    return this;
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/ListResultEntrySchema.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/ListResultEntrySchema.java
@@ -18,251 +18,75 @@
 
 package org.apache.hadoop.fs.azurebfs.contracts.services;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import org.apache.hadoop.classification.InterfaceStability;
-
 /**
  * The ListResultEntrySchema model.
  */
-@InterfaceStability.Evolving
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class ListResultEntrySchema {
-  /**
-   * The name property.
-   */
-  @JsonProperty(value = "name")
-  private String name;
-
-  /**
-   * The isDirectory property.
-   */
-  @JsonProperty(value = "isDirectory")
-  private Boolean isDirectory;
-
-  /**
-   * The lastModified property.
-   */
-  @JsonProperty(value = "lastModified")
-  private String lastModified;
-
-  /**
-   * The eTag property.
-   */
-  @JsonProperty(value = "etag")
-  private String eTag;
-
-  /**
-   * The contentLength property.
-   */
-  @JsonProperty(value = "contentLength")
-  private Long contentLength;
-
-  /**
-   * The owner property.
-   */
-  @JsonProperty(value = "owner")
-  private String owner;
-
-  /**
-   * The group property.
-   */
-  @JsonProperty(value = "group")
-  private String group;
-
-  /**
-   * The permissions property.
-   */
-  @JsonProperty(value = "permissions")
-  private String permissions;
-
-  /**
-   *  The encryption context property
-   */
-  @JsonProperty(value = "EncryptionContext")
-  private String xMsEncryptionContext;
-
-  /**
-   * The customer-provided encryption-256 value
-   * */
-  @JsonProperty(value = "CustomerProvidedKeySha256")
-  private String customerProvidedKeySha256;
+public interface ListResultEntrySchema {
 
   /**
    * Get the name value.
-   *
    * @return the name value
    */
-  public String name() {
-    return name;
-  }
+  String name();
 
   /**
    * Set the name value.
-   *
    * @param name the name value to set
-   * @return the ListEntrySchema object itself.
+   * @return the ListResultEntrySchema object itself.
    */
-  public ListResultEntrySchema withName(String name) {
-    this.name = name;
-    return this;
-  }
+  ListResultEntrySchema withName(String name);
 
   /**
    * Get the isDirectory value.
-   *
    * @return the isDirectory value
    */
-  public Boolean isDirectory() {
-    return isDirectory;
-  }
-
-  /**
-   * Set the isDirectory value.
-   *
-   * @param isDirectory the isDirectory value to set
-   * @return the ListEntrySchema object itself.
-   */
-  public ListResultEntrySchema withIsDirectory(final Boolean isDirectory) {
-    this.isDirectory = isDirectory;
-    return this;
-  }
+  Boolean isDirectory();
 
   /**
    * Get the lastModified value.
-   *
    * @return the lastModified value
    */
-  public String lastModified() {
-    return lastModified;
-  }
+  String lastModified();
 
   /**
-   * Set the lastModified value.
-   *
-   * @param lastModified the lastModified value to set
-   * @return the ListEntrySchema object itself.
+   * Get the eTag value.
+   * @return the eTag value
    */
-  public ListResultEntrySchema withLastModified(String lastModified) {
-    this.lastModified = lastModified;
-    return this;
-  }
-
-  /**
-   * Get the etag value.
-   *
-   * @return the etag value
-   */
-  public String eTag() {
-    return eTag;
-  }
-
-  /**
-   * Set the eTag value.
-   *
-   * @param eTag the eTag value to set
-   * @return the ListEntrySchema object itself.
-   */
-  public ListResultEntrySchema withETag(final String eTag) {
-    this.eTag = eTag;
-    return this;
-  }
+  String eTag();
 
   /**
    * Get the contentLength value.
-   *
    * @return the contentLength value
    */
-  public Long contentLength() {
-    return contentLength;
-  }
+  Long contentLength();
 
   /**
-   * Set the contentLength value.
-   *
-   * @param contentLength the contentLength value to set
-   * @return the ListEntrySchema object itself.
-   */
-  public ListResultEntrySchema withContentLength(final Long contentLength) {
-    this.contentLength = contentLength;
-    return this;
-  }
-
-  /**
-   *
-   Get the owner value.
-   *
+   * Get the owner value.
    * @return the owner value
    */
-  public String owner() {
-    return owner;
-  }
-
-  /**
-   * Set the owner value.
-   *
-   * @param owner the owner value to set
-   * @return the ListEntrySchema object itself.
-   */
-  public ListResultEntrySchema withOwner(final String owner) {
-    this.owner = owner;
-    return this;
-  }
+  String owner();
 
   /**
    * Get the group value.
-   *
    * @return the group value
    */
-  public String group() {
-    return group;
-  }
-
-  /**
-   * Set the group value.
-   *
-   * @param group the group value to set
-   * @return the ListEntrySchema object itself.
-   */
-  public ListResultEntrySchema withGroup(final String group) {
-    this.group = group;
-    return this;
-  }
+  String group();
 
   /**
    * Get the permissions value.
-   *
    * @return the permissions value
    */
-  public String permissions() {
-    return permissions;
-  }
+  String permissions();
 
   /**
-   * Set the permissions value.
-   *
-   * @param permissions the permissions value to set
-   * @return the ListEntrySchema object itself.
+   * Get the encryption context value.
+   * @return the encryption context value
    */
-  public ListResultEntrySchema withPermissions(final String permissions) {
-    this.permissions = permissions;
-    return this;
-  }
+  String getXMsEncryptionContext();
 
   /**
-   * Get the x-ms-encryption-context value.
-   * @return the x-ms-encryption-context value.
-   * */
-  public String getXMsEncryptionContext() {
-    return xMsEncryptionContext;
-  }
-
-  /**
-   * Get the customer-provided sha-256 key
-   * @return the x-ms-encryption-key-sha256 value used by client.
-   * */
-  public String getCustomerProvidedKeySha256() {
-    return customerProvidedKeySha256;
-  }
+   * Get the customer-provided encryption-256 value.
+   * @return the customer-provided encryption-256 value
+   */
+  String getCustomerProvidedKeySha256();
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/StorageErrorResponseSchema.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/StorageErrorResponseSchema.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.contracts.services;
+
+/**
+ * Response Schema for Storage Error Parsing.
+ * Common schema for both endpoints.
+ */
+public class StorageErrorResponseSchema {
+
+  public StorageErrorResponseSchema(final String storageErrorCode,
+      final String storageErrorMessage,
+      final String expectedAppendPos) {
+    this.storageErrorCode = storageErrorCode;
+    this.storageErrorMessage = storageErrorMessage;
+    this.expectedAppendPos = expectedAppendPos;
+  }
+
+  private String storageErrorCode;
+  private String storageErrorMessage;
+  private String expectedAppendPos;
+
+  public String getStorageErrorCode() {
+    return storageErrorCode;
+  }
+
+  public void setStorageErrorCode(final String storageErrorCode) {
+    this.storageErrorCode = storageErrorCode;
+  }
+
+  public String getStorageErrorMessage() {
+    return storageErrorMessage;
+  }
+
+  public void setStorageErrorMessage(final String storageErrorMessage) {
+    this.storageErrorMessage = storageErrorMessage;
+  }
+
+  public String getExpectedAppendPos() {
+    return expectedAppendPos;
+  }
+
+  public void setExpectedAppendPos(final String expectedAppendPos) {
+    this.expectedAppendPos = expectedAppendPos;
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientThrottlingIntercept.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientThrottlingIntercept.java
@@ -154,6 +154,7 @@ public final class AbfsClientThrottlingIntercept implements AbfsThrottlingInterc
 
     switch (operationType) {
       case Append:
+      case PutBlock:
         contentLength = abfsHttpOperation.getBytesSent();
         if (contentLength == 0) {
           /*
@@ -171,6 +172,7 @@ public final class AbfsClientThrottlingIntercept implements AbfsThrottlingInterc
         }
         break;
       case ReadFile:
+      case GetBlob:
         String range = abfsHttpOperation.getRequestProperty(HttpHeaderConfigurations.RANGE);
         contentLength = getContentLengthIfKnown(range);
         if (contentLength > 0) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsJdkHttpOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsJdkHttpOperation.java
@@ -62,15 +62,17 @@ public class AbfsJdkHttpOperation extends AbfsHttpOperation {
    * @param requestHeaders The HTTP request headers.READ_TIMEOUT
    * @param connectionTimeout The Connection Timeout value to be used while establishing http connection
    * @param readTimeout The Read Timeout value to be used with http connection while making a request
+   * @param abfsClient The AbfsClient instance.
    * @throws IOException if an error occurs.
    */
   public AbfsJdkHttpOperation(final URL url,
       final String method,
       final List<AbfsHttpHeader> requestHeaders,
       final Duration connectionTimeout,
-      final Duration readTimeout)
+      final Duration readTimeout,
+      final AbfsClient abfsClient)
       throws IOException {
-    super(LOG, url, method, requestHeaders, connectionTimeout, readTimeout);
+    super(LOG, url, method, requestHeaders, connectionTimeout, readTimeout, abfsClient);
 
     this.connection = openConnection();
     if (this.connection instanceof HttpsURLConnection) {
@@ -94,6 +96,12 @@ public class AbfsJdkHttpOperation extends AbfsHttpOperation {
   /**{@inheritDoc}*/
   public String getResponseHeader(String httpHeader) {
     return connection.getHeaderField(httpHeader);
+  }
+
+  /**{@inheritDoc}*/
+  @Override
+  public Map<String, List<String>> getResponseHeaders() {
+    return connection.getHeaderFields();
   }
 
   /**{@inheritDoc}*/

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -40,11 +40,13 @@ import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationExcep
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.InvalidAbfsRestOperationException;
 import org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations;
+import org.apache.hadoop.fs.azurebfs.contracts.services.ListResultSchema;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding;
 import org.apache.http.impl.execchain.RequestAbortedException;
 
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_CONTINUE;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.PUT_BLOCK_LIST;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.EGRESS_LIMIT_BREACH_ABBREVIATION;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.INGRESS_LIMIT_BREACH_ABBREVIATION;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.TPS_LIMIT_BREACH_ABBREVIATION;
@@ -119,6 +121,25 @@ public class AbfsRestOperation {
   public void hardSetResult(int httpStatus) {
     result = AbfsHttpOperation.getAbfsHttpOperationWithFixedResult(this.url,
         this.method, httpStatus);
+  }
+
+  /**
+   * For setting dummy result of getFileStatus for implicit paths.
+   * @param httpStatus http status code to be set.
+   */
+  public void hardSetGetFileStatusResult(int httpStatus) {
+    result = new AbfsHttpOperation.AbfsHttpOperationWithFixedResultForGetFileStatus(this.url,
+        this.method, httpStatus);
+  }
+
+  /**
+   * For setting dummy result of listPathStatus for file paths.
+   * @param httpStatus http status code to be set.
+   * @param listResultSchema list result schema to be set.
+   */
+  public void hardSetGetListStatusResult(int httpStatus, final ListResultSchema listResultSchema) {
+    result = new AbfsHttpOperation.AbfsHttpOperationWithFixedResultForGetListStatus(this.url,
+        this.method, httpStatus, listResultSchema);
   }
 
   public URL getUrl() {
@@ -196,7 +217,7 @@ public class AbfsRestOperation {
    * @param requestHeaders The HTTP request headers.
    * @param buffer For uploads, this is the request entity body.  For downloads,
    * this will hold the response entity body.
-   * @param bufferOffset An offset into the buffer where the data beings.
+   * @param bufferOffset An offset into the buffer where the data begins.
    * @param bufferLength The length of the data in the buffer.
    * @param sasToken A sasToken for optional re-use by AbfsInputStream/AbfsOutputStream.
    */
@@ -329,7 +350,9 @@ public class AbfsRestOperation {
       if (hasRequestBody) {
         httpOperation.sendPayload(buffer, bufferOffset, bufferLength);
         incrementCounter(AbfsStatistic.SEND_REQUESTS, 1);
-        incrementCounter(AbfsStatistic.BYTES_SENT, bufferLength);
+        if (!(operationType.name().equals(PUT_BLOCK_LIST))) {
+          incrementCounter(AbfsStatistic.BYTES_SENT, bufferLength);
+        }
       }
       httpOperation.processResponse(buffer, bufferOffset, bufferLength);
       incrementCounter(AbfsStatistic.GET_RESPONSES, 1);
@@ -473,7 +496,7 @@ public class AbfsRestOperation {
   AbfsJdkHttpOperation createAbfsHttpOperation() throws IOException {
     return new AbfsJdkHttpOperation(url, method, requestHeaders,
         Duration.ofMillis(client.getAbfsConfiguration().getHttpConnectionTimeout()),
-        Duration.ofMillis(client.getAbfsConfiguration().getHttpReadTimeout()));
+        Duration.ofMillis(client.getAbfsConfiguration().getHttpReadTimeout()), client);
   }
 
   @VisibleForTesting
@@ -481,7 +504,7 @@ public class AbfsRestOperation {
     return new AbfsAHCHttpOperation(url, method, requestHeaders,
         Duration.ofMillis(client.getAbfsConfiguration().getHttpConnectionTimeout()),
         Duration.ofMillis(client.getAbfsConfiguration().getHttpReadTimeout()),
-        client.getAbfsApacheHttpClient());
+        client.getAbfsApacheHttpClient(), client);
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListingSupport.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListingSupport.java
@@ -75,7 +75,7 @@ public interface ListingSupport {
    *                     result.
    * @param continuation Contiuation token. null means start rom the begining.
    * @param tracingContext TracingContext instance to track identifiers
-   * @return Continuation tokem
+   * @return Continuation token
    * @throws IOException in case of error
    */
   String listStatus(Path path, String startFrom, List<FileStatus> fileStatuses,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/UriUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/UriUtils.java
@@ -182,7 +182,7 @@ public final class UriUtils {
    */
   public static URL changeUrlFromBlobToDfs(URL url) throws InvalidUriException {
     try {
-      url = new URL(url.toString().replace(ABFS_BLOB_DOMAIN_NAME, ABFS_DFS_DOMAIN_NAME));
+      url = new URL(replacedUrl(url.toString(), ABFS_BLOB_DOMAIN_NAME, ABFS_DFS_DOMAIN_NAME));
     } catch (MalformedURLException ex) {
       throw new InvalidUriException(url.toString());
     }
@@ -198,11 +198,36 @@ public final class UriUtils {
    */
   public static URL changeUrlFromDfsToBlob(URL url) throws InvalidUriException {
     try {
-      url = new URL(url.toString().replace(ABFS_DFS_DOMAIN_NAME, ABFS_BLOB_DOMAIN_NAME));
+      url = new URL(replacedUrl(url.toString(), ABFS_DFS_DOMAIN_NAME, ABFS_BLOB_DOMAIN_NAME));
     } catch (MalformedURLException ex) {
       throw new InvalidUriException(url.toString());
     }
     return url;
+  }
+
+  /**
+   * Replaces the oldString with newString in the baseUrl.
+   * It will extract the account url path to make sure we do not replace any
+   * matching string in blob path or any other part of url
+   * @param baseUrl the url to be updated.
+   * @param oldString the string to be replaced.
+   * @param newString the string to be replaced with.
+   * @return updated URL
+   */
+  private static String replacedUrl(String baseUrl, String oldString, String newString) {
+    int startIndex = baseUrl.toString().indexOf("//") + 2;
+    int endIndex = baseUrl.toString().indexOf("/", startIndex);
+    if (oldString == null || newString == null|| startIndex < 0
+        || endIndex > baseUrl.length() || startIndex > endIndex) {
+      throw new IllegalArgumentException("Invalid input or indices");
+    }
+    StringBuilder sb = new StringBuilder(baseUrl);
+    int targetIndex = sb.indexOf(oldString, startIndex);
+    if (targetIndex == -1 || targetIndex >= endIndex) {
+      return baseUrl; // target not found within the specified range
+    }
+    sb.replace(targetIndex, targetIndex + oldString.length(), newString);
+    return sb.toString();
   }
 
   private UriUtils() {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsClient.java
@@ -108,7 +108,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
           directory.toString(), false, getListMaxResults(), null,
           getTestTracingContext(getFileSystem(), true));
 
-      List<ListResultEntrySchema> list = op.getResult().getListResultSchema().paths();
+      List<? extends ListResultEntrySchema> list = op.getResult().getListResultSchema().paths();
       String continuationToken = op.getResult().getResponseHeader(HttpHeaderConfigurations.X_MS_CONTINUATION);
 
       if (continuationToken == null) {
@@ -143,7 +143,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
         directory.toString(), false, getListMaxResults(), null,
         getTestTracingContext(getFileSystem(), true));
 
-    List<ListResultEntrySchema> list = op.getResult().getListResultSchema().paths();
+    List<? extends ListResultEntrySchema> list = op.getResult().getListResultSchema().paths();
     String continuationToken = op.getResult().getResponseHeader(HttpHeaderConfigurations.X_MS_CONTINUATION);
 
     if (continuationToken == null) {
@@ -175,7 +175,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
     }
   }
 
-  private List<ListResultEntrySchema> listPath(String directory)
+  private List<? extends ListResultEntrySchema> listPath(String directory)
       throws IOException {
     return getFileSystem().getAbfsClient()
         .listPath(directory, false, getListMaxResults(), null,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
+import org.apache.hadoop.fs.azurebfs.contracts.services.StorageErrorResponseSchema;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClientTestUtil;
 import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
@@ -261,6 +262,9 @@ public class ITestAzureBlobFileSystemDelete extends
 
     // Case 2: Mimic retried case
     // Idempotency check on Delete always returns success
+    StorageErrorResponseSchema storageErrorResponse = new StorageErrorResponseSchema(
+        "NotFound", "NotFound", "NotFound");
+    Mockito.doReturn(storageErrorResponse).when(mockClient).processStorageErrorResponse(any());
     AbfsRestOperation idempotencyRetOp = Mockito.spy(ITestAbfsClient.getRestOp(
         DeletePath, mockClient, HTTP_METHOD_DELETE,
         ITestAbfsClient.getTestUrl(mockClient, "/NonExistingPath"),

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -40,6 +40,8 @@ import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations;
+import org.apache.hadoop.fs.azurebfs.contracts.services.DfsListResultEntrySchema;
+import org.apache.hadoop.fs.azurebfs.contracts.services.DfsListResultSchema;
 import org.apache.hadoop.fs.azurebfs.contracts.services.ListResultEntrySchema;
 import org.apache.hadoop.fs.azurebfs.contracts.services.ListResultSchema;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
@@ -133,18 +135,18 @@ public class ITestAzureBlobFileSystemListStatus extends
     AbfsClientTestUtil.setMockAbfsRestOperationForListPathOperation(spiedClient,
         (httpOperation) -> {
 
-          ListResultEntrySchema entry = new ListResultEntrySchema()
+          ListResultEntrySchema entry = new DfsListResultEntrySchema()
               .withName("a")
               .withIsDirectory(true);
           List<ListResultEntrySchema> paths = new ArrayList<>();
           paths.add(entry);
           paths.clear();
-          entry = new ListResultEntrySchema()
+          entry = new DfsListResultEntrySchema()
               .withName("abc.txt")
               .withIsDirectory(false);
           paths.add(entry);
-          ListResultSchema schema1 = new ListResultSchema().withPaths(paths);
-          ListResultSchema schema2 = new ListResultSchema().withPaths(paths);
+          ListResultSchema schema1 = new DfsListResultSchema().withPaths(paths);
+          ListResultSchema schema2 = new DfsListResultSchema().withPaths(paths);
 
           when(httpOperation.getListResultSchema()).thenReturn(schema1)
               .thenReturn(schema2);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/extensions/MockDelegationSASTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/extensions/MockDelegationSASTokenProvider.java
@@ -108,7 +108,7 @@ public class MockDelegationSASTokenProvider implements SASTokenProvider {
     requestBody.append("</Expiry></KeyInfo>");
 
     AbfsJdkHttpOperation op = new AbfsJdkHttpOperation(url, method, requestHeaders,
-        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT));
+        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT), null);
 
     byte[] requestBuffer = requestBody.toString().getBytes(StandardCharsets.UTF_8.toString());
     op.sendPayload(requestBuffer, 0, requestBuffer.length);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsPerfTracker.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsPerfTracker.java
@@ -77,7 +77,7 @@ public final class TestAbfsPerfTracker {
     try (AbfsPerfInfo tracker = new AbfsPerfInfo(abfsPerfTracker, "disablingCaller",
             "disablingCallee")) {
       AbfsJdkHttpOperation op = new AbfsJdkHttpOperation(url, "GET", new ArrayList<>(),
-          Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT));
+          Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT), null);
       tracker.registerResult(op).registerSuccess(true);
     }
 
@@ -96,7 +96,7 @@ public final class TestAbfsPerfTracker {
 
     List<Callable<Integer>> tasks = new ArrayList<>();
     AbfsJdkHttpOperation httpOperation = new AbfsJdkHttpOperation(url, "GET", new ArrayList<>(),
-        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT));
+        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT), null);
 
     for (int i = 0; i < numTasks; i++) {
       tasks.add(() -> {
@@ -136,7 +136,7 @@ public final class TestAbfsPerfTracker {
 
     List<Callable<Integer>> tasks = new ArrayList<>();
     AbfsJdkHttpOperation httpOperation = new AbfsJdkHttpOperation(url, "GET", new ArrayList<>(),
-        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT));
+        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT), null);
 
     for (int i = 0; i < numTasks; i++) {
       tasks.add(() -> {
@@ -176,7 +176,7 @@ public final class TestAbfsPerfTracker {
     AbfsPerfTracker abfsPerfTracker = new AbfsPerfTracker(accountName, filesystemName, false);
     List<Callable<Long>> tasks = new ArrayList<>();
     final AbfsJdkHttpOperation httpOperation = new AbfsJdkHttpOperation(url, "GET", new ArrayList<>(),
-        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT));
+        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT), null);
 
     for (int i = 0; i < numTasks; i++) {
       tasks.add(() -> {
@@ -212,7 +212,7 @@ public final class TestAbfsPerfTracker {
     AbfsPerfTracker abfsPerfTracker = new AbfsPerfTracker(accountName, filesystemName, false);
     List<Callable<Long>> tasks = new ArrayList<>();
     final AbfsJdkHttpOperation httpOperation = new AbfsJdkHttpOperation(url, "GET", new ArrayList<>(),
-        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT));
+        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT), null);
 
     for (int i = 0; i < numTasks; i++) {
       tasks.add(() -> {
@@ -277,7 +277,7 @@ public final class TestAbfsPerfTracker {
     AbfsPerfTracker abfsPerfTracker = new AbfsPerfTracker(accountName, filesystemName, true);
     List<Callable<Long>> tasks = new ArrayList<>();
     final AbfsJdkHttpOperation httpOperation = new AbfsJdkHttpOperation(url, "GET", new ArrayList<>(),
-        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT));
+        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT), null);
 
     for (int i = 0; i < numTasks; i++) {
       tasks.add(() -> {
@@ -312,7 +312,7 @@ public final class TestAbfsPerfTracker {
     AbfsPerfTracker abfsPerfTracker = new AbfsPerfTracker(accountName, filesystemName, true);
     List<Callable<Long>> tasks = new ArrayList<>();
     final AbfsJdkHttpOperation httpOperation = new AbfsJdkHttpOperation(url, "GET", new ArrayList<>(),
-        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT));
+        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT), null);
 
     for (int i = 0; i < numTasks; i++) {
       tasks.add(() -> {
@@ -373,7 +373,7 @@ public final class TestAbfsPerfTracker {
     AbfsPerfTracker abfsPerfTrackerDisabled = new AbfsPerfTracker(accountName, filesystemName, false);
     AbfsPerfTracker abfsPerfTrackerEnabled = new AbfsPerfTracker(accountName, filesystemName, true);
     final AbfsJdkHttpOperation httpOperation = new AbfsJdkHttpOperation(url, "GET", new ArrayList<AbfsHttpHeader>(),
-        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT));
+        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT), null);
 
     verifyNoException(abfsPerfTrackerDisabled);
     verifyNoException(abfsPerfTrackerEnabled);
@@ -382,7 +382,7 @@ public final class TestAbfsPerfTracker {
   private void verifyNoException(AbfsPerfTracker abfsPerfTracker) throws Exception {
     Instant testInstant = Instant.now();
     final AbfsJdkHttpOperation httpOperation = new AbfsJdkHttpOperation(url, "GET", new ArrayList<AbfsHttpHeader>(),
-        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT));
+        Duration.ofMillis(DEFAULT_HTTP_CONNECTION_TIMEOUT), Duration.ofMillis(DEFAULT_HTTP_READ_TIMEOUT), null);
 
     try (
             AbfsPerfInfo tracker01 = new AbfsPerfInfo(abfsPerfTracker, null, null);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TestUriUtils.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TestUriUtils.java
@@ -18,12 +18,14 @@
 
 package org.apache.hadoop.fs.azurebfs.utils;
 
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,6 +33,8 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicNameValuePair;
 
+import static org.apache.hadoop.fs.azurebfs.utils.UriUtils.changeUrlFromBlobToDfs;
+import static org.apache.hadoop.fs.azurebfs.utils.UriUtils.changeUrlFromDfsToBlob;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
@@ -131,5 +135,61 @@ public final class TestUriUtils {
         "abc=XXXXX&s=1&null1=&null2=", UriUtils
             .maskUrlQueryParameters(keyValueList, fullMask,
                 partialMask)); //no mask
+  }
+
+  @Test
+  public void testConvertUrlFromDfsToBlob() throws Exception{
+    List<String> inputUrls = Arrays.asList(
+        "https://accountName.dfs.core.windows.net/containerName",
+        "https://accountName.blob.core.windows.net/containerName", // Already blob will remain blob
+        "https:/accountName.dfs.core.windows.net/containerName", // Invalid URL will be returned as it is
+        "https://accountNamedfs.dfs.core.windows.net/containerName",
+        "https://accountNameblob.dfs.core.windows.net/containerName",
+        "https://accountName.dfs.core.windows.net/dfsContainer",
+        "https://accountName.dfs.core.windows.net/blobcontainerName",
+        "https://accountName.dfs.core.windows.net/dfs.Container",
+        "https://accountName.dfs.core.windows.net/blob.containerName");
+    List<String> expectedUrls = Arrays.asList(
+        "https://accountName.blob.core.windows.net/containerName",
+        "https://accountName.blob.core.windows.net/containerName", // Already blob will remain blob
+        "https:/accountName.dfs.core.windows.net/containerName", // Invalid URL will be returned as it is
+        "https://accountNamedfs.blob.core.windows.net/containerName",
+        "https://accountNameblob.blob.core.windows.net/containerName",
+        "https://accountName.blob.core.windows.net/dfsContainer",
+        "https://accountName.blob.core.windows.net/blobcontainerName",
+        "https://accountName.blob.core.windows.net/dfs.Container",
+        "https://accountName.blob.core.windows.net/blob.containerName");
+
+    for (int i = 0; i < inputUrls.size(); i++) {
+      Assertions.assertThat(changeUrlFromDfsToBlob(new URL(inputUrls.get(i))).toString())
+          .describedAs("URL conversion not as expected").isEqualTo(expectedUrls.get(i));
+    }
+  }
+
+  @Test
+  public void testConvertUrlFromBlobToDfs() throws Exception{
+    List<String> inputUrls = Arrays.asList(
+        "https://accountName.blob.core.windows.net/containerName",
+        "https://accountName.dfs.core.windows.net/containerName",
+        "https://accountNamedfs.blob.core.windows.net/containerName",
+        "https://accountNameblob.blob.core.windows.net/containerName",
+        "https://accountName.blob.core.windows.net/dfsContainer",
+        "https://accountName.blob.core.windows.net/blobcontainerName",
+        "https://accountName.blob.core.windows.net/dfs.Container",
+        "https://accountName.blob.core.windows.net/blob.containerName");
+    List<String> expectedUrls = Arrays.asList(
+        "https://accountName.dfs.core.windows.net/containerName",
+        "https://accountName.dfs.core.windows.net/containerName",
+        "https://accountNamedfs.dfs.core.windows.net/containerName",
+        "https://accountNameblob.dfs.core.windows.net/containerName",
+        "https://accountName.dfs.core.windows.net/dfsContainer",
+        "https://accountName.dfs.core.windows.net/blobcontainerName",
+        "https://accountName.dfs.core.windows.net/dfs.Container",
+        "https://accountName.dfs.core.windows.net/blob.containerName");
+
+    for (int i = 0; i < inputUrls.size(); i++) {
+      Assertions.assertThat(changeUrlFromBlobToDfs(new URL(inputUrls.get(i))).toString())
+          .describedAs("Url Conversion Not as Expected").isEqualTo(expectedUrls.get(i));
+    }
   }
 }


### PR DESCRIPTION
This is the third PR in the series of work done under Parent Jira: [HADOOP-19179](https://issues.apache.org/jira/browse/HADOOP-19179)
Jira for this Patch: https://issues.apache.org/jira/browse/HADOOP-19207
Scope of this task is to implement Blob Endpoint Rest APIs Response Handling.

### Original PR was merged to trunk and had enough bake time: https://github.com/apache/hadoop/pull/7210
Cherry-picked commit: https://github.com/apache/hadoop/commit/7e673584a12815dc1d3ef37feba5a4c615ac926b

### How was this patch tested?
Test suite was ran.
Results added below
