### PR TITLE
HADOOP-19397. Update LICENSE-binary with jersey 2 details

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -363,16 +363,6 @@ org.xerial.snappy:snappy-java:1.1.10.4
 org.yaml:snakeyaml:2.0
 org.wildfly.openssl:wildfly-openssl:2.1.4.Final
 software.amazon.awssdk:bundle:2.25.53
-org.glassfish.jersey.core:jersey-common:2.46
-org.glassfish.jersey.core:jersey-server:2.46
-org.glassfish.jersey.inject:jersey-hk2:2.46
-org.glassfish.jersey.core:jersey-client:2.46
-org.glassfish.jersey.test-framework:jersey-test-framework-core:2.46
-org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:2.46
-org.glassfish.jersey.containers:jersey-container-servlet:2.46
-org.glassfish.jersey.containers:jersey-container-servlet-core:2.46
-org.glassfish.jersey.media:jersey-media-json-jettison:2.46
-org.glassfish.jersey.media:jersey-media-jaxb:2.46
 net.jodah:failsafe:2.4.4
 
 --------------------------------------------------------------------------------
@@ -534,6 +524,24 @@ Eclipse Public License (EPL) 2.0
 jakarta.ws.rs-api:jakarta.ws.rs-api:2.1.6
 jakarta.servlet.jsp:jakarta.servlet.jsp-api:2.3.6
 jakarta.servlet:jakarta.servlet-api:4.0.4
+
+Eclipse Public License (EPL) 2.0 with some parts being
+GNU General Public License (GPL), Version 2, With Classpath Exception,
+Apache License, 2.0 or Public Domain
+--------------------------
+
+See also https://github.com/eclipse-ee4j/jersey/blob/master/NOTICE.md
+
+org.glassfish.jersey.core:jersey-common:2.46
+org.glassfish.jersey.core:jersey-server:2.46
+org.glassfish.jersey.inject:jersey-hk2:2.46
+org.glassfish.jersey.core:jersey-client:2.46
+org.glassfish.jersey.test-framework:jersey-test-framework-core:2.46
+org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:2.46
+org.glassfish.jersey.containers:jersey-container-servlet:2.46
+org.glassfish.jersey.containers:jersey-container-servlet-core:2.46
+org.glassfish.jersey.media:jersey-media-json-jettison:2.46
+org.glassfish.jersey.media:jersey-media-jaxb:2.46
 
 
 HSQL License


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19397. Update LICENSE-binary with jersey 2 details.

Update license for Jersey.

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

