### PR TITLE
YARN-11754. [JDK17] Fix SpotBugs Issues in YARN.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
@@ -343,7 +343,7 @@ public class ResourceLocalizationService extends CompositeService
       LocalResourceTrackerState state) throws URISyntaxException, IOException {
     try (RecoveryIterator<LocalizedResourceProto> it =
              state.getCompletedResourcesIterator()) {
-      while (it != null && it.hasNext()) {
+      while (it.hasNext()) {
         LocalizedResourceProto proto = it.next();
         LocalResource rsrc = new LocalResourcePBImpl(proto.getResource());
         LocalResourceRequest req = new LocalResourceRequest(rsrc);
@@ -356,7 +356,7 @@ public class ResourceLocalizationService extends CompositeService
 
     try (RecoveryIterator<Map.Entry<LocalResourceProto, Path>> it =
              state.getStartedResourcesIterator()) {
-      while (it != null && it.hasNext()) {
+      while (it.hasNext()) {
         Map.Entry<LocalResourceProto, Path> entry = it.next();
         LocalResource rsrc = new LocalResourcePBImpl(entry.getKey());
         LocalResourceRequest req = new LocalResourceRequest(rsrc);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/ColumnRWHelper.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/ColumnRWHelper.java
@@ -330,7 +330,7 @@ public final class ColumnRWHelper {
               for (Map.Entry<Long, byte[]> cell : cells.entrySet()) {
                 V value =
                     (V) valueConverter.decodeValue(cell.getValue());
-                Long ts = supplementTs ? TimestampGenerator.
+                long ts = supplementTs ? TimestampGenerator.
                     getTruncatedTimestamp(cell.getKey()) : cell.getKey();
                 cellResults.put(ts, value);
               }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11754. [JDK17] Fix SpotBugs Issues in YARN.

I am following up on the upgrade to JDK 17 and have found some SpotBugs issues in YARN. I will address these issues in this JIRA, with the fixes being relatively minor.


> Performance Warnings

```
Code | Warning
-- | --
Bx | Boxed value is unboxed and then immediately reboxed in org.apache.hadoop.yarn.server.timelineservice.storage.common.ColumnRWHelper.readResultsWithTimestamps(Result, byte[], byte[], KeyConverter, ValueConverter, boolean)
  | Bug type BX_UNBOXING_IMMEDIATELY_REBOXED (click for details)In class org.apache.hadoop.yarn.server.timelineservice.storage.common.ColumnRWHelperIn method org.apache.hadoop.yarn.server.timelineservice.storage.common.ColumnRWHelper.readResultsWithTimestamps(Result, byte[], byte[], KeyConverter, ValueConverter, boolean)Called method Long.valueOf(long)At ColumnRWHelper.java:[line 333]
```

> Dodgy code Warnings

```
Code | Warning
-- | --
RCN | Redundant nullcheck of it, which is known to be non-null in org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService.recoverTrackerResources(LocalResourcesTracker, NMStateStoreService$LocalResourceTrackerState)
  | Bug type RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE (click for details)In class org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationServiceIn method org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService.recoverTrackerResources(LocalResourcesTracker, NMStateStoreService$LocalResourceTrackerState)Value loaded from itReturn value of org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService$LocalResourceTrackerState.getCompletedResourcesIterator() of type org.apache.hadoop.yarn.server.nodemanager.recovery.RecoveryIteratorRedundant null check at ResourceLocalizationService.java:[line 344]
RCN | Redundant nullcheck of it, which is known to be non-null in org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService.recoverTrackerResources(LocalResourcesTracker, NMStateStoreService$LocalResourceTrackerState)
  | Bug type RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE (click for details)In class org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationServiceIn method org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService.recoverTrackerResources(LocalResourcesTracker, NMStateStoreService$LocalResourceTrackerState)Value loaded from itReturn value of org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService$LocalResourceTrackerState.getStartedResourcesIterator() of type org.apache.hadoop.yarn.server.nodemanager.recovery.RecoveryIteratorRedundant null check at ResourceLocalizationService.java:[line 357]

Code	Warning
RCN	Redundant nullcheck of it, which is known to be non-null in org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService.recoverTrackerResources(LocalResourcesTracker, NMStateStoreService$LocalResourceTrackerState)
[Bug type RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE (click for details)](https://ci-hadoop.apache.org/job/hadoop-qbt-trunk-java11-linux-x86_64/804/artifact/out/branch-spotbugs-hadoop-yarn-project-warnings.html#RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE)
In class org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService
In method org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService.recoverTrackerResources(LocalResourcesTracker, NMStateStoreService$LocalResourceTrackerState)
Value loaded from it
Return value of org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService$LocalResourceTrackerState.getCompletedResourcesIterator() of type org.apache.hadoop.yarn.server.nodemanager.recovery.RecoveryIterator
Redundant null check at ResourceLocalizationService.java:[line 344]

RCN	Redundant nullcheck of it, which is known to be non-null in org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService.recoverTrackerResources(LocalResourcesTracker, NMStateStoreService$LocalResourceTrackerState)
[Bug type RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE (click for details)](https://ci-hadoop.apache.org/job/hadoop-qbt-trunk-java11-linux-x86_64/804/artifact/out/branch-spotbugs-hadoop-yarn-project-warnings.html#RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE)
In class org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService
In method org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService.recoverTrackerResources(LocalResourcesTracker, NMStateStoreService$LocalResourceTrackerState)
Value loaded from it
Return value of org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService$LocalResourceTrackerState.getStartedResourcesIterator() of type org.apache.hadoop.yarn.server.nodemanager.recovery.RecoveryIterator
Redundant null check at ResourceLocalizationService.java:[line 357]
```


### How was this patch tested?

No unit tests are required.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

