### PR TITLE
HDFS-17711. Change fsimage loading progress percentage discontinuous to continuous

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatPBINode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatPBINode.java
@@ -423,6 +423,7 @@ public final class FSImageFormatPBINode {
       CountDownLatch latch = new CountDownLatch(sections.size());
       AtomicInteger totalLoaded = new AtomicInteger(0);
       final List<IOException> exceptions = Collections.synchronizedList(new ArrayList<>());
+      Counter counter = prog.getCounter(Phase.LOADING_FSIMAGE, currentStep);
 
       for (int i=0; i < sections.size(); i++) {
         FileSummary.Section s = sections.get(i);
@@ -433,9 +434,7 @@ public final class FSImageFormatPBINode {
         }
         service.submit(() -> {
           try {
-            totalLoaded.addAndGet(loadINodesInSection(ins, null));
-            prog.setCount(Phase.LOADING_FSIMAGE, currentStep,
-                totalLoaded.get());
+            totalLoaded.addAndGet(loadINodesInSection(ins, counter));
           } catch (Exception e) {
             LOG.error("An exception occurred loading INodes in parallel", e);
             exceptions.add(new IOException(e));


### PR DESCRIPTION
### Description of PR
When the name node is restarted with dfs.image.parallel.load enabled, the completion percentage(at namenode web) is reflacted after each thread finished after fsimage loading.
For example, if dfs.image.parallel.target.sections=12(default), the completion percentage increases by 0% -> 8.3% (1/12) -> 16.6% (2/12) ->.... -> 100%.
This is because each thread uses a separate counter.
According docs of `org.apache.hadoop.hdfs.server.namenode.startupprogress.getCounter`, the counter guarantees thread-safe, so it seems that each fimage loading thread can use the same counter.

### How was this patch tested?
run hadoop unit test and tested my test hadoop cluster (version 3.4.0)


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

