### PR TITLE
HADOOP-19392: Upgrade ftpserver to resolve maven/pom issue

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
@@ -245,15 +245,9 @@ public class TestFTPFileSystem {
 
   private static void touch(FileSystem fs, Path path, byte[] data)
           throws IOException {
-    FSDataOutputStream out = null;
-    try {
-      out = fs.create(path);
+    try (FSDataOutputStream out = fs.create(path)) {
       if (data != null) {
         out.write(data);
-      }
-    } finally {
-      if (out != null) {
-        out.close();
       }
     }
   }

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1131,12 +1131,12 @@
       <dependency>
         <groupId>org.apache.ftpserver</groupId>
         <artifactId>ftplet-api</artifactId>
-        <version>1.0.0</version>
+        <version>1.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ftpserver</groupId>
         <artifactId>ftpserver-core</artifactId>
-        <version>1.0.0</version>
+        <version>1.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ftpserver</groupId>


### PR DESCRIPTION
### Description of PR

Resolves https://issues.apache.org/jira/browse/HADOOP-19392 -
Test class fails compilation due to maven/pom issue.

### How was this patch tested?

Ran tests locally within dev environment.
