### PR TITLE
HADOOP-19389: Optimize shell -text command I/O with multi-byte read.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestTextCommand.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestTextCommand.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.fs.shell;
 
-import static org.junit.Assert.*;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_KEY;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -34,7 +34,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * This class tests the logic for displaying the binary formats supported
@@ -44,62 +47,253 @@ public class TestTextCommand {
   private static final File TEST_ROOT_DIR =
       GenericTestUtils.getTestDir("testText");
   private static final String AVRO_FILENAME =
-    new File(TEST_ROOT_DIR, "weather.avro").toURI().getPath();
+      new File(TEST_ROOT_DIR, "weather.avro").toURI().getPath();
   private static final String TEXT_FILENAME =
-    new File(TEST_ROOT_DIR, "testtextfile.txt").toURI().getPath();
+      new File(TEST_ROOT_DIR, "testtextfile.txt").toURI().getPath();
+  private static final String SEQUENCE_FILENAME =
+      new File(TEST_ROOT_DIR, "NonWritableSequenceFile").toURI().getPath();
 
   private static final String SEPARATOR = System.getProperty("line.separator");
+
+  private static final String AVRO_EXPECTED_OUTPUT =
+      "{\"station\":\"011990-99999\",\"time\":-619524000000,\"temp\":0}" + SEPARATOR
+      + "{\"station\":\"011990-99999\",\"time\":-619506000000,\"temp\":22}" + SEPARATOR
+      + "{\"station\":\"011990-99999\",\"time\":-619484400000,\"temp\":-11}" + SEPARATOR
+      + "{\"station\":\"012650-99999\",\"time\":-655531200000,\"temp\":111}" + SEPARATOR
+      + "{\"station\":\"012650-99999\",\"time\":-655509600000,\"temp\":78}" + SEPARATOR;
+
+  private static final String SEQUENCE_FILE_EXPECTED_OUTPUT =
+      "Key1\tValue1" + SEPARATOR + "Key2\tValue2" + SEPARATOR;
+
+  @Rule
+  public final Timeout testTimeout = new Timeout(30000);
 
   /**
    * Tests whether binary Avro data files are displayed correctly.
    */
-  @Test (timeout = 30000)
+  @Test
   public void testDisplayForAvroFiles() throws Exception {
-    String expectedOutput =
-        "{\"station\":\"011990-99999\",\"time\":-619524000000,\"temp\":0}" + SEPARATOR
-        + "{\"station\":\"011990-99999\",\"time\":-619506000000,\"temp\":22}" + SEPARATOR
-        + "{\"station\":\"011990-99999\",\"time\":-619484400000,\"temp\":-11}" + SEPARATOR
-        + "{\"station\":\"012650-99999\",\"time\":-655531200000,\"temp\":111}" + SEPARATOR
-        + "{\"station\":\"012650-99999\",\"time\":-655509600000,\"temp\":78}" + SEPARATOR;
-
     String output = readUsingTextCommand(AVRO_FILENAME,
                                          generateWeatherAvroBinaryData());
-    assertEquals(expectedOutput, output);
+    Assertions.assertThat(output).describedAs("output").isEqualTo(AVRO_EXPECTED_OUTPUT);
+  }
+
+  @Test
+  public void testDisplayForAvroFilesSmallMultiByteReads() throws Exception {
+    Configuration conf = new Configuration();
+    conf.setInt(IO_FILE_BUFFER_SIZE_KEY, 2);
+    createFile(AVRO_FILENAME, generateWeatherAvroBinaryData());
+    URI uri = new URI(AVRO_FILENAME);
+    String output = readUsingTextCommand(uri, conf);
+    Assertions.assertThat(output).describedAs("output").isEqualTo(AVRO_EXPECTED_OUTPUT);
+  }
+
+  @Test
+  public void testEmptyAvroFile() throws Exception {
+    String output = readUsingTextCommand(AVRO_FILENAME,
+                                         generateEmptyAvroBinaryData());
+    Assertions.assertThat(output).describedAs("output").isEmpty();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testAvroFileInputStreamNullBuffer() throws Exception {
+    createFile(AVRO_FILENAME, generateWeatherAvroBinaryData());
+    URI uri = new URI(AVRO_FILENAME);
+    Configuration conf = new Configuration();
+    try (InputStream is = getInputStream(uri, conf)) {
+      is.read(null, 0, 10);
+    }
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testAvroFileInputStreamNegativePosition() throws Exception {
+    createFile(AVRO_FILENAME, generateWeatherAvroBinaryData());
+    URI uri = new URI(AVRO_FILENAME);
+    Configuration conf = new Configuration();
+    try (InputStream is = getInputStream(uri, conf)) {
+      is.read(new byte[10], -1, 10);
+    }
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testAvroFileInputStreamTooLong() throws Exception {
+    createFile(AVRO_FILENAME, generateWeatherAvroBinaryData());
+    URI uri = new URI(AVRO_FILENAME);
+    Configuration conf = new Configuration();
+    try (InputStream is = getInputStream(uri, conf)) {
+      is.read(new byte[10], 0, 11);
+    }
+  }
+
+  @Test
+  public void testAvroFileInputStreamZeroLengthRead() throws Exception {
+    createFile(AVRO_FILENAME, generateWeatherAvroBinaryData());
+    URI uri = new URI(AVRO_FILENAME);
+    Configuration conf = new Configuration();
+    try (InputStream is = getInputStream(uri, conf)) {
+      Assertions.assertThat(is.read(new byte[10], 0, 0)).describedAs("bytes read").isEqualTo(0);
+    }
+  }
+
+  @Test
+  public void testAvroFileInputStreamConsistentEOF() throws Exception {
+    createFile(AVRO_FILENAME, generateWeatherAvroBinaryData());
+    URI uri = new URI(AVRO_FILENAME);
+    Configuration conf = new Configuration();
+    try (InputStream is = getInputStream(uri, conf)) {
+      inputStreamToString(is);
+      Assertions.assertThat(is.read()).describedAs("single byte EOF").isEqualTo(-1);
+      Assertions.assertThat(is.read(new byte[10], 0, 10)).describedAs("multi byte EOF")
+              .isEqualTo(-1);
+    }
+  }
+
+  @Test
+  public void testAvroFileInputStreamSingleAndMultiByteReads() throws Exception {
+    createFile(AVRO_FILENAME, generateWeatherAvroBinaryData());
+    URI uri = new URI(AVRO_FILENAME);
+    Configuration conf = new Configuration();
+    try (InputStream is1 = getInputStream(uri, conf);
+        InputStream is2 = getInputStream(uri, conf)) {
+      String multiByteReads = inputStreamToString(is1);
+      String singleByteReads = inputStreamSingleByteReadsToString(is2);
+      Assertions.assertThat(multiByteReads)
+          .describedAs("same bytes read from multi and single byte reads")
+          .isEqualTo(singleByteReads);
+    }
   }
 
   /**
    * Tests that a zero-length file is displayed correctly.
    */
-  @Test (timeout = 30000)
-  public void testEmptyTextFil() throws Exception {
-    byte[] emptyContents = { };
+  @Test
+  public void testEmptyTextFile() throws Exception {
+    byte[] emptyContents = {};
     String output = readUsingTextCommand(TEXT_FILENAME, emptyContents);
-    assertTrue("".equals(output));
+    Assertions.assertThat(output).describedAs("output").isEmpty();
   }
 
   /**
    * Tests that a one-byte file is displayed correctly.
    */
-  @Test (timeout = 30000)
-  public void testOneByteTextFil() throws Exception {
-    byte[] oneByteContents = { 'x' };
+  @Test
+  public void testOneByteTextFile() throws Exception {
+    byte[] oneByteContents = {'x'};
     String output = readUsingTextCommand(TEXT_FILENAME, oneByteContents);
-    assertTrue(new String(oneByteContents).equals(output));
+    String expected = new String(oneByteContents, StandardCharsets.UTF_8);
+    Assertions.assertThat(output).describedAs("output").isEqualTo(expected);
   }
 
   /**
-   * Tests that a one-byte file is displayed correctly.
+   * Tests that a two-byte file is displayed correctly.
    */
-  @Test (timeout = 30000)
-  public void testTwoByteTextFil() throws Exception {
-    byte[] twoByteContents = { 'x', 'y' };
+  @Test
+  public void testTwoByteTextFile() throws Exception {
+    byte[] twoByteContents = {'x', 'y'};
     String output = readUsingTextCommand(TEXT_FILENAME, twoByteContents);
-    assertTrue(new String(twoByteContents).equals(output));
+    String expected = new String(twoByteContents, StandardCharsets.UTF_8);
+    Assertions.assertThat(output).describedAs("output").isEqualTo(expected);
+  }
+
+  @Test
+  public void testDisplayForNonWritableSequenceFile() throws Exception {
+    Configuration conf = new Configuration();
+    createNonWritableSequenceFile(SEQUENCE_FILENAME, conf);
+    URI uri = new URI(SEQUENCE_FILENAME);
+    String output = readUsingTextCommand(uri, conf);
+    Assertions.assertThat(output).describedAs("output").isEqualTo(SEQUENCE_FILE_EXPECTED_OUTPUT);
+  }
+
+  @Test
+  public void testDisplayForSequenceFileSmallMultiByteReads() throws Exception {
+    Configuration conf = new Configuration();
+    conf.setInt(IO_FILE_BUFFER_SIZE_KEY, 2);
+    createNonWritableSequenceFile(SEQUENCE_FILENAME, conf);
+    URI uri = new URI(SEQUENCE_FILENAME);
+    String output = readUsingTextCommand(uri, conf);
+    Assertions.assertThat(output).describedAs("output").isEqualTo(SEQUENCE_FILE_EXPECTED_OUTPUT);
+  }
+
+  @Test
+  public void testEmptySequenceFile() throws Exception {
+    Configuration conf = new Configuration();
+    createEmptySequenceFile(SEQUENCE_FILENAME, conf);
+    URI uri = new URI(SEQUENCE_FILENAME);
+    String output = readUsingTextCommand(uri, conf);
+    Assertions.assertThat(output).describedAs("output").isEmpty();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testSequenceFileInputStreamNullBuffer() throws Exception {
+    Configuration conf = new Configuration();
+    createNonWritableSequenceFile(SEQUENCE_FILENAME, conf);
+    URI uri = new URI(SEQUENCE_FILENAME);
+    try (InputStream is = getInputStream(uri, conf)) {
+      is.read(null, 0, 10);
+    }
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testSequenceFileInputStreamNegativePosition() throws Exception {
+    Configuration conf = new Configuration();
+    createNonWritableSequenceFile(SEQUENCE_FILENAME, conf);
+    URI uri = new URI(SEQUENCE_FILENAME);
+    try (InputStream is = getInputStream(uri, conf)) {
+      is.read(new byte[10], -1, 10);
+    }
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testSequenceFileInputStreamTooLong() throws Exception {
+    Configuration conf = new Configuration();
+    createNonWritableSequenceFile(SEQUENCE_FILENAME, conf);
+    URI uri = new URI(SEQUENCE_FILENAME);
+    try (InputStream is = getInputStream(uri, conf)) {
+      is.read(new byte[10], 0, 11);
+    }
+  }
+
+  @Test
+  public void testSequenceFileInputStreamZeroLengthRead() throws Exception {
+    Configuration conf = new Configuration();
+    createNonWritableSequenceFile(SEQUENCE_FILENAME, conf);
+    URI uri = new URI(SEQUENCE_FILENAME);
+    try (InputStream is = getInputStream(uri, conf)) {
+      Assertions.assertThat(is.read(new byte[10], 0, 0)).describedAs("bytes read").isEqualTo(0);
+    }
+  }
+
+  @Test
+  public void testSequenceFileInputStreamConsistentEOF() throws Exception {
+    Configuration conf = new Configuration();
+    createNonWritableSequenceFile(SEQUENCE_FILENAME, conf);
+    URI uri = new URI(SEQUENCE_FILENAME);
+    try (InputStream is = getInputStream(uri, conf)) {
+      inputStreamToString(is);
+      Assertions.assertThat(is.read()).describedAs("single byte EOF").isEqualTo(-1);
+      Assertions.assertThat(is.read(new byte[10], 0, 10)).describedAs("multi byte EOF")
+              .isEqualTo(-1);
+    }
+  }
+
+  @Test
+  public void testSequenceFileInputStreamSingleAndMultiByteReads() throws Exception {
+    Configuration conf = new Configuration();
+    createNonWritableSequenceFile(SEQUENCE_FILENAME, conf);
+    URI uri = new URI(SEQUENCE_FILENAME);
+    try (InputStream is1 = getInputStream(uri, conf);
+        InputStream is2 = getInputStream(uri, conf)) {
+      String multiByteReads = inputStreamToString(is1);
+      String singleByteReads = inputStreamSingleByteReadsToString(is2);
+      Assertions.assertThat(multiByteReads)
+          .describedAs("same bytes read from multi and single byte reads")
+          .isEqualTo(singleByteReads);
+    }
   }
 
   // Create a file on the local file system and read it using
   // the Display.Text class.
-  private String readUsingTextCommand(String fileName, byte[] fileContents)
+  private static String readUsingTextCommand(String fileName, byte[] fileContents)
           throws Exception {
     createFile(fileName, fileContents);
 
@@ -108,29 +302,27 @@ public class TestTextCommand {
     return readUsingTextCommand(localPath, conf);
   }
   // Read a file using Display.Text class.
-  private String readUsingTextCommand(URI uri, Configuration conf)
+  private static String readUsingTextCommand(URI uri, Configuration conf)
       throws Exception {
-    // Prepare and call the Text command's protected getInputStream method
-    // using reflection.
-    PathData pathData = new PathData(uri, conf);
-    Display.Text text = new Display.Text() {
-      @Override
-      public InputStream getInputStream(PathData item) throws IOException {
-        return super.getInputStream(item);
-      }
-    };
-    text.setConf(conf);
-    InputStream stream = text.getInputStream(pathData);
+    InputStream stream = getInputStream(uri, conf);
     return inputStreamToString(stream);
   }
 
-  private String inputStreamToString(InputStream stream) throws IOException {
+  private static String inputStreamToString(InputStream stream) throws IOException {
     StringWriter writer = new StringWriter();
     IOUtils.copy(stream, writer, StandardCharsets.UTF_8);
     return writer.toString();
   }
 
-  private void createFile(String fileName, byte[] contents) throws IOException {
+  private static String inputStreamSingleByteReadsToString(InputStream stream) throws IOException {
+    StringWriter writer = new StringWriter();
+    for (int b = stream.read(); b != -1; b = stream.read()) {
+      writer.write(b);
+    }
+    return writer.toString();
+  }
+
+  private static void createFile(String fileName, byte[] contents) throws IOException {
     Files.createDirectories(TEST_ROOT_DIR.toPath());
     File file = new File(fileName);
     file.createNewFile();
@@ -139,118 +331,207 @@ public class TestTextCommand {
     stream.close();
   }
 
-  private byte[] generateWeatherAvroBinaryData() {
+  private static byte[] generateWeatherAvroBinaryData() {
     // The contents of a simple binary Avro file with weather records.
     byte[] contents = {
-      (byte) 0x4f, (byte) 0x62, (byte) 0x6a, (byte)  0x1,
-      (byte)  0x4, (byte) 0x14, (byte) 0x61, (byte) 0x76,
-      (byte) 0x72, (byte) 0x6f, (byte) 0x2e, (byte) 0x63,
-      (byte) 0x6f, (byte) 0x64, (byte) 0x65, (byte) 0x63,
-      (byte)  0x8, (byte) 0x6e, (byte) 0x75, (byte) 0x6c,
-      (byte) 0x6c, (byte) 0x16, (byte) 0x61, (byte) 0x76,
-      (byte) 0x72, (byte) 0x6f, (byte) 0x2e, (byte) 0x73,
-      (byte) 0x63, (byte) 0x68, (byte) 0x65, (byte) 0x6d,
-      (byte) 0x61, (byte) 0xf2, (byte)  0x2, (byte) 0x7b,
-      (byte) 0x22, (byte) 0x74, (byte) 0x79, (byte) 0x70,
-      (byte) 0x65, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
-      (byte) 0x72, (byte) 0x65, (byte) 0x63, (byte) 0x6f,
-      (byte) 0x72, (byte) 0x64, (byte) 0x22, (byte) 0x2c,
-      (byte) 0x22, (byte) 0x6e, (byte) 0x61, (byte) 0x6d,
-      (byte) 0x65, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
-      (byte) 0x57, (byte) 0x65, (byte) 0x61, (byte) 0x74,
-      (byte) 0x68, (byte) 0x65, (byte) 0x72, (byte) 0x22,
-      (byte) 0x2c, (byte) 0x22, (byte) 0x6e, (byte) 0x61,
-      (byte) 0x6d, (byte) 0x65, (byte) 0x73, (byte) 0x70,
-      (byte) 0x61, (byte) 0x63, (byte) 0x65, (byte) 0x22,
-      (byte) 0x3a, (byte) 0x22, (byte) 0x74, (byte) 0x65,
-      (byte) 0x73, (byte) 0x74, (byte) 0x22, (byte) 0x2c,
-      (byte) 0x22, (byte) 0x66, (byte) 0x69, (byte) 0x65,
-      (byte) 0x6c, (byte) 0x64, (byte) 0x73, (byte) 0x22,
-      (byte) 0x3a, (byte) 0x5b, (byte) 0x7b, (byte) 0x22,
-      (byte) 0x6e, (byte) 0x61, (byte) 0x6d, (byte) 0x65,
-      (byte) 0x22, (byte) 0x3a, (byte) 0x22, (byte) 0x73,
-      (byte) 0x74, (byte) 0x61, (byte) 0x74, (byte) 0x69,
-      (byte) 0x6f, (byte) 0x6e, (byte) 0x22, (byte) 0x2c,
-      (byte) 0x22, (byte) 0x74, (byte) 0x79, (byte) 0x70,
-      (byte) 0x65, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
-      (byte) 0x73, (byte) 0x74, (byte) 0x72, (byte) 0x69,
-      (byte) 0x6e, (byte) 0x67, (byte) 0x22, (byte) 0x7d,
-      (byte) 0x2c, (byte) 0x7b, (byte) 0x22, (byte) 0x6e,
-      (byte) 0x61, (byte) 0x6d, (byte) 0x65, (byte) 0x22,
-      (byte) 0x3a, (byte) 0x22, (byte) 0x74, (byte) 0x69,
-      (byte) 0x6d, (byte) 0x65, (byte) 0x22, (byte) 0x2c,
-      (byte) 0x22, (byte) 0x74, (byte) 0x79, (byte) 0x70,
-      (byte) 0x65, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
-      (byte) 0x6c, (byte) 0x6f, (byte) 0x6e, (byte) 0x67,
-      (byte) 0x22, (byte) 0x7d, (byte) 0x2c, (byte) 0x7b,
-      (byte) 0x22, (byte) 0x6e, (byte) 0x61, (byte) 0x6d,
-      (byte) 0x65, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
-      (byte) 0x74, (byte) 0x65, (byte) 0x6d, (byte) 0x70,
-      (byte) 0x22, (byte) 0x2c, (byte) 0x22, (byte) 0x74,
-      (byte) 0x79, (byte) 0x70, (byte) 0x65, (byte) 0x22,
-      (byte) 0x3a, (byte) 0x22, (byte) 0x69, (byte) 0x6e,
-      (byte) 0x74, (byte) 0x22, (byte) 0x7d, (byte) 0x5d,
-      (byte) 0x2c, (byte) 0x22, (byte) 0x64, (byte) 0x6f,
-      (byte) 0x63, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
-      (byte) 0x41, (byte) 0x20, (byte) 0x77, (byte) 0x65,
-      (byte) 0x61, (byte) 0x74, (byte) 0x68, (byte) 0x65,
-      (byte) 0x72, (byte) 0x20, (byte) 0x72, (byte) 0x65,
-      (byte) 0x61, (byte) 0x64, (byte) 0x69, (byte) 0x6e,
-      (byte) 0x67, (byte) 0x2e, (byte) 0x22, (byte) 0x7d,
-      (byte)  0x0, (byte) 0xb0, (byte) 0x81, (byte) 0xb3,
-      (byte) 0xc4, (byte)  0xa, (byte)  0xc, (byte) 0xf6,
-      (byte) 0x62, (byte) 0xfa, (byte) 0xc9, (byte) 0x38,
-      (byte) 0xfd, (byte) 0x7e, (byte) 0x52, (byte)  0x0,
-      (byte) 0xa7, (byte)  0xa, (byte) 0xcc, (byte)  0x1,
-      (byte) 0x18, (byte) 0x30, (byte) 0x31, (byte) 0x31,
-      (byte) 0x39, (byte) 0x39, (byte) 0x30, (byte) 0x2d,
-      (byte) 0x39, (byte) 0x39, (byte) 0x39, (byte) 0x39,
-      (byte) 0x39, (byte) 0xff, (byte) 0xa3, (byte) 0x90,
-      (byte) 0xe8, (byte) 0x87, (byte) 0x24, (byte)  0x0,
-      (byte) 0x18, (byte) 0x30, (byte) 0x31, (byte) 0x31,
-      (byte) 0x39, (byte) 0x39, (byte) 0x30, (byte) 0x2d,
-      (byte) 0x39, (byte) 0x39, (byte) 0x39, (byte) 0x39,
-      (byte) 0x39, (byte) 0xff, (byte) 0x81, (byte) 0xfb,
-      (byte) 0xd6, (byte) 0x87, (byte) 0x24, (byte) 0x2c,
-      (byte) 0x18, (byte) 0x30, (byte) 0x31, (byte) 0x31,
-      (byte) 0x39, (byte) 0x39, (byte) 0x30, (byte) 0x2d,
-      (byte) 0x39, (byte) 0x39, (byte) 0x39, (byte) 0x39,
-      (byte) 0x39, (byte) 0xff, (byte) 0xa5, (byte) 0xae,
-      (byte) 0xc2, (byte) 0x87, (byte) 0x24, (byte) 0x15,
-      (byte) 0x18, (byte) 0x30, (byte) 0x31, (byte) 0x32,
-      (byte) 0x36, (byte) 0x35, (byte) 0x30, (byte) 0x2d,
-      (byte) 0x39, (byte) 0x39, (byte) 0x39, (byte) 0x39,
-      (byte) 0x39, (byte) 0xff, (byte) 0xb7, (byte) 0xa2,
-      (byte) 0x8b, (byte) 0x94, (byte) 0x26, (byte) 0xde,
-      (byte)  0x1, (byte) 0x18, (byte) 0x30, (byte) 0x31,
-      (byte) 0x32, (byte) 0x36, (byte) 0x35, (byte) 0x30,
-      (byte) 0x2d, (byte) 0x39, (byte) 0x39, (byte) 0x39,
-      (byte) 0x39, (byte) 0x39, (byte) 0xff, (byte) 0xdb,
-      (byte) 0xd5, (byte) 0xf6, (byte) 0x93, (byte) 0x26,
-      (byte) 0x9c, (byte)  0x1, (byte) 0xb0, (byte) 0x81,
-      (byte) 0xb3, (byte) 0xc4, (byte)  0xa, (byte)  0xc,
-      (byte) 0xf6, (byte) 0x62, (byte) 0xfa, (byte) 0xc9,
-      (byte) 0x38, (byte) 0xfd, (byte) 0x7e, (byte) 0x52,
-      (byte)  0x0, (byte) 0xa7,
+        (byte) 0x4f, (byte) 0x62, (byte) 0x6a, (byte)  0x1,
+        (byte)  0x4, (byte) 0x14, (byte) 0x61, (byte) 0x76,
+        (byte) 0x72, (byte) 0x6f, (byte) 0x2e, (byte) 0x63,
+        (byte) 0x6f, (byte) 0x64, (byte) 0x65, (byte) 0x63,
+        (byte)  0x8, (byte) 0x6e, (byte) 0x75, (byte) 0x6c,
+        (byte) 0x6c, (byte) 0x16, (byte) 0x61, (byte) 0x76,
+        (byte) 0x72, (byte) 0x6f, (byte) 0x2e, (byte) 0x73,
+        (byte) 0x63, (byte) 0x68, (byte) 0x65, (byte) 0x6d,
+        (byte) 0x61, (byte) 0xf2, (byte)  0x2, (byte) 0x7b,
+        (byte) 0x22, (byte) 0x74, (byte) 0x79, (byte) 0x70,
+        (byte) 0x65, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
+        (byte) 0x72, (byte) 0x65, (byte) 0x63, (byte) 0x6f,
+        (byte) 0x72, (byte) 0x64, (byte) 0x22, (byte) 0x2c,
+        (byte) 0x22, (byte) 0x6e, (byte) 0x61, (byte) 0x6d,
+        (byte) 0x65, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
+        (byte) 0x57, (byte) 0x65, (byte) 0x61, (byte) 0x74,
+        (byte) 0x68, (byte) 0x65, (byte) 0x72, (byte) 0x22,
+        (byte) 0x2c, (byte) 0x22, (byte) 0x6e, (byte) 0x61,
+        (byte) 0x6d, (byte) 0x65, (byte) 0x73, (byte) 0x70,
+        (byte) 0x61, (byte) 0x63, (byte) 0x65, (byte) 0x22,
+        (byte) 0x3a, (byte) 0x22, (byte) 0x74, (byte) 0x65,
+        (byte) 0x73, (byte) 0x74, (byte) 0x22, (byte) 0x2c,
+        (byte) 0x22, (byte) 0x66, (byte) 0x69, (byte) 0x65,
+        (byte) 0x6c, (byte) 0x64, (byte) 0x73, (byte) 0x22,
+        (byte) 0x3a, (byte) 0x5b, (byte) 0x7b, (byte) 0x22,
+        (byte) 0x6e, (byte) 0x61, (byte) 0x6d, (byte) 0x65,
+        (byte) 0x22, (byte) 0x3a, (byte) 0x22, (byte) 0x73,
+        (byte) 0x74, (byte) 0x61, (byte) 0x74, (byte) 0x69,
+        (byte) 0x6f, (byte) 0x6e, (byte) 0x22, (byte) 0x2c,
+        (byte) 0x22, (byte) 0x74, (byte) 0x79, (byte) 0x70,
+        (byte) 0x65, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
+        (byte) 0x73, (byte) 0x74, (byte) 0x72, (byte) 0x69,
+        (byte) 0x6e, (byte) 0x67, (byte) 0x22, (byte) 0x7d,
+        (byte) 0x2c, (byte) 0x7b, (byte) 0x22, (byte) 0x6e,
+        (byte) 0x61, (byte) 0x6d, (byte) 0x65, (byte) 0x22,
+        (byte) 0x3a, (byte) 0x22, (byte) 0x74, (byte) 0x69,
+        (byte) 0x6d, (byte) 0x65, (byte) 0x22, (byte) 0x2c,
+        (byte) 0x22, (byte) 0x74, (byte) 0x79, (byte) 0x70,
+        (byte) 0x65, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
+        (byte) 0x6c, (byte) 0x6f, (byte) 0x6e, (byte) 0x67,
+        (byte) 0x22, (byte) 0x7d, (byte) 0x2c, (byte) 0x7b,
+        (byte) 0x22, (byte) 0x6e, (byte) 0x61, (byte) 0x6d,
+        (byte) 0x65, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
+        (byte) 0x74, (byte) 0x65, (byte) 0x6d, (byte) 0x70,
+        (byte) 0x22, (byte) 0x2c, (byte) 0x22, (byte) 0x74,
+        (byte) 0x79, (byte) 0x70, (byte) 0x65, (byte) 0x22,
+        (byte) 0x3a, (byte) 0x22, (byte) 0x69, (byte) 0x6e,
+        (byte) 0x74, (byte) 0x22, (byte) 0x7d, (byte) 0x5d,
+        (byte) 0x2c, (byte) 0x22, (byte) 0x64, (byte) 0x6f,
+        (byte) 0x63, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
+        (byte) 0x41, (byte) 0x20, (byte) 0x77, (byte) 0x65,
+        (byte) 0x61, (byte) 0x74, (byte) 0x68, (byte) 0x65,
+        (byte) 0x72, (byte) 0x20, (byte) 0x72, (byte) 0x65,
+        (byte) 0x61, (byte) 0x64, (byte) 0x69, (byte) 0x6e,
+        (byte) 0x67, (byte) 0x2e, (byte) 0x22, (byte) 0x7d,
+        (byte)  0x0, (byte) 0xb0, (byte) 0x81, (byte) 0xb3,
+        (byte) 0xc4, (byte)  0xa, (byte)  0xc, (byte) 0xf6,
+        (byte) 0x62, (byte) 0xfa, (byte) 0xc9, (byte) 0x38,
+        (byte) 0xfd, (byte) 0x7e, (byte) 0x52, (byte)  0x0,
+        (byte) 0xa7, (byte)  0xa, (byte) 0xcc, (byte)  0x1,
+        (byte) 0x18, (byte) 0x30, (byte) 0x31, (byte) 0x31,
+        (byte) 0x39, (byte) 0x39, (byte) 0x30, (byte) 0x2d,
+        (byte) 0x39, (byte) 0x39, (byte) 0x39, (byte) 0x39,
+        (byte) 0x39, (byte) 0xff, (byte) 0xa3, (byte) 0x90,
+        (byte) 0xe8, (byte) 0x87, (byte) 0x24, (byte)  0x0,
+        (byte) 0x18, (byte) 0x30, (byte) 0x31, (byte) 0x31,
+        (byte) 0x39, (byte) 0x39, (byte) 0x30, (byte) 0x2d,
+        (byte) 0x39, (byte) 0x39, (byte) 0x39, (byte) 0x39,
+        (byte) 0x39, (byte) 0xff, (byte) 0x81, (byte) 0xfb,
+        (byte) 0xd6, (byte) 0x87, (byte) 0x24, (byte) 0x2c,
+        (byte) 0x18, (byte) 0x30, (byte) 0x31, (byte) 0x31,
+        (byte) 0x39, (byte) 0x39, (byte) 0x30, (byte) 0x2d,
+        (byte) 0x39, (byte) 0x39, (byte) 0x39, (byte) 0x39,
+        (byte) 0x39, (byte) 0xff, (byte) 0xa5, (byte) 0xae,
+        (byte) 0xc2, (byte) 0x87, (byte) 0x24, (byte) 0x15,
+        (byte) 0x18, (byte) 0x30, (byte) 0x31, (byte) 0x32,
+        (byte) 0x36, (byte) 0x35, (byte) 0x30, (byte) 0x2d,
+        (byte) 0x39, (byte) 0x39, (byte) 0x39, (byte) 0x39,
+        (byte) 0x39, (byte) 0xff, (byte) 0xb7, (byte) 0xa2,
+        (byte) 0x8b, (byte) 0x94, (byte) 0x26, (byte) 0xde,
+        (byte)  0x1, (byte) 0x18, (byte) 0x30, (byte) 0x31,
+        (byte) 0x32, (byte) 0x36, (byte) 0x35, (byte) 0x30,
+        (byte) 0x2d, (byte) 0x39, (byte) 0x39, (byte) 0x39,
+        (byte) 0x39, (byte) 0x39, (byte) 0xff, (byte) 0xdb,
+        (byte) 0xd5, (byte) 0xf6, (byte) 0x93, (byte) 0x26,
+        (byte) 0x9c, (byte)  0x1, (byte) 0xb0, (byte) 0x81,
+        (byte) 0xb3, (byte) 0xc4, (byte)  0xa, (byte)  0xc,
+        (byte) 0xf6, (byte) 0x62, (byte) 0xfa, (byte) 0xc9,
+        (byte) 0x38, (byte) 0xfd, (byte) 0x7e, (byte) 0x52,
+        (byte)  0x0, (byte) 0xa7,
     };
 
     return contents;
   }
 
-  @Test
-  public void testDisplayForNonWritableSequenceFile() throws Exception {
-    Configuration conf = new Configuration();
+  private static byte[] generateEmptyAvroBinaryData() {
+    // The binary contents of an empty Avro file (no records).
+    byte[] contents = new byte[] {
+        (byte) 0x4f, (byte) 0x62, (byte) 0x6a, (byte) 0x01,
+        (byte) 0x04, (byte) 0x16, (byte) 0x61, (byte) 0x76,
+        (byte) 0x72, (byte) 0x6f, (byte) 0x2e, (byte) 0x73,
+        (byte) 0x63, (byte) 0x68, (byte) 0x65, (byte) 0x6d,
+        (byte) 0x61, (byte) 0x92, (byte) 0x03, (byte) 0x7b,
+        (byte) 0x22, (byte) 0x74, (byte) 0x79, (byte) 0x70,
+        (byte) 0x65, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
+        (byte) 0x72, (byte) 0x65, (byte) 0x63, (byte) 0x6f,
+        (byte) 0x72, (byte) 0x64, (byte) 0x22, (byte) 0x2c,
+        (byte) 0x22, (byte) 0x6e, (byte) 0x61, (byte) 0x6d,
+        (byte) 0x65, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
+        (byte) 0x55, (byte) 0x73, (byte) 0x65, (byte) 0x72,
+        (byte) 0x22, (byte) 0x2c, (byte) 0x22, (byte) 0x6e,
+        (byte) 0x61, (byte) 0x6d, (byte) 0x65, (byte) 0x73,
+        (byte) 0x70, (byte) 0x61, (byte) 0x63, (byte) 0x65,
+        (byte) 0x22, (byte) 0x3a, (byte) 0x22, (byte) 0x65,
+        (byte) 0x78, (byte) 0x61, (byte) 0x6d, (byte) 0x70,
+        (byte) 0x6c, (byte) 0x65, (byte) 0x2e, (byte) 0x61,
+        (byte) 0x76, (byte) 0x72, (byte) 0x6f, (byte) 0x22,
+        (byte) 0x2c, (byte) 0x22, (byte) 0x66, (byte) 0x69,
+        (byte) 0x65, (byte) 0x6c, (byte) 0x64, (byte) 0x73,
+        (byte) 0x22, (byte) 0x3a, (byte) 0x5b, (byte) 0x7b,
+        (byte) 0x22, (byte) 0x6e, (byte) 0x61, (byte) 0x6d,
+        (byte) 0x65, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
+        (byte) 0x6e, (byte) 0x61, (byte) 0x6d, (byte) 0x65,
+        (byte) 0x22, (byte) 0x2c, (byte) 0x22, (byte) 0x74,
+        (byte) 0x79, (byte) 0x70, (byte) 0x65, (byte) 0x22,
+        (byte) 0x3a, (byte) 0x22, (byte) 0x73, (byte) 0x74,
+        (byte) 0x72, (byte) 0x69, (byte) 0x6e, (byte) 0x67,
+        (byte) 0x22, (byte) 0x7d, (byte) 0x2c, (byte) 0x7b,
+        (byte) 0x22, (byte) 0x6e, (byte) 0x61, (byte) 0x6d,
+        (byte) 0x65, (byte) 0x22, (byte) 0x3a, (byte) 0x22,
+        (byte) 0x66, (byte) 0x61, (byte) 0x76, (byte) 0x6f,
+        (byte) 0x72, (byte) 0x69, (byte) 0x74, (byte) 0x65,
+        (byte) 0x5f, (byte) 0x6e, (byte) 0x75, (byte) 0x6d,
+        (byte) 0x62, (byte) 0x65, (byte) 0x72, (byte) 0x22,
+        (byte) 0x2c, (byte) 0x22, (byte) 0x74, (byte) 0x79,
+        (byte) 0x70, (byte) 0x65, (byte) 0x22, (byte) 0x3a,
+        (byte) 0x5b, (byte) 0x22, (byte) 0x69, (byte) 0x6e,
+        (byte) 0x74, (byte) 0x22, (byte) 0x2c, (byte) 0x22,
+        (byte) 0x6e, (byte) 0x75, (byte) 0x6c, (byte) 0x6c,
+        (byte) 0x22, (byte) 0x5d, (byte) 0x7d, (byte) 0x2c,
+        (byte) 0x7b, (byte) 0x22, (byte) 0x6e, (byte) 0x61,
+        (byte) 0x6d, (byte) 0x65, (byte) 0x22, (byte) 0x3a,
+        (byte) 0x22, (byte) 0x66, (byte) 0x61, (byte) 0x76,
+        (byte) 0x6f, (byte) 0x72, (byte) 0x69, (byte) 0x74,
+        (byte) 0x65, (byte) 0x5f, (byte) 0x63, (byte) 0x6f,
+        (byte) 0x6c, (byte) 0x6f, (byte) 0x72, (byte) 0x22,
+        (byte) 0x2c, (byte) 0x22, (byte) 0x74, (byte) 0x79,
+        (byte) 0x70, (byte) 0x65, (byte) 0x22, (byte) 0x3a,
+        (byte) 0x5b, (byte) 0x22, (byte) 0x73, (byte) 0x74,
+        (byte) 0x72, (byte) 0x69, (byte) 0x6e, (byte) 0x67,
+        (byte) 0x22, (byte) 0x2c, (byte) 0x22, (byte) 0x6e,
+        (byte) 0x75, (byte) 0x6c, (byte) 0x6c, (byte) 0x22,
+        (byte) 0x5d, (byte) 0x7d, (byte) 0x5d, (byte) 0x7d,
+        (byte) 0x14, (byte) 0x61, (byte) 0x76, (byte) 0x72,
+        (byte) 0x6f, (byte) 0x2e, (byte) 0x63, (byte) 0x6f,
+        (byte) 0x64, (byte) 0x65, (byte) 0x63, (byte) 0x0e,
+        (byte) 0x64, (byte) 0x65, (byte) 0x66, (byte) 0x6c,
+        (byte) 0x61, (byte) 0x74, (byte) 0x65, (byte) 0x00,
+        (byte) 0xed, (byte) 0xe0, (byte) 0xfa, (byte) 0x87,
+        (byte) 0x3c, (byte) 0x86, (byte) 0xf5, (byte) 0x5f,
+        (byte) 0x7d, (byte) 0x8d, (byte) 0x2f, (byte) 0xdb,
+        (byte) 0xc7, (byte) 0xe3, (byte) 0x11, (byte) 0x39,
+    };
+
+    return contents;
+  }
+
+  private static void createEmptySequenceFile(String fileName, Configuration conf)
+      throws IOException {
     conf.set("io.serializations", "org.apache.hadoop.io.serializer.JavaSerialization");
-    Path path = new Path(String.valueOf(TEST_ROOT_DIR), "NonWritableSequenceFile");
+    Path path = new Path(fileName);
     SequenceFile.Writer writer = SequenceFile.createWriter(conf, SequenceFile.Writer.file(path),
         SequenceFile.Writer.keyClass(String.class), SequenceFile.Writer.valueClass(String.class));
-    writer.append("Key1", "Value1");
-    writer.append("Key2", "Value2");
     writer.close();
-    String expected = "Key1\tValue1" + SEPARATOR + "Key2\tValue2" + SEPARATOR;
-    URI uri = path.toUri();
-    System.out.println(expected);
-    assertEquals(expected, readUsingTextCommand(uri, conf));
+  }
+
+  private static void createNonWritableSequenceFile(String fileName, Configuration conf)
+      throws IOException {
+    conf.set("io.serializations", "org.apache.hadoop.io.serializer.JavaSerialization");
+    Path path = new Path(fileName);
+    try (SequenceFile.Writer writer = SequenceFile.createWriter(conf,
+        SequenceFile.Writer.file(path), SequenceFile.Writer.keyClass(String.class),
+        SequenceFile.Writer.valueClass(String.class))) {
+      writer.append("Key1", "Value1");
+      writer.append("Key2", "Value2");
+    }
+  }
+
+  private static InputStream getInputStream(URI uri, Configuration conf) throws IOException {
+    // Prepare and call the Text command's protected getInputStream method.
+    PathData pathData = new PathData(uri, conf);
+    Display.Text text = new Display.Text() {
+      @Override
+      public InputStream getInputStream(PathData item) throws IOException {
+        return super.getInputStream(item);
+      }
+    };
+    text.setConf(conf);
+    return text.getInputStream(pathData);
   }
 }
-


### PR DESCRIPTION
### Description of PR

`hadoop fs -text` reads Avro files and sequence files by internally wrapping the stream in [`AvroFileInputStream`](https://github.com/apache/hadoop/blob/rel/release-3.4.1/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Display.java#L270) or [`TextRecordInputStream`](https://github.com/apache/hadoop/blob/rel/release-3.4.1/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Display.java#L217). These classes implement the required single-byte [`read()`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/InputStream.html#read()), but not the optional multi-byte buffered [`read(byte[], int, int)`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/InputStream.html#read(byte%5B%5D,int,int)). The default implementation in the JDK is a [loop over single-byte read](https://github.com/openjdk/jdk11u-dev/blob/a47c72fad455bfdf9053cb8e94c99e73965ab50d/src/java.base/share/classes/java/io/InputStream.java#L280), which causes sub-optimal I/O and method call overhead. We can optimize this by overriding the multi-byte read method.

### How was this patch tested?

Multiple new unit tests cover expectations for both single-byte and multi-byte read. I ran these tests both before and after the code change to make sure there is no unexpected behavioral change.

Here is some benchmarking I ran to test the effects of this patch. This shows a ~1.7x throughput improvement for sequence files.

```
# Generate random text data with block Snappy compression (sequence file format framing).
hadoop jar /usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar randomtextwriter \
    -D mapreduce.output.fileoutputformat.compress=true \
    -D mapreduce.output.fileoutputformat.compress.codec=org.apache.hadoop.io.compress.SnappyCodec \
    -D mapreduce.output.fileoutputformat.compress.type=BLOCK \
    random-snappy

# Install pv utility for benchmarking throughput of data through a command pipeline.
sudo apt-get install pv

# Benchmark before and after the patch.
# Also calculate checksums to confirm returned data is identical.

# Before:
hadoop fs -text 'random-snappy/*' | pv | sha256sum
20.1GiB 0:04:29 [76.2MiB/s] [                                                                      <=>                                     ]
9ec540014192ba9522c58a6fa8e26c912707493566a42e8a22de9edce474a6f4  -

# After:
hadoop fs -text 'random-snappy/*' | pv | sha256sum
20.1GiB 0:02:36 [ 131MiB/s] [                                                                                                  <=>         ]
9ec540014192ba9522c58a6fa8e26c912707493566a42e8a22de9edce474a6f4  -
```

The improvement is more modest for Avro, where there are unrelated overheads from deserializing and reserializing to JSON:

```
# Generate random Avro data. This yields a ~1 GB file, and I staged 10 copies into a directory.
java -jar avro-tools-1.11.4.jar random users-4000000.avro \
    --schema-file user.asvc \
    --count 40000000

# Before:
hadoop fs -text 'random-avro/*' | pv | sha256sum
36.4GiB 0:15:38 [39.7MiB/s] [                                                                             <=>                              ]
41d4ed96ef1fc3f74c0a6faf3ad3e94202ed4863a7d405a6a555aae2fe89df65  -

# After:
hadoop fs -text 'random-avro/*' | pv | sha256sum
36.4GiB 0:13:36 [45.7MiB/s] [                             <=>                                                                              ]
41d4ed96ef1fc3f74c0a6faf3ad3e94202ed4863a7d405a6a555aae2fe89df65  -
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
