### PR TITLE
HDFS-17714. MockResolver#removeLocation should also remove src path.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MockResolver.java
@@ -101,6 +101,7 @@ public class MockResolver
     final RemoteLocation remoteLocation =
         new RemoteLocation(nsId, location, mount);
     if (locationsList != null) {
+      locations.remove(mount);
       return locationsList.remove(remoteLocation);
     }
     return false;


### PR DESCRIPTION
### Description of PR
When running TestRouterAsyncRpc in local,  the testProxyMkdir always failed because of 
```java
FileStatus[] filesInitial = routerFS.listStatus(new Path("/"));
```
BTW, the getListing source codes in my company has a little bit difference from the community's, but this is not important.

![image](https://github.com/user-attachments/assets/ba8f68a8-d9e2-4e34-9b76-00a6ea69c325)

The path `/mntsnapshot` is only appeared in testManageSnapshot,  after diving into this problem, i found the reason is MockResolver#removeLocation only remove locations of a source path. This will leave the source path in `MockResolver#locations`.