### PR TITLE
YARN-11753. Ensure NM is marked unhealthy if the ProcessBuilder reports an issue with the container-executor

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/LinuxContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/LinuxContainerExecutor.java
@@ -466,10 +466,12 @@ public class LinuxContainerExecutor extends ContainerExecutor {
       Throwable cause = e.getCause() != null ? e.getCause() : e;
       if (cause instanceof IOException) {
         IOException io = (IOException) cause;
-        if (io.getMessage().contains("No such file or directory")) {
+        String containerExecutorPath = getContainerExecutorExecutablePath(conf);
+        if (io.getMessage().contains("Cannot run program \"" +
+            containerExecutorPath + "\"")) {
           throw new ConfigurationException("Application " + appId + " initialization failed" +
               "(exitCode=" + exitCode + "). Container executor not found at "
-              + getContainerExecutorExecutablePath(conf), e);
+              + containerExecutorPath, e);
         }
       }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/LinuxContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/LinuxContainerExecutor.java
@@ -467,7 +467,7 @@ public class LinuxContainerExecutor extends ContainerExecutor {
       if (cause instanceof IOException) {
         IOException io = (IOException) cause;
         String containerExecutorPath = getContainerExecutorExecutablePath(conf);
-        if (io.getMessage().contains("Cannot run program \"" +
+        if (io.getMessage() != null && io.getMessage().contains("Cannot run program \"" +
             containerExecutorPath + "\"")) {
           throw new ConfigurationException("Application " + appId + " initialization failed" +
               "(exitCode=" + exitCode + "). Container executor not found at "

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestLinuxContainerExecutorWithMocks.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestLinuxContainerExecutorWithMocks.java
@@ -628,15 +628,17 @@ public class TestLinuxContainerExecutorWithMocks {
     when(context.getEnvironment()).thenReturn(env);
     Path workDir = new Path("/tmp");
 
+    LocalizerStartContext lsc = new LocalizerStartContext.Builder()
+        .setNmPrivateContainerTokens(nmPrivateCTokensPath)
+        .setNmAddr(address)
+        .setUser(appSubmitter)
+        .setAppId(appId.toString())
+        .setLocId("12345")
+        .setDirsHandler(dirService)
+        .build();
+
     try {
-      lce.startLocalizer(new LocalizerStartContext.Builder()
-          .setNmPrivateContainerTokens(nmPrivateCTokensPath)
-          .setNmAddr(address)
-          .setUser(appSubmitter)
-          .setAppId(appId.toString())
-          .setLocId("12345")
-          .setDirsHandler(dirService)
-          .build());
+      lce.startLocalizer(lsc);
       Assert.fail("startLocalizer should have thrown an exception");
     } catch (IOException e) {
       assertTrue("Unexpected exception " + e,
@@ -648,22 +650,14 @@ public class TestLinuxContainerExecutorWithMocks {
         LinuxContainerExecutor.ExitCode.INVALID_CONFIG_FILE.getExitCode(),
     };
 
-    for (int i = 0; i < exitCodesToThrow.length; i++) {
-      int exitCode = exitCodesToThrow[i];
+    for (int exitCode : exitCodesToThrow) {
       doThrow(new PrivilegedOperationException("invalid config", exitCode, null, null))
           .when(spyPrivilegedExecutor).executePrivilegedOperation(
               any(), any(PrivilegedOperation.class),
               any(), any(), anyBoolean(), anyBoolean());
 
       try {
-        lce.startLocalizer(new LocalizerStartContext.Builder()
-            .setNmPrivateContainerTokens(nmPrivateCTokensPath)
-            .setNmAddr(address)
-            .setUser(appSubmitter)
-            .setAppId(appId.toString())
-            .setLocId("12345")
-            .setDirsHandler(dirService)
-            .build());
+        lce.startLocalizer(lsc);
         Assert.fail("startLocalizer should have thrown a ConfigurationException");
       } catch (ConfigurationException e) {
         assertTrue("Unexpected exception " + e,
@@ -671,7 +665,8 @@ public class TestLinuxContainerExecutorWithMocks {
       }
     }
 
-    // Assert that we do catch an IOException thrown by the ProcessBuilder.start method as a misconfiguration
+    // Assert that we do catch an IOException thrown by the ProcessBuilder.start
+    // method as a misconfiguration
     String containerExecutorPath = lce.getContainerExecutorExecutablePath(conf);
     doThrow(new PrivilegedOperationException("IO error",
         new IOException("Cannot run program \""+ containerExecutorPath + "\"")))
@@ -680,14 +675,7 @@ public class TestLinuxContainerExecutorWithMocks {
             any(), any(), anyBoolean(), anyBoolean());
 
     try {
-      lce.startLocalizer(new LocalizerStartContext.Builder()
-          .setNmPrivateContainerTokens(nmPrivateCTokensPath)
-          .setNmAddr(address)
-          .setUser(appSubmitter)
-          .setAppId(appId.toString())
-          .setLocId("12345")
-          .setDirsHandler(dirService)
-          .build());
+      lce.startLocalizer(lsc);
       Assert.fail("startLocalizer should have thrown an ConfigurationException");
     } catch (ConfigurationException e) {
       assertTrue("Unexpected exception " + e,
@@ -702,14 +690,7 @@ public class TestLinuxContainerExecutorWithMocks {
             any(), any(), anyBoolean(), anyBoolean());
 
     try {
-      lce.startLocalizer(new LocalizerStartContext.Builder()
-          .setNmPrivateContainerTokens(nmPrivateCTokensPath)
-          .setNmAddr(address)
-          .setUser(appSubmitter)
-          .setAppId(appId.toString())
-          .setLocId("12345")
-          .setDirsHandler(dirService)
-          .build());
+      lce.startLocalizer(lsc);
       Assert.fail("startLocalizer should have thrown an IOException");
     } catch (ConfigurationException e) {
       Assert.fail("startLocalizer should not have thrown a ConfigurationException");


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The ProcessBuilder.start method has a specific error message if the launched executable has some issues. The code introduced in YARN-11709 should match for that message instead of a generic file is missing message:
```
    public Process start() throws IOException {
        // Must convert to array first -- a malicious user-supplied
        // list might try to circumvent the security check.
        String[] cmdarray = command.toArray(new String[command.size()]);
        cmdarray = cmdarray.clone();

        for (String arg : cmdarray)
            if (arg == null)
                throw new NullPointerException();
        // Throws IndexOutOfBoundsException if command is empty
        String prog = cmdarray[0];

        SecurityManager security = System.getSecurityManager();
        if (security != null)
            security.checkExec(prog);

        String dir = directory == null ? null : directory.toString();

        for (String s : cmdarray) {
            if (s.indexOf('\u0000') >= 0) {
                throw new IOException("invalid null character in command");
            }
        }

        try {
            return ProcessImpl.start(cmdarray,
                                     environment,
                                     dir,
                                     redirects,
                                     redirectErrorStream);
        } catch (IOException | IllegalArgumentException e) {
            String exceptionInfo = ": " + e.getMessage();
            Throwable cause = e;
            if ((e instanceof IOException) && security != null) {
                // Can not disclose the fail reason for read-protected files.
                try {
                    security.checkRead(prog);
                } catch (SecurityException se) {
                    exceptionInfo = "";
                    cause = se;
                }
            }
            // It's much easier for us to create a high-quality error
            // message than the low-level C code which found the problem.
            throw new IOException(
                "Cannot run program \"" + prog + "\""
                + (dir == null ? "" : " (in directory \"" + dir + "\")")
                + exceptionInfo,
                cause);
        }
    }
```


### How was this patch tested?
UTs, deployed on a cluster.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

