### PR TITLE
HADOOP-19387: Fix LocalDirAllocator::getLocalPathForWrite unable to recover when the thread is interrupted

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/LocalDirAllocator.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/LocalDirAllocator.java
@@ -346,9 +346,9 @@ public class LocalDirAllocator {
         }
         ctx.localDirs = dirs.toArray(new Path[dirs.size()]);
         ctx.dirDF = dfList.toArray(new DF[dirs.size()]);
-        ctx.savedLocalDirs = newLocalDirs;
 
         if (dirs.size() > 0) {
+          ctx.savedLocalDirs = newLocalDirs;
           // randomize the first disk picked in the round-robin selection
           ctx.dirNumLastAccessed.set(dirIndexRandomizer.nextInt(dirs.size()));
         }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalDirAllocator.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalDirAllocator.java
@@ -567,5 +567,23 @@ public class TestLocalDirAllocator {
     // and expect to get a new file back
     dirAllocator.getLocalPathForWrite("file2", -1, conf);
   }
+
+  /**
+   * Test for HADOOP-19387 LocalDirAllocator cannot recover after thread interruption.
+   */
+  @Test(timeout = 30000)
+  public void testInterruptionRecovery() throws Throwable {
+
+    String dir0 = buildBufferDir(ROOT, 7);
+    conf.set(CONTEXT, dir0);
+    try {
+      Thread.currentThread().interrupt();
+      assertThrows(DiskErrorException.class, () -> dirAllocator.getLocalPathForWrite("file2", 1, conf));
+    } finally {
+      Thread.interrupted();
+    }
+    // expect to get a file with no exceptions
+    dirAllocator.getLocalPathForWrite("file2", 1, conf);
+  }
 }
 


### PR DESCRIPTION
### Description of PR
See [HADOOP-19387](https://issues.apache.org/jira/projects/HADOOP/issues/HADOOP-19387)

### How was this patch tested?
Added a unit test in hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalDirAllocator.java

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

